### PR TITLE
fix(squash): never reach past the branch point or stray cycle markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,12 +442,17 @@ loop before the next one starts.
    (`gtd: done`) → **Squashing** → **Idle**. The Squashing agent authors a
    conventional-commits message from the full process diff and squashes all
    intermediate `gtd: *` commits into one with `git reset --soft <base>` +
-   `git commit`, then **gtd STOPs**. Post-squash review does not fire
-   automatically — it fires only on the next manual `gtd` run (when the squash
-   commit is the boundary HEAD and a reviewable diff exists). Squashing fires
-   when the tree has no unrelated code dirty — a lone untracked `SQUASH_MSG.md`
-   is tolerated and deleted before the squash commit. If unrelated code is dirty
-   at `gtd: done`, gtd routes to **New Feature** instead. Set `squash: false` in
+   `git commit`, then **gtd STOPs**. The base is the parent of the current
+   cycle's start marker **nearest to HEAD** (the last `gtd: new task`; for
+   legacy cycles the last contiguous `gtd: grilling` run), and on a feature
+   branch it never reaches below the merge-base with the default branch — stray
+   markers left behind by older squashes can never drag the squash into
+   previously shipped features. Post-squash review does not fire automatically —
+   it fires only on the next manual `gtd` run (when the squash commit is the
+   boundary HEAD and a reviewable diff exists). Squashing fires when the tree
+   has no unrelated code dirty — a lone untracked `SQUASH_MSG.md` is tolerated
+   and deleted before the squash commit. If unrelated code is dirty at
+   `gtd: done`, gtd routes to **New Feature** instead. Set `squash: false` in
    `.gtdrc` to skip squashing and go straight to Idle. Checking off REVIEW.md
    checkboxes (`- [ ]` → `- [x]`) also counts as approval and routes to **Done**
    — they are navigation aids, not feedback. Only **non-checkbox** edits (code

--- a/src/Events.test.ts
+++ b/src/Events.test.ts
@@ -855,6 +855,72 @@ describe(
       expect(p.squashMsgContent).toBe("")
     })
 
