### PR TITLE
feat: redesign review triggering and unify feedback capture

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -74,15 +74,20 @@ Precedence ladder:
 | 3        | .gtd/ + code dirty / pending ERRORS.md deletion / no-op fixer | Testing            |
 | 3        | .gtd/ clean + HEAD `gtd: planning` or `gtd: package done`     | Building           |
 | 3        | .gtd/ clean + HEAD `gtd: building`                            | Agentic Review     |
+| 4        | REVIEW.md + HEAD `gtd: review feedback` (lost seed)           | Accept Review      |
 | 4        | REVIEW.md committed + clean tree                              | Done               |
 | 4        | REVIEW.md committed + dirty tree                              | Accept Review      |
 | 4        | REVIEW.md uncommitted                                         | Await Review       |
-| 5        | Boundary HEAD + pending changes                               | New Feature        |
+| 5        | Boundary HEAD + pending changes (no committed TODO.md)        | New Feature        |
 | 6        | TODO.md + `<!-- user answers here -->` marker                 | Grilling (STOP)    |
 | 6        | TODO.md + no marker + dirty                                   | Grilling (iterate) |
 | 6        | TODO.md + no marker + clean                                   | Grilled            |
-| 7        | Clean tree + boundary/`package done` HEAD + reviewable diff   | Clean              |
-| 7        | Clean tree + boundary/`package done` HEAD + no diff           | Idle               |
+| 7        | Clean tree + boundary/`package done` HEAD + reviewable diff\* | Clean              |
+| 7        | Clean tree + boundary/`package done` HEAD, otherwise          | Idle               |
+
+\* Reviewable = the workflow-file-filtered diff since the review base is
+non-empty AND commits exist after the last `gtd: done` (or none exists) — an
+approved review settles Idle instead of immediately re-firing.
 
 A "boundary" commit is any non-`gtd:` subject, or exactly `gtd: done`.
 
@@ -96,7 +101,7 @@ re-gathers and re-resolves automatically):
 | Transport     | Mixed-reset the `gtd: transport` HEAD into the working tree                                                    |
 | New Feature   | Commit raw input `gtd: new task`, revert it, seed TODO.md                                                      |
 | Testing       | Commit pending code `gtd: building`; run tests; on red write FEEDBACK.md or ERRORS.md and commit `gtd: errors` |
-| Accept Review | Seed TODO.md from the pending changeset, discard code edits, remove REVIEW.md                                  |
+| Accept Review | Capture the changeset `gtd: review feedback` (commit-then-revert), remove REVIEW.md, seed TODO.md              |
 | Close package | Remove FEEDBACK.md + finished package dir + empty .gtd/, commit `gtd: package done`                            |
 | Done          | Remove REVIEW.md, commit `gtd: done`                                                                           |
 
@@ -163,20 +168,43 @@ the build loop runs:
 
 ## Review flow
 
-After all packages close (or for any committed code with no active workflow),
-**Clean** generates REVIEW.md for the diff since the auto-computed base:
+After all packages close (or for any committed branch work with no active
+workflow), **Clean** generates REVIEW.md for the diff since the auto-computed
+base:
 
-- Feature branch → merge-base with the default branch
-- Default branch → last `gtd: done` commit (or the first `gtd: grilling` after
-  the last accepted review), else the repository root
+- Within a process → the first `gtd: grilling` of the current cycle (the whole
+  task); after a feedback cycle → the last `gtd: awaiting review` (only the new
+  work packages)
+- Outside a process, feature branch → merge-base with the default branch —
+  always the whole branch, even after a prior `gtd: done` on it
+- Outside a process, default branch → no review (Idle)
+
+A review only fires when commits exist after the last `gtd: done` (or none
+exists), so an approved review settles Idle until new commits land. Workflow
+files (REVIEW.md, TODO.md, FEEDBACK.md, ERRORS.md, `.gtd/`) are excluded from
+every review diff.
 
 **Await Review** commits REVIEW.md (`gtd: awaiting review`) and STOPs.
 
-- **Human edits** → Accept Review (edge-only): seeds TODO.md from the changeset,
-  discards code edits, removes REVIEW.md. Next state is Grilling, which develops
-  the feedback into a new plan.
-- **No edits (clean tree)** → Done (edge-only): removes REVIEW.md, commits
-  `gtd: done` → Idle.
+- **Substantive edits** (code edits, new files, inline comments, textual
+  REVIEW.md notes, or an uncommitted TODO.md) → Accept Review (edge-only):
+  captures the whole changeset as `gtd: review feedback` (commit-then-revert —
+  untracked files are dropped by construction), removes REVIEW.md, seeds TODO.md
+  from the captured diff. Next state is Grilling, which develops the feedback
+  into a new plan — the process stays open; no `gtd: done` is committed on the
+  feedback path. If a checkout/pull loses the uncommitted seed, HEAD
+  `gtd: review feedback` + REVIEW.md regenerates it (never Done).
+- **No edits (clean tree) or checkbox-only ticks** → Done (edge-only): removes
+  REVIEW.md, commits `gtd: done` → Idle.
+
+Everywhere a change is captured (New Feature, Accept Review, grilling rounds on
+a committed plan — where code sketches are appended to TODO.md and reverted),
+the seed embeds the interpretation rules: code changes are suggestions to
+re-implement properly (including tests), code comments are positional feedback,
+TODO.md/REVIEW.md text is global feedback, checkbox flips are approval noise.
+During the build (`.gtd/` present) user edits are instead adopted and verified
+by tests + agentic review — pending code there is indistinguishable from
+builder-agent output.
 
 ## Configuration
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -26,10 +26,12 @@ resolves to exactly one active state per invocation.
    ```
 
    Resolve `scripts/gtd.js` relative to this skill's directory, not the user's
-   repo. The script must be invoked with the user's repo as cwd so it can read
-   `git status`, commit history, and diffs. The only supported subcommand is
-   `format <file>`; there is no `gtd transport` command — a `gtd: transport`
-   HEAD is hand-committed by the user and consumed by the Transport state.
+   repo. The script must be invoked with the user's **repository root** as cwd
+   so it can read `git status`, commit history, and diffs — gtd refuses to run
+   from a subdirectory (or outside a repository) with a clear error rather than
+   mis-deriving state. The only supported subcommand is `format <file>`; there
+   is no `gtd transport` command — a `gtd: transport` HEAD is hand-committed by
+   the user and consumed by the Transport state.
 
 2. Treat the script's stdout as a complete, self-contained prompt — read it and
    follow its instructions verbatim. Do not edit, paraphrase, or summarize it

--- a/STATES.md
+++ b/STATES.md
@@ -49,9 +49,11 @@ The last commit message is bucketed:
 - **Boundary** — a non-`gtd:` commit, or `gtd: done`. Marks a cold start: no
   workflow in progress.
 - **Mid-phase** —
-  `gtd: new task | grilling | grilled | planning | building | errors | fixing | feedback | package done | awaiting review`.
+  `gtd: new task | grilling | grilled | planning | building | errors | fixing | feedback | package done | awaiting review | review feedback`.
   Identifies the exact phase of an in-progress workflow; disambiguates states
-  the filesystem alone cannot separate.
+  the filesystem alone cannot separate. (`gtd: review feedback` is the
+  accept-review capture commit — distinct from the `gtd: feedback` marker the
+  review-fix counter folds on.)
 
 ### Precedence (first match wins)
 
@@ -66,11 +68,17 @@ The last commit message is bucketed:
    - else clean, by HEAD: `planning`/`package done` → Building; `building` →
      Agentic Review
 4. **REVIEW.md present** → review lifecycle (Await Review / Accept Review /
-   Done), routed by committed-ness + tree.
-5. **Boundary HEAD + pending changes** (no .gtd/REVIEW/FEEDBACK), or HEAD
-   `gtd: new task` + clean tree (regenerate a lost seed) → New Feature.
+   Done), routed by committed-ness + tree. HEAD `gtd: review feedback` (the
+   accept-review capture commit, whose annotated REVIEW.md rematerialized after
+   a checkout/pull lost the uncommitted seed) → Accept Review regen, never Done.
+5. **Boundary HEAD + pending changes** (no .gtd/REVIEW/FEEDBACK, no _committed_
+   TODO.md — that is a resumed grill → rule 6), or HEAD `gtd: new task` + clean
+   tree (regenerate a lost seed) → New Feature.
 6. **TODO.md present** → Grilling / Grilled.
-7. **Boundary/`package done` HEAD + clean tree** → Clean (review) or Idle.
+7. **Boundary/`package done` HEAD + clean tree** → Clean (review) or Idle. A
+   review fires only when the re-trigger gate is open — commits exist after the
+   last `gtd: done` (or none exists) — and the workflow-file-filtered diff from
+   the review base is non-empty.
 
 Anything matching no rule is corruption — hard-error rather than guess.
 
@@ -86,8 +94,9 @@ on the far side).
 These never arise in normal flow; if seen, `gtd` hard-errors rather than
 guessing:
 
+- REVIEW.md + **committed** TODO.md
+- **uncommitted** REVIEW.md + TODO.md
 - REVIEW.md + .gtd
-- REVIEW.md + TODO.md
 - FEEDBACK.md + REVIEW.md
 - FEEDBACK.md without .gtd
 - ERRORS.md + FEEDBACK.md
@@ -95,7 +104,9 @@ guessing:
 
 Legal coexistence: `.gtd`+TODO.md (plan + packages during **Planning** only —
 TODO.md is deleted at the first Building turn); FEEDBACK.md+`.gtd` (fix during
-build).
+build); **committed** REVIEW.md + **uncommitted** TODO.md (plan-level notes
+written during a review are global feedback — the reviewDirty path captures them
+via Accept Review).
 
 ## States
 
@@ -115,8 +126,10 @@ scratch.
 **Conditions:** either boundary HEAD (non-gtd or `gtd: done`) with pending
 **code changes and/or a new (uncommitted) TODO.md** and no
 `.gtd`/REVIEW.md/FEEDBACK.md (a _committed_ TODO.md under a boundary HEAD is a
-resumed grill — see Grilling); **or** HEAD `gtd: new task` with a clean tree (a
-checkout/pull that lost the uncommitted seed — regenerate it).
+resumed grill — see Grilling; that routing holds even with pending code, which
+Grilling captures rather than re-seeding over the developed plan); **or** HEAD
+`gtd: new task` with a clean tree (a checkout/pull that lost the uncommitted
+seed — regenerate it).
 
 **Actions:**
 
@@ -125,7 +138,9 @@ checkout/pull that lost the uncommitted seed — regenerate it).
 - revert `gtd: new task`'s diff into the working tree, uncommitted — back to a
   clean baseline
 - seed TODO.md, uncommitted, from that diff (any prior TODO.md text, code
-  comments, code suggestions)
+  comments, code suggestions). The seed embeds the interpretation rules: code
+  changes are suggestions to re-implement properly (including tests), code
+  comments are positional feedback, TODO.md/REVIEW.md text is global feedback
 
 **Prompt:** none — auto-advance. _(Next: TODO.md present + reverted code →
 Grilling, which commits the revert + seed as the first `gtd: grilling` and
@@ -152,6 +167,17 @@ reverted code + seeded TODO.md, committed together as the first
   still unresolved (re-opening `?` markers if needed). _(auto-advance)_
 
 **3 — Converged** (no markers, clean tree) → **Grilled**.
+
+**Code capture on committed-plan rounds** (cases 1 and 2): when TODO.md is
+already committed (any round after the seed) and the pending changes include
+code, the code diff — untracked files included, steering files excluded — is
+appended to TODO.md as a fenced "Captured input (grilling)" suggestion block and
+the code changes are dropped (tracked paths hard-reset, untracked files deleted)
+before the round commits `gtd: grilling`. Code sketched during grilling is
+feedback to plan and re-implement (with tests), never work that lands verbatim.
+The **seed round** (TODO.md still uncommitted, carrying the seed revert from New
+Feature / Accept Review) commits everything verbatim. Binary edits survive only
+as the diff's "Binary files differ" line — an accepted limitation.
 
 Advance happens only at case 3 — an invocation where nobody changed anything and
 no question is open — so the user (or agent) may iterate indefinitely.
@@ -219,6 +245,12 @@ that produced no change — re-test it).
 - ERRORS.md written → **STOP**, no auto-advance: report that the fix-attempt cap
   was reached and the human must investigate (→ Escalate)
 
+User code edits made while `.gtd/` exists are **adopted**, not captured (by
+design): pending code during a build is indistinguishable from builder-agent
+output, so it is committed `gtd: building` and verified by the test gate and the
+package's agentic review instead. Grilling and review phases capture instead —
+no agent writes code there, so pending code is provably human feedback.
+
 ### Fixing (auto-advance)
 
 **Conditions:** **non-empty** FEEDBACK.md present (an empty FEEDBACK.md is a
@@ -283,21 +315,34 @@ Clean.)_
 
 ### Clean
 
-**Conditions:** no steering files, clean tree, and either non-gtd HEAD (review
-freshly committed work) or HEAD `gtd: package done` with `.gtd` gone (review the
-finished feature).
+**Conditions:** no steering files, clean tree, and either boundary HEAD (review
+committed work) or HEAD `gtd: package done` with `.gtd` gone (review the
+finished feature) — provided the **re-trigger gate** is open: commits exist
+after the last `gtd: done`, or no `gtd: done` exists on the branch. A HEAD
+sitting on `gtd: done` with nothing after it settles Idle instead of re-firing
+the review it just closed (the gate controls _whether_ a review fires, never
+what it covers).
 
-**Actions:** determine the base commit for the review — the **more recent
-ancestor of HEAD** of these two candidates:
+**Actions:** determine the base commit for the review (its scope):
 
-- the last commit that deleted REVIEW.md (`gtd: done`, or the first
-  `gtd: grilling` after an accepted review), on **any** branch;
-- the merge-base with the default branch (a proper ancestor on a feature
-  branch).
+- **within a process** (a `gtd: grilling` commit exists after the last
+  `gtd: done`):
+  - first review — base = the first `gtd: grilling` of the current cycle; the
+    review spans the whole task, across all its work packages;
+  - follow-up review (a `gtd: awaiting review` also exists in the current cycle)
+    — base = the last `gtd: awaiting review`; the review covers only the work
+    packages built after that review (the feedback cycle's output).
+- **outside a process, on a feature branch** — base = the merge-base with the
+  default branch: always the whole branch, even when a prior process completed
+  on it (already-approved work is re-covered by design).
+- **outside a process, on the default branch** — no base: the branch review
+  never fires on trunk (Idle). Everything else still works on trunk — a dirty
+  tree seeds New Feature and open processes continue.
 
-The deletion wins whenever it post-dates the merge-base, so a completed branch
-review advances the base past `gtd: done` instead of re-reviewing the whole
-branch. If neither candidate exists, the base is the root.
+Workflow files (REVIEW.md, TODO.md, FEEDBACK.md, ERRORS.md, `.gtd/`) are
+excluded from the review diff, so the reviewer never writes chunks about
+plumbing churn. If the filtered diff is empty, there is nothing to review
+(Idle).
 
 **Prompt:** create REVIEW.md for the changes since the base commit. _(not
 auto-advance; agent writes REVIEW.md → Await Review.)_
@@ -314,22 +359,31 @@ auto-advance — human turn.)_
 ### Accept Review (auto-advance)
 
 **Conditions:** REVIEW.md present and **committed**, with pending
-**non-checkbox** changes — code edits, inline code comments, or textual
-annotations added to REVIEW.md. Checkbox-only edits (`- [ ]` ↔ `- [x]`) do
-**not** qualify and route to Done instead.
+**non-checkbox** changes — code edits, inline code comments, textual annotations
+added to REVIEW.md, or an uncommitted TODO.md with plan-level notes.
+Checkbox-only edits (`- [ ]` ↔ `- [x]`) do **not** qualify and route to Done
+instead. Also fires as **regen** whenever HEAD is `gtd: review feedback` and
+REVIEW.md is present: the capture commit's annotated REVIEW.md rematerialized
+after a checkout/pull (or crash) lost the uncommitted seed — routing to Done
+here would silently approve the annotations.
 
-**Actions:** (all left uncommitted — no commit of its own)
+**Actions:** (commit-then-revert, mirroring New Feature)
 
-- seed TODO.md with the changeset (REVIEW.md annotations, code comments, change
-  suggestions)
-- discard the human's code edits (`git checkout` — back to the reviewed
-  baseline)
-- remove REVIEW.md
+- commit the whole pending changeset verbatim as `gtd: review feedback` —
+  annotations, code edits, and new (untracked) files alike: a durable capture
+  that survives checkout/pull. (Skipped when HEAD already carries the subject —
+  the regen case discards partial state with a hard reset instead.)
+- revert the capture commit into the working tree, uncommitted — back to the
+  reviewed baseline. Untracked files are dropped by construction; a plain
+  checkout would leak them into the next grilling commit.
+- remove REVIEW.md (which is what stops Accept Review re-firing)
+- seed TODO.md, uncommitted, from the captured diff
 
 **Prompt:** none — auto-advance. _(Next: REVIEW.md gone + TODO.md present →
-Grilling, which commits the lot as the first `gtd: grilling` and synthesizes the
-plan. Removing REVIEW.md is what stops Accept Review re-firing — no commit
-needed.)_
+Grilling, which commits the revert + seed as the first `gtd: grilling` and
+synthesizes the plan. The process stays open: **no `gtd: done` is ever committed
+on the feedback path**; the seeded plan re-enters grilling → planning →
+building, and the follow-up review covers only the new work packages.)_
 
 ### Done
 
@@ -351,9 +405,13 @@ closes the review.)_
 
 ### Idle
 
-**Conditions:** no steering files, clean tree, HEAD `gtd: done`.
+**Conditions:** no steering files, clean tree, and no review to run — the
+re-trigger gate is closed (no commits after the last `gtd: done`), the review
+base's workflow-file-filtered diff is empty, or the trunk rule applies (outside
+a process on the default branch).
 
 **Actions:** none.
 
-**Prompt:** nothing to do. _(Prevents a finished review from spawning a spurious
-empty re-review.)_
+**Prompt:** nothing to do. _(Prevents an approved review from spawning a
+spurious re-review: review → approve → done → review. gtd stays idle until new
+commits land after the `gtd: done`.)_

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,169 @@
+# Test coverage plan — close the gaps around the state machine's edges
+
+## Goal
+
+Systematically cover every use and edge case of gtd. The core state ladder and
+the review/capture redesign are well covered (250 unit tests, 93 e2e scenarios
+before this plan); the remaining risk lives in (1) full multi-run journeys
+across state seams, (2) hostile git environments, (3) capture-path content edge
+cases, and (4) interruption/resume windows. Each case lists the expected
+behavior so a failing test is a spec violation, not a surprise.
+
+**Status: implemented.** Suite now: 269 unit tests (265 pass), 118 e2e scenarios
+(113 pass). The 4 + 5 failures are intentional — expected-fail tests pinning the
+bugs below, left red per the no-fixes instruction.
+
+## Bugs found (documented, NOT fixed — tests left failing)
+
+- **B1 — git exit codes are silently swallowed.** `Git.ts`'s `run` helper uses
+  `Command.string`, which only collects stdout; non-zero git exits do not fail
+  the Effect. Consequences pinned by failing tests:
+  - a rejected pre-commit hook → gtd prints a normal prompt, exit 0, nothing
+    committed (`environment.feature` "failing pre-commit hook");
+  - unusable gpg signing → same silent success (`environment.feature` "Unusable
+    commit signing");
+  - outside a git repository every probe "succeeds" empty → Idle, exit 0
+    (`environment.feature` "outside a git repository");
+  - `diffHead`'s intent-to-add feeds C-quoted (`"sketch \303\251..."`) ls-files
+    output back to `git add`, the add fails SILENTLY, the capture diff comes
+    back empty — and `captureGrillingEdits` then DELETES the file it failed to
+    capture: **data loss** (`Events.test.ts` "unicode/space/emoji filename").
+    Fix: fail on exit codes (Command.exitCode) or unquote/-z the path
+    round-trip.
+  - Side effect: `hasCommits` is always true (`rev-parse --verify HEAD`
+    "succeeds" on empty repos), which _accidentally_ makes fresh-repo seeding
+    work — pinned green by "A fresh repository with no commits seeds a new
+    feature".
+- **B2 — stripCode stops at the first fenced line.** The fence regex ends with
+  `(?:\n\1[^\n]*|$)` under the `m` flag, where `$` matches at EVERY line end —
+  so only the first line inside a fence is stripped and a
+  `<!-- user answers here -->` marker deeper inside a captured diff arms the
+  answers gate, breaking the seed's documented "markers in captures are inert"
+  promise (`Events.test.ts` "raw seed containing a deep fenced marker"). Fix:
+  anchor the fallback to end-of-input, e.g. `$(?![\s\S])`.
+- **B3 — capture fences break under the gtd-format round-trip.** `seedTodo` /
+  `appendCapturedInput` use a fixed three-backtick fence; CommonMark accepts a
+  space-indented ` ``` ` diff CONTEXT line as a CLOSING fence, so
+  `gtd format TODO.md` (instructed after every edit; run by the recommended
+  pre-commit hook) truncates the fence and rewrites the captured diff — marker
+  included — into plain paragraphs (`Events.test.ts` format round-trip tests).
+  Fix: fenceFor-style fence sizing (closing fence must be ≥ opener).
+- **B4 — subdirectory invocation mis-derives state.** Steering files and
+  pathspecs resolve against cwd, not the repo root; from a subdir gtd hits a
+  misleading corruption error (or would silently mis-derive in dirtier states).
+  Decided spec: hard-error naming the repo-root requirement
+  (`environment.feature` "from a subdirectory refuses").
+- **B5 — a CRLF editor defeats checkbox-only approval.** Rewriting line endings
+  makes every line a change, so pure ticking routes to Accept Review (feedback)
+  instead of Done (`environment.feature` "Checkbox approval survives a CRLF
+  editor"). Fix: normalize `\r` in `isCheckboxOnlyDiff`.
+
+## Decisions (grilled 2026-07-02, answered inline)
+
+- Subdir invocation → **hard error** with a clear repo-root message.
+- Manual steering-file deletion → **keep the corruption hard-error** (current
+  behavior pinned green in `steering-misuse.feature`); message-quality
+  improvements welcome later.
+- Hanging `testCommand` → **document** (no timeout): the runner waits forever on
+  a hung command; noted here as a known limitation. Also documented-
+  unsupported: shell metacharacters in `testCommand` (whitespace-tokenized argv,
+  no shell — see `TestRunner.ts`).
+
+## Current coverage (inventory)
+
+- Pure machine: all 7 precedence rules, illegal combos, corruption, counter
+  folds, gate/filter, capture-action emission, regen carve-out (Machine.test) —
+  plus a fast-check property sweep (Machine.property.test).
+- Edge: payload facts, review-base rules 1–4 + gate + filter, all EdgeActions
+  incl. commit-then-revert and grilling capture (Events.test, Git.test).
+- E2e: per-state scenarios across 16 feature files, five full-lifecycle
+  journeys, environment/hostility matrix, replay/idempotence sweep.
+
+## 1. Full-journey e2e scenarios — DONE (`journeys.feature`)
+
+- [x] Happy path: dirty tree → … → done → idle, exact subject sequence, idle
+      stable on re-run.
+- [x] Feedback journey: annotations → `gtd: review feedback` capture → rebuild →
+      follow-up review covers only the new package → approve → idle.
+- [x] Escalation journey: red ×cap → ERRORS.md → human resume → fresh budget →
+      green (no re-escalation).
+- [x] Two-package journey: counters reset at the package seam.
+- [x] Multi-review branch: approve → gate holds idle → new commit re-opens
+      whole-branch review → second approve.
+
+## 2. Pure-machine property sweep — DONE (`Machine.property.test.ts`)
+
+- [x] 2000-run sweep over edge-consistent payloads: only GtdStateError throws,
+      illegal throws match the documented combos, one known state, edge action
+      from the state's allowed set, `done` requires REVIEW.md, regen carve-out
+      shadows Done, deterministic resolution.
+- [x] Fold invariants: non-negative counters; RESOLVE events are fold no-ops.
+
+## 3. Capture-path content edge cases — DONE (`Events.test.ts`)
+
+- [x] Binary file added during review → preserved in the capture commit.
+- [x] Binary file in a grilling round → accepted loss, pinned.
+- [x] `.gitignore`d files survive capture untouched.
+- [x] Untracked nested directory captured + removed recursively.
+- [x] `git mv` rename during review AND during a grilling round.
+- [x] Unicode/space/emoji filename — **FAILING, documents B1 data loss**.
+- [x] Mixed checkbox-tick + code edit → feedback, not approval
+      (`review.feature`).
+- [x] Emptied REVIEW.md → textual change, not approval (`review.feature`).
+- [x] Fence collisions — **FAILING ×3, documents B2 + B3**.
+- [x] Idempotence false-positive (prose identical to capture) → pinned as
+      accepted behavior.
+
+## 4. Hostile environments — DONE (`environment.feature`)
+
+- [x] Subdirectory invocation — **FAILING, documents B4** (decided: hard error).
+- [x] Not a git repository — **FAILING, documents B1** (exit 0 Idle today).
+- [x] Fresh repo, no commits, dirty tree → seeds correctly (green, via the B1
+      accident — will need attention when B1 is fixed).
+- [x] Detached HEAD → reviews from merge-base (green).
+- [x] Merge commit at HEAD → graceful Idle, no destructive action (green).
+- [x] Transport commit as root → clear error (green).
+- [x] Reformatting pre-commit hook → flow converges (green).
+- [x] Failing pre-commit hook — **FAILING, documents B1** (silent success
+      today); resume-after-removal part passes.
+- [x] CRLF editor on REVIEW.md checkboxes — **FAILING, documents B5**.
+- [x] Unusable gpg signing — **FAILING, documents B1**.
+- [x] Submodule pointer change → routed as code change, no crash (green).
+
+## 5. Interruption & resume — DONE (`replay.feature`)
+
+- [x] Escalate, Clean, and pending-Agentic-Review double-runs: identical prompt,
+      zero new commits. (Auto/approval states are intentionally NOT idempotent —
+      regen re-seeds, a committed REVIEW.md approves.)
+- [x] Grilling-capture crash window: identical re-capture never double-appends
+      (`Events.test.ts`).
+- [x] Kill mid-test recovery: clean `gtd: building` HEAD re-enters agentic
+      review losslessly.
+- [ ] DEFERRED: MAX_EDGE_HOPS runaway guard — untestable without either a
+      machine bug to bounce on or extracting the driver loop from `main.ts` into
+      a testable unit; revisit if the driver is ever refactored.
+
+## 6. Steering-file misuse — DONE (`steering-misuse.feature`)
+
+- [x] Hand-committed FEEDBACK.md deletion at `gtd: errors` → corruption
+      hard-error (pinned; decided to keep).
+- [x] Hand-committed REVIEW.md deletion at `gtd: awaiting review` → same.
+- [x] Non-package junk inside `.gtd/` ignored by the build loop.
+- [x] Empty `.gtd/` directory → Building without a package, no crash.
+- [x] Stale-steering illegal-combo messages name the offending file (existing
+      `illegal-combinations.feature`, extended with the committed-TODO and
+      uncommitted-REVIEW variants).
+
+## 7. Config & test-runner edges — mostly pre-existing
+
+- [x] Malformed YAML/JSON, null-root, list-root, unknown keys, validation
+      messages (existing `config.feature`).
+- [x] Parent-directory cascade + innermost-wins (existing `config.feature`).
+- [x] `fixAttemptCap: 1` boundary (existing "lowered fixAttemptCap" scenario).
+- [ ] DEFERRED by decision: hanging `testCommand` (documented, no timeout) and
+      shell metacharacters (documented-unsupported tokenized argv).
+
+## 8. Performance smokes — DONE (`Perf.test.ts`)
+
+- [x] 300-commit history: full gatherEvents under 5s (generous CI budget).
+- [x] 10k-line review diff renders through buildPrompt under 2s.

--- a/TODO.md
+++ b/TODO.md
@@ -9,11 +9,11 @@ across state seams, (2) hostile git environments, (3) capture-path content edge
 cases, and (4) interruption/resume windows. Each case lists the expected
 behavior so a failing test is a spec violation, not a surprise.
 
-**Status: implemented.** Suite now: 269 unit tests (265 pass), 118 e2e scenarios
-(113 pass). The 4 + 5 failures are intentional — expected-fail tests pinning the
-bugs below, left red per the no-fixes instruction.
+**Status: implemented, and all five bugs below are now FIXED** — the nine
+expected-fail tests that pinned them are green and remain in the suite as
+regression guards. Suite: 269 unit tests, 118 e2e scenarios, all passing.
 
-## Bugs found (documented, NOT fixed — tests left failing)
+## Bugs found (pinned first with failing tests, then fixed)
 
 - **B1 — git exit codes are silently swallowed.** `Git.ts`'s `run` helper uses
   `Command.string`, which only collects stdout; non-zero git exits do not fail
@@ -106,28 +106,30 @@ bugs below, left red per the no-fixes instruction.
 - [x] `.gitignore`d files survive capture untouched.
 - [x] Untracked nested directory captured + removed recursively.
 - [x] `git mv` rename during review AND during a grilling round.
-- [x] Unicode/space/emoji filename — **FAILING, documents B1 data loss**.
+- [x] Unicode/space/emoji filename — regression guard for the B1 data loss
+      (fixed).
 - [x] Mixed checkbox-tick + code edit → feedback, not approval
       (`review.feature`).
 - [x] Emptied REVIEW.md → textual change, not approval (`review.feature`).
-- [x] Fence collisions — **FAILING ×3, documents B2 + B3**.
+- [x] Fence collisions — regression guards ×3 for B2 + B3 (fixed).
 - [x] Idempotence false-positive (prose identical to capture) → pinned as
       accepted behavior.
 
 ## 4. Hostile environments — DONE (`environment.feature`)
 
-- [x] Subdirectory invocation — **FAILING, documents B4** (decided: hard error).
-- [x] Not a git repository — **FAILING, documents B1** (exit 0 Idle today).
-- [x] Fresh repo, no commits, dirty tree → seeds correctly (green, via the B1
-      accident — will need attention when B1 is fixed).
+- [x] Subdirectory invocation — regression guard for B4 (fixed: clear repo-root
+      hard error).
+- [x] Not a git repository — regression guard for B1 (fixed: fails fast).
+- [x] Fresh repo, no commits, dirty tree → seeds correctly (now via the real
+      path: the porcelain probe runs unconditionally).
 - [x] Detached HEAD → reviews from merge-base (green).
 - [x] Merge commit at HEAD → graceful Idle, no destructive action (green).
 - [x] Transport commit as root → clear error (green).
 - [x] Reformatting pre-commit hook → flow converges (green).
-- [x] Failing pre-commit hook — **FAILING, documents B1** (silent success
-      today); resume-after-removal part passes.
-- [x] CRLF editor on REVIEW.md checkboxes — **FAILING, documents B5**.
-- [x] Unusable gpg signing — **FAILING, documents B1**.
+- [x] Failing pre-commit hook — regression guard for B1 (fixed: the git error
+      surfaces, exit 1); resume-after-removal covered too.
+- [x] CRLF editor on REVIEW.md checkboxes — regression guard for B5 (fixed).
+- [x] Unusable gpg signing — regression guard for B1 (fixed).
 - [x] Submodule pointer change → routed as code change, no crash (green).
 
 ## 5. Interruption & resume — DONE (`replay.feature`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gtd",
-  "version": "1.1.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gtd",
-      "version": "1.1.0",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@effect/platform": "^0.94.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@semantic-release/github": "^12.0.8",
         "@types/node": "^25.9.3",
         "eslint": "^9.39.2",
+        "fast-check": "^4.8.0",
         "husky": "^9.1.7",
         "jiti": "^2.6.1",
         "lint-staged": "^17.0.8",
@@ -3943,6 +3944,44 @@
         "fast-check": "^3.23.1"
       }
     },
