### PR TITLE
fix: replace clean state's re-run directive with a STOP banner

### DIFF
--- a/src/Prompt.test.ts
+++ b/src/Prompt.test.ts
@@ -215,9 +215,9 @@ describe("buildPrompt", () => {
       expect(out.indexOf("⛔")).toBeGreaterThan(out.indexOf("Open questions await the user"))
     })
 
-    it("clean does NOT get the STOP banner despite autoAdvance: false", () => {
+    it("clean gets the STOP banner", () => {
       const out = buildPrompt(result("clean"))
-      expect(out).not.toContain("⛔")
+      expect(out).toContain("⛔")
     })
 
     it("auto-advance states do NOT get the STOP banner", () => {
@@ -230,7 +230,6 @@ describe("buildPrompt", () => {
         buildPrompt(
           result("grilling", { autoAdvance: true, context: { grillingCase: "iterate" } }),
         ),
-        buildPrompt(result("clean")),
       ]) {
         expect(out).not.toContain("⛔")
       }
@@ -398,10 +397,10 @@ describe("buildPrompt", () => {
       expect(buildPrompt(result("idle"))).not.toContain("Re-run gtd immediately")
     })
 
-    it("clean is not-auto-advance but carries its own re-run instruction", () => {
+    it("clean is not-auto-advance and carries a STOP directive", () => {
       const out = buildPrompt(result("clean"))
       expect(out).not.toContain("Re-run gtd immediately")
-      expect(out).toContain("Re-run gtd")
+      expect(out).toContain("⛔")
     })
   })
 })

--- a/src/prompts/clean.md
+++ b/src/prompts/clean.md
@@ -50,7 +50,9 @@ review. It must:
 4. Normalize formatting (run `gtd format REVIEW.md` with the same gtd you
    invoked), then leave `REVIEW.md` **uncommitted**.
 
-Re-run gtd — the next cycle commits `REVIEW.md` as `gtd: awaiting review` and
-stops for the user. The user then re-runs gtd with **no** changes to approve and
-finish, or edits the code / annotates `REVIEW.md` to request changes (which seed
-a fresh plan).
+Tell the user `REVIEW.md` is ready and that they should run `gtd` to proceed to
+the review.
+
+⛔ **STOP — do not re-run `gtd`.** The next cycle commits `REVIEW.md` as
+`gtd: awaiting review` and stops for the user. Re-running gtd now advances
+without human input.


### PR DESCRIPTION
The `clean.md` prompt ended with "Re-run gtd — the next cycle commits REVIEW.md…" which agents treated as an auto-advance instruction, immediately advancing to Await Review without stopping for the human.

## Fix

Replace the trailing "Re-run gtd" sentence with a STOP banner (matching the pattern used by other human-gate states), and add a sentence telling the agent to inform the user that REVIEW.md is ready.

## Test changes

- `"clean does NOT get the STOP banner"` → `"clean gets the STOP banner"`
- `"clean is not-auto-advance but carries its own re-run instruction"` → `"clean is not-auto-advance and carries a STOP directive"` (assert `⛔` present instead of bare "Re-run gtd")
- Removed `clean` from the auto-advance STOP-banner exclusion list

🤖 Generated with [Claude Code](https://claude.com/claude-code)