+    // Regression: stray `gtd: new task` markers from older, already-squashed
+    // cycles (their `gtd: done` boundary was deleted by the squash itself) must
+    // not drag the squash base past prior features.
+
+    it("stray gtd: new task below the branch point → squashBase stays within the branch", async () => {
+      initRepo(false)
+      // On main: a stray marker left behind by an old squash, then a squashed
+      // previous feature — mirrors the incident history.
+      git("commit", "--allow-empty", "-q", "-m", "gtd: new task")
+      commitFile("feat: previous feature", "previous.ts", "export const previous = 1\n")
+      git("checkout", "-q", "-b", "feature")
+      const branchPoint = git("rev-parse", "HEAD")
+      // Current cycle on the branch.
+      git("commit", "--allow-empty", "-q", "-m", "gtd: new task")
+      commitFile("gtd: grilling", "TODO.md", "# Plan\n")
+      git("rm", "-q", "TODO.md")
+      git("commit", "-q", "-m", "gtd: planning")
+      commitFile("feat: work", "work.ts", "export const work = 1\n")
+      git("commit", "--allow-empty", "-q", "-m", "gtd: done")
+
+      const p = resolveOf(await runGather({ squash: true }))
+      // Base = parent of the branch's own gtd: new task = the branch point —
+      // never the stray marker's parent below it.
+      expect(p.squashBase).toBe(branchPoint)
+      expect(p.squashDiff).toContain("work.ts")
+      expect(p.squashDiff).not.toContain("previous.ts")
+    })
+
+    it("stray gtd: new task on trunk → squashBase = parent of the LAST gtd: new task", async () => {
+      initRepo(false)
+      git("commit", "--allow-empty", "-q", "-m", "gtd: new task")
+      commitFile("feat: previous feature", "previous.ts", "export const previous = 1\n")
+      const prevFeatureHash = git("rev-parse", "HEAD")
+      git("commit", "--allow-empty", "-q", "-m", "gtd: new task")
+      commitFile("gtd: grilling", "TODO.md", "# Plan\n")
+      git("rm", "-q", "TODO.md")
+      git("commit", "-q", "-m", "gtd: planning")
+      commitFile("feat: work", "work.ts", "export const work = 1\n")
+      git("commit", "--allow-empty", "-q", "-m", "gtd: done")
+
+      const p = resolveOf(await runGather({ squash: true }))
+      expect(p.squashBase).toBe(prevFeatureHash)
+      expect(p.squashDiff).toContain("work.ts")
+      expect(p.squashDiff).not.toContain("previous.ts")
+    })
+
+    it("stray gtd: grilling on trunk, cycle without gtd: new task → squashBase = start of the LAST contiguous grilling run", async () => {
+      initRepo(false)
+      // Stray grilling left by an ancient squash, then the squashed feature.
+      git("commit", "--allow-empty", "-q", "-m", "gtd: grilling")
+      commitFile("feat: previous feature", "previous.ts", "export const previous = 1\n")
+      const prevFeatureHash = git("rev-parse", "HEAD")
+      // Legacy cycle (no gtd: new task) with a two-commit grilling run.
+      commitFile("gtd: grilling", "TODO.md", "# Plan\n")
+      commitFile("gtd: grilling", "TODO.md", "# Plan v2\n")
+      git("rm", "-q", "TODO.md")
+      git("commit", "-q", "-m", "gtd: planning")
+      commitFile("feat: work", "work.ts", "export const work = 1\n")
+      git("commit", "--allow-empty", "-q", "-m", "gtd: done")
+
+      const p = resolveOf(await runGather({ squash: true }))
+      expect(p.squashBase).toBe(prevFeatureHash)
+      expect(p.squashDiff).toContain("work.ts")
+      expect(p.squashDiff).not.toContain("previous.ts")
+    })
+
     it("SQUASH_MSG.md excluded from codeDirty (not treated as a code change)", async () => {
       initRepo(true)
       commitFile("gtd: grilling", "TODO.md", "# Plan\n")

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -580,34 +580,53 @@ export const gatherEvents = (): Effect.Effect<
     let squashBase: string | undefined
     let squashDiff: string | undefined
     if (hasCommits && lastCommitSubject === DONE_SUBJECT && config.squash) {
-      // allHistory is already resolved above inside the `if (hasCommits)` block.
-      const allHistoryForSquash = Option.isNone(base) ? history : yield* git.commitHistory()
-      const lastDoneIdxForSquash = (() => {
-        let idx = -1
-        for (let i = 0; i < allHistoryForSquash.length; i++) {
-          const subject = (allHistoryForSquash[i]!.message.split("\n")[0] ?? "").trim()
-          if (subject === DONE_SUBJECT) idx = i
+      // Scan `history` (merge-base..HEAD on a feature branch), NOT the whole
+      // history: commits below the merge-base exist on the default branch, and
+      // a squash reset must never rewrite them. On trunk (no merge-base),
+      // `history` is already the whole history.
+      const squashHistory = history
+      const subjectOf = (c: (typeof squashHistory)[number]): string =>
+        (c.message.split("\n")[0] ?? "").trim()
+      // Last `gtd: done` (= HEAD) and the previous one (cycle boundary), in one
+      // oldest-first pass.
+      let lastDoneIdxForSquash = -1
+      let prevDoneIdx = -1
+      for (let i = 0; i < squashHistory.length; i++) {
+        if (subjectOf(squashHistory[i]!) === DONE_SUBJECT) {
+          prevDoneIdx = lastDoneIdxForSquash
+          lastDoneIdxForSquash = i
         }
-        return idx
-      })()
+      }
 
       if (lastDoneIdxForSquash !== -1) {
-        // Find the previous `gtd: done` (the cycle boundary before this one).
-        let prevDoneIdx = -1
-        for (let i = 0; i < lastDoneIdxForSquash; i++) {
-          const subject = (allHistoryForSquash[i]!.message.split("\n")[0] ?? "").trim()
-          if (subject === DONE_SUBJECT) prevDoneIdx = i
+        const squashCycle = squashHistory.slice(prevDoneIdx + 1, lastDoneIdxForSquash + 1)
+        // Cycle start = the LAST `gtd: new task` in the cycle (nearest HEAD).
+        // Squashing deletes the `gtd: done` boundary it replaces, so stray
+        // markers from older, already-squashed cycles can survive inside the
+        // range — picking the first match would drag the base past them (and
+        // past entire prior features).
+        let startIdx = -1
+        for (let i = squashCycle.length - 1; i >= 0; i--) {
+          if (subjectOf(squashCycle[i]!) === NEW_TASK_SUBJECT) {
+            startIdx = i
+            break
+          }
         }
-        const squashCycle = allHistoryForSquash.slice(prevDoneIdx + 1, lastDoneIdxForSquash + 1)
-        // Prefer gtd: new task as the cycle start (it precedes grilling and must
-        // be included in the squash); fall back to the first gtd: grilling.
-        const squashNewTask = squashCycle.find(
-          (c) => (c.message.split("\n")[0] ?? "").trim() === NEW_TASK_SUBJECT,
-        )
-        const squashGrilling = squashCycle.find(
-          (c) => (c.message.split("\n")[0] ?? "").trim() === GRILLING_SUBJECT,
-        )
-        const squashStart = squashNewTask ?? squashGrilling
+        if (startIdx === -1) {
+          // Legacy fallback (cycles predating `gtd: new task`): the first
+          // grilling of the LAST contiguous grilling run — not the first
+          // grilling in the cycle, which could equally be a stray.
+          for (let i = squashCycle.length - 1; i >= 0; i--) {
+            if (subjectOf(squashCycle[i]!) === GRILLING_SUBJECT) {
+              startIdx = i
+              while (startIdx > 0 && subjectOf(squashCycle[startIdx - 1]!) === GRILLING_SUBJECT) {
+                startIdx--
+              }
+              break
+            }
+          }
+        }
+        const squashStart = startIdx === -1 ? undefined : squashCycle[startIdx]
 
         if (squashStart !== undefined) {
           const squashStartParent = yield* git

--- a/tests/integration/features/squashing.feature
+++ b/tests/integration/features/squashing.feature
@@ -275,6 +275,49 @@ Feature: Squashing — collapse gtd: * commits into one conventional-commits mes
     And stdout does not contain "## Task: Squash all `gtd: *` commits into one conventional-commits message"
 
   @squashing
+  Scenario: Stray gtd: new task below the branch point — squash never rewrites previous features
+    Given a test project
+    And a default branch "main"
+    And a commit "gtd: new task"
+    And a commit "feat: previous feature" that adds "previous.ts" with:
+      """
+      export const previous = 1
+      """
+    And a branch "feature"
+    And a commit "gtd: new task"
+    And a commit "gtd: grilling" that adds "TODO.md" with:
+      """
+      # Plan
+      - [ ] add calculator
+      """
+    And a commit "gtd: planning" that deletes "TODO.md"
+    And a commit "gtd: building" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd: package done"
+    And a commit "gtd: awaiting review" that adds "REVIEW.md" with:
+      """
+      # Review
+      - [ ] ./src/calc.ts#1
+      """
+    And a commit "gtd: done" that deletes "REVIEW.md"
+    And a file "SQUASH_MSG.md" with content:
+      """
+      feat(calc): add calculator
+      """
+    When I run gtd
+    Then it succeeds
+    And the HEAD commit subject is "feat(calc): add calculator"
+    And the git log contains "feat: previous feature"
+    # The stray marker sits on main, below the merge-base — the squash reset
+    # must not rewrite it (or anything else on the default branch).
+    And the git log contains "gtd: new task"
+    And the git log does not contain "gtd: grilling"
+    And "previous.ts" exists
+    And "src/calc.ts" exists
+
+  @squashing
   Scenario: Post-squash on feature branch — manual gtd run triggers review
     Given a test project
     And a default branch "main"


### PR DESCRIPTION
## Incident

Two herdr worktrees (`46-config-schema`, `prompt-review`) both squashed down to `fd0b1fc` — **below their branch point** — folding the entire previous npm-CLI feature and main's 1.5.x release commits into the squash commit. Both squash messages consequently described the npm CLI feature instead of the branch's own work.

## Root cause

Two compounding flaws in the squash-base selection (`src/Events.ts`):

1. **The cycle boundary never exists.** The squash range was bounded by the previous `gtd: done` commit — but squashing *deletes* `gtd: done` commits by design, so after any successful squash the "cycle" degenerated to the entire repo history.
2. **First match instead of nearest.** `commitHistory` is oldest-first, and `.find()` for `gtd: new task` returned the *oldest* stray marker in history. Main carries three orphaned `gtd: new task` commits left behind by an old squash-base bug (`3c0c50c`, `9aa10ad`, `2e83462`); the oldest one's parent is exactly `fd0b1fc`.

## Fix

- Scan only `merge-base..HEAD` on a feature branch — commits on the default branch can never be swallowed by a squash reset.
- Pick the cycle start **nearest to HEAD**: the last `gtd: new task`, falling back to the start of the last contiguous `gtd: grilling` run for legacy cycles without a new-task marker.

## Tests

- 3 unit tests in `Events.test.ts`: stray marker below the branch point, stray marker on trunk, stray grilling with a legacy (no-new-task) cycle.
- Cucumber regression scenario in `squashing.feature` reproducing the incident shape end-to-end: squash keeps the previous feature's commits and main's stray marker intact.
- README updated with the base-selection guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)