+    "node_modules/effect/node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/effect/node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
@@ -4456,7 +4495,10 @@
       }
     },
     "node_modules/fast-check": {
-      "version": "3.23.2",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -4469,10 +4511,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "pure-rand": "^6.1.0"
+        "pure-rand": "^8.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.17.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -8566,7 +8608,10 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.1.0",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.1.tgz",
+      "integrity": "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@semantic-release/github": "^12.0.8",
     "@types/node": "^25.9.3",
     "eslint": "^9.39.2",
+    "fast-check": "^4.8.0",
     "husky": "^9.1.7",
     "jiti": "^2.6.1",
     "lint-staged": "^17.0.8",

--- a/src/Events.test.ts
+++ b/src/Events.test.ts
@@ -14,6 +14,7 @@ import {
   perform,
   seedTodo,
 } from "./Events.js"
+import { formatFile } from "./Format.js"
 import { GitService } from "./Git.js"
 import { ConfigService } from "./Config.js"
 import type { ConfigOperations } from "./Config.js"
@@ -155,6 +156,81 @@ describe("appendCapturedInput", () => {
     expect(twice).toContain("+ first")
     expect(twice).toContain("+ second")
     expect(twice.split("Interpret the captured diff").length - 1).toBe(1)
+  })
+
+  // Accepted behavior (TODO.md plan): the idempotence check matches the raw
+  // diff body anywhere in the TODO, so prose that happens to contain the exact
+  // same text as a new capture suppresses the append. Pathological in
+  // practice; documented rather than special-cased.
+  it("skips the append when the TODO already contains the diff body as prose (accepted)", () => {
+    const prose = "# Plan\n\nSee this snippet:\n\n+ sketch\n"
+    expect(appendCapturedInput(prose, "+ sketch\n")).toBe(prose)
+  })
+})
+
+// ── capture fencing vs the answers gate ──────────────────────────────────────
+// All three tests below assert the documented contract — "the captured diff is
+// fenced so any marker it contains is stripped by stripCode and does not trip
+// the open-question gate" (seedTodo docstring) — and all three FAIL. Two
+// distinct KNOWN BUGS (documented, not fixed — TODO.md § Bugs found):
+//
+// 1. stripCode's fence regex ends with `(?:\n\1[^\n]*|$)` under the `m` flag,
+//    where `$` matches at EVERY line end — the lazy quantifier therefore stops
+//    at the first line end inside the fence, so only the first fenced line is
+//    stripped. A marker anywhere deeper in a fenced block leaks through to the
+//    gate. (This is why even the raw, un-formatted seed fails.) Fix: anchor
+//    the fallback to end-of-input, e.g. `$(?![\s\S])`.
+// 2. The `gtd format` round-trip (the prompts instruct it after every TODO.md
+//    edit; the recommended pre-commit hook runs it on commit): CommonMark
+//    treats a diff CONTEXT line like " ```" (space-prefixed, ≤3-space indent)
+//    as a valid CLOSING fence, so prettier terminates the seed's fixed
+//    three-backtick fence early and rewrites the rest of the captured diff —
+//    marker included — into plain paragraphs. Fix: fenceFor-style fence sizing
+//    in seedTodo / appendCapturedInput (a CommonMark closing fence must be at
+//    least as long as the opener, so a sized-up outer fence survives).
+
+describe("capture fencing vs the answers gate (KNOWN BUGS)", { timeout: 30_000 }, () => {
+  afterEach(cleanup)
+
+  const runFormat = (path: string): Promise<void> =>
+    Effect.runPromise(
+      formatFile(path).pipe(Effect.provide(NodeContext.layer)) as Effect.Effect<void, never, never>,
+    )
+
+  // A markdown file with its own code fences, captured as a diff: the fence
+  // lines arrive prefixed (" " context, "+" added) — never at line start.
+  const capturedMarkdownDiff = [
+    "diff --git a/doc.md b/doc.md",
+    "--- a/doc.md",
+    "+++ b/doc.md",
+    "@@ -1,3 +1,4 @@",
+    " some text",
+    " ```",
+    "+<!-- user answers here -->",
+    " more text",
+  ].join("\n")
+
+  it("KNOWN BUG: a raw seed containing a deep fenced marker keeps the gate inert (stripCode $)", async () => {
+    initRepo(false)
+    writeFileSync(join(repoDir, "TODO.md"), seedTodo(capturedMarkdownDiff))
+    const p = resolveOf(await runGather())
+    expect(p.todoMarkerPresent).toBe(false)
+  })
+
+  it("KNOWN BUG: the seed survives a gtd-format round-trip without arming the marker gate", async () => {
+    initRepo(false)
+    writeFileSync(join(repoDir, "TODO.md"), seedTodo(capturedMarkdownDiff))
+    await runFormat(join(repoDir, "TODO.md"))
+    const p = resolveOf(await runGather())
+    expect(p.todoMarkerPresent).toBe(false)
+  })
+
+  it("KNOWN BUG: an appended grilling capture survives a gtd-format round-trip", async () => {
+    initRepo(false)
+    writeFileSync(join(repoDir, "TODO.md"), appendCapturedInput("# Plan\n", capturedMarkdownDiff))
+    await runFormat(join(repoDir, "TODO.md"))
+    const p = resolveOf(await runGather())
+    expect(p.todoMarkerPresent).toBe(false)
   })
 })
 
@@ -795,6 +871,143 @@ describe("perform — EdgeAction execution", { timeout: 30_000 }, () => {
     expect(git("rev-list", "--count", "HEAD")).toBe(countBefore) // no extra commit
     expect(existsSync(join(repoDir, "REVIEW.md"))).toBe(false)
     expect(readFileSync(join(repoDir, "TODO.md"), "utf8")).toContain("HUMAN FEEDBACK")
+  })
+
+  it("seedAcceptReview: binary reviewer file is preserved in the capture commit and dropped from the tree", async () => {
+    writeFileSync(join(repoDir, "code.ts"), "v1\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "feat: base")
+    writeFileSync(join(repoDir, "REVIEW.md"), "# Review\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "gtd: awaiting review")
+    writeFileSync(join(repoDir, "logo.bin"), Buffer.from([0, 1, 2, 255, 254, 0, 10]))
+
+    await runPerform({ kind: "seedAcceptReview" })
+
+    expect(existsSync(join(repoDir, "logo.bin"))).toBe(false) // dropped from the tree
+    // …but durably preserved in the capture commit.
+    expect(() => git("cat-file", "-e", "HEAD:logo.bin")).not.toThrow()
+    expect(readFileSync(join(repoDir, "TODO.md"), "utf8")).toContain("Binary files")
+  })
+
+  // Accepted limitation (TODO.md plan): the grilling capture has no commit, so
+  // binary content survives only as the diff's "Binary files differ" line.
+  it("captureGrillingEdits: binary sketch is dropped with only a 'Binary files differ' record", async () => {
+    writeFileSync(join(repoDir, "TODO.md"), "# Plan\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "gtd: grilling")
+    writeFileSync(join(repoDir, "logo.bin"), Buffer.from([0, 1, 2, 255, 254, 0, 10]))
+
+    await runPerform({ kind: "captureGrillingEdits" })
+
+    expect(existsSync(join(repoDir, "logo.bin"))).toBe(false)
+    expect(() => git("cat-file", "-e", "HEAD:logo.bin")).toThrow() // content is gone
+    expect(readFileSync(join(repoDir, "TODO.md"), "utf8")).toContain("Binary files")
+  })
+
+  it("captureGrillingEdits: .gitignore'd files are neither captured nor deleted", async () => {
+    writeFileSync(join(repoDir, ".gitignore"), "secret.env\n")
+    writeFileSync(join(repoDir, "TODO.md"), "# Plan\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "gtd: grilling")
+    writeFileSync(join(repoDir, "secret.env"), "TOKEN=hunter2\n")
+    writeFileSync(join(repoDir, "sketch.ts"), "export const sketch = 1\n")
+
+    await runPerform({ kind: "captureGrillingEdits" })
+
+    expect(existsSync(join(repoDir, "secret.env"))).toBe(true) // untouched
+    const todo = readFileSync(join(repoDir, "TODO.md"), "utf8")
+    expect(todo).not.toContain("secret.env")
+    expect(todo).toContain("export const sketch = 1")
+    expect(existsSync(join(repoDir, "sketch.ts"))).toBe(false)
+  })
+
+  it("captureGrillingEdits: an untracked nested directory is captured and removed recursively", async () => {
+    mkdirSync(join(repoDir, "src"), { recursive: true })
+    writeFileSync(join(repoDir, "src", "keep.ts"), "export const keep = 1\n")
+    writeFileSync(join(repoDir, "TODO.md"), "# Plan\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "gtd: grilling")
+    mkdirSync(join(repoDir, "src", "new", "deep"), { recursive: true })
+    writeFileSync(join(repoDir, "src", "new", "deep", "file.ts"), "export const deep = 1\n")
+
+    await runPerform({ kind: "captureGrillingEdits" })
+
+    expect(existsSync(join(repoDir, "src", "new"))).toBe(false) // whole dir gone
+    expect(existsSync(join(repoDir, "src", "keep.ts"))).toBe(true)
+    expect(readFileSync(join(repoDir, "TODO.md"), "utf8")).toContain("export const deep = 1")
+    expect(git("status", "--porcelain").trim()).toBe("")
+  })
+
+  it("seedAcceptReview: a staged git mv rename is captured and reverted to the original path", async () => {
+    writeFileSync(join(repoDir, "code.ts"), "v1\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "feat: base")
+    writeFileSync(join(repoDir, "REVIEW.md"), "# Review\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "gtd: awaiting review")
+    git("mv", "code.ts", "renamed.ts")
+
+    await runPerform({ kind: "seedAcceptReview" })
+
+    expect(existsSync(join(repoDir, "code.ts"))).toBe(true) // restored
+    expect(readFileSync(join(repoDir, "code.ts"), "utf8")).toBe("v1\n")
+    expect(existsSync(join(repoDir, "renamed.ts"))).toBe(false)
+  })
+
+  it("captureGrillingEdits: a staged git mv rename is captured and reverted", async () => {
+    writeFileSync(join(repoDir, "code.ts"), "v1\n")
+    writeFileSync(join(repoDir, "TODO.md"), "# Plan\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "gtd: grilling")
+    git("mv", "code.ts", "renamed.ts")
+
+    await runPerform({ kind: "captureGrillingEdits" })
+
+    expect(existsSync(join(repoDir, "code.ts"))).toBe(true)
+    expect(existsSync(join(repoDir, "renamed.ts"))).toBe(false)
+    expect(readFileSync(join(repoDir, "TODO.md"), "utf8")).toContain("renamed.ts")
+    expect(git("status", "--porcelain").trim()).toBe("")
+  })
+
+  // KNOWN BUG (documented, not fixed — TODO.md § Bugs found): diffHead's
+  // intent-to-add trick feeds `git ls-files --others` output back to
+  // `git add --intent-to-add` VERBATIM. For non-ASCII/quoted paths ls-files
+  // emits the C-quoted form (`"sketch \303\251..."`), the add matches nothing
+  // (its non-zero exit is swallowed — Command.string does not fail on exit
+  // codes), the diff comes back empty — and captureGrillingEdits then DELETES
+  // the file it failed to capture. Data loss. Fix: unquote ls-files output
+  // (unquoteGitPath) or use `-z` output before feeding paths back to git.
+  it("KNOWN BUG: captureGrillingEdits: a unicode/space/emoji filename round-trips porcelain quoting", async () => {
+    writeFileSync(join(repoDir, "TODO.md"), "# Plan\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "gtd: grilling")
+    const wild = "sketch émoji 🚀.ts"
+    writeFileSync(join(repoDir, wild), "export const wild = 1\n")
+
+    await runPerform({ kind: "captureGrillingEdits" })
+
+    expect(existsSync(join(repoDir, wild))).toBe(false)
+    expect(readFileSync(join(repoDir, "TODO.md"), "utf8")).toContain("export const wild = 1")
+    expect(git("status", "--porcelain").trim()).toBe("")
+  })
+
+  // Crash window: the previous round appended the capture but the commit was
+  // lost (or the user re-created the identical sketch). Re-running the capture
+  // must not double-append the section.
+  it("captureGrillingEdits: re-capturing an identical diff does not double-append", async () => {
+    writeFileSync(join(repoDir, "TODO.md"), "# Plan\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "gtd: grilling")
+    writeFileSync(join(repoDir, "sketch.ts"), "export const sketch = 1\n")
+    await runPerform({ kind: "captureGrillingEdits" })
+    // Same sketch reappears (crash replay / user re-creates it).
+    writeFileSync(join(repoDir, "sketch.ts"), "export const sketch = 1\n")
+    await runPerform({ kind: "captureGrillingEdits" })
+
+    const todo = readFileSync(join(repoDir, "TODO.md"), "utf8")
+    expect(todo.split("export const sketch = 1").length - 1).toBe(1)
+    expect(existsSync(join(repoDir, "sketch.ts"))).toBe(false)
   })
 
   it("captureGrillingEdits: folds code edits into TODO.md, drops them, commits gtd: grilling", async () => {

--- a/src/Events.test.ts
+++ b/src/Events.test.ts
@@ -657,9 +657,9 @@ describe("gatherEvents — review base (reviewBase / refDiff)", { timeout: 30_00
 
 // ── gatherEvents: review re-trigger gate ─────────────────────────────────────
 // `hasCommitsAfterLastDone` — the loop fix. The gate decides *whether* a review
-// fires (machine rule 7); the base rules above decide *what it covers*. Both
-// are resolved independently, so a closed gate still carries the whole-branch
-// reviewBase in the payload.
+// fires (machine rule 7); the base rules above decide *what* a fired review
+// covers. When the gate is closed the edge skips computing the (potentially
+// whole-branch-sized) diff entirely — reviewBase/refDiff stay unset.
 
 describe(
   "gatherEvents — review re-trigger gate (hasCommitsAfterLastDone)",
@@ -674,16 +674,15 @@ describe(
       expect(p.hasCommitsAfterLastDone).toBe(true)
     })
 
-    it("HEAD is the last gtd: done → gate closed; whole-branch scope still computed", async () => {
+    it("HEAD is the last gtd: done → gate closed; the unused diff is not computed", async () => {
       initRepo(true)
       commitFile("feat: branch work", "branch.ts", "export const branch = 1\n")
       git("commit", "--allow-empty", "-q", "-m", "gtd: done")
-      const mergeBase = git("rev-parse", "main")
       const p = resolveOf(await runGather())
       expect(p.hasCommitsAfterLastDone).toBe(false)
-      // Scope is untouched by the gate: the merge-base diff is still non-empty.
-      expect(p.reviewBase).toBe(mergeBase)
-      expect(p.refDiff).toContain("branch.ts")
+      // A closed gate forces Idle, so the whole-branch diff is skipped entirely.
+      expect(p.reviewBase).toBeUndefined()
+      expect(p.refDiff).toBeUndefined()
     })
 
     it("commits after the last gtd: done → gate reopens; base stays the merge-base (whole branch)", async () => {

--- a/src/Events.test.ts
+++ b/src/Events.test.ts
@@ -6,7 +6,14 @@ import { NodeContext } from "@effect/platform-node"
 import { FileSystem } from "@effect/platform"
 import { Effect, Layer } from "effect"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { gatherEvents, getPackages, isCheckboxOnlyDiff, perform, seedTodo } from "./Events.js"
+import {
+  appendCapturedInput,
+  gatherEvents,
+  getPackages,
+  isCheckboxOnlyDiff,
+  perform,
+  seedTodo,
+} from "./Events.js"
 import { GitService } from "./Git.js"
 import { ConfigService } from "./Config.js"
 import type { ConfigOperations } from "./Config.js"
@@ -111,6 +118,43 @@ describe("seedTodo", () => {
     expect(out).toContain("- old line")
     expect(out).toContain("+ new line")
     expect(out).not.toContain("<!-- user answers here -->")
+  })
+
+  it("embeds the three-way interpretation rules (code = suggestions incl. tests, comments = positional, steering text = global)", () => {
+    const out = seedTodo("+ x\n")
+    expect(out).toContain("Interpret the captured diff")
+    expect(out).toContain("suggestions, not finished work")
+    expect(out).toContain("including test coverage")
+    expect(out).toContain("positional feedback")
+    expect(out).toContain("global feedback")
+    expect(out).toContain("approval noise")
+  })
+})
+
+// ── appendCapturedInput (pure) ───────────────────────────────────────────────
+
+describe("appendCapturedInput", () => {
+  const todo = "# Plan\n\nBuild it.\n"
+
+  it("appends a fenced grilling capture section with the interpretation rules", () => {
+    const out = appendCapturedInput(todo, "+ sketch\n")
+    expect(out.startsWith("# Plan")).toBe(true)
+    expect(out).toContain("## Captured input (grilling)")
+    expect(out).toContain("```diff\n+ sketch\n```")
+    expect(out).toContain("Interpret the captured diff")
+  })
+
+  it("is idempotent — the exact diff body already present returns the TODO unchanged", () => {
+    const once = appendCapturedInput(todo, "+ sketch\n")
+    expect(appendCapturedInput(once, "+ sketch\n")).toBe(once)
+  })
+
+  it("includes the interpretation rules at most once across appends", () => {
+    const once = appendCapturedInput(todo, "+ first\n")
+    const twice = appendCapturedInput(once, "+ second\n")
+    expect(twice).toContain("+ first")
+    expect(twice).toContain("+ second")
+    expect(twice.split("Interpret the captured diff").length - 1).toBe(1)
   })
 })
 
@@ -408,6 +452,21 @@ describe("gatherEvents — RESOLVE payload", { timeout: 30_000 }, () => {
     expect(p.reviewCheckboxOnly).toBe(false)
   })
 
+  it("todoCommitted: tracked at HEAD → true (even with pending edits)", async () => {
+    commitFile("gtd: grilling", "TODO.md", "# Plan\n")
+    writeFileSync(join(repoDir, "TODO.md"), "# Plan\n\nedited\n")
+    const p = resolveOf(await runGather())
+    expect(p.todoExists).toBe(true)
+    expect(p.todoCommitted).toBe(true)
+  })
+
+  it("todoCommitted: freshly written (untracked) TODO.md → false (seed round)", async () => {
+    writeFileSync(join(repoDir, "TODO.md"), "# Plan\n")
+    const p = resolveOf(await runGather())
+    expect(p.todoExists).toBe(true)
+    expect(p.todoCommitted).toBe(false)
+  })
+
   it("pendingErrorsDeletion reflects a working-tree ERRORS.md deletion", async () => {
     commitFile("gtd: errors", "ERRORS.md", "boom\n")
     rmSync(join(repoDir, "ERRORS.md")) // human removes the committed ERRORS.md
@@ -452,30 +511,53 @@ describe("gatherEvents — review base (reviewBase / refDiff)", { timeout: 30_00
   afterEach(cleanup)
 
   // Rule 1: within-process, first review — base = first `gtd: grilling` of the
-  // current task cycle; refDiff spans the whole task since grilling started.
+  // current task cycle; refDiff spans the whole task since grilling started,
+  // minus the workflow files (TODO.md's add/delete churn is filtered out).
   it("within-process first review → base is the first gtd: grilling commit; refDiff spans whole task", async () => {
     initRepo(false)
     commitFile("gtd: grilling", "TODO.md", "# Plan\n")
     const grillingHash = git("rev-parse", "HEAD")
+    git("rm", "-q", "TODO.md")
+    git("commit", "-q", "-m", "gtd: planning")
     commitFile("feat: add widget", "widget.ts", "export const widget = 1\n")
     const p = resolveOf(await runGather())
     expect(p.reviewBase).toBe(grillingHash)
     expect(p.refDiff).toContain("widget.ts")
+    expect(p.refDiff).not.toContain("TODO.md")
   })
 
   // Rule 2: within-process, incremental — `gtd: awaiting review` already present;
-  // base = last `gtd: awaiting review` hash; refDiff spans only post-review changes.
+  // base = last `gtd: awaiting review` hash; refDiff spans only post-review
+  // changes, minus the workflow files (REVIEW.md's removal is filtered out).
   it("within-process incremental review → base is the last gtd: awaiting review commit; refDiff spans only post-review changes", async () => {
     initRepo(false)
     commitFile("gtd: grilling", "TODO.md", "# Plan\n")
+    git("rm", "-q", "TODO.md")
+    git("commit", "-q", "-m", "gtd: planning")
     commitFile("feat: first batch", "first.ts", "export const first = 1\n")
     commitFile("gtd: awaiting review", "REVIEW.md", "# Review\n")
     const lastAwaiting = git("rev-parse", "HEAD")
+    // Accept Review seeds + Grilling commits REVIEW.md's removal (feedback path).
+    git("rm", "-q", "REVIEW.md")
+    git("commit", "-q", "-m", "gtd: grilling")
     commitFile("feat: second batch", "second.ts", "export const second = 2\n")
     const p = resolveOf(await runGather())
     expect(p.reviewBase).toBe(lastAwaiting)
     expect(p.refDiff).toContain("second.ts")
     expect(p.refDiff).not.toContain("first.ts")
+    expect(p.refDiff).not.toContain("REVIEW.md")
+  })
+
+  // Only workflow-file churn since the base → the filtered diff is empty, so
+  // reviewBase/refDiff stay unset and the machine settles Idle.
+  it("only workflow-file churn since base → reviewBase/refDiff unset (Idle)", async () => {
+    initRepo(false)
+    commitFile("gtd: grilling", "TODO.md", "# Plan\n")
+    git("rm", "-q", "TODO.md")
+    git("commit", "-q", "-m", "gtd: planning")
+    const p = resolveOf(await runGather())
+    expect(p.reviewBase).toBeUndefined()
+    expect(p.refDiff).toBeUndefined()
   })
 
   // Rule 3: outside a process, on a feature branch — base = merge-base(default, HEAD);
@@ -507,6 +589,65 @@ describe("gatherEvents — review base (reviewBase / refDiff)", { timeout: 30_00
     expect(p.refDiff).toBeUndefined()
   })
 })
+
+// ── gatherEvents: review re-trigger gate ─────────────────────────────────────
+// `hasCommitsAfterLastDone` — the loop fix. The gate decides *whether* a review
+// fires (machine rule 7); the base rules above decide *what it covers*. Both
+// are resolved independently, so a closed gate still carries the whole-branch
+// reviewBase in the payload.
+
+describe(
+  "gatherEvents — review re-trigger gate (hasCommitsAfterLastDone)",
+  { timeout: 30_000 },
+  () => {
+    afterEach(cleanup)
+
+    it("no gtd: done in history → gate open", async () => {
+      initRepo(true)
+      commitFile("feat: branch work", "branch.ts", "export const branch = 1\n")
+      const p = resolveOf(await runGather())
+      expect(p.hasCommitsAfterLastDone).toBe(true)
+    })
+
+    it("HEAD is the last gtd: done → gate closed; whole-branch scope still computed", async () => {
+      initRepo(true)
+      commitFile("feat: branch work", "branch.ts", "export const branch = 1\n")
+      git("commit", "--allow-empty", "-q", "-m", "gtd: done")
+      const mergeBase = git("rev-parse", "main")
+      const p = resolveOf(await runGather())
+      expect(p.hasCommitsAfterLastDone).toBe(false)
+      // Scope is untouched by the gate: the merge-base diff is still non-empty.
+      expect(p.reviewBase).toBe(mergeBase)
+      expect(p.refDiff).toContain("branch.ts")
+    })
+
+    it("commits after the last gtd: done → gate reopens; base stays the merge-base (whole branch)", async () => {
+      initRepo(true)
+      commitFile("feat: first slice", "first.ts", "export const first = 1\n")
+      git("commit", "--allow-empty", "-q", "-m", "gtd: done")
+      commitFile("feat: second slice", "second.ts", "export const second = 2\n")
+      const mergeBase = git("rev-parse", "main")
+      const p = resolveOf(await runGather())
+      expect(p.hasCommitsAfterLastDone).toBe(true)
+      // No "since last done" scoping: the approved first slice is re-covered.
+      expect(p.reviewBase).toBe(mergeBase)
+      expect(p.refDiff).toContain("first.ts")
+      expect(p.refDiff).toContain("second.ts")
+    })
+
+    it("empty repo → gate open (degenerate default)", async () => {
+      repoDir = mkdtempSync(join(tmpdir(), "gtd-events-"))
+      git("init", "-q")
+      git("config", "user.name", "Test")
+      git("config", "user.email", "test@test.com")
+      git("config", "commit.gpgsign", "false")
+      savedCwd = process.cwd()
+      process.chdir(repoDir)
+      const p = resolveOf(await runGather())
+      expect(p.hasCommitsAfterLastDone).toBe(true)
+    })
+  },
+)
 
 // ── gatherEvents: COMMIT-stream base folds ───────────────────────────────────
 
@@ -593,7 +734,7 @@ describe("perform — EdgeAction execution", { timeout: 30_000 }, () => {
     expect(existsSync(join(repoDir, "feature.ts"))).toBe(false) // reverted to baseline
   })
 
-  it("seedAcceptReview: discards code edits, seeds TODO.md from the changeset, removes REVIEW.md", async () => {
+  it("seedAcceptReview: captures the changeset as gtd: review feedback, reverts it, seeds TODO.md, removes REVIEW.md", async () => {
     writeFileSync(join(repoDir, "code.ts"), "v1\n")
     git("add", "-A")
     git("commit", "-q", "-m", "feat: base")
@@ -606,10 +747,80 @@ describe("perform — EdgeAction execution", { timeout: 30_000 }, () => {
 
     await runPerform({ kind: "seedAcceptReview" })
 
+    // The changeset is durably captured (commit-then-revert, like New Feature).
+    expect(git("log", "-1", "--format=%s")).toBe("gtd: review feedback")
     expect(existsSync(join(repoDir, "REVIEW.md"))).toBe(false)
     expect(existsSync(join(repoDir, "TODO.md"))).toBe(true)
     expect(readFileSync(join(repoDir, "TODO.md"), "utf8")).toContain("HUMAN FEEDBACK")
     expect(readFileSync(join(repoDir, "code.ts"), "utf8")).toBe("v1\n") // edits discarded
+  })
+
+  // The leak regression: a plain `git checkout -- .` discards only tracked
+  // edits, so a reviewer-added NEW file used to survive and get committed
+  // verbatim by the next grilling round while also being re-planned in TODO.md.
+  // Commit-then-revert drops it by construction and preserves it in history.
+  it("seedAcceptReview: drops untracked reviewer-added files (captured, not leaked)", async () => {
+    writeFileSync(join(repoDir, "code.ts"), "v1\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "feat: base")
+    writeFileSync(join(repoDir, "REVIEW.md"), "# Review\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "gtd: awaiting review")
+    writeFileSync(join(repoDir, "newfile.ts"), "export const subtract = 1\n")
+
+    await runPerform({ kind: "seedAcceptReview" })
+
+    expect(existsSync(join(repoDir, "newfile.ts"))).toBe(false) // dropped from the tree
+    expect(readFileSync(join(repoDir, "TODO.md"), "utf8")).toContain("export const subtract = 1")
+    // …and preserved in the capture commit.
+    expect(git("show", "HEAD:newfile.ts")).toBe("export const subtract = 1")
+  })
+
+  // Regen: HEAD already carries the capture commit (checkout/pull or crash lost
+  // the uncommitted seed) — re-derive the seed from the commit, no new commit.
+  it("seedAcceptReview (HEAD gtd: review feedback + clean): regenerates the seed without a new commit", async () => {
+    writeFileSync(join(repoDir, "code.ts"), "v1\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "feat: base")
+    writeFileSync(join(repoDir, "REVIEW.md"), "# Review\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "gtd: awaiting review")
+    writeFileSync(join(repoDir, "REVIEW.md"), "# Review\n\nHUMAN FEEDBACK\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "gtd: review feedback")
+    const countBefore = git("rev-list", "--count", "HEAD")
+
+    await runPerform({ kind: "seedAcceptReview" })
+
+    expect(git("rev-list", "--count", "HEAD")).toBe(countBefore) // no extra commit
+    expect(existsSync(join(repoDir, "REVIEW.md"))).toBe(false)
+    expect(readFileSync(join(repoDir, "TODO.md"), "utf8")).toContain("HUMAN FEEDBACK")
+  })
+
+  it("captureGrillingEdits: folds code edits into TODO.md, drops them, commits gtd: grilling", async () => {
+    writeFileSync(join(repoDir, "code.ts"), "v1\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "feat: base")
+    writeFileSync(join(repoDir, "TODO.md"), "# Plan\n\nBuild it.\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "gtd: grilling")
+    // User sketches code (tracked edit + untracked file) and refines the plan:
+    writeFileSync(join(repoDir, "code.ts"), "v2 sketch\n")
+    writeFileSync(join(repoDir, "sketch.ts"), "export const sketch = 1\n")
+    writeFileSync(join(repoDir, "TODO.md"), "# Plan\n\nBuild it with sketches.\n")
+
+    await runPerform({ kind: "captureGrillingEdits" })
+
+    expect(git("log", "-1", "--format=%s")).toBe("gtd: grilling")
+    expect(git("status", "--porcelain").trim()).toBe("") // one commit, clean tree
+    expect(readFileSync(join(repoDir, "code.ts"), "utf8")).toBe("v1\n") // reverted
+    expect(existsSync(join(repoDir, "sketch.ts"))).toBe(false) // dropped
+    const todo = readFileSync(join(repoDir, "TODO.md"), "utf8")
+    expect(todo).toContain("Build it with sketches.") // user's plan edit preserved
+    expect(todo).toContain("## Captured input (grilling)")
+    expect(todo).toContain("v2 sketch")
+    expect(todo).toContain("export const sketch = 1")
+    expect(todo).toContain("Interpret the captured diff")
   })
 
   it("runTest green: commits gtd: building, writes no FEEDBACK/ERRORS", async () => {

--- a/src/Events.test.ts
+++ b/src/Events.test.ts
@@ -169,27 +169,16 @@ describe("appendCapturedInput", () => {
 })
 
 // ── capture fencing vs the answers gate ──────────────────────────────────────
-// All three tests below assert the documented contract — "the captured diff is
-// fenced so any marker it contains is stripped by stripCode and does not trip
-// the open-question gate" (seedTodo docstring) — and all three FAIL. Two
-// distinct KNOWN BUGS (documented, not fixed — TODO.md § Bugs found):
-//
-// 1. stripCode's fence regex ends with `(?:\n\1[^\n]*|$)` under the `m` flag,
-//    where `$` matches at EVERY line end — the lazy quantifier therefore stops
-//    at the first line end inside the fence, so only the first fenced line is
-//    stripped. A marker anywhere deeper in a fenced block leaks through to the
-//    gate. (This is why even the raw, un-formatted seed fails.) Fix: anchor
-//    the fallback to end-of-input, e.g. `$(?![\s\S])`.
-// 2. The `gtd format` round-trip (the prompts instruct it after every TODO.md
-//    edit; the recommended pre-commit hook runs it on commit): CommonMark
-//    treats a diff CONTEXT line like " ```" (space-prefixed, ≤3-space indent)
-//    as a valid CLOSING fence, so prettier terminates the seed's fixed
-//    three-backtick fence early and rewrites the rest of the captured diff —
-//    marker included — into plain paragraphs. Fix: fenceFor-style fence sizing
-//    in seedTodo / appendCapturedInput (a CommonMark closing fence must be at
-//    least as long as the opener, so a sized-up outer fence survives).
+// Regression guards for two fixed bugs (see the commit history / TODO.md
+// § Bugs found): (1) stripCode's unclosed-fence fallback used a bare `$` under
+// the `m` flag, stopping the strip at the first fenced line and leaking deep
+// markers to the answers gate; (2) seedTodo/appendCapturedInput used a fixed
+// three-backtick fence that the `gtd format` round-trip (prettier) closed
+// early on a space-indented ``` diff-context line, spilling the captured diff
+// — markers included — out of the fence. The fence is now sized past any
+// backtick run (fenceFor) and the strip is anchored to end-of-input.
 
-describe("capture fencing vs the answers gate (KNOWN BUGS)", { timeout: 30_000 }, () => {
+describe("capture fencing vs the answers gate", { timeout: 30_000 }, () => {
   afterEach(cleanup)
 
   const runFormat = (path: string): Promise<void> =>
@@ -210,14 +199,14 @@ describe("capture fencing vs the answers gate (KNOWN BUGS)", { timeout: 30_000 }
     " more text",
   ].join("\n")
 
-  it("KNOWN BUG: a raw seed containing a deep fenced marker keeps the gate inert (stripCode $)", async () => {
+  it("a raw seed containing a deep fenced marker keeps the gate inert", async () => {
     initRepo(false)
     writeFileSync(join(repoDir, "TODO.md"), seedTodo(capturedMarkdownDiff))
     const p = resolveOf(await runGather())
     expect(p.todoMarkerPresent).toBe(false)
   })
 
-  it("KNOWN BUG: the seed survives a gtd-format round-trip without arming the marker gate", async () => {
+  it("the seed survives a gtd-format round-trip without arming the marker gate", async () => {
     initRepo(false)
     writeFileSync(join(repoDir, "TODO.md"), seedTodo(capturedMarkdownDiff))
     await runFormat(join(repoDir, "TODO.md"))
@@ -225,7 +214,7 @@ describe("capture fencing vs the answers gate (KNOWN BUGS)", { timeout: 30_000 }
     expect(p.todoMarkerPresent).toBe(false)
   })
 
-  it("KNOWN BUG: an appended grilling capture survives a gtd-format round-trip", async () => {
+  it("an appended grilling capture survives a gtd-format round-trip", async () => {
     initRepo(false)
     writeFileSync(join(repoDir, "TODO.md"), appendCapturedInput("# Plan\n", capturedMarkdownDiff))
     await runFormat(join(repoDir, "TODO.md"))
@@ -970,15 +959,12 @@ describe("perform — EdgeAction execution", { timeout: 30_000 }, () => {
     expect(git("status", "--porcelain").trim()).toBe("")
   })
 
-  // KNOWN BUG (documented, not fixed — TODO.md § Bugs found): diffHead's
-  // intent-to-add trick feeds `git ls-files --others` output back to
-  // `git add --intent-to-add` VERBATIM. For non-ASCII/quoted paths ls-files
-  // emits the C-quoted form (`"sketch \303\251..."`), the add matches nothing
-  // (its non-zero exit is swallowed — Command.string does not fail on exit
-  // codes), the diff comes back empty — and captureGrillingEdits then DELETES
-  // the file it failed to capture. Data loss. Fix: unquote ls-files output
-  // (unquoteGitPath) or use `-z` output before feeding paths back to git.
-  it("KNOWN BUG: captureGrillingEdits: a unicode/space/emoji filename round-trips porcelain quoting", async () => {
+  // Regression guard (fixed data-loss bug): diffHead used to feed C-quoted
+  // ls-files output back to `git add --intent-to-add`, whose failure was
+  // silently swallowed — the capture came back empty and the file was then
+  // deleted. Paths now round-trip via `-z` (NUL-separated, unquoted) and git
+  // exit codes fail loudly.
+  it("captureGrillingEdits: a unicode/space/emoji filename round-trips porcelain quoting", async () => {
     writeFileSync(join(repoDir, "TODO.md"), "# Plan\n")
     git("add", "-A")
     git("commit", "-q", "-m", "gtd: grilling")

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -1,6 +1,6 @@
 import { FileSystem } from "@effect/platform"
 import { Effect, Option } from "effect"
-import { GitService } from "./Git.js"
+import { GitService, type GitOperations } from "./Git.js"
 import { ConfigService } from "./Config.js"
 import { fenceFor } from "./Prompt.js"
 import { TestRunner } from "./TestRunner.js"
@@ -50,21 +50,22 @@ const DONE_SUBJECT = "gtd: done"
 // Distinct from the exact `gtd: feedback` marker the reviewFixCount fold reads.
 const REVIEW_FEEDBACK_SUBJECT = "gtd: review feedback"
 
-// Workflow plumbing excluded from every review diff (refDiff) and from the
-// grilling-round code capture: neither the reviewer nor a captured suggestion
-// block should ever contain steering-file churn (TODO.md seeded/deleted,
-// REVIEW.md committed/removed, `.gtd/` packages created/closed).
-const WORKFLOW_FILE_EXCLUDES: ReadonlyArray<string> = [
-  REVIEW_FILE,
-  TODO_FILE,
-  FEEDBACK_FILE,
-  ERRORS_FILE,
-  GTD_DIR,
-]
+// The steering-file set, single source of truth: the predicates below and the
+// diff exclusions all derive from it. Workflow plumbing is excluded from every
+// review diff (refDiff) and from the grilling-round code capture — neither the
+// reviewer nor a captured suggestion block should ever contain steering-file
+// churn (TODO.md seeded/deleted, REVIEW.md committed/removed, `.gtd/` packages
+// created/closed).
+const STEERING_FILES: ReadonlyArray<string> = [TODO_FILE, REVIEW_FILE, FEEDBACK_FILE, ERRORS_FILE]
+const WORKFLOW_FILE_EXCLUDES: ReadonlyArray<string> = [...STEERING_FILES, GTD_DIR]
 
 const isGtdPath = (path: string): boolean => path === GTD_DIR || path.startsWith(`${GTD_DIR}/`)
-const isSteeringFile = (path: string): boolean =>
-  path === TODO_FILE || path === REVIEW_FILE || path === FEEDBACK_FILE || path === ERRORS_FILE
+const isSteeringFile = (path: string): boolean => STEERING_FILES.includes(path)
+
+// A porcelain status flagging the entry as untracked (`?`) or freshly added
+// (`A`) — i.e. not tracked at HEAD.
+const isUncommittedStatus = (status: string): boolean =>
+  status.includes("?") || status.includes("A")
 
 // git's empty-tree object. `git diff <empty-tree> HEAD` yields the entire tree
 // as additions — the Clean review base when HEAD is on the default branch and
@@ -298,24 +299,27 @@ export const isCheckboxOnlyDiff = (diff: string): boolean => {
   const addedLines: string[] = []
 
   for (const raw of diff.split("\n")) {
+    // Normalize once before any classification so every use of line content
+    // below is CRLF-agnostic.
+    const line = raw.replace(/\r$/, "")
     // Skip diff header lines
     if (
-      raw.startsWith("---") ||
-      raw.startsWith("+++") ||
-      raw.startsWith("@@") ||
-      raw.startsWith("diff ") ||
-      raw.startsWith("index ") ||
-      raw.startsWith("new file") ||
-      raw.startsWith("deleted file") ||
-      raw.startsWith("similarity") ||
-      raw.startsWith("rename")
+      line.startsWith("---") ||
+      line.startsWith("+++") ||
+      line.startsWith("@@") ||
+      line.startsWith("diff ") ||
+      line.startsWith("index ") ||
+      line.startsWith("new file") ||
+      line.startsWith("deleted file") ||
+      line.startsWith("similarity") ||
+      line.startsWith("rename")
     )
       continue
 
-    if (raw.startsWith("-")) {
-      removedLines.push(raw.slice(1).replace(/\r$/, ""))
-    } else if (raw.startsWith("+")) {
-      addedLines.push(raw.slice(1).replace(/\r$/, ""))
+    if (line.startsWith("-")) {
+      removedLines.push(line.slice(1))
+    } else if (line.startsWith("+")) {
+      addedLines.push(line.slice(1))
     }
   }
 
@@ -410,11 +414,11 @@ export const gatherEvents = (): Effect.Effect<
     const todoContent = todoExists ? yield* fs.readFileString(TODO_FILE) : ""
     const todoMarkerPresent = todoExists && stripCode(todoContent).includes(UNANSWERED_MARKER)
 
-    // A porcelain entry whose status flags it untracked (`?`) or freshly added
-    // (`A`) is uncommitted; otherwise the file is tracked at HEAD.
+    // The file at `path` is uncommitted (untracked or freshly added); otherwise
+    // it is tracked at HEAD.
     const isUncommitted = (path: string): boolean => {
       const entry = entries.find((e) => e.path === path)
-      return entry !== undefined && (entry.status.includes("?") || entry.status.includes("A"))
+      return entry !== undefined && isUncommittedStatus(entry.status)
     }
 
     // FEEDBACK.md: committed (Testing wrote it as `gtd: errors`) vs uncommitted
@@ -474,9 +478,11 @@ export const gatherEvents = (): Effect.Effect<
     // commits exist after the last `gtd: done` (or no `gtd: done` exists).
     // Resolved here at the edge, consumed by the machine's Clean/Idle rule, so
     // an approved review settles Idle instead of immediately re-firing (the
-    // review → approve → done → review loop). It gates *whether*, never *what*.
+    // review → approve → done → review loop). It gates *whether*, never *what*
+    // a fired review covers — and when it is closed, the edge skips computing
+    // the (potentially whole-branch-sized) diff that could never be consumed.
     //
-    // The refDiff excludes workflow files (REVIEW_DIFF_EXCLUDES) so the
+    // The refDiff excludes workflow files (WORKFLOW_FILE_EXCLUDES) so the
     // reviewer never sees plumbing churn. Only set reviewBase/refDiff when the
     // filtered diff is non-empty (non-empty distinguishes Clean from Idle).
     let reviewBase: string | undefined
@@ -484,8 +490,10 @@ export const gatherEvents = (): Effect.Effect<
     let hasCommitsAfterLastDone = true
     if (hasCommits) {
       // Scan ALL commits (no base arg) to properly detect process boundaries
-      // across `gtd: done` commits even on trunk.
-      const allHistory = yield* git.commitHistory()
+      // across `gtd: done` commits even on trunk. When the COMMIT stream above
+      // already scanned the whole history (no merge-base), reuse it rather
+      // than spawning the identical `git log` again.
+      const allHistory = Option.isNone(base) ? history : yield* git.commitHistory()
 
       // Find the current task cycle: commits after the last `gtd: done`.
       const lastDoneIdx = (() => {
@@ -537,7 +545,7 @@ export const gatherEvents = (): Effect.Effect<
         // Rule 4: default branch → leave candidate undefined (Idle).
       }
 
-      if (candidate !== undefined) {
+      if (candidate !== undefined && hasCommitsAfterLastDone) {
         const candidateDiff = yield* git
           .diffRef(candidate, WORKFLOW_FILE_EXCLUDES)
           .pipe(Effect.catchAll(() => Effect.succeed("")))
@@ -582,6 +590,35 @@ export const gatherEvents = (): Effect.Effect<
   }).pipe(Effect.mapError((e) => (e instanceof Error ? e : new Error(String(e)))))
 
 /**
+ * The commit-then-revert capture shared by New Feature and Accept Review:
+ * commit everything pending verbatim under `subject` (a durable capture that
+ * survives checkout/pull; untracked files are dropped by construction — a
+ * plain checkout would leak them), revert the capture into the working tree,
+ * and return its diff for the TODO.md seed. When HEAD already carries the
+ * subject this is the lost-seed regen case: run `onRegen` instead of
+ * committing (discard partial state) and re-derive from the existing commit.
+ */
+const captureAndRevert = (
+  git: GitOperations,
+  subject: string,
+  onRegen: Effect.Effect<void, Error>,
+): Effect.Effect<string, Error> =>
+  Effect.gen(function* () {
+    const head = yield* git.lastCommitSubject().pipe(Effect.catchAll(() => Effect.succeed("")))
+    if (head !== subject) {
+      yield* git.commitAllWithPrefix(subject)
+    } else {
+      yield* onRegen
+    }
+    const base = yield* git
+      .resolveRef("HEAD~1")
+      .pipe(Effect.catchAll(() => Effect.succeed(EMPTY_TREE)))
+    const captured = yield* git.diffRef(base).pipe(Effect.catchAll(() => Effect.succeed("")))
+    yield* git.revertNoCommit("HEAD")
+    return captured
+  })
+
+/**
  * Execute the side effect the machine's `resolve()` chose. The driver performs
  * this, then re-gathers + re-resolves. Each case maps to the primitives in
  * Git.ts / the FileSystem; the machine only decides *which* action.
@@ -605,44 +642,19 @@ export const perform = (
       // already there — the lost-seed regenerate case), revert it back to a
       // clean baseline (inverse staged), and seed TODO.md from that diff.
       case "seedNewFeature": {
-        const subject = yield* git
-          .lastCommitSubject()
-          .pipe(Effect.catchAll(() => Effect.succeed("")))
-        if (subject !== NEW_TASK_SUBJECT) {
-          yield* git.commitAllWithPrefix(NEW_TASK_SUBJECT)
-        }
-        const base = yield* git
-          .resolveRef("HEAD~1")
-          .pipe(Effect.catchAll(() => Effect.succeed(EMPTY_TREE)))
-        const captured = yield* git.diffRef(base).pipe(Effect.catchAll(() => Effect.succeed("")))
-        yield* git.revertNoCommit("HEAD")
+        const captured = yield* captureAndRevert(git, NEW_TASK_SUBJECT, Effect.void)
         yield* fs.writeFileString(TODO_FILE, seedTodo(captured))
         return
       }
 
-      // Accept Review: capture the human's pending changeset durably — commit it
-      // verbatim as `gtd: review feedback` (annotations, code edits, and new
-      // files alike), revert it back to the reviewed baseline, rm REVIEW.md
-      // (which is what stops Accept Review re-firing), and seed TODO.md from the
-      // captured diff. Commit-then-revert mirrors New Feature so untracked files
-      // are dropped by construction (a plain checkout leaks them) and the
-      // changeset survives checkout/pull. When HEAD already carries the capture
-      // subject this is the regen case (the machine's rule-4 carve-out fired):
-      // discard any partial revert/seed state and re-derive from the commit.
+      // Accept Review: capture the human's pending changeset durably as
+      // `gtd: review feedback` (annotations, code edits, and new files alike),
+      // revert it back to the reviewed baseline, rm REVIEW.md (which is what
+      // stops Accept Review re-firing), and seed TODO.md from the captured
+      // diff. The regen case (the machine's rule-4 carve-out fired) discards
+      // any partial revert/seed state with a hard reset first.
       case "seedAcceptReview": {
-        const subject = yield* git
-          .lastCommitSubject()
-          .pipe(Effect.catchAll(() => Effect.succeed("")))
-        if (subject !== REVIEW_FEEDBACK_SUBJECT) {
-          yield* git.commitAllWithPrefix(REVIEW_FEEDBACK_SUBJECT)
-        } else {
-          yield* git.resetHard()
-        }
-        const base = yield* git
-          .resolveRef("HEAD~1")
-          .pipe(Effect.catchAll(() => Effect.succeed(EMPTY_TREE)))
-        const captured = yield* git.diffRef(base).pipe(Effect.catchAll(() => Effect.succeed("")))
-        yield* git.revertNoCommit("HEAD")
+        const captured = yield* captureAndRevert(git, REVIEW_FEEDBACK_SUBJECT, git.resetHard())
         yield* fs.remove(REVIEW_FILE).pipe(Effect.catchAll(() => Effect.void))
         yield* fs.writeFileString(TODO_FILE, seedTodo(captured))
         return
@@ -662,10 +674,7 @@ export const perform = (
         // (`A`) ones are included too in case the hard reset leaves them on
         // disk — fs.remove tolerates either outcome.
         const pendingCodeFiles = entries.filter(
-          (e) =>
-            (e.status.includes("?") || e.status.includes("A")) &&
-            !isSteeringFile(e.path) &&
-            !isGtdPath(e.path),
+          (e) => isUncommittedStatus(e.status) && !isSteeringFile(e.path) && !isGtdPath(e.path),
         )
         // Snapshot TODO.md (with the user's pending plan edits) and the code
         // diff BEFORE the reset discards them.

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -2,6 +2,7 @@ import { FileSystem } from "@effect/platform"
 import { Effect, Option } from "effect"
 import { GitService } from "./Git.js"
 import { ConfigService } from "./Config.js"
+import { fenceFor } from "./Prompt.js"
 import { TestRunner } from "./TestRunner.js"
 import type {
   CommitEvent,
@@ -160,10 +161,15 @@ const isTaskFile = (name: string): boolean => name.endsWith(".md")
 
 /**
  * Strip fenced code blocks and inline code spans so a marker token that appears
- * inside a code example does not count as a live open-question marker.
+ * inside a code example does not count as a live open-question marker. The
+ * unclosed-fence fallback is anchored to the END OF INPUT (`$(?![\s\S])`) — a
+ * bare `$` under the `m` flag matches at every line end, which made the lazy
+ * quantifier stop after the first fenced line and leak deeper markers.
  */
 const stripCode = (content: string): string =>
-  content.replace(/^(`{3,}|~{3,})[^\n]*\n[\s\S]*?(?:\n\1[^\n]*|$)/gm, "").replace(/`[^`\n]+`/g, "")
+  content
+    .replace(/^(`{3,}|~{3,})[^\n]*\n[\s\S]*?(?:\n\1[^\n]*|$(?![\s\S]))/gm, "")
+    .replace(/`[^`\n]+`/g, "")
 
 /**
  * Read the `.gtd/` work packages, lowest-numbered first. `packages[0]` is the
@@ -224,8 +230,13 @@ const CAPTURE_RULES = [
  * fenced so any marker it contains is stripped by `stripCode` and does not trip
  * the open-question gate.
  */
-export const seedTodo = (capturedDiff: string): string =>
-  [
+export const seedTodo = (capturedDiff: string): string => {
+  const body = capturedDiff.replace(/\n+$/, "")
+  // Sized past any backtick run in the diff (fenceFor) so formatters cannot
+  // close the block early on an indented ``` context line and spill the
+  // capture — markers included — out of the fence.
+  const fence = fenceFor(body)
+  return [
     "# Plan",
     "",
     "## Captured input",
@@ -235,11 +246,12 @@ export const seedTodo = (capturedDiff: string): string =>
     "",
     CAPTURE_RULES,
     "",
-    "```diff",
-    capturedDiff.replace(/\n+$/, ""),
-    "```",
+    `${fence}diff`,
+    body,
+    fence,
     "",
   ].join("\n")
+}
 
 /**
  * Append a grilling-round capture to an existing TODO.md: code the user
@@ -252,6 +264,7 @@ export const seedTodo = (capturedDiff: string): string =>
 export const appendCapturedInput = (todo: string, capturedDiff: string): string => {
   const body = capturedDiff.replace(/\n+$/, "")
   if (todo.includes(body)) return todo
+  const fence = fenceFor(body)
   const section = [
     "## Captured input (grilling)",
     "",
@@ -259,20 +272,23 @@ export const appendCapturedInput = (todo: string, capturedDiff: string): string 
     "gtd has reverted them from the working tree.",
     "",
     ...(todo.includes(CAPTURE_RULES) ? [] : [CAPTURE_RULES, ""]),
-    "```diff",
+    `${fence}diff`,
     body,
-    "```",
+    fence,
     "",
   ].join("\n")
   return todo.replace(/\n*$/, "\n\n") + section
 }
 
 /**
- * Returns true iff the diff contains at least one change and every changed
- * line is a checkbox flip (`- [ ]` ↔ `- [x]`, case-insensitive). Diff header
- * lines (`---`, `+++`, `@@`, file metadata) are ignored; only actual `+`/`-`
- * content lines are evaluated. Removed lines must be paired with added lines
- * that differ only in the box marker.
+ * Returns true iff the diff contains at least one checkbox flip (`- [ ]` ↔
+ * `- [x]`, case-insensitive) and every other changed line is pure
+ * line-ending churn. Diff header lines (`---`, `+++`, `@@`, file metadata)
+ * are ignored; only actual `+`/`-` content lines are evaluated. Trailing
+ * `\r` is stripped from line content before comparison, and removed/added
+ * pairs that become identical after the strip are treated as line-ending
+ * conversion noise (a CRLF editor rewrites EVERY line while the user merely
+ * ticks boxes) — approval must survive that churn.
  */
 export const isCheckboxOnlyDiff = (diff: string): boolean => {
   if (diff.trim() === "") return false
@@ -297,32 +313,30 @@ export const isCheckboxOnlyDiff = (diff: string): boolean => {
       continue
 
     if (raw.startsWith("-")) {
-      const content = raw.slice(1)
-      if (!checkboxRe.test(content)) return false
-      removedLines.push(content)
+      removedLines.push(raw.slice(1).replace(/\r$/, ""))
     } else if (raw.startsWith("+")) {
-      const content = raw.slice(1)
-      if (!checkboxRe.test(content)) return false
-      addedLines.push(content)
+      addedLines.push(raw.slice(1).replace(/\r$/, ""))
     }
   }
 
-  // Must have actual changes and removed/added counts must match
-  if (removedLines.length === 0 && addedLines.length === 0) return false
+  // Removed/added counts must match so lines pair up positionally.
   if (removedLines.length !== addedLines.length) return false
 
-  // Each pair must differ only in the checkbox marker
+  let flips = 0
   for (let i = 0; i < removedLines.length; i++) {
     const rm = removedLines[i]!
     const add = addedLines[i]!
+    // Identical after \r-stripping = pure line-ending churn — ignore.
+    if (rm === add) continue
+    // Anything else must be a checkbox flip and nothing more.
+    if (!checkboxRe.test(rm) || !checkboxRe.test(add)) return false
     const rmNorm = rm.replace(/\[[ xX]\]/, "[ ]")
     const addNorm = add.replace(/\[[ xX]\]/, "[ ]")
     if (rmNorm !== addNorm) return false
-    // Must actually be a flip (not identical)
-    if (rm === add) return false
+    flips += 1
   }
 
-  return true
+  return flips > 0
 }
 
 /**
@@ -371,7 +385,10 @@ export const gatherEvents = (): Effect.Effect<
 
     // --- RESOLVE payload (working-tree snapshot) -----------------------------
     const hasCommits = yield* git.hasCommits()
-    const porcelain = hasCommits ? yield* git.statusPorcelain() : ""
+    // Unconditional: `git status` works before the first commit, so a dirty
+    // tree in a freshly initialized repository is visible and seeds New
+    // Feature (it fails fast outside a repository, which is what we want).
+    const porcelain = yield* git.statusPorcelain()
     const entries = parsePorcelainPaths(porcelain)
     const workingTreeClean = entries.length === 0
     const lastCommitSubject = hasCommits ? yield* git.lastCommitSubject() : ""
@@ -424,7 +441,9 @@ export const gatherEvents = (): Effect.Effect<
     )
 
     const packages = yield* getPackages(fs)
-    const diff = entries.length > 0 ? yield* git.diffHead() : ""
+    // `git diff HEAD` needs a HEAD; before the first commit the prompt-context
+    // diff stays empty (the seed action captures the content itself).
+    const diff = hasCommits && entries.length > 0 ? yield* git.diffHead() : ""
 
     // When REVIEW.md is committed and the tree is dirty, check whether the only
     // pending change is checkbox ticks/un-ticks in REVIEW.md (no new text lines).

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -37,6 +37,7 @@ const UNANSWERED_MARKER = "<!-- user answers here -->"
 // Flat `gtd: <phase>` taxonomy — the only commit subjects the machine reads or
 // the edge writes. Counters fold from these prefixes + the `removedErrors` flag.
 const NEW_TASK_SUBJECT = "gtd: new task"
+const GRILLING_SUBJECT = "gtd: grilling"
 const PLANNING_SUBJECT = "gtd: planning"
 const BUILDING_SUBJECT = "gtd: building"
 const ERRORS_SUBJECT = "gtd: errors"
@@ -44,6 +45,25 @@ const FEEDBACK_SUBJECT = "gtd: feedback"
 const PACKAGE_DONE_SUBJECT = "gtd: package done"
 const AWAITING_REVIEW_SUBJECT = "gtd: awaiting review"
 const DONE_SUBJECT = "gtd: done"
+// The accept-review capture commit (commit-then-revert, like `gtd: new task`).
+// Distinct from the exact `gtd: feedback` marker the reviewFixCount fold reads.
+const REVIEW_FEEDBACK_SUBJECT = "gtd: review feedback"
+
+// Workflow plumbing excluded from every review diff (refDiff) and from the
+// grilling-round code capture: neither the reviewer nor a captured suggestion
+// block should ever contain steering-file churn (TODO.md seeded/deleted,
+// REVIEW.md committed/removed, `.gtd/` packages created/closed).
+const WORKFLOW_FILE_EXCLUDES: ReadonlyArray<string> = [
+  REVIEW_FILE,
+  TODO_FILE,
+  FEEDBACK_FILE,
+  ERRORS_FILE,
+  GTD_DIR,
+]
+
+const isGtdPath = (path: string): boolean => path === GTD_DIR || path.startsWith(`${GTD_DIR}/`)
+const isSteeringFile = (path: string): boolean =>
+  path === TODO_FILE || path === REVIEW_FILE || path === FEEDBACK_FILE || path === ERRORS_FILE
 
 // git's empty-tree object. `git diff <empty-tree> HEAD` yields the entire tree
 // as additions — the Clean review base when HEAD is on the default branch and
@@ -180,6 +200,24 @@ export const getPackages = (
   }).pipe(Effect.mapError((e) => (e instanceof Error ? e : new Error(String(e)))))
 
 /**
+ * How the grilling agent must read a captured diff: the three-way feedback
+ * interpretation. Embedded in every captured section (seed and grilling-round
+ * appends) so the rules travel with TODO.md — they survive checkouts and reach
+ * whichever agent picks the file up, not just the one gtd prompts next.
+ */
+const CAPTURE_RULES = [
+  "Interpret the captured diff with these rules:",
+  "",
+  "- **Code changes** are suggestions, not finished work — plan to re-implement",
+  "  them properly, including test coverage, rather than restoring them verbatim.",
+  "- **Code comments** are positional feedback about the code at that location.",
+  "- **TODO.md / REVIEW.md text changes** are global feedback on the plan or the",
+  "  reviewed work as a whole.",
+  "- **Checkbox flips** in a captured REVIEW.md diff are approval noise — ignore",
+  "  them.",
+].join("\n")
+
+/**
  * Deterministic, edge-built TODO.md seed for New Feature / Accept Review. No
  * agent runs during seeding (both states list `Prompt: none`); the next
  * Grilling invocation develops this into a real plan. The captured diff is
@@ -195,11 +233,39 @@ export const seedTodo = (capturedDiff: string): string =>
     "These changes were captured as the starting point for this feature. Develop",
     "them into a concrete plan and surface any open questions for the user.",
     "",
+    CAPTURE_RULES,
+    "",
     "```diff",
     capturedDiff.replace(/\n+$/, ""),
     "```",
     "",
   ].join("\n")
+
+/**
+ * Append a grilling-round capture to an existing TODO.md: code the user
+ * sketched while the plan was already committed is folded in as a fenced
+ * suggestion block; the edge then drops those changes from the working tree
+ * (STATES.md § Grilling). Idempotent — when the exact diff body is already
+ * present (a crash between append and commit re-runs the capture), the TODO is
+ * returned unchanged. The interpretation rules are included at most once.
+ */
+export const appendCapturedInput = (todo: string, capturedDiff: string): string => {
+  const body = capturedDiff.replace(/\n+$/, "")
+  if (todo.includes(body)) return todo
+  const section = [
+    "## Captured input (grilling)",
+    "",
+    "These code changes were made during grilling and captured as suggestions;",
+    "gtd has reverted them from the working tree.",
+    "",
+    ...(todo.includes(CAPTURE_RULES) ? [] : [CAPTURE_RULES, ""]),
+    "```diff",
+    body,
+    "```",
+    "",
+  ].join("\n")
+  return todo.replace(/\n*$/, "\n\n") + section
+}
 
 /**
  * Returns true iff the diff contains at least one change and every changed
@@ -310,10 +376,6 @@ export const gatherEvents = (): Effect.Effect<
     const workingTreeClean = entries.length === 0
     const lastCommitSubject = hasCommits ? yield* git.lastCommitSubject() : ""
 
-    const isGtdPath = (p: string): boolean => p === GTD_DIR || p.startsWith(`${GTD_DIR}/`)
-    const isSteeringFile = (p: string): boolean =>
-      p === TODO_FILE || p === REVIEW_FILE || p === FEEDBACK_FILE || p === ERRORS_FILE
-
     // `.gtd/` package files added/edited vs the committed tree.
     const gtdModified = entries.some((e) => isGtdPath(e.path))
     // Pending changes outside the steering set (TODO/REVIEW/FEEDBACK/ERRORS/.gtd).
@@ -350,6 +412,11 @@ export const gatherEvents = (): Effect.Effect<
     const reviewCommitted = reviewTrackedAtHead && workingTreeClean
     const reviewDirty = reviewTrackedAtHead && !workingTreeClean
 
+    // TODO.md tracked at HEAD — distinguishes a committed plan being iterated
+    // (later grilling rounds, which capture user code sketches) from a freshly
+    // seeded, uncommitted one (the seed round, which commits the seed revert).
+    const todoCommitted = todoExists && !isUncommitted(TODO_FILE)
+
     // The working tree deletes a committed ERRORS.md (human resume → fresh
     // budget). A status probe, distinct from the committed `removedErrors` flag.
     const pendingErrorsDeletion = entries.some(
@@ -368,8 +435,8 @@ export const gatherEvents = (): Effect.Effect<
         yield* git.diffPath(REVIEW_FILE).pipe(Effect.catchAll(() => Effect.succeed(""))),
       )
 
-    // --- Review base (Clean review) ------------------------------------------
-    // Four-rule logic to determine the review base:
+    // --- Review base + re-trigger gate (Clean review) -------------------------
+    // Scope — what a review covers — is a four-rule logic:
     //
     // Rule 1: Within a process (has a `gtd: grilling` commit after last
     //         `gtd: done`), no `gtd: awaiting review` yet → cover the whole
@@ -378,14 +445,24 @@ export const gatherEvents = (): Effect.Effect<
     //         changes since the last review: base = last `gtd: awaiting review`
     //         of the current task cycle (takes precedence over rule 1).
     // Rule 3: Outside a process, on a feature branch (base is Some) → cover
-    //         the whole branch: base = merge-base(defaultBranch, HEAD).
+    //         the whole branch: base = merge-base(defaultBranch, HEAD) —
+    //         unconditionally, even when a prior process completed on the
+    //         branch (already-approved work is re-covered by design).
     // Rule 4: Outside a process, on the default branch (base is None) → skip
     //         review: leave reviewBase/refDiff unset so the machine settles Idle.
     //
-    // Only set reviewBase/refDiff when the resulting diff is non-empty
-    // (non-empty distinguishes Clean from Idle).
+    // Trigger — whether a review fires — is the `hasCommitsAfterLastDone` gate:
+    // commits exist after the last `gtd: done` (or no `gtd: done` exists).
+    // Resolved here at the edge, consumed by the machine's Clean/Idle rule, so
+    // an approved review settles Idle instead of immediately re-firing (the
+    // review → approve → done → review loop). It gates *whether*, never *what*.
+    //
+    // The refDiff excludes workflow files (REVIEW_DIFF_EXCLUDES) so the
+    // reviewer never sees plumbing churn. Only set reviewBase/refDiff when the
+    // filtered diff is non-empty (non-empty distinguishes Clean from Idle).
     let reviewBase: string | undefined
     let refDiff: string | undefined
+    let hasCommitsAfterLastDone = true
     if (hasCommits) {
       // Scan ALL commits (no base arg) to properly detect process boundaries
       // across `gtd: done` commits even on trunk.
@@ -396,21 +473,22 @@ export const gatherEvents = (): Effect.Effect<
         let idx = -1
         for (let i = 0; i < allHistory.length; i++) {
           const subject = (allHistory[i]!.message.split("\n")[0] ?? "").trim()
-          if (subject === "gtd: done") idx = i
+          if (subject === DONE_SUBJECT) idx = i
         }
         return idx
       })()
       const currentCycle = lastDoneIdx === -1 ? allHistory : allHistory.slice(lastDoneIdx + 1)
+      hasCommitsAfterLastDone = lastDoneIdx === -1 || currentCycle.length > 0
 
       // Find first `gtd: grilling` in the current cycle (task start).
       const firstGrilling = currentCycle.find(
-        (c) => (c.message.split("\n")[0] ?? "").trim() === "gtd: grilling",
+        (c) => (c.message.split("\n")[0] ?? "").trim() === GRILLING_SUBJECT,
       )
       // Find last `gtd: awaiting review` in the current cycle.
       const lastAwaitingReview = (() => {
         let found: (typeof currentCycle)[number] | undefined
         for (const c of currentCycle) {
-          if ((c.message.split("\n")[0] ?? "").trim().startsWith("gtd: awaiting review")) {
+          if ((c.message.split("\n")[0] ?? "").trim().startsWith(AWAITING_REVIEW_SUBJECT)) {
             found = c
           }
         }
@@ -442,7 +520,7 @@ export const gatherEvents = (): Effect.Effect<
 
       if (candidate !== undefined) {
         const candidateDiff = yield* git
-          .diffRef(candidate)
+          .diffRef(candidate, WORKFLOW_FILE_EXCLUDES)
           .pipe(Effect.catchAll(() => Effect.succeed("")))
         if (candidateDiff.trim().length > 0) {
           reviewBase = candidate
@@ -453,6 +531,7 @@ export const gatherEvents = (): Effect.Effect<
 
     const payload: ResolvePayload = {
       todoExists,
+      todoCommitted,
       gtdDirExists,
       reviewPresent,
       feedbackPresent,
@@ -473,6 +552,7 @@ export const gatherEvents = (): Effect.Effect<
       diff,
       ...(reviewBase !== undefined ? { reviewBase } : {}),
       ...(refDiff !== undefined ? { refDiff } : {}),
+      hasCommitsAfterLastDone,
       agenticReviewEnabled: config.agenticReview,
       fixAttemptCap: config.fixAttemptCap,
       reviewThreshold: config.reviewThreshold,
@@ -521,14 +601,63 @@ export const perform = (
         return
       }
 
-      // Accept Review: seed TODO.md from the human's pending changeset, discard
-      // their code edits back to the reviewed baseline, and rm REVIEW.md (which
-      // is what stops Accept Review re-firing). All left uncommitted.
+      // Accept Review: capture the human's pending changeset durably — commit it
+      // verbatim as `gtd: review feedback` (annotations, code edits, and new
+      // files alike), revert it back to the reviewed baseline, rm REVIEW.md
+      // (which is what stops Accept Review re-firing), and seed TODO.md from the
+      // captured diff. Commit-then-revert mirrors New Feature so untracked files
+      // are dropped by construction (a plain checkout leaks them) and the
+      // changeset survives checkout/pull. When HEAD already carries the capture
+      // subject this is the regen case (the machine's rule-4 carve-out fired):
+      // discard any partial revert/seed state and re-derive from the commit.
       case "seedAcceptReview": {
-        const changeset = yield* git.diffHead().pipe(Effect.catchAll(() => Effect.succeed("")))
-        yield* git.checkoutAll()
+        const subject = yield* git
+          .lastCommitSubject()
+          .pipe(Effect.catchAll(() => Effect.succeed("")))
+        if (subject !== REVIEW_FEEDBACK_SUBJECT) {
+          yield* git.commitAllWithPrefix(REVIEW_FEEDBACK_SUBJECT)
+        } else {
+          yield* git.resetHard()
+        }
+        const base = yield* git
+          .resolveRef("HEAD~1")
+          .pipe(Effect.catchAll(() => Effect.succeed(EMPTY_TREE)))
+        const captured = yield* git.diffRef(base).pipe(Effect.catchAll(() => Effect.succeed("")))
+        yield* git.revertNoCommit("HEAD")
         yield* fs.remove(REVIEW_FILE).pipe(Effect.catchAll(() => Effect.void))
-        yield* fs.writeFileString(TODO_FILE, seedTodo(changeset))
+        yield* fs.writeFileString(TODO_FILE, seedTodo(captured))
+        return
+      }
+
+      // Grilling capture: the plan is already committed and the user sketched
+      // code during the round. Fold the code diff (untracked included, steering
+      // files excluded) into TODO.md as a suggestion block, drop the code
+      // changes — reset tracked, delete untracked/added — and commit the lot as
+      // one `gtd: grilling`. TODO.md's own pending edits are preserved verbatim
+      // (snapshotted before the reset). Binary edits survive only as the diff's
+      // "Binary files differ" line — an accepted limitation.
+      case "captureGrillingEdits": {
+        const porcelain = yield* git.statusPorcelain()
+        const entries = parsePorcelainPaths(porcelain)
+        // Untracked (`??`) code files must be deleted explicitly; staged-new
+        // (`A`) ones are included too in case the hard reset leaves them on
+        // disk — fs.remove tolerates either outcome.
+        const pendingCodeFiles = entries.filter(
+          (e) =>
+            (e.status.includes("?") || e.status.includes("A")) &&
+            !isSteeringFile(e.path) &&
+            !isGtdPath(e.path),
+        )
+        // Snapshot TODO.md (with the user's pending plan edits) and the code
+        // diff BEFORE the reset discards them.
+        const todoNow = yield* fs.readFileString(TODO_FILE)
+        const captured = yield* git.diffHead(WORKFLOW_FILE_EXCLUDES)
+        yield* git.resetHard()
+        for (const entry of pendingCodeFiles) {
+          yield* fs.remove(entry.path, { recursive: true }).pipe(Effect.catchAll(() => Effect.void))
+        }
+        yield* fs.writeFileString(TODO_FILE, appendCapturedInput(todoNow, captured))
+        yield* git.commitAllWithPrefix(GRILLING_SUBJECT)
         return
       }
 

--- a/src/Git.test.ts
+++ b/src/Git.test.ts
@@ -217,21 +217,6 @@ describe("GitService", () => {
     })
   })
 
-  describe("checkoutAll", () => {
-    it("discards tracked working-tree edits back to HEAD", async () => {
-      commit("feat: add src", "src.ts", "original content")
-      writeFileSync(join(repoDir, "src.ts"), "modified content")
-
-      const statusBefore = git("status", "--porcelain")
-      expect(statusBefore).toContain("src.ts")
-
-      await run(Effect.flatMap(GitService, (g) => g.checkoutAll()))
-
-      const statusAfter = git("status", "--porcelain")
-      expect(statusAfter.trim()).toBe("")
-    })
-  })
-
   describe("lastDeletionOf", () => {
     it("returns Option.none when the file has never been deleted", async () => {
       commit("feat: add review", "REVIEW.md", "# Review")

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -3,10 +3,19 @@ import { Context, Effect, Layer, Option } from "effect"
 
 export interface GitOperations {
   readonly statusPorcelain: () => Effect.Effect<string, Error>
-  readonly diffHead: () => Effect.Effect<string, Error>
+  /**
+   * `git diff HEAD` including untracked files (via a transient intent-to-add),
+   * optionally with `:(exclude)` pathspecs. Exclusions match repo-root-relative
+   * paths; a directory path excludes everything under it.
+   */
+  readonly diffHead: (exclude?: ReadonlyArray<string>) => Effect.Effect<string, Error>
   readonly lastCommitSubject: () => Effect.Effect<string, Error>
   readonly hasCommits: () => Effect.Effect<boolean, Error>
-  readonly diffRef: (ref: string) => Effect.Effect<string, Error>
+  /**
+   * `git diff <ref> HEAD`, optionally with `:(exclude)` pathspecs. Exclusions
+   * match repo-root-relative paths; a directory path excludes everything under it.
+   */
+  readonly diffRef: (ref: string, exclude?: ReadonlyArray<string>) => Effect.Effect<string, Error>
   readonly diffPath: (path: string) => Effect.Effect<string, Error>
   readonly resolveRef: (ref: string) => Effect.Effect<string, Error>
   readonly resolveDefaultBranch: () => Effect.Effect<Option.Option<string>, Error>
@@ -21,6 +30,11 @@ export interface GitOperations {
   readonly mixedResetHead: () => Effect.Effect<void, Error>
   /** `git checkout -- .` — discards tracked working-tree edits back to HEAD. */
   readonly checkoutAll: () => Effect.Effect<void, Error>
+  /**
+   * `git reset --hard HEAD` — index and tracked working tree back to HEAD;
+   * staged-but-new files are dropped, pure untracked (`??`) files survive.
+   */
+  readonly resetHard: () => Effect.Effect<void, Error>
   /**
    * `git log --first-parent --diff-filter=D --format=%H -- <path>` — returns the
    * most recent commit that deleted `path` as `Option.some(sha)`, or `Option.none()`.
@@ -73,16 +87,18 @@ export class GitService extends Context.Tag("GitService")<GitService, GitOperati
       return {
         statusPorcelain: () => exec("git", "status", "--porcelain"),
 
-        diffHead: () =>
+        diffHead: (exclude: ReadonlyArray<string> = []) =>
           Effect.gen(function* () {
+            const excludeArgs =
+              exclude.length > 0 ? ["--", ".", ...exclude.map((path) => `:(exclude)${path}`)] : []
             const untrackedRaw = yield* exec("git", "ls-files", "--others", "--exclude-standard")
             const untracked = untrackedRaw
               .split("\n")
               .map((s) => s.trim())
               .filter((s) => s !== "")
-            if (untracked.length === 0) return yield* exec("git", "diff", "HEAD")
+            if (untracked.length === 0) return yield* exec("git", "diff", "HEAD", ...excludeArgs)
             yield* exec("git", "add", "--intent-to-add", "--", ...untracked)
-            const diff = yield* exec("git", "diff", "HEAD")
+            const diff = yield* exec("git", "diff", "HEAD", ...excludeArgs)
             yield* exec("git", "reset", "--", ...untracked).pipe(Effect.catchAll(() => Effect.void))
             return diff
           }),
@@ -96,7 +112,16 @@ export class GitService extends Context.Tag("GitService")<GitService, GitOperati
             Effect.catchAll(() => Effect.succeed(false)),
           ),
 
-        diffRef: (ref: string) => exec("git", "diff", ref, "HEAD"),
+        diffRef: (ref: string, exclude: ReadonlyArray<string> = []) =>
+          exec(
+            "git",
+            "diff",
+            ref,
+            "HEAD",
+            ...(exclude.length > 0
+              ? ["--", ".", ...exclude.map((path) => `:(exclude)${path}`)]
+              : []),
+          ),
 
         diffPath: (path: string) => exec("git", "diff", "HEAD", "--", path),
 
@@ -181,6 +206,8 @@ export class GitService extends Context.Tag("GitService")<GitService, GitOperati
           }),
 
         checkoutAll: () => exec("git", "checkout", "--", ".").pipe(Effect.asVoid),
+
+        resetHard: () => exec("git", "reset", "--hard", "HEAD").pipe(Effect.asVoid),
 
         lastDeletionOf: (path: string) =>
           exec("git", "log", "--first-parent", "--diff-filter=D", "--format=%H", "--", path).pipe(

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -1,5 +1,5 @@
 import { Command, CommandExecutor } from "@effect/platform"
-import { Context, Effect, Layer, Option } from "effect"
+import { Context, Effect, Layer, Option, Stream } from "effect"
 
 export interface GitOperations {
   readonly statusPorcelain: () => Effect.Effect<string, Error>
@@ -18,6 +18,8 @@ export interface GitOperations {
   readonly diffRef: (ref: string, exclude?: ReadonlyArray<string>) => Effect.Effect<string, Error>
   readonly diffPath: (path: string) => Effect.Effect<string, Error>
   readonly resolveRef: (ref: string) => Effect.Effect<string, Error>
+  /** `git rev-parse --show-toplevel` — the working-tree root; fails outside a repository. */
+  readonly topLevel: () => Effect.Effect<string, Error>
   readonly resolveDefaultBranch: () => Effect.Effect<Option.Option<string>, Error>
   readonly mergeBase: (a: string, b: string) => Effect.Effect<Option.Option<string>, Error>
   /** `git merge-base --is-ancestor a b` — true iff `a` is an ancestor of `b` (or equal). */
@@ -68,13 +70,38 @@ export interface GitOperations {
   readonly commitAllWithPrefix: (prefix: string) => Effect.Effect<void, Error>
 }
 
+/**
+ * Run a command and return its stdout — FAILING on a non-zero exit code with
+ * the command line and stderr in the error message. `Command.string` alone
+ * only collects stdout and silently ignores exit codes, which used to make
+ * gtd report success on rejected commits (hooks, gpg), resolve Idle outside a
+ * repository, and lose files whose quoted paths broke a swallowed `git add`.
+ * Callers that expect a probe to fail (missing refs, empty repos) handle it
+ * with an explicit `catchAll`.
+ */
 const run = (
   ...args: [string, ...Array<string>]
 ): Effect.Effect<string, Error, CommandExecutor.CommandExecutor> =>
-  Command.make(...args).pipe(
-    Command.string,
-    Effect.mapError((e) => new Error(String(e))),
-  )
+  Effect.scoped(
+    Effect.gen(function* () {
+      const executor = yield* CommandExecutor.CommandExecutor
+      const process = yield* executor.start(
+        Command.make(...args).pipe(Command.stdout("pipe"), Command.stderr("pipe")),
+      )
+      const collect = (stream: typeof process.stdout) =>
+        stream.pipe(Stream.decodeText(), Stream.mkString)
+      const [stdout, stderr, exitCode] = yield* Effect.all(
+        [collect(process.stdout), collect(process.stderr), process.exitCode],
+        { concurrency: "unbounded" },
+      )
+      if (exitCode !== 0) {
+        return yield* Effect.fail(
+          new Error(`${args.join(" ")} failed (exit ${exitCode}): ${stderr.trim()}`),
+        )
+      }
+      return stdout
+    }),
+  ).pipe(Effect.mapError((e) => (e instanceof Error ? e : new Error(String(e)))))
 
 export class GitService extends Context.Tag("GitService")<GitService, GitOperations>() {
   static Live = Layer.effect(
@@ -91,11 +118,17 @@ export class GitService extends Context.Tag("GitService")<GitService, GitOperati
           Effect.gen(function* () {
             const excludeArgs =
               exclude.length > 0 ? ["--", ".", ...exclude.map((path) => `:(exclude)${path}`)] : []
-            const untrackedRaw = yield* exec("git", "ls-files", "--others", "--exclude-standard")
-            const untracked = untrackedRaw
-              .split("\n")
-              .map((s) => s.trim())
-              .filter((s) => s !== "")
+            // `-z` yields NUL-separated, UNQUOTED paths — the newline format
+            // C-quotes non-ASCII/special names, and feeding a quoted string
+            // back to `git add` matches nothing.
+            const untrackedRaw = yield* exec(
+              "git",
+              "ls-files",
+              "--others",
+              "--exclude-standard",
+              "-z",
+            )
+            const untracked = untrackedRaw.split("\0").filter((s) => s.length > 0)
             if (untracked.length === 0) return yield* exec("git", "diff", "HEAD", ...excludeArgs)
             yield* exec("git", "add", "--intent-to-add", "--", ...untracked)
             const diff = yield* exec("git", "diff", "HEAD", ...excludeArgs)
@@ -134,6 +167,9 @@ export class GitService extends Context.Tag("GitService")<GitService, GitOperati
                 : Effect.fail(new Error(`Invalid ref: ${ref}`)),
             ),
           ),
+
+        topLevel: () =>
+          exec("git", "rev-parse", "--show-toplevel").pipe(Effect.map((s) => s.trim())),
 
         resolveDefaultBranch: () =>
           exec("git", "rev-parse", "--abbrev-ref", "origin/HEAD").pipe(

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -30,8 +30,6 @@ export interface GitOperations {
   readonly revertNoCommit: (ref: string) => Effect.Effect<void, Error>
   /** `git reset HEAD~1` (mixed) — undoes the last commit, keeping changes in the working tree. */
   readonly mixedResetHead: () => Effect.Effect<void, Error>
-  /** `git checkout -- .` — discards tracked working-tree edits back to HEAD. */
-  readonly checkoutAll: () => Effect.Effect<void, Error>
   /**
    * `git reset --hard HEAD` — index and tracked working tree back to HEAD;
    * staged-but-new files are dropped, pure untracked (`??`) files survive.
@@ -69,6 +67,14 @@ export interface GitOperations {
    */
   readonly commitAllWithPrefix: (prefix: string) => Effect.Effect<void, Error>
 }
+
+/**
+ * `:(exclude)` pathspec arguments for a diff command. The `"."` include anchor
+ * is required alongside exclusions; both are cwd-relative, which is correct
+ * only because gtd pins its cwd to the repository root (main.ts).
+ */
+const excludePathspecs = (exclude: ReadonlyArray<string>): ReadonlyArray<string> =>
+  exclude.length === 0 ? [] : ["--", ".", ...exclude.map((path) => `:(exclude)${path}`)]
 
 /**
  * Run a command and return its stdout — FAILING on a non-zero exit code with
@@ -116,8 +122,7 @@ export class GitService extends Context.Tag("GitService")<GitService, GitOperati
 
         diffHead: (exclude: ReadonlyArray<string> = []) =>
           Effect.gen(function* () {
-            const excludeArgs =
-              exclude.length > 0 ? ["--", ".", ...exclude.map((path) => `:(exclude)${path}`)] : []
+            const excludeArgs = excludePathspecs(exclude)
             // `-z` yields NUL-separated, UNQUOTED paths — the newline format
             // C-quotes non-ASCII/special names, and feeding a quoted string
             // back to `git add` matches nothing.
@@ -146,15 +151,7 @@ export class GitService extends Context.Tag("GitService")<GitService, GitOperati
           ),
 
         diffRef: (ref: string, exclude: ReadonlyArray<string> = []) =>
-          exec(
-            "git",
-            "diff",
-            ref,
-            "HEAD",
-            ...(exclude.length > 0
-              ? ["--", ".", ...exclude.map((path) => `:(exclude)${path}`)]
-              : []),
-          ),
+          exec("git", "diff", ref, "HEAD", ...excludePathspecs(exclude)),
 
         diffPath: (path: string) => exec("git", "diff", "HEAD", "--", path),
 
@@ -240,8 +237,6 @@ export class GitService extends Context.Tag("GitService")<GitService, GitOperati
               return yield* Effect.fail(new Error(`git reset HEAD~1 failed (exit ${resetCode})`))
             }
           }),
-
-        checkoutAll: () => exec("git", "checkout", "--", ".").pipe(Effect.asVoid),
 
         resetHard: () => exec("git", "reset", "--hard", "HEAD").pipe(Effect.asVoid),
 

--- a/src/Machine.property.test.ts
+++ b/src/Machine.property.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest"
+import fc from "fast-check"
+import {
+  type EdgeAction,
+  type GtdEvent,
+  type GtdState,
+  type ResolvePayload,
+  foldCounters,
+  GtdStateError,
+  resolve,
+} from "./Machine.js"
+
+/**
+ * Property sweep over edge-consistent payloads: random payloads are generated
+ * from primitive facts and then constrained the way `gatherEvents` derives
+ * them (e.g. `reviewCommitted` implies a clean tree, `codeDirty` implies a
+ * dirty one), so every generated payload is one the edge could actually
+ * produce. The invariants pin the machine's public contract:
+ *
+ *  - `resolve` never throws anything but `GtdStateError`, and an
+ *    illegal-combination throw only fires on the documented combos;
+ *  - exactly one of the 16 states comes back, with an edge action from that
+ *    state's allowed set;
+ *  - the `done` action is only ever emitted with REVIEW.md present, and the
+ *    accept-review regen carve-out shadows Done under a
+ *    `gtd: review feedback` HEAD;
+ *  - resolution is deterministic, and the counter folds ignore RESOLVE events.
+ */
+
+const HEADS = [
+  "",
+  "chore: init",
+  "feat: shipped",
+  "Merge branch side",
+  "gtd: transport",
+  "gtd: new task",
+  "gtd: grilling",
+  "gtd: grilled",
+  "gtd: planning",
+  "gtd: building",
+  "gtd: errors",
+  "gtd: fixing",
+  "gtd: feedback",
+  "gtd: package done",
+  "gtd: awaiting review",
+  "gtd: review feedback",
+  "gtd: done",
+] as const
+
+/** Raw independent facts, constrained into an edge-consistent payload below. */
+const arbPayload: fc.Arbitrary<ResolvePayload> = fc
+  .record({
+    head: fc.constantFrom(...HEADS),
+    clean: fc.boolean(),
+    codeDirtyRaw: fc.boolean(),
+    gtdModifiedRaw: fc.boolean(),
+    pendingErrorsDeletionRaw: fc.boolean(),
+    checkboxOnlyRaw: fc.boolean(),
+    todoExists: fc.boolean(),
+    todoCommittedRaw: fc.boolean(),
+    markerRaw: fc.boolean(),
+    gtdDirExists: fc.boolean(),
+    reviewPresent: fc.boolean(),
+    reviewTrackedRaw: fc.boolean(),
+    feedbackPresent: fc.boolean(),
+    feedbackCommittedRaw: fc.boolean(),
+    feedbackEmptyRaw: fc.boolean(),
+    errorsPresent: fc.boolean(),
+    hasReviewBase: fc.boolean(),
+    hasCommitsAfterLastDone: fc.boolean(),
+    agenticReviewEnabled: fc.boolean(),
+    fixAttemptCap: fc.integer({ min: 0, max: 4 }),
+    reviewThreshold: fc.integer({ min: 1, max: 4 }),
+  })
+  .map((raw): ResolvePayload => {
+    const workingTreeClean = raw.clean
+    const codeDirty = !workingTreeClean && raw.codeDirtyRaw
+    const gtdModified = !workingTreeClean && raw.gtdDirExists && raw.gtdModifiedRaw
+    const pendingErrorsDeletion = !workingTreeClean && raw.pendingErrorsDeletionRaw
+    const reviewTracked = raw.reviewPresent && raw.reviewTrackedRaw
+    const reviewCommitted = reviewTracked && workingTreeClean
+    const reviewDirty = reviewTracked && !workingTreeClean
+    const reviewCheckboxOnly = reviewDirty && !codeDirty && raw.checkboxOnlyRaw
+    return {
+      todoExists: raw.todoExists,
+      todoCommitted: raw.todoExists && raw.todoCommittedRaw,
+      gtdDirExists: raw.gtdDirExists,
+      reviewPresent: raw.reviewPresent,
+      feedbackPresent: raw.feedbackPresent,
+      errorsPresent: raw.errorsPresent,
+      gtdModified,
+      codeDirty,
+      todoMarkerPresent: raw.todoExists && raw.markerRaw,
+      feedbackCommitted: raw.feedbackPresent && raw.feedbackCommittedRaw,
+      feedbackEmpty: raw.feedbackPresent && raw.feedbackEmptyRaw,
+      feedbackContent: raw.feedbackPresent && !raw.feedbackEmptyRaw ? "finding" : "",
+      reviewCommitted,
+      reviewDirty,
+      reviewCheckboxOnly,
+      pendingErrorsDeletion,
+      lastCommitSubject: raw.head,
+      workingTreeClean,
+      packages: [],
+      diff: workingTreeClean ? "" : "diff --git a/x b/x\n+x\n",
+      ...(raw.hasReviewBase ? { reviewBase: "abc123", refDiff: "diff --git a/x b/x\n+x\n" } : {}),
+      hasCommitsAfterLastDone: raw.hasCommitsAfterLastDone,
+      agenticReviewEnabled: raw.agenticReviewEnabled,
+      fixAttemptCap: raw.fixAttemptCap,
+      reviewThreshold: raw.reviewThreshold,
+    }
+  })
+
+const arbCommit: fc.Arbitrary<GtdEvent> = fc
+  .record({
+    isErrors: fc.boolean(),
+    isFeedback: fc.boolean(),
+    isPackageStart: fc.boolean(),
+    removedErrors: fc.boolean(),
+  })
+  .map((f) => ({ type: "COMMIT", isWorkflowCommit: true, ...f }))
+
+const arbEvents: fc.Arbitrary<GtdEvent[]> = fc
+  .tuple(fc.array(arbCommit, { maxLength: 12 }), arbPayload)
+  .map(([commits, payload]) => [...commits, { type: "RESOLVE", payload }])
+
+/** The documented illegal steering-file combinations (STATES.md). */
+const isIllegal = (p: ResolvePayload): boolean =>
+  (p.reviewPresent && p.gtdDirExists) ||
+  (p.reviewPresent && p.todoCommitted) ||
+  (p.reviewPresent && !(p.reviewCommitted || p.reviewDirty) && p.todoExists) ||
+  (p.feedbackPresent && p.reviewPresent) ||
+  (p.feedbackPresent && !p.gtdDirExists) ||
+  (p.errorsPresent && p.feedbackPresent) ||
+  (p.errorsPresent && !p.gtdDirExists)
+
+const STATES: ReadonlySet<GtdState> = new Set<GtdState>([
+  "transport",
+  "new-feature",
+  "grilling",
+  "grilled",
+  "planning",
+  "building",
+  "testing",
+  "fixing",
+  "escalate",
+  "agentic-review",
+  "close-package",
+  "clean",
+  "await-review",
+  "accept-review",
+  "done",
+  "idle",
+])
+
+/** Which edge-action kinds each state may carry ("none" = no action). */
+const ALLOWED: Record<GtdState, ReadonlyArray<EdgeAction["kind"] | "none">> = {
+  transport: ["transportReset"],
+  "new-feature": ["seedNewFeature"],
+  grilling: ["commitPending", "captureGrillingEdits", "none"],
+  grilled: ["commitPending"],
+  planning: ["commitPending"],
+  building: ["commitPending", "none"],
+  testing: ["runTest"],
+  fixing: ["commitPending"],
+  escalate: ["none"],
+  "agentic-review": ["none"],
+  "close-package": ["closePackage"],
+  clean: ["none"],
+  "await-review": ["commitReview"],
+  "accept-review": ["seedAcceptReview"],
+  done: ["done"],
+  idle: ["none"],
+}
+
+const COMMIT_PREFIXES = new Set([
+  "gtd: grilling",
+  "gtd: grilled",
+  "gtd: planning",
+  "gtd: fixing",
+  "gtd: feedback",
+])
+
+describe("resolve — property sweep over edge-consistent payloads", () => {
+  it("never throws anything but GtdStateError; illegal throws match the documented combos", () => {
+    fc.assert(
+      fc.property(arbEvents, (events) => {
+        const payload = (events[events.length - 1] as { payload: ResolvePayload }).payload
+        try {
+          resolve(events)
+          expect(isIllegal(payload)).toBe(false)
+        } catch (e) {
+          expect(e).toBeInstanceOf(GtdStateError)
+          const err = e as GtdStateError
+          expect(["illegal-combination", "corruption"]).toContain(err.kind)
+          if (err.kind === "illegal-combination") expect(isIllegal(payload)).toBe(true)
+        }
+      }),
+      { numRuns: 2000 },
+    )
+  })
+
+  it("returns exactly one known state with an edge action from its allowed set", () => {
+    fc.assert(
+      fc.property(arbEvents, (events) => {
+        let result
+        try {
+          result = resolve(events)
+        } catch {
+          return // throw-paths covered above
+        }
+        expect(STATES.has(result.state)).toBe(true)
+        const kind = result.edgeAction?.kind ?? "none"
+        expect(ALLOWED[result.state]).toContain(kind)
+        if (result.edgeAction?.kind === "commitPending") {
+          expect(COMMIT_PREFIXES.has(result.edgeAction.prefix)).toBe(true)
+        }
+      }),
+      { numRuns: 2000 },
+    )
+  })
+
+  it("the done action requires REVIEW.md, and the regen carve-out shadows Done", () => {
+    fc.assert(
+      fc.property(arbEvents, (events) => {
+        const payload = (events[events.length - 1] as { payload: ResolvePayload }).payload
+        let result
+        try {
+          result = resolve(events)
+        } catch {
+          return
+        }
+        if (result.edgeAction?.kind === "done") expect(payload.reviewPresent).toBe(true)
+        if (result.state === "done") expect(payload.reviewPresent).toBe(true)
+        // The feedback path can never approve: under the capture HEAD, REVIEW.md
+        // present always regenerates the seed instead of resolving Done.
+        if (payload.reviewPresent && payload.lastCommitSubject === "gtd: review feedback") {
+          expect(result.state).toBe("accept-review")
+        }
+      }),
+      { numRuns: 2000 },
+    )
+  })
+
+  it("resolution is deterministic", () => {
+    fc.assert(
+      fc.property(arbEvents, (events) => {
+        const run = () => {
+          try {
+            return JSON.stringify(resolve(events))
+          } catch (e) {
+            return `throw:${(e as GtdStateError).kind}:${(e as Error).message}`
+          }
+        }
+        expect(run()).toBe(run())
+      }),
+      { numRuns: 500 },
+    )
+  })
+})
+
+describe("foldCounters — property invariants", () => {
+  it("counters are non-negative and unaffected by RESOLVE events", () => {
+    fc.assert(
+      fc.property(fc.array(arbCommit, { maxLength: 30 }), arbPayload, (commits, payload) => {
+        const bare = foldCounters(commits)
+        expect(bare.testFixCount).toBeGreaterThanOrEqual(0)
+        expect(bare.reviewFixCount).toBeGreaterThanOrEqual(0)
+        const withResolve = foldCounters([...commits, { type: "RESOLVE", payload }])
+        expect(withResolve).toEqual(bare)
+      }),
+      { numRuns: 1000 },
+    )
+  })
+})

--- a/src/Machine.property.test.ts
+++ b/src/Machine.property.test.ts
@@ -133,25 +133,6 @@ const isIllegal = (p: ResolvePayload): boolean =>
   (p.errorsPresent && p.feedbackPresent) ||
   (p.errorsPresent && !p.gtdDirExists)
 
-const STATES: ReadonlySet<GtdState> = new Set<GtdState>([
-  "transport",
-  "new-feature",
-  "grilling",
-  "grilled",
-  "planning",
-  "building",
-  "testing",
-  "fixing",
-  "escalate",
-  "agentic-review",
-  "close-package",
-  "clean",
-  "await-review",
-  "accept-review",
-  "done",
-  "idle",
-])
-
 /** Which edge-action kinds each state may carry ("none" = no action). */
 const ALLOWED: Record<GtdState, ReadonlyArray<EdgeAction["kind"] | "none">> = {
   transport: ["transportReset"],
@@ -171,6 +152,10 @@ const ALLOWED: Record<GtdState, ReadonlyArray<EdgeAction["kind"] | "none">> = {
   done: ["done"],
   idle: ["none"],
 }
+
+// Derived from ALLOWED (whose Record<GtdState, …> typing is exhaustive) so the
+// two can never drift.
+const STATES: ReadonlySet<GtdState> = new Set(Object.keys(ALLOWED) as GtdState[])
 
 const COMMIT_PREFIXES = new Set([
   "gtd: grilling",

--- a/src/Machine.test.ts
+++ b/src/Machine.test.ts
@@ -29,6 +29,7 @@ const commit = (
 
 const basePayload = (overrides: Partial<ResolvePayload> = {}): ResolvePayload => ({
   todoExists: false,
+  todoCommitted: false,
   gtdDirExists: false,
   reviewPresent: false,
   feedbackPresent: false,
@@ -47,6 +48,7 @@ const basePayload = (overrides: Partial<ResolvePayload> = {}): ResolvePayload =>
   workingTreeClean: true,
   packages: [],
   diff: "",
+  hasCommitsAfterLastDone: true,
   agenticReviewEnabled: true,
   fixAttemptCap: 3,
   reviewThreshold: 3,
@@ -146,7 +148,8 @@ describe("foldCounters — reviewFixCount", () => {
 describe("illegal-combination hard-errors (throw before the ladder)", () => {
   const cases: Array<[string, Partial<ResolvePayload>]> = [
     ["REVIEW + .gtd", { reviewPresent: true, gtdDirExists: true }],
-    ["REVIEW + TODO", { reviewPresent: true, todoExists: true }],
+    ["REVIEW + committed TODO", { reviewPresent: true, todoExists: true, todoCommitted: true }],
+    ["uncommitted REVIEW + TODO", { reviewPresent: true, todoExists: true }],
     ["FEEDBACK + REVIEW", { feedbackPresent: true, reviewPresent: true }],
     ["FEEDBACK without .gtd", { feedbackPresent: true, gtdDirExists: false }],
     ["ERRORS + FEEDBACK", { errorsPresent: true, feedbackPresent: true, gtdDirExists: true }],
@@ -162,6 +165,21 @@ describe("illegal-combination hard-errors (throw before the ladder)", () => {
       }
     })
   }
+
+  it("committed REVIEW + uncommitted TODO is legal — review feedback (Accept Review)", () => {
+    const res = resolve([
+      R({
+        reviewPresent: true,
+        reviewDirty: true,
+        workingTreeClean: false,
+        todoExists: true,
+        todoCommitted: false,
+        lastCommitSubject: "gtd: awaiting review",
+      }),
+    ])
+    expect(res.state).toBe("accept-review")
+    expect(res.edgeAction).toEqual({ kind: "seedAcceptReview" })
+  })
 })
 
 // ── Corruption hard-error ────────────────────────────────────────────────────
@@ -378,6 +396,10 @@ describe("rule 4 — review lifecycle", () => {
     expect(res.state).toBe("accept-review")
     expect(res.autoAdvance).toBe(true)
     expect(res.edgeAction).toEqual({ kind: "seedAcceptReview" })
+    // The feedback path never commits `gtd: done` in the same resolve: the one
+    // returned edgeAction is the seed, and the two done branches are unreachable
+    // (`reviewCommitted` needs a clean tree, checkbox-only is excluded here).
+    expect(res.edgeAction!.kind).not.toBe("done")
   })
 
   it("reviewDirty + reviewCheckboxOnly → done, auto, done", () => {
@@ -390,6 +412,31 @@ describe("rule 4 — review lifecycle", () => {
     expect(res.state).toBe("done")
     expect(res.autoAdvance).toBe(true)
     expect(res.edgeAction).toEqual({ kind: "done" })
+  })
+
+  // Regen carve-out: HEAD is the accept-review capture commit and REVIEW.md is
+  // present again (its annotated copy is IN that commit) — the uncommitted seed
+  // was lost. Routing to Done here would silently approve the annotations.
+  it("REVIEW present + HEAD gtd: review feedback + clean → accept-review regen, never done", () => {
+    const res = r({
+      reviewPresent: true,
+      reviewCommitted: true,
+      lastCommitSubject: "gtd: review feedback",
+    })
+    expect(res.state).toBe("accept-review")
+    expect(res.autoAdvance).toBe(true)
+    expect(res.edgeAction).toEqual({ kind: "seedAcceptReview" })
+  })
+
+  it("REVIEW present + HEAD gtd: review feedback + dirty (partial revert) → accept-review regen", () => {
+    const res = r({
+      reviewPresent: true,
+      reviewDirty: true,
+      workingTreeClean: false,
+      lastCommitSubject: "gtd: review feedback",
+    })
+    expect(res.state).toBe("accept-review")
+    expect(res.edgeAction).toEqual({ kind: "seedAcceptReview" })
   })
 })
 
@@ -418,6 +465,21 @@ describe("rule 5 — New Feature", () => {
   it("HEAD gtd: new task + dirty tree → grilling (commit the seed), not new-feature", () => {
     const res = r({ lastCommitSubject: "gtd: new task", todoExists: true, workingTreeClean: false })
     expect(res.state).toBe("grilling")
+  })
+
+  // A committed TODO.md under a boundary HEAD is a resumed grill — even with a
+  // dirty tree it must route to Grilling (which captures the code edits), not
+  // re-seed and clobber the developed plan (STATES.md § New Feature).
+  it("boundary HEAD + dirty + committed TODO → grilling (resumed grill), not new-feature", () => {
+    const res = r({
+      lastCommitSubject: "feat: unrelated",
+      workingTreeClean: false,
+      codeDirty: true,
+      todoExists: true,
+      todoCommitted: true,
+    })
+    expect(res.state).toBe("grilling")
+    expect(res.edgeAction).toEqual({ kind: "captureGrillingEdits" })
   })
 })
 
@@ -455,6 +517,62 @@ describe("rule 6 — Grilling / Grilled (3-way)", () => {
     expect(res.context.grillingCase).toBeUndefined()
     expect(res.edgeAction).toEqual({ kind: "commitPending", prefix: "gtd: grilled" })
   })
+
+  // Later grilling rounds (committed plan) with pending code changes capture
+  // the code into TODO.md as a suggestion block instead of committing it
+  // verbatim — on BOTH the iterate and STOP paths.
+  it("committed TODO + code changes (iterate) → captureGrillingEdits", () => {
+    const res = r({
+      todoExists: true,
+      todoCommitted: true,
+      codeDirty: true,
+      workingTreeClean: false,
+      lastCommitSubject: "gtd: grilling",
+    })
+    expect(res.state).toBe("grilling")
+    expect(res.autoAdvance).toBe(true)
+    expect(res.context.grillingCase).toBe("iterate")
+    expect(res.edgeAction).toEqual({ kind: "captureGrillingEdits" })
+  })
+
+  it("committed TODO + code changes + open marker (STOP) → captureGrillingEdits, still stops", () => {
+    const res = r({
+      todoExists: true,
+      todoCommitted: true,
+      todoMarkerPresent: true,
+      codeDirty: true,
+      workingTreeClean: false,
+      lastCommitSubject: "gtd: grilling",
+    })
+    expect(res.state).toBe("grilling")
+    expect(res.autoAdvance).toBe(false)
+    expect(res.context.grillingCase).toBe("stop")
+    expect(res.edgeAction).toEqual({ kind: "captureGrillingEdits" })
+  })
+
+  it("committed TODO + only TODO edits pending → plain commitPending (no capture)", () => {
+    const res = r({
+      todoExists: true,
+      todoCommitted: true,
+      codeDirty: false,
+      workingTreeClean: false,
+      lastCommitSubject: "gtd: grilling",
+    })
+    expect(res.state).toBe("grilling")
+    expect(res.edgeAction).toEqual({ kind: "commitPending", prefix: "gtd: grilling" })
+  })
+
+  it("uncommitted TODO (seed round) + code dirty → plain commitPending (the seed revert)", () => {
+    const res = r({
+      todoExists: true,
+      todoCommitted: false,
+      codeDirty: true,
+      workingTreeClean: false,
+      lastCommitSubject: "gtd: review feedback",
+    })
+    expect(res.state).toBe("grilling")
+    expect(res.edgeAction).toEqual({ kind: "commitPending", prefix: "gtd: grilling" })
+  })
 })
 
 describe("rule 7 — Clean / Idle", () => {
@@ -489,6 +607,31 @@ describe("rule 7 — Clean / Idle", () => {
   it("reviewBase present but whitespace-only refDiff → idle (nothing to review)", () => {
     const res = r({ lastCommitSubject: "feat: x", reviewBase: "abc", refDiff: "  \n " })
     expect(res.state).toBe("idle")
+  })
+
+  // The loop fix: after an approved review (`gtd: done` with nothing after it)
+  // the whole-branch diff is still non-empty, but the closed re-trigger gate
+  // keeps the machine Idle instead of re-entering Clean.
+  it("reviewable diff but closed re-trigger gate → idle (no review re-fire after done)", () => {
+    const res = r({
+      lastCommitSubject: "gtd: done",
+      reviewBase: "abc123",
+      refDiff: "diff --git a/x b/x\n+hello\n",
+      hasCommitsAfterLastDone: false,
+    })
+    expect(res.state).toBe("idle")
+    expect(res.autoAdvance).toBe(false)
+    expect(res.edgeAction).toBeUndefined()
+  })
+
+  it("open gate + reviewable diff after new commits land → clean (review re-fires)", () => {
+    const res = r({
+      lastCommitSubject: "feat: post-done work",
+      reviewBase: "abc123",
+      refDiff: "diff --git a/x b/x\n+hello\n",
+      hasCommitsAfterLastDone: true,
+    })
+    expect(res.state).toBe("clean")
   })
 
   it("resolve([]) → idle (degenerate input, no throw)", () => {

--- a/src/Machine.test.ts
+++ b/src/Machine.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  DEFAULT_PAYLOAD,
   type EdgeAction,
   type GtdEvent,
   type ResolvePayload,
@@ -28,30 +29,8 @@ const commit = (
 })
 
 const basePayload = (overrides: Partial<ResolvePayload> = {}): ResolvePayload => ({
-  todoExists: false,
-  todoCommitted: false,
-  gtdDirExists: false,
-  reviewPresent: false,
-  feedbackPresent: false,
-  errorsPresent: false,
-  gtdModified: false,
-  codeDirty: false,
-  todoMarkerPresent: false,
-  feedbackCommitted: false,
-  feedbackEmpty: false,
-  feedbackContent: "",
-  reviewCommitted: false,
-  reviewDirty: false,
-  reviewCheckboxOnly: false,
-  pendingErrorsDeletion: false,
+  ...DEFAULT_PAYLOAD,
   lastCommitSubject: "chore: init",
-  workingTreeClean: true,
-  packages: [],
-  diff: "",
-  hasCommitsAfterLastDone: true,
-  agenticReviewEnabled: true,
-  fixAttemptCap: 3,
-  reviewThreshold: 3,
   ...overrides,
 })
 
@@ -399,7 +378,6 @@ describe("rule 4 — review lifecycle", () => {
     // The feedback path never commits `gtd: done` in the same resolve: the one
     // returned edgeAction is the seed, and the two done branches are unreachable
     // (`reviewCommitted` needs a clean tree, checkbox-only is excluded here).
-    expect(res.edgeAction!.kind).not.toBe("done")
   })
 
   it("reviewDirty + reviewCheckboxOnly → done, auto, done", () => {

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -275,7 +275,12 @@ export const foldCounters = (events: readonly GtdEvent[]): Counters => {
 const isBoundary = (subject: string): boolean =>
   !subject.startsWith("gtd: ") || subject === "gtd: done"
 
-const DEFAULT_PAYLOAD: ResolvePayload = {
+/**
+ * The payload a degenerate `RESOLVE`-less stream resolves against — also the
+ * canonical field-default table tests spread-override instead of hand-writing
+ * every `ResolvePayload` field.
+ */
+export const DEFAULT_PAYLOAD: ResolvePayload = {
   todoExists: false,
   todoCommitted: false,
   gtdDirExists: false,

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -87,6 +87,12 @@ export interface GtdPackageFact {
 export interface ResolvePayload {
   /** `TODO.md` exists (committed or pending). */
   readonly todoExists: boolean
+  /**
+   * The present `TODO.md` is tracked at HEAD — a committed plan being iterated
+   * (later grilling rounds capture user code sketches) vs a freshly seeded,
+   * uncommitted one (the seed round commits the seed revert verbatim).
+   */
+  readonly todoCommitted: boolean
   /** `.gtd/` exists. */
   readonly gtdDirExists: boolean
   /** `REVIEW.md` is present (committed and/or pending). */
@@ -125,8 +131,16 @@ export interface ResolvePayload {
   readonly diff: string
   /** The base commit for a Clean review, if one is available. */
   readonly reviewBase?: string
-  /** `git diff <reviewBase> HEAD` — non-empty distinguishes Clean from Idle. */
+  /** `git diff <reviewBase> HEAD` (workflow files excluded) — non-empty distinguishes Clean from Idle. */
   readonly refDiff?: string
+  /**
+   * The review re-trigger gate, resolved at the edge: commits exist after the
+   * last `gtd: done` (or no `gtd: done` exists). `false` forces the Clean/Idle
+   * rule to Idle even with a reviewable diff, so an approved review settles
+   * instead of immediately re-firing (the review → approve → done → review loop).
+   * Gates only *whether* a review fires — never what `reviewBase` covers.
+   */
+  readonly hasCommitsAfterLastDone: boolean
   /** Agentic review enabled (config kill-switch; false → Agentic Review force-approves). */
   readonly agenticReviewEnabled: boolean
   /** Fix-attempt cap (config, default 3). `capReached` = `testFixCount >= fixAttemptCap`. */
@@ -141,7 +155,13 @@ export interface ResolvePayload {
  * semantics live in the Events/driver tasks.
  *   - `transportReset`   — mixed-reset the `gtd: transport` HEAD, re-derive.
  *   - `seedNewFeature`   — capture raw input `gtd: new task`, revert it, seed TODO.md.
- *   - `seedAcceptReview` — seed TODO.md from the review changeset, checkout, rm REVIEW.md.
+ *   - `seedAcceptReview` — capture the review changeset `gtd: review feedback`
+ *                          (commit-then-revert), rm REVIEW.md, seed TODO.md. When HEAD
+ *                          already carries the capture subject (regen), discard partial
+ *                          state and re-derive from the commit.
+ *   - `captureGrillingEdits` — fold the pending code diff into TODO.md as a suggestion
+ *                          block, drop the code changes (reset tracked, delete
+ *                          untracked), commit the lot `gtd: grilling`.
  *   - `runTest`          — commit pending `gtd: building`, run tests; on red write
  *                          FEEDBACK (below cap) or ERRORS (`capReached`), commit `gtd: errors`.
  *                          A green re-test of a no-op fixer (clean tree, HEAD
@@ -161,6 +181,7 @@ export type EdgeAction =
   | { readonly kind: "transportReset" }
   | { readonly kind: "seedNewFeature" }
   | { readonly kind: "seedAcceptReview" }
+  | { readonly kind: "captureGrillingEdits" }
   | { readonly kind: "runTest"; readonly errorCount: number; readonly capReached: boolean }
   | {
       readonly kind: "commitPending"
@@ -256,6 +277,7 @@ const isBoundary = (subject: string): boolean =>
 
 const DEFAULT_PAYLOAD: ResolvePayload = {
   todoExists: false,
+  todoCommitted: false,
   gtdDirExists: false,
   reviewPresent: false,
   feedbackPresent: false,
@@ -274,6 +296,7 @@ const DEFAULT_PAYLOAD: ResolvePayload = {
   workingTreeClean: true,
   packages: [],
   diff: "",
+  hasCommitsAfterLastDone: true,
   agenticReviewEnabled: true,
   fixAttemptCap: 3,
   reviewThreshold: 3,
@@ -306,7 +329,12 @@ const assertLegal = (p: ResolvePayload): void => {
     throw new GtdStateError("illegal-combination", msg)
   }
   if (p.reviewPresent && p.gtdDirExists) fail("illegal combination: REVIEW.md + .gtd")
-  if (p.reviewPresent && p.todoExists) fail("illegal combination: REVIEW.md + TODO.md")
+  // An uncommitted TODO.md under a *committed* REVIEW.md is legal — plan-level
+  // notes written during a review are global feedback; the reviewDirty path
+  // captures them (Accept Review). Everything else stays illegal.
+  if (p.reviewPresent && p.todoCommitted) fail("illegal combination: REVIEW.md + committed TODO.md")
+  if (p.reviewPresent && !(p.reviewCommitted || p.reviewDirty) && p.todoExists)
+    fail("illegal combination: uncommitted REVIEW.md + TODO.md")
   if (p.feedbackPresent && p.reviewPresent) fail("illegal combination: FEEDBACK.md + REVIEW.md")
   if (p.feedbackPresent && !p.gtdDirExists) fail("illegal combination: FEEDBACK.md without .gtd")
   if (p.errorsPresent && p.feedbackPresent) fail("illegal combination: ERRORS.md + FEEDBACK.md")
@@ -445,6 +473,20 @@ export const resolve = (events: readonly GtdEvent[]): Result => {
 
   // ── 4. REVIEW.md present → review lifecycle (exhaustive) ──────────────────
   if (p.reviewPresent) {
+    // Regen carve-out: HEAD is the accept-review capture commit and REVIEW.md
+    // is present again (its annotated copy is IN that commit) — a checkout/pull
+    // or crash lost the uncommitted seed. Without this, `reviewCommitted` +
+    // clean tree would route to Done and silently approve the annotations.
+    // Re-run the seed instead; the perform discards any partial revert/seed
+    // state and re-derives everything from the capture commit.
+    if (head === "gtd: review feedback") {
+      return {
+        state: "accept-review",
+        autoAdvance: true,
+        edgeAction: { kind: "seedAcceptReview" },
+        context: buildContext(p, counters),
+      }
+    }
     if (p.reviewCommitted) {
       return {
         state: "done",
@@ -482,8 +524,11 @@ export const resolve = (events: readonly GtdEvent[]): Result => {
   // Boundary HEAD + pending changes (code and/or a new uncommitted TODO.md — the
   // only steering file possible here), or HEAD `gtd: new task` + clean tree
   // (a checkout/pull that lost the uncommitted seed — regenerate it).
+  // A *committed* TODO.md is a resumed grill: route to rule 6 even when the
+  // tree is dirty (grilling captures the code edits) — re-seeding here would
+  // clobber the developed plan with a raw seed.
   if (
-    (isBoundary(head) && !p.workingTreeClean) ||
+    (isBoundary(head) && !p.workingTreeClean && !p.todoCommitted) ||
     (head === "gtd: new task" && p.workingTreeClean)
   ) {
     return {
@@ -496,6 +541,15 @@ export const resolve = (events: readonly GtdEvent[]): Result => {
 
   // ── 6. Grilling / Grilled ─────────────────────────────────────────────────
   if (p.todoExists) {
+    // Later grilling rounds (committed plan) with pending code changes capture
+    // the code into TODO.md as a suggestion block and revert it; the seed round
+    // (uncommitted TODO.md) must instead commit the pending seed revert
+    // verbatim. Applies to BOTH the STOP and iterate paths so code cannot leak
+    // through the answer-questions round.
+    const grillCommit: EdgeAction =
+      p.todoCommitted && p.codeDirty
+        ? { kind: "captureGrillingEdits" }
+        : { kind: "commitPending", prefix: "gtd: grilling" }
     if (p.todoMarkerPresent) {
       // Open question marker → STOP for the human to answer inline.
       // If tree is already clean and HEAD is already `gtd: grilling`, this is a
@@ -504,9 +558,7 @@ export const resolve = (events: readonly GtdEvent[]): Result => {
       return {
         state: "grilling",
         autoAdvance: false,
-        ...(alreadyAtGrillingStop
-          ? {}
-          : { edgeAction: { kind: "commitPending", prefix: "gtd: grilling" } }),
+        ...(alreadyAtGrillingStop ? {} : { edgeAction: grillCommit }),
         context: buildContext(p, counters, "stop"),
       }
     }
@@ -515,7 +567,7 @@ export const resolve = (events: readonly GtdEvent[]): Result => {
       return {
         state: "grilling",
         autoAdvance: true,
-        edgeAction: { kind: "commitPending", prefix: "gtd: grilling" },
+        edgeAction: grillCommit,
         context: buildContext(p, counters, "iterate"),
       }
     }
@@ -530,10 +582,12 @@ export const resolve = (events: readonly GtdEvent[]): Result => {
 
   // ── 7. Clean / Idle ───────────────────────────────────────────────────────
   // Reached only with no steering files. A clean tree under a boundary or
-  // `gtd: package done` HEAD reviews the work (Clean) when the review base yields
-  // a non-empty diff, else there is nothing to review (Idle).
+  // `gtd: package done` HEAD reviews the work (Clean) when the re-trigger gate
+  // is open (commits exist after the last `gtd: done`) AND the review base
+  // yields a non-empty filtered diff, else there is nothing to review (Idle).
   if (p.workingTreeClean && (isBoundary(head) || head === "gtd: package done")) {
-    const reviewable = p.reviewBase !== undefined && (p.refDiff ?? "").trim().length > 0
+    const reviewable =
+      p.hasCommitsAfterLastDone && p.reviewBase !== undefined && (p.refDiff ?? "").trim().length > 0
     return {
       state: reviewable ? "clean" : "idle",
       autoAdvance: false,

--- a/src/Perf.test.ts
+++ b/src/Perf.test.ts
@@ -9,7 +9,7 @@ import { gatherEvents } from "./Events.js"
 import { GitService } from "./Git.js"
 import { ConfigService } from "./Config.js"
 import { buildPrompt } from "./Prompt.js"
-import { resolve } from "./Machine.js"
+import { DEFAULT_PAYLOAD, resolve } from "./Machine.js"
 
 // Performance smokes (non-blocking budgets, sized generously to avoid CI
 // flake): gatherEvents scans the FULL commit history on every invocation, so a
@@ -40,9 +40,21 @@ describe("performance smoke", { timeout: 180_000 }, () => {
     writeFileSync(join(repoDir, "README.md"), "# perf\n")
     git("add", "-A")
     git("commit", "-q", "-m", "chore: init")
+    git("branch", "-M", "main")
+    // Build the 300-commit history with a single `git fast-import` stream —
+    // one spawn instead of 300, keeping the suite's setup cost negligible.
+    // A commit with no file commands keeps its parent's tree (empty commits).
+    const ident = "T <t@t> 1700000000 +0000"
+    let stream = ""
     for (let i = 0; i < 300; i++) {
-      git("commit", "-q", "--allow-empty", "-m", `feat: change ${i}`)
+      const msg = `feat: change ${i}\n`
+      stream += `commit refs/heads/main\nauthor ${ident}\ncommitter ${ident}\ndata ${Buffer.byteLength(msg)}\n${msg}`
+      if (i === 0) stream += "from refs/heads/main^0\n"
+      stream += "\n"
     }
+    execFileSync("git", ["fast-import", "--quiet"], { cwd: repoDir, input: stream })
+    // fast-import moves the ref without touching the working tree; re-align.
+    git("reset", "-q", "--hard", "main")
     savedCwd = process.cwd()
     process.chdir(repoDir)
 
@@ -80,32 +92,10 @@ describe("performance smoke", { timeout: 180_000 }, () => {
       {
         type: "RESOLVE",
         payload: {
-          todoExists: false,
-          todoCommitted: false,
-          gtdDirExists: false,
-          reviewPresent: false,
-          feedbackPresent: false,
-          errorsPresent: false,
-          gtdModified: false,
-          codeDirty: false,
-          todoMarkerPresent: false,
-          feedbackCommitted: false,
-          feedbackEmpty: false,
-          feedbackContent: "",
-          reviewCommitted: false,
-          reviewDirty: false,
-          reviewCheckboxOnly: false,
-          pendingErrorsDeletion: false,
+          ...DEFAULT_PAYLOAD,
           lastCommitSubject: "feat: shipped",
-          workingTreeClean: true,
-          packages: [],
-          diff: "",
           reviewBase: "abc123",
           refDiff: bigDiff,
-          hasCommitsAfterLastDone: true,
-          agenticReviewEnabled: true,
-          fixAttemptCap: 3,
-          reviewThreshold: 3,
         },
       },
     ])

--- a/src/Perf.test.ts
+++ b/src/Perf.test.ts
@@ -1,0 +1,121 @@
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { NodeContext } from "@effect/platform-node"
+import { Effect, Layer } from "effect"
+import { afterEach, describe, expect, it } from "vitest"
+import { gatherEvents } from "./Events.js"
+import { GitService } from "./Git.js"
+import { ConfigService } from "./Config.js"
+import { buildPrompt } from "./Prompt.js"
+import { resolve } from "./Machine.js"
+
+// Performance smokes (non-blocking budgets, sized generously to avoid CI
+// flake): gatherEvents scans the FULL commit history on every invocation, so a
+// long-lived repo must not make each gtd run crawl; prompt assembly must cope
+// with a five-digit-line review diff.
+
+let repoDir: string
+let savedCwd: string
+
+const git = (...args: string[]): void => {
+  execFileSync("git", args, { cwd: repoDir, stdio: "pipe" })
+}
+
+const cleanup = (): void => {
+  process.chdir(savedCwd)
+  rmSync(repoDir, { recursive: true, force: true })
+}
+
+describe("performance smoke", { timeout: 180_000 }, () => {
+  afterEach(cleanup)
+
+  it("gatherEvents stays under 5s on a 300-commit history", async () => {
+    repoDir = mkdtempSync(join(tmpdir(), "gtd-perf-"))
+    git("init", "-q")
+    git("config", "user.name", "Test")
+    git("config", "user.email", "test@test.com")
+    git("config", "commit.gpgsign", "false")
+    writeFileSync(join(repoDir, "README.md"), "# perf\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "chore: init")
+    for (let i = 0; i < 300; i++) {
+      git("commit", "-q", "--allow-empty", "-m", `feat: change ${i}`)
+    }
+    savedCwd = process.cwd()
+    process.chdir(repoDir)
+
+    const start = performance.now()
+    const events = await Effect.runPromise(
+      gatherEvents().pipe(
+        Effect.provide(GitService.Live),
+        Effect.provide(NodeContext.layer),
+        Effect.provide(
+          Layer.succeed(ConfigService, {
+            testCommand: "true",
+            resolveModel: () => "claude-opus-4-8",
+            agenticReview: true,
+            fixAttemptCap: 3,
+            reviewThreshold: 3,
+          }),
+        ),
+      ),
+    )
+    const elapsed = performance.now() - start
+
+    expect(events.length).toBeGreaterThan(300)
+    expect(elapsed).toBeLessThan(5000)
+  })
+
+  it("prompt assembly copes with a 10k-line review diff under 2s", () => {
+    // Pure — no repo needed, but afterEach expects one to clean up.
+    repoDir = mkdtempSync(join(tmpdir(), "gtd-perf-"))
+    savedCwd = process.cwd()
+
+    const bigDiff =
+      "diff --git a/big.ts b/big.ts\n" +
+      Array.from({ length: 10_000 }, (_, i) => `+const line${i} = ${i}`).join("\n")
+    const result = resolve([
+      {
+        type: "RESOLVE",
+        payload: {
+          todoExists: false,
+          todoCommitted: false,
+          gtdDirExists: false,
+          reviewPresent: false,
+          feedbackPresent: false,
+          errorsPresent: false,
+          gtdModified: false,
+          codeDirty: false,
+          todoMarkerPresent: false,
+          feedbackCommitted: false,
+          feedbackEmpty: false,
+          feedbackContent: "",
+          reviewCommitted: false,
+          reviewDirty: false,
+          reviewCheckboxOnly: false,
+          pendingErrorsDeletion: false,
+          lastCommitSubject: "feat: shipped",
+          workingTreeClean: true,
+          packages: [],
+          diff: "",
+          reviewBase: "abc123",
+          refDiff: bigDiff,
+          hasCommitsAfterLastDone: true,
+          agenticReviewEnabled: true,
+          fixAttemptCap: 3,
+          reviewThreshold: 3,
+        },
+      },
+    ])
+
+    const start = performance.now()
+    const prompt = buildPrompt(result)
+    const elapsed = performance.now() - start
+
+    expect(result.state).toBe("clean")
+    expect(prompt).toContain("const line9999 = 9999")
+    expect(elapsed).toBeLessThan(2000)
+  })
+})

--- a/src/Prompt.ts
+++ b/src/Prompt.ts
@@ -78,8 +78,12 @@ const builtinResolveModel = (state: ModelState): string => builtinTierDefault[st
 /**
  * Picks a code fence long enough to safely wrap `content`, even when the content
  * itself contains runs of backticks (mirrors GitHub-flavored Markdown fencing).
+ * Exported for the TODO.md capture builders in Events.ts: a CommonMark closing
+ * fence must be at least as long as its opener, so sizing the outer fence past
+ * any backtick run in a captured diff keeps formatters (gtd format / prettier)
+ * from closing the block early on an indented ``` context line.
  */
-const fenceFor = (content: string): string => {
+export const fenceFor = (content: string): string => {
   let longest = 0
   for (const match of content.matchAll(/`+/g)) longest = Math.max(longest, match[0].length)
   return "`".repeat(Math.max(3, longest + 1))

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import { FileSystem } from "@effect/platform"
 import { NodeContext, NodeRuntime } from "@effect/platform-node"
 import { Effect } from "effect"
 import { ConfigService } from "./Config.js"
@@ -59,6 +60,25 @@ const program = Effect.gen(function* () {
   }
 
   const config = yield* ConfigService
+
+  // Everything gtd derives — steering files, diffs, pathspecs — is resolved
+  // against the process cwd, so running from anywhere but the repository root
+  // would silently mis-derive state. Refuse with a clear error instead. (Fails
+  // fast outside a repository too: `--show-toplevel` errors there.) Real paths
+  // are compared so symlinked cwds (e.g. macOS /tmp → /private/tmp) match.
+  const git = yield* GitService
+  const fs = yield* FileSystem.FileSystem
+  const topLevel = yield* git.topLevel()
+  const topReal = yield* fs.realPath(topLevel)
+  const cwdReal = yield* fs.realPath(process.cwd())
+  if (topReal !== cwdReal) {
+    return yield* Effect.fail(
+      new Error(
+        `gtd must be run from the repository root (${topLevel}); ` +
+          `the current directory is ${process.cwd()}`,
+      ),
+    )
+  }
 
   // Driver loop: gather → resolve → (perform edgeAction) → auto-advance past
   // edge-only states, else emit the prompt and stop.

--- a/src/prompts/clean.md
+++ b/src/prompts/clean.md
@@ -2,7 +2,9 @@
 
 The working tree is clean and there is unreviewed work since the review base.
 Produce a `REVIEW.md` that guides the user through it. The diff to review
-(`git diff <base> HEAD`) is inlined below.
+(`git diff <base> HEAD`) is inlined below; workflow files (REVIEW.md, TODO.md,
+FEEDBACK.md, ERRORS.md, `.gtd/`) are already excluded — never write review
+chunks about them.
 
 ### Orchestration
 

--- a/src/prompts/grilling.md
+++ b/src/prompts/grilling.md
@@ -33,11 +33,19 @@ The subagent works entirely by editing `TODO.md` (it cannot talk to the user):
    exactly what changes, and why — grounded in the codebase. Do this on every
    iteration, whether or not any questions remain open. A plan that still
    contains only the seed "Captured input" block is never ready to converge.
-2. For every question the user has just answered (the answer written in place of
+2. **Read any "Captured input" diff block as feedback, not finished work:** code
+   changes are suggestions — fold them into the plan and re-implement them
+   properly, including test coverage, rather than restoring them verbatim; code
+   comments are positional feedback about the code at that location;
+   TODO.md/REVIEW.md text changes are global feedback on the plan or the
+   reviewed work as a whole; checkbox flips in a captured REVIEW.md diff are
+   approval noise — ignore them. gtd has already reverted captured code from the
+   working tree.
+3. For every question the user has just answered (the answer written in place of
    its `<!-- user answers here -->` marker): integrate the answer into the plan
    body, then move the question into a `## Resolved` section at the bottom,
    recording the user's response as `**Answer:** …`.
-3. Continue interviewing the plan with this discipline:
+4. Continue interviewing the plan with this discipline:
    - **Explore before asking** — if the codebase or docs answer it, explore
      instead of asking.
    - **Prioritize high-stakes questions** — hard-to-reverse decisions before
@@ -48,9 +56,9 @@ The subagent works entirely by editing `TODO.md` (it cannot talk to the user):
      change the implementation.
    - Every answer opens new branches; generate fresh questions for any ambiguity
      the answers surface.
-4. Write each new open question near the top of the file, each followed on its
+5. Write each new open question near the top of the file, each followed on its
    own line by the `<!-- user answers here -->` marker.
-5. If the plan is now fully resolved, leave **no** markers and write the
+6. If the plan is now fully resolved, leave **no** markers and write the
    sentinel `no open questions — run gtd to plan` instead. Only write the
    sentinel once `TODO.md` holds a concrete plan — the sentinel signals the plan
    is ready to decompose, not that planning can be skipped.

--- a/src/prompts/idle.md
+++ b/src/prompts/idle.md
@@ -1,7 +1,7 @@
 ## Task: Nothing to do
 
-There are no steering files, the working tree is clean, and the last review is
-already closed (`gtd: done`). No plan is in progress and there is nothing to
-review.
+There are no steering files, the working tree is clean, and there is nothing to
+review — the last review is already closed (`gtd: done`, with no new commits
+since), or no reviewable changes exist. No plan is in progress.
 
 Report that the repository is idle — nothing for gtd to do.

--- a/tests/integration/features/close-package.feature
+++ b/tests/integration/features/close-package.feature
@@ -27,13 +27,27 @@ Feature: Close package — one gtd: package done per package
 
   Scenario: Closing the last package removes .gtd and advances to Clean
     Given a test project
+    And a commit "gtd: grilling" that adds "TODO.md" with:
+      """
+      # Plan
+      - [ ] implement the only helper
+      """
+    And a commit "gtd: planning" that deletes "TODO.md"
     And a commit "gtd: planning" that adds ".gtd/01-foo/01-task.md" with:
       """
       Implement the only helper.
+      """
+    And a commit "gtd: building" that adds "src/helper.ts" with:
+      """
+      export const helper = () => 42
       """
     And an empty file "FEEDBACK.md"
     When I run gtd
     Then it succeeds
     And the last commit subject is "gtd: package done"
     And the file ".gtd" does not exist
+    # The review spans the whole task (base = first gtd: grilling) but the
+    # workflow-file churn (TODO.md, .gtd/) is filtered out of the diff.
     And stdout contains "## Task: Create `REVIEW.md` for the finished work"
+    And stdout contains "src/helper.ts"
+    And stdout does not contain "a/.gtd/01-foo/01-task.md"

--- a/tests/integration/features/environment.feature
+++ b/tests/integration/features/environment.feature
@@ -1,0 +1,189 @@
+Feature: Hostile environments and unusual invocations
+
+  gtd derives everything from the repository it is invoked in. These scenarios
+  pin the behavior at the environment's edges: wrong cwd, missing repo, empty
+  repo, unusual HEADs, user hooks, platform line endings, signing, and
+  submodules. Scenarios marked KNOWN BUG assert the intended (spec) behavior
+  and are expected to fail until the bug is fixed — see TODO.md § Bugs found.
+
+  # KNOWN BUG (documented, not fixed): steering files and diff pathspecs are
+  # resolved against the process cwd, not the repo root. From a subdirectory
+  # the committed TODO.md is invisible and gtd stumbles into a MISLEADING
+  # corruption error ("no precedence rule matched") — or worse, in other
+  # states it would silently mis-derive and commit. Decided spec (grilled
+  # 2026-07-02): hard-error with a clear message naming the repo-root
+  # requirement.
+  Scenario: Running gtd from a subdirectory refuses with a clear repo-root error
+    Given a test project
+    And a commit "gtd: grilling" that adds "TODO.md" with:
+      """
+      # Plan
+
+      A converged plan.
+
+      no open questions — run gtd to plan
+      """
+    And a subdirectory "src"
+    When I run gtd from the subdirectory "src"
+    Then it fails
+    And stderr contains "repository root"
+
+  # KNOWN BUG (documented, not fixed): outside a git repository every git
+  # probe is swallowed by a fallback, so gtd resolves to Idle and prints
+  # "Nothing to do" with exit 0. Spec: fail fast with a clear error.
+  Scenario: Running gtd outside a git repository fails cleanly
+    Given a plain directory that is not a git repository
+    When I run gtd
+    Then it fails
+    And stderr contains "gtd:"
+
+  # KNOWN BUG (documented, not fixed): with no commits, gatherEvents skips the
+  # porcelain probe entirely (`hasCommits ? statusPorcelain() : ""`), so a
+  # dirty tree in a freshly initialized repository is invisible and gtd
+  # settles Idle instead of seeding the new feature.
+  Scenario: A fresh repository with no commits seeds a new feature from the empty tree
+    Given a fresh git repository with no commits
+    And a file "src/idea.ts" with:
+      """
+      export const idea = () => 42
+      """
+    When I run gtd
+    Then it succeeds
+    And the git log contains "gtd: new task"
+    And the last commit subject is "gtd: grilling"
+    And the file "TODO.md" contains "src/idea.ts"
+
+  Scenario: A detached HEAD on branch work still reviews from the merge-base
+    Given a test project
+    And a default branch "main"
+    And a branch "feature"
+    And a commit "feat: detached work" that adds "src/work.ts" with:
+      """
+      export const work = () => 1
+      """
+    And the repository is in detached HEAD state
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Create `REVIEW.md` for the finished work"
+    And stdout contains "src/work.ts"
+
+  # A merge commit at HEAD is documented-unsupported (STATES.md): the machine
+  # folds first-parent history only. It must degrade gracefully — no crash,
+  # no destructive action — on the default branch it settles Idle.
+  Scenario: A merge commit at HEAD degrades gracefully
+    Given a test project
+    And a merge commit merging a branch with a commit "feat: side work" that adds "src/side.ts" with:
+      """
+      export const side = () => 1
+      """
+    Then I record the commit count
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Nothing to do"
+    And the commit count is unchanged
+
+  Scenario: A transport commit as the root commit fails with a clear error
+    Given a fresh git repository with no commits
+    And a file "work.ts" with:
+      """
+      export const carried = 1
+      """
+    And the working tree is committed as "gtd: transport"
+    When I run gtd
+    Then it fails
+    And stderr contains "cannot reset transport commit"
+
+  Scenario: A pre-commit hook that reformats steering files does not break the flow
+    Given a test project
+    And prettier is available in the test project
+    And the working tree is committed as "chore: prettier config"
+    And an executable pre-commit hook with:
+      """
+      #!/bin/sh
+      FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^(TODO|REVIEW)\.md$')
+      if [ -n "$FILES" ]; then
+        npx prettier --write $FILES
+        git add $FILES
+      fi
+      """
+    And a file "TODO.md" with:
+      """
+      # Plan
+
+      This is a very long line that exceeds eighty characters and will be wrapped by the hook on commit.
+
+      no open questions — run gtd to plan
+      """
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: grilling"
+    When I run gtd
+    Then it succeeds
+
+  Scenario: A failing pre-commit hook surfaces the error and the flow resumes after removal
+    Given a test project
+    And an executable pre-commit hook with:
+      """
+      #!/bin/sh
+      echo "hook rejected" >&2
+      exit 1
+      """
+    And a file "src/idea.ts" with:
+      """
+      export const idea = () => 1
+      """
+    When I run gtd
+    Then it fails
+    Given the pre-commit hook is removed
+    When I run gtd
+    Then it succeeds
+    And the git log contains "gtd: new task"
+    And the last commit subject is "gtd: grilling"
+
+  # KNOWN BUG (documented, not fixed): a CRLF editor rewrites every line
+  # ending, so the checkbox-only detector sees changed line content and treats
+  # pure ticking as substantive feedback (Accept Review) instead of approval.
+  # Spec: checkbox-only ticking approves regardless of line-ending churn.
+  Scenario: Checkbox approval survives a CRLF editor
+    Given a test project
+    And a commit "feat: add calculator" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd: awaiting review" that adds "REVIEW.md" with:
+      """
+      # Review
+
+      - [ ] ./src/calc.ts#1
+      """
+    And "REVIEW.md" is modified with CRLF line endings to:
+      """
+      # Review
+
+      - [x] ./src/calc.ts#1
+      """
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: done"
+    And the file "REVIEW.md" does not exist
+
+  Scenario: Unusable commit signing surfaces a clean error
+    Given a test project
+    And git config "commit.gpgsign" is "true"
+    And git config "gpg.program" is "/nonexistent-gpg-binary"
+    And a file "src/idea.ts" with:
+      """
+      export const idea = () => 1
+      """
+    When I run gtd
+    Then it fails
+
+  Scenario: A submodule pointer change is routed as a code change without crashing
+    Given a test project
+    And a committed submodule at "vendor/dep"
+    And the submodule at "vendor/dep" has a new commit
+    When I run gtd
+    Then it succeeds
+    And the git log contains "gtd: new task"
+    And the last commit subject is "gtd: grilling"
+    And the file "TODO.md" exists

--- a/tests/integration/features/environment.feature
+++ b/tests/integration/features/environment.feature
@@ -3,16 +3,11 @@ Feature: Hostile environments and unusual invocations
   gtd derives everything from the repository it is invoked in. These scenarios
   pin the behavior at the environment's edges: wrong cwd, missing repo, empty
   repo, unusual HEADs, user hooks, platform line endings, signing, and
-  submodules. Scenarios marked KNOWN BUG assert the intended (spec) behavior
-  and are expected to fail until the bug is fixed — see TODO.md § Bugs found.
+  submodules.
 
-  # KNOWN BUG (documented, not fixed): steering files and diff pathspecs are
-  # resolved against the process cwd, not the repo root. From a subdirectory
-  # the committed TODO.md is invisible and gtd stumbles into a MISLEADING
-  # corruption error ("no precedence rule matched") — or worse, in other
-  # states it would silently mis-derive and commit. Decided spec (grilled
-  # 2026-07-02): hard-error with a clear message naming the repo-root
-  # requirement.
+  # Steering files and diff pathspecs are resolved against the process cwd, so
+  # anywhere but the repo root would silently mis-derive state — gtd refuses
+  # with a clear error instead (decided spec, grilled 2026-07-02).
   Scenario: Running gtd from a subdirectory refuses with a clear repo-root error
     Given a test project
     And a commit "gtd: grilling" that adds "TODO.md" with:
@@ -28,19 +23,12 @@ Feature: Hostile environments and unusual invocations
     Then it fails
     And stderr contains "repository root"
 
-  # KNOWN BUG (documented, not fixed): outside a git repository every git
-  # probe is swallowed by a fallback, so gtd resolves to Idle and prints
-  # "Nothing to do" with exit 0. Spec: fail fast with a clear error.
   Scenario: Running gtd outside a git repository fails cleanly
     Given a plain directory that is not a git repository
     When I run gtd
     Then it fails
     And stderr contains "gtd:"
 
-  # KNOWN BUG (documented, not fixed): with no commits, gatherEvents skips the
-  # porcelain probe entirely (`hasCommits ? statusPorcelain() : ""`), so a
-  # dirty tree in a freshly initialized repository is invisible and gtd
-  # settles Idle instead of seeding the new feature.
   Scenario: A fresh repository with no commits seeds a new feature from the empty tree
     Given a fresh git repository with no commits
     And a file "src/idea.ts" with:
@@ -140,10 +128,8 @@ Feature: Hostile environments and unusual invocations
     And the git log contains "gtd: new task"
     And the last commit subject is "gtd: grilling"
 
-  # KNOWN BUG (documented, not fixed): a CRLF editor rewrites every line
-  # ending, so the checkbox-only detector sees changed line content and treats
-  # pure ticking as substantive feedback (Accept Review) instead of approval.
-  # Spec: checkbox-only ticking approves regardless of line-ending churn.
+  # A CRLF editor rewrites every line ending; the checkbox-only detector
+  # treats identical-after-\r pairs as churn so pure ticking still approves.
   Scenario: Checkbox approval survives a CRLF editor
     Given a test project
     And a commit "feat: add calculator" that adds "src/calc.ts" with:
@@ -170,6 +156,10 @@ Feature: Hostile environments and unusual invocations
   Scenario: Unusable commit signing surfaces a clean error
     Given a test project
     And git config "commit.gpgsign" is "true"
+    # Pin the signing mechanism locally: a host-level `gpg.format = ssh` (e.g.
+    # 1Password's signer in the developer's global config) would otherwise
+    # bypass gpg.program entirely and sign successfully.
+    And git config "gpg.format" is "openpgp"
     And git config "gpg.program" is "/nonexistent-gpg-binary"
     And a file "src/idea.ts" with:
       """

--- a/tests/integration/features/environment.feature
+++ b/tests/integration/features/environment.feature
@@ -18,7 +18,7 @@ Feature: Hostile environments and unusual invocations
 
       no open questions — run gtd to plan
       """
-    And a subdirectory "src"
+    And a directory "src"
     When I run gtd from the subdirectory "src"
     Then it fails
     And stderr contains "repository root"

--- a/tests/integration/features/formatting.feature
+++ b/tests/integration/features/formatting.feature
@@ -3,7 +3,16 @@ Feature: Automatic markdown formatting on commit
   Scenario: Pre-commit hook wraps long lines in TODO.md
     Given a test project
     And prettier is available in the test project
-    And the pre-commit hook from the project is installed
+    And an executable pre-commit hook with:
+      """
+      #!/bin/sh
+      FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^(TODO|REVIEW)\.md$')
+
+      if [ -n "$FILES" ]; then
+        npx prettier --write $FILES
+        git add $FILES
+      fi
+      """
     And a file "TODO.md" with:
       """
       This is a very long line that exceeds eighty characters and should be wrapped by prettier when committed.
@@ -15,7 +24,16 @@ Feature: Automatic markdown formatting on commit
   Scenario: Pre-commit hook wraps long lines in REVIEW.md
     Given a test project
     And prettier is available in the test project
-    And the pre-commit hook from the project is installed
+    And an executable pre-commit hook with:
+      """
+      #!/bin/sh
+      FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^(TODO|REVIEW)\.md$')
+
+      if [ -n "$FILES" ]; then
+        npx prettier --write $FILES
+        git add $FILES
+      fi
+      """
     And a file "REVIEW.md" with:
       """
       This is a very long line that exceeds eighty characters and should be wrapped by prettier when committed.
@@ -90,7 +108,16 @@ Feature: Automatic markdown formatting on commit
   Scenario: Pre-commit hook does not modify other markdown files
     Given a test project
     And prettier is available in the test project
-    And the pre-commit hook from the project is installed
+    And an executable pre-commit hook with:
+      """
+      #!/bin/sh
+      FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^(TODO|REVIEW)\.md$')
+
+      if [ -n "$FILES" ]; then
+        npx prettier --write $FILES
+        git add $FILES
+      fi
+      """
     And a file "notes.md" with:
       """
       This is a very long line that exceeds eighty characters and should NOT be wrapped because it is not TODO or REVIEW.

--- a/tests/integration/features/grilling.feature
+++ b/tests/integration/features/grilling.feature
@@ -117,6 +117,77 @@ Feature: Grilling — the 3-way convergence gate on TODO.md
     And the last commit subject is "gtd: grilling"
     And stdout contains "Open questions await the user"
 
+  # Later grilling rounds (committed plan) treat user code sketches as
+  # suggestions: the diff is folded into TODO.md and the code is reverted, so
+  # nothing lands on the branch without going through plan → build → test →
+  # review. The seed round (uncommitted TODO.md) still commits the seed revert
+  # verbatim.
+  Scenario: Code sketched during grilling is captured into the plan and reverted
+    Given a test project
+    And a commit "gtd: grilling" that adds "TODO.md" with:
+      """
+      # Plan
+
+      Build a calculator.
+      """
+    And a file "src/sketch.ts" with:
+      """
+      export const sketch = () => 1
+      """
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: grilling"
+    And the file "src/sketch.ts" does not exist
+    And the file "TODO.md" contains "Captured input (grilling)"
+    And the file "TODO.md" contains "export const sketch"
+    And the file "TODO.md" contains "Interpret the captured diff"
+    And stdout contains "## Task: Grill the plan in `TODO.md`"
+
+  Scenario: Code sketched while questions are open is captured and gtd still stops
+    Given a test project
+    And a commit "gtd: grilling" that adds "TODO.md" with:
+      """
+      # Plan
+
+      ## Which operations?
+
+      <!-- user answers here -->
+      """
+    And a file "src/sketch.ts" with:
+      """
+      export const sketch = () => 1
+      """
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: grilling"
+    And the file "src/sketch.ts" does not exist
+    And the file "TODO.md" contains "export const sketch"
+    And stdout contains "Open questions await the user"
+
+  # A committed TODO.md under a boundary HEAD is a resumed grill — even with a
+  # dirty tree it must not re-seed (New Feature would clobber the developed
+  # plan); the code edits are captured instead.
+  Scenario: A resumed grill with code edits does not re-seed over the committed plan
+    Given a test project
+    And a commit "gtd: grilling" that adds "TODO.md" with:
+      """
+      # Plan
+
+      A carefully developed plan.
+      """
+    And a commit "chore: unrelated housekeeping"
+    And a file "src/sketch.ts" with:
+      """
+      export const sketch = () => 1
+      """
+    When I run gtd
+    Then it succeeds
+    And the git log does not contain "gtd: new task"
+    And the last commit subject is "gtd: grilling"
+    And the file "TODO.md" contains "A carefully developed plan."
+    And the file "TODO.md" contains "export const sketch"
+    And the file "src/sketch.ts" does not exist
+
   Scenario: A .gtd package file whose name contains a space is classified as gtd, not code
     Given a test project
     And a commit "gtd: planning" that adds ".gtd/01-feature/my task.md" with:

--- a/tests/integration/features/illegal-combinations.feature
+++ b/tests/integration/features/illegal-combinations.feature
@@ -33,6 +33,35 @@ Feature: Illegal steering-file combinations hard-error
     Then it fails
     And stderr contains "illegal combination: FEEDBACK.md without .gtd"
 
+  Scenario: A committed TODO.md alongside REVIEW.md hard-errors
+    Given a test project
+    And a file "TODO.md" with:
+      """
+      # Plan
+      """
+    And a file "REVIEW.md" with:
+      """
+      # Review
+      """
+    And the working tree is committed as "feat: both steering files"
+    When I run gtd
+    Then it fails
+    And stderr contains "illegal combination: REVIEW.md + committed TODO.md"
+
+  Scenario: An uncommitted REVIEW.md alongside TODO.md hard-errors
+    Given a test project
+    And a file "TODO.md" with:
+      """
+      # Plan
+      """
+    And a file "REVIEW.md" with:
+      """
+      # Review
+      """
+    When I run gtd
+    Then it fails
+    And stderr contains "illegal combination: uncommitted REVIEW.md + TODO.md"
+
   Scenario: REVIEW.md alongside a .gtd directory hard-errors
     Given a test project
     And a file ".gtd/01-foo/01-task.md" with:

--- a/tests/integration/features/journeys.feature
+++ b/tests/integration/features/journeys.feature
@@ -1,0 +1,396 @@
+Feature: Full lifecycle journeys — many gtd runs across every state seam
+
+  Per-state scenarios pin each state in isolation; these journeys chain many
+  gtd invocations through complete lifecycles, simulating the agent between
+  runs (developing the plan, decomposing packages, writing code, recording
+  review verdicts) and asserting the exact commit-subject sequence at the end.
+  They guard the seams between states that isolated scenarios cannot see.
+
+  Scenario: Happy path — raw input to approved review and stable idle
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      testCommand: "true"
+      """
+    And a file "src/input.ts" with:
+      """
+      export const rawIdea = () => 42
+      """
+    # Run 1: New Feature captures the input, reverts it, seeds TODO.md;
+    # Grilling commits the seed and prompts.
+    When I run gtd
+    Then it succeeds
+    And the git log contains "gtd: new task"
+    And the last commit subject is "gtd: grilling"
+    And the file "src/input.ts" does not exist
+    And the file "TODO.md" contains "src/input.ts"
+    And stdout contains "## Task: Grill the plan in `TODO.md`"
+    # The agent develops the plan and leaves an open question.
+    When "TODO.md" is modified to:
+      """
+      # Plan
+
+      Implement a calculator.
+
+      ## Which operations?
+
+      <!-- user answers here -->
+      """
+    # Run 2: open marker → commit and STOP for the user.
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: grilling"
+    And stdout contains "Open questions await the user"
+    # The user answers inline and the plan converges.
+    When "TODO.md" is modified to:
+      """
+      # Plan
+
+      Implement a calculator with add only, in src/calc.ts.
+
+      no open questions — run gtd to plan
+      """
+    # Run 3: pending plan edits → grilling iterates.
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: grilling"
+    And stdout contains "### Develop the plan"
+    # Run 4: clean converged plan → Grilled, prompts decomposition.
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: grilled"
+    And stdout contains "## Task: Decompose the plan into work packages"
+    # The agent decomposes into one package.
+    When a file ".gtd/01-calc/01-add.md" with:
+      """
+      Implement add() in src/calc.ts.
+      """
+    # Run 5: modified .gtd → Planning commits it.
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: planning"
+    # Run 6: clean .gtd → Building deletes TODO.md and prompts the build.
+    When I run gtd
+    Then it succeeds
+    And the file "TODO.md" does not exist
+    And stdout contains "## Task: Build one work package"
+    And stdout contains "Implement add() in src/calc.ts."
+    # The builder writes the code.
+    When a file "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    # Run 7: Testing commits gtd: building, gate is green → Agentic Review.
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: building"
+    And stdout contains "## Task: Agentic review of the built package"
+    # The review agent approves with an empty FEEDBACK.md.
+    When an empty file "FEEDBACK.md"
+    # Run 8: Close package, .gtd gone → Clean prompts the human review.
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: package done"
+    And the file ".gtd" does not exist
+    And stdout contains "## Task: Create `REVIEW.md` for the finished work"
+    And stdout contains "src/calc.ts"
+    And stdout does not contain "a/TODO.md"
+    # The review agent writes REVIEW.md.
+    When a file "REVIEW.md" with:
+      """
+      # Review
+
+      ## Add calculator
+
+      - [ ] ./src/calc.ts#1
+      """
+    # Run 9: Await Review commits it and stops for the human.
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: awaiting review"
+    And stdout contains "## Task: Await the user's review"
+    # Run 10: the human approves by running gtd with no edits → Done → Idle.
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: done"
+    And the file "REVIEW.md" does not exist
+    And stdout contains "## Task: Nothing to do"
+    And I record the commit count
+    # Run 11: Idle is stable — no loop back into review.
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Nothing to do"
+    And the commit count is unchanged
+    And the commit subjects from oldest to newest are:
+      """
+      chore: initial commit
+      chore: add .gtdrc
+      gtd: new task
+      gtd: grilling
+      gtd: grilling
+      gtd: grilling
+      gtd: grilled
+      gtd: planning
+      gtd: planning
+      gtd: building
+      gtd: package done
+      gtd: awaiting review
+      gtd: done
+      """
+
+  Scenario: Feedback journey — annotations rebuild within the open process
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      testCommand: "true"
+      """
+    And a commit "gtd: grilling" that adds "TODO.md" with:
+      """
+      # Plan
+      - [ ] add greeter
+      """
+    And a commit "gtd: planning" that deletes "TODO.md"
+    And a commit "gtd: building" that adds "src/greet.ts" with:
+      """
+      export const greet = (name: string) => `Hello, ${name}`
+      """
+    And a commit "gtd: awaiting review" that adds "REVIEW.md" with:
+      """
+      # Review
+
+      ## Add greeter
+
+      - [ ] ./src/greet.ts#1
+      """
+    # The reviewer asks for more instead of approving.
+    When "REVIEW.md" is modified to:
+      """
+      # Review
+
+      ## Add greeter
+
+      - [ ] ./src/greet.ts#1
+
+      Please also add a farewell function.
+      """
+    # Run 1: Accept Review captures the feedback and re-enters grilling.
+    When I run gtd
+    Then it succeeds
+    And the git log contains "gtd: review feedback"
+    And the last commit subject is "gtd: grilling"
+    And the file "REVIEW.md" does not exist
+    And the file "TODO.md" contains "farewell"
+    # The agent develops the follow-up plan to convergence.
+    When "TODO.md" is modified to:
+      """
+      # Plan
+
+      Add farewell() in src/farewell.ts.
+
+      no open questions — run gtd to plan
+      """
+    When I run gtd
+    Then it succeeds
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: grilled"
+    When a file ".gtd/01-farewell/01-task.md" with:
+      """
+      Implement farewell() in src/farewell.ts.
+      """
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: planning"
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Build one work package"
+    When a file "src/farewell.ts" with:
+      """
+      export const farewell = (name: string) => `Goodbye, ${name}`
+      """
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: building"
+    When an empty file "FEEDBACK.md"
+    # The follow-up review covers only the new work — and the process is still
+    # open: no `gtd: done` was ever committed on the feedback path.
+    When I run gtd
+    Then it succeeds
+    And the git log does not contain "gtd: done"
+    And stdout contains "## Task: Create `REVIEW.md` for the finished work"
+    And stdout contains "src/farewell.ts"
+    And stdout does not contain "src/greet.ts"
+    And stdout does not contain "a/REVIEW.md"
+    And stdout does not contain "a/TODO.md"
+    When a file "REVIEW.md" with:
+      """
+      # Review
+
+      ## Add farewell
+
+      - [ ] ./src/farewell.ts#1
+      """
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: awaiting review"
+    # The human approves the follow-up → the process finally closes.
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: done"
+    And stdout contains "## Task: Nothing to do"
+
+  Scenario: Escalation journey — cap, human resume, fresh budget
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      testCommand: bash gate.sh
+      fixAttemptCap: 2
+      """
+    And a commit "chore: gate" that adds "gate.sh" with:
+      """
+      test -f green.marker
+      """
+    And a commit "gtd: grilling" that adds "TODO.md" with:
+      """
+      # Plan
+      - [ ] add helper
+      """
+    And a commit "gtd: planning" that deletes "TODO.md"
+    And a commit "gtd: planning" that adds ".gtd/01-helper/01-task.md" with:
+      """
+      Implement the helper.
+      """
+    And a file "src/helper.ts" with:
+      """
+      export const helper = () => 1
+      """
+    # Run 1: red gate below the cap → FEEDBACK.md → Fixing commits its removal.
+    When I run gtd
+    Then it succeeds
+    And the git log contains "gtd: errors"
+    And the last commit subject is "gtd: fixing"
+    And stdout contains "## Task: Fix the package against `FEEDBACK.md`"
+    # Run 2: the fixer produced no change — re-test is still red, budget 1/2.
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: fixing"
+    And stdout contains "## Task: Fix the package against `FEEDBACK.md`"
+    # Run 3: re-test red at the cap → ERRORS.md → Escalate STOP.
+    When I run gtd
+    Then it succeeds
+    And the file "ERRORS.md" exists
+    And stdout contains "## Task: Escalate — the test gate is stuck"
+    # The human fixes the underlying problem and removes ERRORS.md.
+    Given a deleted committed file "ERRORS.md"
+    And a file "green.marker" with:
+      """
+      green
+      """
+    # Run 4: the budget is reset — re-test goes green, no re-escalation.
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: building"
+    And the file "ERRORS.md" does not exist
+    And stdout contains "## Task: Agentic review of the built package"
+
+  Scenario: Two-package journey — counters reset at the package seam
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      testCommand: "true"
+      """
+    And a commit "gtd: grilling" that adds "TODO.md" with:
+      """
+      # Plan
+      - [ ] two helpers
+      """
+    And a commit "gtd: planning" that deletes "TODO.md"
+    And a commit "gtd: planning" that adds ".gtd/01-one/01-task.md" with:
+      """
+      Implement the first helper.
+      """
+    And a commit "gtd: planning" that adds ".gtd/02-two/01-task.md" with:
+      """
+      Implement the second helper.
+      """
+    # Run 1: Building selects the first package.
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Build one work package"
+    And stdout contains "Implement the first helper."
+    When a file "src/one.ts" with:
+      """
+      export const one = 1
+      """
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: building"
+    When an empty file "FEEDBACK.md"
+    # Close the first package → Building immediately offers the second.
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: package done"
+    And the file ".gtd/01-one/01-task.md" does not exist
+    And the file ".gtd/02-two/01-task.md" exists
+    And stdout contains "Implement the second helper."
+    When a file "src/two.ts" with:
+      """
+      export const two = 2
+      """
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: building"
+    When an empty file "FEEDBACK.md"
+    # Close the last package → Clean reviews the whole task, plumbing-free.
+    When I run gtd
+    Then it succeeds
+    And the file ".gtd" does not exist
+    And stdout contains "## Task: Create `REVIEW.md` for the finished work"
+    And stdout contains "src/one.ts"
+    And stdout contains "src/two.ts"
+    And stdout does not contain "a/.gtd"
+
+  Scenario: Multi-review branch — approvals gate, new commits re-open
+    Given a test project
+    And a default branch "main"
+    And a branch "feature"
+    And a commit "feat: first slice" that adds "src/first.ts" with:
+      """
+      export const first = 1
+      """
+    And a commit "gtd: awaiting review" that adds "REVIEW.md" with:
+      """
+      # Review
+
+      - [ ] ./src/first.ts#1
+      """
+    # Run 1: approve → done → idle; the gate keeps it there.
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: done"
+    And stdout contains "## Task: Nothing to do"
+    # New work lands after the approval — the whole-branch review re-opens.
+    Given a commit "feat: second slice" that adds "src/second.ts" with:
+      """
+      export const second = 2
+      """
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Create `REVIEW.md` for the finished work"
+    And stdout contains "src/first.ts"
+    And stdout contains "src/second.ts"
+    When a file "REVIEW.md" with:
+      """
+      # Review
+
+      - [ ] ./src/first.ts#1
+      - [ ] ./src/second.ts#1
+      """
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: awaiting review"
+    # Run: approve the second review → done → idle again.
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: done"
+    And stdout contains "## Task: Nothing to do"

--- a/tests/integration/features/replay.feature
+++ b/tests/integration/features/replay.feature
@@ -19,3 +19,72 @@ Feature: Replay — any committed point resumes deterministically
     Then it succeeds
     And the last commit subject is "gtd: planning"
     And stdout contains "## Task: Build one work package"
+
+  # STOP/prompt states with no edge action must be perfectly replayable. (Auto
+  # and approval states are intentionally NOT idempotent: re-running at
+  # `gtd: new task` regenerates the seed, and re-running at a committed
+  # REVIEW.md approves it — see STATES.md § Done.)
+  Scenario: Re-running at the Escalate gate is idempotent
+    Given a test project
+    And a commit "gtd: planning" that adds ".gtd/01-foo/01-task.md" with:
+      """
+      Implement the helper.
+      """
+    And a commit "gtd: errors" that adds "ERRORS.md" with:
+      """
+      persistent failure output
+      """
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Escalate — the test gate is stuck"
+    And I record the commit count
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Escalate — the test gate is stuck"
+    And the commit count is unchanged
+    And the file "ERRORS.md" exists
+
+  Scenario: Re-running at Clean (review authoring pending) is idempotent
+    Given a test project
+    And a default branch "main"
+    And a branch "feature"
+    And a commit "feat: branch work" that adds "src/feat.ts" with:
+      """
+      export const feat = 1
+      """
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Create `REVIEW.md` for the finished work"
+    And I record the commit count
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Create `REVIEW.md` for the finished work"
+    And the commit count is unchanged
+
+  # Interruption recovery: a run killed between the `gtd: building` commit and
+  # the review verdict leaves a clean tree under HEAD `gtd: building` — the
+  # next run re-detects Agentic Review with no data loss, indefinitely.
+  Scenario: Re-running at a pending agentic review is idempotent
+    Given a test project
+    And a commit "gtd: grilling" that adds "TODO.md" with:
+      """
+      # Plan
+      - [ ] helper
+      """
+    And a commit "gtd: planning" that deletes "TODO.md"
+    And a commit "gtd: planning" that adds ".gtd/01-foo/01-task.md" with:
+      """
+      Implement the helper.
+      """
+    And a commit "gtd: building" that adds "src/helper.ts" with:
+      """
+      export const helper = () => 1
+      """
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Agentic review of the built package"
+    And I record the commit count
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Agentic review of the built package"
+    And the commit count is unchanged

--- a/tests/integration/features/review.feature
+++ b/tests/integration/features/review.feature
@@ -262,6 +262,58 @@ Feature: Review lifecycle — Clean → Await → Accept/Done → Idle
     And the file "TODO.md" contains "Please also add a subtract function."
     And stdout contains "## Task: Grill the plan in `TODO.md`"
 
+  # Checkbox ticks are approval signals, but ONLY when nothing else changed:
+  # mixed with a code edit they ride along as feedback into the capture.
+  Scenario: Checkbox ticks mixed with a code edit are feedback, not approval
+    Given a test project
+    And a commit "feat: add calculator" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd: awaiting review" that adds "REVIEW.md" with:
+      """
+      # Review
+
+      - [ ] ./src/calc.ts#1
+      """
+    And "REVIEW.md" is modified to:
+      """
+      # Review
+
+      - [x] ./src/calc.ts#1
+      """
+    And "src/calc.ts" is modified to:
+      """
+      export const add = (a: number, b: number) => a + b
+      export const sub = (a: number, b: number) => a - b
+      """
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: grilling"
+    And the git log contains "gtd: review feedback"
+    And the git log does not contain "gtd: done"
+    And the file "TODO.md" contains "export const sub"
+    And the file "src/calc.ts" does not contain "export const sub"
+
+  Scenario: Emptying REVIEW.md's content is a textual change, not an approval
+    Given a test project
+    And a commit "feat: add calculator" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd: awaiting review" that adds "REVIEW.md" with:
+      """
+      # Review
+
+      - [ ] ./src/calc.ts#1
+      """
+    And an empty file "REVIEW.md"
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: grilling"
+    And the git log does not contain "gtd: done"
+    And the file "TODO.md" exists
+
   # An uncommitted TODO.md under a committed REVIEW.md is global feedback, not
   # an illegal combination — the reviewer reached for plan-level notes.
   Scenario: Plan notes written into TODO.md during a review are feedback, not an error

--- a/tests/integration/features/review.feature
+++ b/tests/integration/features/review.feature
@@ -2,23 +2,35 @@ Feature: Review lifecycle — Clean → Await → Accept/Done → Idle
 
   With no steering files and a clean tree, unreviewed work since the review base
   enters Clean (author REVIEW.md). Committing REVIEW.md awaits the user; a later
-  run with no edits approves (`gtd: done` → Idle), while edits to the code or
-  REVIEW.md seed a fresh plan (Accept Review → Grilling).
+  run with no edits approves (`gtd: done` → Idle), while substantive edits to
+  the code or REVIEW.md are feedback: they seed a fresh plan (Accept Review →
+  Grilling) within the same open process — no `gtd: done` is committed on the
+  feedback path.
 
-  The review base is determined by four rules:
+  The review base (what a review covers) is determined by four rules:
   1. Within a gtd process (a `gtd: grilling` commit exists after the last
      `gtd: done`), first review → base = first `gtd: grilling` of the current
      cycle; refDiff spans the whole task.
-  2. Within a process, incremental (a `gtd: awaiting review` also exists in the
+  2. Within a process, follow-up (a `gtd: awaiting review` also exists in the
      current cycle) → base = last `gtd: awaiting review`; refDiff spans only
-     post-review changes.
-  3. Outside a process, on a feature branch → base = merge-base with the default
-     branch; refDiff spans the whole branch.
+     the work packages built after that review.
+  3. Outside a process, on a feature branch → base = merge-base with the
+     default branch; refDiff always spans the whole branch, even when a prior
+     process completed on it (approved work is re-covered by design).
   4. Outside a process, on the default branch → skip review (Idle;
      `reviewBase`/`refDiff` unset).
 
-  Scenario: Freshly committed work with a clean tree enters Clean to author REVIEW.md
+  Whether a review fires is gated separately: the outside-process review only
+  fires when commits exist after the last `gtd: done` (or none exists), so an
+  approved review settles Idle instead of looping review → approve → done →
+  review. Workflow files (REVIEW.md, TODO.md, FEEDBACK.md, ERRORS.md, `.gtd/`)
+  are excluded from every review diff — the reviewer never writes chunks about
+  plumbing churn; a diff that is empty after filtering settles Idle too.
+
+  Scenario: Freshly committed branch work with a clean tree enters Clean to author REVIEW.md
     Given a test project
+    And a default branch "main"
+    And a branch "feature"
     And a commit "feat: add calculator" that adds "src/calc.ts" with:
       """
       export const add = (a: number, b: number) => a + b
@@ -120,7 +132,7 @@ Feature: Review lifecycle — Clean → Await → Accept/Done → Idle
     And the file "TODO.md" does not exist
     And stdout does not contain "Grilling"
 
-  Scenario: A textual annotation in REVIEW.md (non-checkbox edit) requests changes
+  Scenario: A textual annotation in REVIEW.md (non-checkbox edit) is feedback, not approval
     Given a test project
     And a commit "feat: add calculator" that adds "src/calc.ts" with:
       """
@@ -147,8 +159,12 @@ Feature: Review lifecycle — Clean → Await → Accept/Done → Idle
     When I run gtd
     Then it succeeds
     And the last commit subject is "gtd: grilling"
+    # The changeset is durably captured before being reverted.
+    And the git log contains "gtd: review feedback"
     And the file "REVIEW.md" does not exist
     And the file "TODO.md" exists
+    # The process stays open: no `gtd: done` is committed on the feedback path.
+    And the git log does not contain "gtd: done"
     And stdout contains "## Task: Grill the plan in `TODO.md`"
 
   Scenario: Editing the code under a committed REVIEW.md seeds a fresh plan
@@ -173,12 +189,103 @@ Feature: Review lifecycle — Clean → Await → Accept/Done → Idle
     When I run gtd
     Then it succeeds
     And the last commit subject is "gtd: grilling"
+    And the git log contains "gtd: review feedback"
     And the file "REVIEW.md" does not exist
     And the file "TODO.md" exists
     # The reviewer's annotation is captured into the plan but discarded from code.
     And the file "TODO.md" contains "please also add subtract"
     And the file "src/calc.ts" does not contain "please also add subtract"
+    # The process stays open: no `gtd: done` is committed on the feedback path.
+    And the git log does not contain "gtd: done"
     And stdout contains "## Task: Grill the plan in `TODO.md`"
+
+  # The leak regression: a plain checkout discards only tracked edits, so a
+  # reviewer-added NEW file used to be committed verbatim by the next grilling
+  # round while also being re-planned in TODO.md. Commit-then-revert drops it
+  # from the tree and captures it as a suggestion instead.
+  Scenario: A new file added by the reviewer is captured as a suggestion, not committed verbatim
+    Given a test project
+    And a commit "feat: add calculator" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd: awaiting review" that adds "REVIEW.md" with:
+      """
+      # Review
+
+      - ./src/calc.ts#1
+      """
+    And a file "src/subtract.ts" with:
+      """
+      export const subtract = (a: number, b: number) => a - b
+      """
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: grilling"
+    And the git log contains "gtd: review feedback"
+    # Dropped from the tree, planned for re-implementation instead.
+    And the file "src/subtract.ts" does not exist
+    And the file "TODO.md" contains "export const subtract"
+    And the git log does not contain "gtd: done"
+
+  # The capture commit contains the annotated REVIEW.md. If a checkout/pull
+  # loses the uncommitted seed, the machine sees committed REVIEW + clean tree —
+  # which must regenerate the seed, NOT route to Done and silently approve the
+  # annotations.
+  Scenario: A lost accept-review seed regenerates instead of approving the annotations
+    Given a test project
+    And a commit "feat: add calculator" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd: awaiting review" that adds "REVIEW.md" with:
+      """
+      # Review
+
+      - [ ] ./src/calc.ts#1
+      """
+    And "REVIEW.md" is modified to:
+      """
+      # Review
+
+      - [ ] ./src/calc.ts#1
+
+      Please also add a subtract function.
+      """
+    And the working tree is committed as "gtd: review feedback"
+    When I run gtd
+    Then it succeeds
+    And the git log does not contain "gtd: done"
+    And the last commit subject is "gtd: grilling"
+    And the file "REVIEW.md" does not exist
+    And the file "TODO.md" exists
+    And the file "TODO.md" contains "Please also add a subtract function."
+    And stdout contains "## Task: Grill the plan in `TODO.md`"
+
+  # An uncommitted TODO.md under a committed REVIEW.md is global feedback, not
+  # an illegal combination — the reviewer reached for plan-level notes.
+  Scenario: Plan notes written into TODO.md during a review are feedback, not an error
+    Given a test project
+    And a commit "feat: add calculator" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd: awaiting review" that adds "REVIEW.md" with:
+      """
+      # Review
+
+      - ./src/calc.ts#1
+      """
+    And a file "TODO.md" with:
+      """
+      Next iteration should cover division too.
+      """
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: grilling"
+    And the file "REVIEW.md" does not exist
+    And the file "TODO.md" contains "division"
+    And the git log does not contain "gtd: done"
 
   Scenario: A closed review with nothing left to review is Idle
     Given a test project
@@ -190,7 +297,11 @@ Feature: Review lifecycle — Clean → Await → Accept/Done → Idle
     And stdout contains "## Task: Nothing to do"
     And stdout does not contain "## Task: Create `REVIEW.md`"
 
-  Scenario: A completed branch review settles in Idle, not a fresh review
+  # Regression anchor: the review used to loop — after approval, the merge-base
+  # diff was still non-empty, so the next run re-entered Clean and wrote the
+  # same REVIEW.md again (review → approve → done → review → …). The
+  # commits-after-last-done gate keeps gtd Idle until new commits land.
+  Scenario: Approving a review settles Idle and never loops back into a fresh review
     Given a test project
     And a default branch "main"
     And a branch "feature"
@@ -206,12 +317,39 @@ Feature: Review lifecycle — Clean → Await → Accept/Done → Idle
       """
     When I run gtd
     Then it succeeds
-    # Approves the review (gtd: done). HEAD gtd: done is an Idle boundary — the
-    # machine settles Idle without re-reviewing the branch.
+    # Approves the review (gtd: done). The branch diff against the merge-base is
+    # still non-empty, but no commits exist after `gtd: done` — Idle, not Clean.
     And the last commit subject is "gtd: done"
     And the file "REVIEW.md" does not exist
     And stdout contains "## Task: Nothing to do"
     And stdout does not contain "## Task: Create `REVIEW.md`"
+    And I record the commit count
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Nothing to do"
+    And stdout does not contain "## Task: Create `REVIEW.md`"
+    And the file "REVIEW.md" does not exist
+    And the commit count is unchanged
+
+  Scenario: A new commit after gtd: done re-opens the review for the whole branch
+    Given a test project
+    And a default branch "main"
+    And a branch "feature"
+    And a commit "feat: first slice" that adds "src/first.ts" with:
+      """
+      export const first = 1
+      """
+    And a commit "gtd: done"
+    And a commit "feat: second slice" that adds "src/second.ts" with:
+      """
+      export const second = 2
+      """
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Create `REVIEW.md` for the finished work"
+    # Whole-branch scope: the already-approved first slice is re-covered.
+    And stdout contains "src/first.ts"
+    And stdout contains "src/second.ts"
 
   Scenario: A coworker's non-gtd commit on a feature branch reviews against the merge-base
     Given a test project
@@ -227,7 +365,8 @@ Feature: Review lifecycle — Clean → Await → Accept/Done → Idle
     And stdout contains "src/parser.ts"
 
   # Rule 1: within-process first review — base = first gtd: grilling of the
-  # current task cycle; only work committed after grilling appears in the review.
+  # current task cycle; only work committed after grilling appears in the
+  # review, and the TODO.md plumbing churn is filtered out of the diff.
   Scenario: Within-process first review covers work since gtd: grilling (Rule 1)
     Given a test project
     And a commit "gtd: grilling" that adds "TODO.md" with:
@@ -235,6 +374,7 @@ Feature: Review lifecycle — Clean → Await → Accept/Done → Idle
       # Plan
       - [ ] add greeter
       """
+    And a commit "gtd: planning" that deletes "TODO.md"
     And a commit "feat: add greeter" that adds "src/greet.ts" with:
       """
       export const greet = (name: string) => `Hello, ${name}`
@@ -243,23 +383,54 @@ Feature: Review lifecycle — Clean → Await → Accept/Done → Idle
     Then it succeeds
     And stdout contains "## Task: Create `REVIEW.md` for the finished work"
     And stdout contains "src/greet.ts"
+    And stdout does not contain "a/TODO.md"
 
-  # Rule 2: within-process incremental review — a `gtd: awaiting review` exists
-  # in the current cycle (no REVIEW.md at HEAD; review already processed); only
-  # work committed after that marker appears in the next review.
-  Scenario: Within-process incremental review covers only post-review changes (Rule 2)
+  # Rule 2: within-process follow-up review — after review feedback re-entered
+  # grilling → planning → building, the next review covers only the new work
+  # packages (base = last `gtd: awaiting review`), and the workflow-file churn
+  # (REVIEW.md removal, TODO.md seed/delete) never shows up as review chunks.
+  Scenario: After a feedback cycle the follow-up review covers only the new work (Rule 2)
     Given a test project
     And a commit "gtd: grilling" that adds "TODO.md" with:
       """
       # Plan
       - [ ] add greeter
-      - [ ] add farewell
       """
+    And a commit "gtd: planning" that deletes "TODO.md"
     And a commit "feat: add greeter" that adds "src/greet.ts" with:
       """
       export const greet = (name: string) => `Hello, ${name}`
       """
-    And a commit "gtd: awaiting review"
+    And a commit "gtd: awaiting review" that adds "REVIEW.md" with:
+      """
+      # Review
+
+      ## Add greeter
+
+      - [ ] ./src/greet.ts#1
+      """
+    # The user left feedback; Accept Review captured it durably as
+    # `gtd: review feedback`, then Grilling committed the seeded plan together
+    # with REVIEW.md's removal (the feedback path).
+    And "REVIEW.md" is modified to:
+      """
+      # Review
+
+      ## Add greeter
+
+      - [ ] ./src/greet.ts#1
+
+      Please also add a farewell function.
+      """
+    And the working tree is committed as "gtd: review feedback"
+    And a deleted committed file "REVIEW.md"
+    And a file "TODO.md" with:
+      """
+      # Plan
+      - [ ] add farewell
+      """
+    And the working tree is committed as "gtd: grilling"
+    And a commit "gtd: planning" that deletes "TODO.md"
     And a commit "feat: add farewell" that adds "src/farewell.ts" with:
       """
       export const farewell = (name: string) => `Goodbye, ${name}`
@@ -269,6 +440,11 @@ Feature: Review lifecycle — Clean → Await → Accept/Done → Idle
     And stdout contains "## Task: Create `REVIEW.md` for the finished work"
     And stdout contains "src/farewell.ts"
     And stdout does not contain "src/greet.ts"
+    # Workflow-file churn is filtered out of the review diff.
+    And stdout does not contain "a/REVIEW.md"
+    And stdout does not contain "a/TODO.md"
+    # The process stayed open throughout: no `gtd: done` was ever committed.
+    And the git log does not contain "gtd: done"
 
   # Rule 3: outside a process, feature branch — base = merge-base; whole branch reviewed.
   Scenario: Outside-process feature branch reviews from the merge-base (Rule 3)
@@ -284,7 +460,7 @@ Feature: Review lifecycle — Clean → Await → Accept/Done → Idle
     And stdout contains "## Task: Create `REVIEW.md` for the finished work"
     And stdout contains "src/parser.ts"
 
-  # Rule 4: outside a process, default branch — skip review (Idle).
+  # Rule 4: outside a process, default branch — the branch review never fires.
   Scenario: Outside-process default branch skips review and settles Idle (Rule 4)
     Given a test project
     And a commit "feat: trunk work" that adds "src/trunk.ts" with:
@@ -295,3 +471,21 @@ Feature: Review lifecycle — Clean → Await → Accept/Done → Idle
     Then it succeeds
     And stdout contains "## Task: Nothing to do"
     And stdout does not contain "## Task: Create `REVIEW.md`"
+
+  # On the default branch only the review trigger is suppressed — a dirty tree
+  # still seeds New Feature exactly as on any branch.
+  Scenario: On the default branch a dirty tree still seeds a new feature
+    Given a test project
+    And a commit "gtd: done"
+    And a file "src/extra.ts" with:
+      """
+      export const extra = () => "extra"
+      """
+    When I run gtd
+    Then it succeeds
+    And the git log contains "gtd: new task"
+    And the last commit subject is "gtd: grilling"
+    And the file "src/extra.ts" does not exist
+    And the file "TODO.md" exists
+    And the file "TODO.md" contains "src/extra.ts"
+    And stdout contains "## Task: Grill the plan in `TODO.md`"

--- a/tests/integration/features/steering-misuse.feature
+++ b/tests/integration/features/steering-misuse.feature
@@ -1,0 +1,68 @@
+Feature: Manual steering-file misuse and odd .gtd contents
+
+  Users sometimes fight the workflow by hand — deleting a steering file to
+  abandon a loop, or leaving junk in `.gtd/`. These scenarios pin the CURRENT
+  behavior: manual deletions land in states no precedence rule matches, and
+  gtd hard-errors with the corruption message rather than guessing (the
+  recovery policy is an open decision — TODO.md § Open questions). Junk in
+  `.gtd/` is ignored gracefully.
+
+  # Abandoning the fix loop by deleting a non-empty FEEDBACK.md leaves HEAD
+  # `gtd: errors` with a pending deletion — Testing picks that up. But once
+  # the deletion is COMMITTED by hand, the clean `gtd: errors` HEAD matches no
+  # rule: corruption, by design (documented, pending a recovery decision).
+  Scenario: A hand-committed FEEDBACK.md deletion at gtd: errors is corruption
+    Given a test project
+    And a commit "gtd: planning" that adds ".gtd/01-foo/01-task.md" with:
+      """
+      Implement the helper.
+      """
+    And a commit "gtd: errors" that adds "FEEDBACK.md" with:
+      """
+      test failure output
+      """
+    And a commit "gtd: errors" that deletes "FEEDBACK.md"
+    When I run gtd
+    Then it fails
+    And stderr contains "no precedence rule matched"
+
+  Scenario: A hand-committed REVIEW.md deletion at gtd: awaiting review is corruption
+    Given a test project
+    And a commit "feat: work" that adds "src/work.ts" with:
+      """
+      export const work = 1
+      """
+    And a commit "gtd: awaiting review" that adds "REVIEW.md" with:
+      """
+      # Review
+      """
+    And a commit "gtd: awaiting review" that deletes "REVIEW.md"
+    When I run gtd
+    Then it fails
+    And stderr contains "no precedence rule matched"
+
+  Scenario: Non-package junk inside .gtd is ignored by the build loop
+    Given a test project
+    And a commit "gtd: planning" that adds ".gtd/notes.txt" with:
+      """
+      scratch notes, not a package
+      """
+    And a commit "gtd: planning" that adds ".gtd/01-real/01-task.md" with:
+      """
+      Implement the real package.
+      """
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Build one work package"
+    And stdout contains "Implement the real package."
+    And stdout does not contain "notes.txt"
+
+  # An empty (untracked) .gtd/ directory under a planning HEAD: gtd must not
+  # crash — it resolves Building with no package to offer.
+  Scenario: An empty .gtd directory does not crash the build loop
+    Given a test project
+    And a commit "gtd: planning"
+    And a directory ".gtd"
+    When I run gtd
+    Then it succeeds
+    And stdout contains "## Task: Build one work package"

--- a/tests/integration/features/testing.feature
+++ b/tests/integration/features/testing.feature
@@ -31,6 +31,30 @@ Feature: Testing — the bounded test/fix loop and escalation
     And the last commit subject is "gtd: building"
     And stdout contains "## Task: Agentic review of the built package"
 
+  # The build-phase asymmetry (by design): while .gtd/ exists, pending code is
+  # indistinguishable from builder-agent output, so user edits are ADOPTED into
+  # `gtd: building` and verified by tests + agentic review — never captured as
+  # suggestions the way grilling and review edits are.
+  Scenario: A user code edit during the build is adopted and verified, not captured
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      testCommand: "true"
+      """
+    And a commit "gtd: planning" that adds ".gtd/01-foo/01-task.md" with:
+      """
+      Implement the helper.
+      """
+    And a file "src/hotfix.ts" with:
+      """
+      export const hotfix = () => 1
+      """
+    When I run gtd
+    Then it succeeds
+    And the last commit subject is "gtd: building"
+    And the file "src/hotfix.ts" exists
+    And the file "TODO.md" does not exist
+
   Scenario: A red gate below the cap writes FEEDBACK.md and routes to Fixing
     Given a test project
     And a commit "chore: test gate" that adds "gate.sh" with:

--- a/tests/integration/helpers/project-setup.ts
+++ b/tests/integration/helpers/project-setup.ts
@@ -3,8 +3,9 @@ import { writeFileSync, mkdirSync, mkdtempSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-function git(dir: string, ...args: string[]) {
-  execFileSync("git", args, { cwd: dir, stdio: "pipe" })
+/** Run git in `dir`, returning trimmed stdout — the suite's shared exec wrapper. */
+export function git(dir: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd: dir, encoding: "utf-8" }).trim()
 }
 
 function writeFile(dir: string, path: string, content: string) {

--- a/tests/integration/support/steps/common.steps.ts
+++ b/tests/integration/support/steps/common.steps.ts
@@ -187,6 +187,20 @@ Then(
   },
 )
 
+// Full-history assertion for journey scenarios: the exact commit subject
+// sequence, oldest → newest, one subject per docstring line.
+Then("the commit subjects from oldest to newest are:", function (this: GtdWorld, doc: string) {
+  const actual = execFileSync("git", ["log", "--reverse", "--format=%s"], {
+    cwd: this.repoDir,
+    encoding: "utf-8",
+  }).trim()
+  assert.strictEqual(
+    actual,
+    doc.trim(),
+    `Commit subject sequence mismatch.\nExpected:\n${doc.trim()}\nActual:\n${actual}`,
+  )
+})
+
 Then("I record the commit count", function (this: GtdWorld) {
   this.savedCommitCount = this.commitCount()
 })

--- a/tests/integration/support/steps/environment.steps.ts
+++ b/tests/integration/support/steps/environment.steps.ts
@@ -4,14 +4,12 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { GtdWorld } from "../world.js"
+import { git } from "../../helpers/project-setup.js"
 
 // Steps for hostile-environment scenarios: non-repo directories, fresh repos,
 // subdirectory invocation, detached HEAD, merge commits, git config knobs,
 // custom pre-commit hooks, and submodules. Setup is inlined per step (one step
 // = one observable repo mutation) so scenarios spell out the exact environment.
-
-const git = (dir: string, ...args: string[]): string =>
-  execFileSync("git", args, { cwd: dir, encoding: "utf-8" }).trim()
 
 Given("a plain directory that is not a git repository", function (this: GtdWorld) {
   this.repoDir = mkdtempSync(join(tmpdir(), "gtd-norepo-"))
@@ -24,10 +22,6 @@ Given("a fresh git repository with no commits", function (this: GtdWorld) {
   git(dir, "config", "user.email", "test@test.com")
   git(dir, "config", "commit.gpgsign", "false")
   this.repoDir = dir
-})
-
-Given("a subdirectory {string}", function (this: GtdWorld, sub: string) {
-  mkdirSync(join(this.repoDir, sub), { recursive: true })
 })
 
 When("I run gtd from the subdirectory {string}", function (this: GtdWorld, sub: string) {

--- a/tests/integration/support/steps/environment.steps.ts
+++ b/tests/integration/support/steps/environment.steps.ts
@@ -1,0 +1,111 @@
+import { Given, When } from "@cucumber/cucumber"
+import { execFileSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { GtdWorld } from "../world.js"
+
+// Steps for hostile-environment scenarios: non-repo directories, fresh repos,
+// subdirectory invocation, detached HEAD, merge commits, git config knobs,
+// custom pre-commit hooks, and submodules. Setup is inlined per step (one step
+// = one observable repo mutation) so scenarios spell out the exact environment.
+
+const git = (dir: string, ...args: string[]): string =>
+  execFileSync("git", args, { cwd: dir, encoding: "utf-8" }).trim()
+
+Given("a plain directory that is not a git repository", function (this: GtdWorld) {
+  this.repoDir = mkdtempSync(join(tmpdir(), "gtd-norepo-"))
+})
+
+Given("a fresh git repository with no commits", function (this: GtdWorld) {
+  const dir = mkdtempSync(join(tmpdir(), "gtd-fresh-"))
+  git(dir, "init", "-q")
+  git(dir, "config", "user.name", "Test")
+  git(dir, "config", "user.email", "test@test.com")
+  git(dir, "config", "commit.gpgsign", "false")
+  this.repoDir = dir
+})
+
+Given("a subdirectory {string}", function (this: GtdWorld, sub: string) {
+  mkdirSync(join(this.repoDir, sub), { recursive: true })
+})
+
+When("I run gtd from the subdirectory {string}", function (this: GtdWorld, sub: string) {
+  this.runCwd = join(this.repoDir, sub)
+  this.runGtd()
+  this.runCwd = undefined
+})
+
+Given("git config {string} is {string}", function (this: GtdWorld, key: string, value: string) {
+  git(this.repoDir, "config", key, value)
+})
+
+Given("the repository is in detached HEAD state", function (this: GtdWorld) {
+  git(this.repoDir, "checkout", "-q", "--detach")
+})
+
+// Creates a side branch with one file commit and merges it back with --no-ff,
+// leaving a merge commit at HEAD (the documented-unsupported topology).
+Given(
+  "a merge commit merging a branch with a commit {string} that adds {string} with:",
+  function (this: GtdWorld, message: string, path: string, content: string) {
+    const current = git(this.repoDir, "rev-parse", "--abbrev-ref", "HEAD")
+    git(this.repoDir, "checkout", "-q", "-b", "gtd-test-side")
+    const full = join(this.repoDir, path)
+    mkdirSync(join(full, ".."), { recursive: true })
+    writeFileSync(full, content.endsWith("\n") ? content : content + "\n")
+    git(this.repoDir, "add", path)
+    git(this.repoDir, "commit", "-q", "-m", message)
+    git(this.repoDir, "checkout", "-q", current)
+    git(this.repoDir, "merge", "--no-ff", "-q", "-m", "Merge branch gtd-test-side", "gtd-test-side")
+  },
+)
+
+// Writes an executable `.git/hooks/pre-commit` with the docstring body — for
+// scenarios exercising user hooks that rewrite files or fail.
+Given("an executable pre-commit hook with:", function (this: GtdWorld, content: string) {
+  const dest = join(this.repoDir, ".git/hooks/pre-commit")
+  writeFileSync(dest, content.endsWith("\n") ? content : content + "\n", { mode: 0o755 })
+})
+
+Given("the pre-commit hook is removed", function (this: GtdWorld) {
+  rmSync(join(this.repoDir, ".git/hooks/pre-commit"), { force: true })
+})
+
+// Modifies a file with CRLF line endings — simulating a Windows-style editor
+// touching a file during review.
+Given(
+  "{string} is modified with CRLF line endings to:",
+  function (this: GtdWorld, path: string, content: string) {
+    const body = content.endsWith("\n") ? content : content + "\n"
+    writeFileSync(join(this.repoDir, path), body.replace(/\n/g, "\r\n"))
+  },
+)
+
+// Adds a submodule at `path` backed by a freshly created side repository with
+// one commit. Uses `protocol.file.allow=always` (required by modern git for
+// local-path submodules).
+Given("a committed submodule at {string}", function (this: GtdWorld, path: string) {
+  const side = mkdtempSync(join(tmpdir(), "gtd-submodule-"))
+  git(side, "init", "-q")
+  git(side, "config", "user.name", "Test")
+  git(side, "config", "user.email", "test@test.com")
+  git(side, "config", "commit.gpgsign", "false")
+  writeFileSync(join(side, "lib.ts"), "export const lib = 1\n")
+  git(side, "add", "-A")
+  git(side, "commit", "-q", "-m", "chore: submodule init")
+  execFileSync("git", ["-c", "protocol.file.allow=always", "submodule", "add", "-q", side, path], {
+    cwd: this.repoDir,
+    stdio: "pipe",
+  })
+  git(this.repoDir, "commit", "-q", "-m", "chore: add submodule")
+})
+
+// Advances the submodule's checked-out worktree to a new commit, leaving a
+// pending gitlink (pointer) change in the superproject.
+Given("the submodule at {string} has a new commit", function (this: GtdWorld, path: string) {
+  const sub = join(this.repoDir, path)
+  writeFileSync(join(sub, "lib.ts"), "export const lib = 2\n")
+  git(sub, "add", "-A")
+  git(sub, "commit", "-q", "-m", "feat: bump")
+})

--- a/tests/integration/support/steps/formatting.steps.ts
+++ b/tests/integration/support/steps/formatting.steps.ts
@@ -27,21 +27,6 @@ Then("stdout is empty", function (this: GtdWorld) {
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "../../../..")
 
-// The recommended consumer-repo pre-commit hook: auto-format TODO.md/REVIEW.md
-// with prettier on commit. Inlined as a fixture — the previous source
-// (`PROJECT_ROOT/.git/hooks/pre-commit`) was an untracked local file that does
-// not exist in fresh clones or git worktrees (where `.git` is a pointer file).
-const PRE_COMMIT_HOOK = `#!/bin/sh
-# Auto-format TODO.md and REVIEW.md on commit
-
-FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^(TODO|REVIEW)\\.md$')
-
-if [ -n "$FILES" ]; then
-  npx prettier --write $FILES
-  git add $FILES
-fi
-`
-
 Given("prettier is available in the test project", function (this: GtdWorld) {
   const nodeModulesSrc = join(PROJECT_ROOT, "node_modules")
   const nodeModulesDest = join(this.repoDir, "node_modules")
@@ -60,11 +45,6 @@ Given("prettier is available in the test project", function (this: GtdWorld) {
       ],
     }),
   )
-})
-
-Given("the pre-commit hook from the project is installed", function (this: GtdWorld) {
-  const dest = join(this.repoDir, ".git/hooks/pre-commit")
-  writeFileSync(dest, PRE_COMMIT_HOOK, { mode: 0o755 })
 })
 
 Given("{string} is staged", function (this: GtdWorld, path: string) {

--- a/tests/integration/support/steps/formatting.steps.ts
+++ b/tests/integration/support/steps/formatting.steps.ts
@@ -26,7 +26,21 @@ Then("stdout is empty", function (this: GtdWorld) {
 })
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "../../../..")
-const HOOK_PATH = join(PROJECT_ROOT, ".git/hooks/pre-commit")
+
+// The recommended consumer-repo pre-commit hook: auto-format TODO.md/REVIEW.md
+// with prettier on commit. Inlined as a fixture — the previous source
+// (`PROJECT_ROOT/.git/hooks/pre-commit`) was an untracked local file that does
+// not exist in fresh clones or git worktrees (where `.git` is a pointer file).
+const PRE_COMMIT_HOOK = `#!/bin/sh
+# Auto-format TODO.md and REVIEW.md on commit
+
+FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^(TODO|REVIEW)\\.md$')
+
+if [ -n "$FILES" ]; then
+  npx prettier --write $FILES
+  git add $FILES
+fi
+`
 
 Given("prettier is available in the test project", function (this: GtdWorld) {
   const nodeModulesSrc = join(PROJECT_ROOT, "node_modules")
@@ -49,9 +63,8 @@ Given("prettier is available in the test project", function (this: GtdWorld) {
 })
 
 Given("the pre-commit hook from the project is installed", function (this: GtdWorld) {
-  const hookContent = readFileSync(HOOK_PATH, "utf-8")
   const dest = join(this.repoDir, ".git/hooks/pre-commit")
-  writeFileSync(dest, hookContent, { mode: 0o755 })
+  writeFileSync(dest, PRE_COMMIT_HOOK, { mode: 0o755 })
 })
 
 Given("{string} is staged", function (this: GtdWorld, path: string) {

--- a/tests/integration/support/world.ts
+++ b/tests/integration/support/world.ts
@@ -15,10 +15,13 @@ export class GtdWorld extends World {
   }
   savedCommitCount: number | undefined = undefined
 
+  /** Directory the next `runGtd` uses as cwd; defaults to the repo root. */
+  runCwd: string | undefined = undefined
+
   runGtd(...args: string[]) {
     const verbose = process.env["GTD_E2E_VERBOSE"] === "1"
     const result = spawnSync(process.execPath, [GTD_BIN, ...args], {
-      cwd: this.repoDir,
+      cwd: this.runCwd ?? this.repoDir,
       env: { ...process.env },
       encoding: "utf-8",
       timeout: 30_000,


### PR DESCRIPTION
## Summary

Four commits, three phases of work:

### 1. Review-step redesign (fixes the review loop)
- **Re-trigger gate**: outside-process reviews only fire when commits exist after the last `gtd: done`, fixing the `review → approve → done → review` loop; scope stays whole-branch (merge-base), so new commits after an approval re-cover approved work by design.
- **Workflow-file filter**: TODO.md, REVIEW.md, FEEDBACK.md, ERRORS.md, and `.gtd/` are excluded from every review diff; an empty filtered diff settles Idle.

### 2. Feedback-capture unification (every user change is feedback)
- **Accept Review is now commit-then-revert**: the changeset — annotations, code edits, untracked new files — is captured durably as `gtd: review feedback`, then reverted; untracked reviewer files no longer leak verbatim into the next grilling commit.
- **Lost-seed regen carve-out**: `REVIEW.md + HEAD gtd: review feedback` re-seeds instead of silently approving the annotations as Done after a checkout/pull.
- **Grilling rounds capture code sketches** into TODO.md as suggestion blocks and revert them (both iterate and STOP paths); a resumed grill no longer re-seeds over the committed plan.
- Committed REVIEW.md + uncommitted TODO.md is now legal review feedback; the interpretation rules (code = suggestions to re-implement with tests, comments = positional, steering text = global, checkbox flips = noise) are embedded in every capture and the grilling prompt.

### 3. Test-coverage plan + five bug fixes
- New coverage: five full-lifecycle journey scenarios, a fast-check property sweep over the pure machine, a hostile-environment matrix, capture-content edge cases, replay/idempotence and steering-misuse scenarios, and performance smokes.
- The suite first pinned five real bugs with expected-fail tests, then fixed them:
  - **B1**: git exit codes were silently swallowed (`Command.string`) — rejected hooks/gpg reported success, non-repo resolved Idle, and a silently failed intent-to-add caused **data loss** for unicode-named files during grilling capture. The runner now fails loudly; untracked paths round-trip via `ls-files -z`.
  - **B2**: `stripCode` stopped stripping at the first fenced line (multiline `$`), leaking deep markers to the answers gate.
  - **B3**: fixed three-backtick capture fences broke under the `gtd format` round-trip; fences are now sized past any backtick run.
  - **B4**: gtd now refuses to run anywhere but the repository root with a clear error.
  - **B5**: checkbox-only approval now survives CRLF editors.

## Test plan
- [x] 269/269 unit tests (incl. property sweep and perf smokes)
- [x] 118/118 cucumber scenarios (1200 steps), including five multi-run journey scenarios and the environment matrix
- [x] lint, typecheck, prettier clean
- [x] Live repros of the loop fix, capture, regen, and repo-root guard against the built bundle

Docs: STATES.md and SKILL.md updated; README sync intentionally deferred per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)