### PR TITLE
feat(config-schema): ship @pmelab/gtd as npm CLI with config schema, JSON mode, and in-mem test tier

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,7 +13,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["package.json"],
+        "assets": ["package.json", "schema.json"],
         "message": "chore(release): ${nextRelease.version} [skip ci]"
       }
     ],

--- a/README.md
+++ b/README.md
@@ -442,9 +442,9 @@ loop before the next one starts.
    (`gtd: done`) → **Squashing** → **Idle**. The Squashing agent authors a
    conventional-commits message from the full process diff and squashes all
    intermediate `gtd: *` commits into one with `git reset --soft <base>` +
-   `git commit`, then **gtd STOPs**. The base is the parent of the current
-   cycle's start marker **nearest to HEAD** (the last `gtd: new task`; for
-   legacy cycles the last contiguous `gtd: grilling` run), and on a feature
+   <<<<<<< HEAD `git commit`, then **gtd STOPs**. The base is the parent of the
+   current cycle's start marker **nearest to HEAD** (the last `gtd: new task`;
+   for legacy cycles the last contiguous `gtd: grilling` run), and on a feature
    branch it never reaches below the merge-base with the default branch — stray
    markers left behind by older squashes can never drag the squash into
    previously shipped features. Post-squash review does not fire automatically —
@@ -453,13 +453,20 @@ loop before the next one starts.
    has no unrelated code dirty — a lone untracked `SQUASH_MSG.md` is tolerated
    and deleted before the squash commit. If unrelated code is dirty at
    `gtd: done`, gtd routes to **New Feature** instead. Set `squash: false` in
-   `.gtdrc` to skip squashing and go straight to Idle. Checking off REVIEW.md
-   checkboxes (`- [ ]` → `- [x]`) also counts as approval and routes to **Done**
-   — they are navigation aids, not feedback. Only **non-checkbox** edits (code
-   changes, inline comments, textual annotations in REVIEW.md) trigger **Accept
-   Review**, which seeds a fresh `TODO.md` from your feedback, discards your
-   code edits, removes `REVIEW.md`, and re-enters Grilling — the loop starts
-   over.
+   ======= `git commit`, then **gtd STOPs**. Post-squash review does not fire
+   automatically — it fires only on the next manual `gtd` run (when the squash
+   commit is the boundary HEAD and a reviewable diff exists). Squashing fires
+   when the tree has no unrelated code dirty — a lone untracked `SQUASH_MSG.md`
+   is tolerated and deleted before the squash commit. If unrelated code is dirty
+   at `gtd: done`, gtd routes to **New Feature** instead. Set `squash: false` in
+   > > > > > > > origin/46-config-schema `.gtdrc` to skip squashing and go
+   > > > > > > > straight to Idle. Checking off REVIEW.md checkboxes (`- [ ]` →
+   > > > > > > > `- [x]`) also counts as approval and routes to **Done** — they
+   > > > > > > > are navigation aids, not feedback. Only **non-checkbox** edits
+   > > > > > > > (code changes, inline comments, textual annotations in
+   > > > > > > > REVIEW.md) trigger **Accept Review**, which seeds a fresh
+   > > > > > > > `TODO.md` from your feedback, discards your code edits, removes
+   > > > > > > > `REVIEW.md`, and re-enters Grilling — the loop starts over.
 
 ## Configuration
 
@@ -501,6 +508,11 @@ built-in defaults apply. Supported filenames (searched in this order):
   - `states.*` — per-state overrides keyed by the six agent states: `decompose`
     (shared by the Grilled and Planning states), `grilling`, `building`,
     `fixing`, `agentic-review`, `clean`. Unknown `states` keys are **rejected**.
+- **`$schema`** (string, optional) — a recognized key that is **stripped before
+  validation**, so it never counts as an unknown key. Point it at the published
+  schema to get schema-backed autocompletion and inline docs in your editor. A
+  `schema.json` is generated from the config schema at build time and ships with
+  the package (and is published/committed on release).
 
 ### Validation and errors
 
@@ -530,6 +542,28 @@ finds along the way. All found levels are **deep-merged**, with the **innermost
 This makes the worktree-parent case easy: drop a single `.gtdrc` in a shared
 parent directory and it cascades to **all** checkouts/worktrees beneath it,
 while any individual checkout can still override settings with its own `.gtdrc`.
+
+### Auto-init
+
+On every run, if the cwd→root walk finds **no** config anywhere, gtd creates and
+commits a starter config at the **git root**: a `.gtdrc.json` containing only a
+`$schema` link:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/pmelab/gtd/main/schema.json"
+}
+```
+
+It is committed as `chore: add .gtdrc.json`. This wires up editor autocompletion
+out of the box; add any settings below the `$schema` line to override the
+defaults.
+
+Auto-init is skipped when HEAD is a `gtd: transport` commit: transport is a
+consume-only handoff HEAD (mixed-reset in the Transport pre-pass), so committing
+a config stub on top of it would displace the transport commit — and, when it is
+the repository root, silently mask the "cannot reset transport commit" error.
+The stub is created on a later run, once the transport HEAD has been consumed.
 
 ### Example
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pmelab/gtd",
-  "version": "1.4.3",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pmelab/gtd",
-      "version": "1.4.3",
+      "version": "1.5.5",
       "license": "MIT",
       "dependencies": {
         "@effect/platform": "^0.94.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "files": [
     "dist/",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "schema.json"
   ],
   "publishConfig": {
     "access": "public",
@@ -28,6 +29,7 @@
     "prepare": "husky",
     "dev": "node dev/run.mjs",
     "build": "tsup",
+    "postbuild": "jiti scripts/generate-schema.ts",
     "watch": "tsup --watch",
     "test": "npm run format:check && npm run typecheck && npm run lint && npm run test:unit && npm run test:e2e && fallow --summary --quiet",
     "test:unit": "vitest run --project unit",

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$defs": {
+    "Int": {
+      "type": "integer",
+      "description": "an integer",
+      "title": "int"
+    }
+  },
+  "type": "object",
+  "required": [],
+  "properties": {
+    "testCommand": {
+      "type": "string"
+    },
+    "models": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "planning": {
+          "type": "string"
+        },
+        "execution": {
+          "type": "string"
+        },
+        "states": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "decompose": {
+              "type": "string"
+            },
+            "grilling": {
+              "type": "string"
+            },
+            "building": {
+              "type": "string"
+            },
+            "fixing": {
+              "type": "string"
+            },
+            "agentic-review": {
+              "type": "string"
+            },
+            "clean": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "agenticReview": {
+      "type": "boolean"
+    },
+    "squash": {
+      "type": "boolean"
+    },
+    "fixAttemptCap": {
+      "$ref": "#/$defs/Int",
+      "description": "a non-negative number",
+      "title": "greaterThanOrEqualTo(0)",
+      "minimum": 0
+    },
+    "reviewThreshold": {
+      "$ref": "#/$defs/Int",
+      "description": "a number greater than or equal to 1",
+      "title": "greaterThanOrEqualTo(1)",
+      "minimum": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/generate-schema.ts
+++ b/scripts/generate-schema.ts
@@ -1,0 +1,6 @@
+import { writeFileSync } from "node:fs"
+import { JSONSchema } from "effect"
+import { ConfigSchema } from "../src/Config.js"
+
+const schema = JSONSchema.make(ConfigSchema)
+writeFileSync("schema.json", JSON.stringify(schema, null, 2) + "\n")

--- a/src/Config.test.ts
+++ b/src/Config.test.ts
@@ -1,21 +1,36 @@
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs"
+import { execFileSync } from "node:child_process"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { Effect, Exit, Layer } from "effect"
+import { NodeContext } from "@effect/platform-node"
 import { ConfigService } from "./Config.js"
 import { Cwd } from "./Cwd.js"
 
+// ConfigService.Live now also requires FileSystem + CommandExecutor (auto-init
+// writes and git-commits `.gtdrc.json`); NodeContext.layer satisfies both.
+const layer = (dir: string) =>
+  Layer.provide(ConfigService.Live, Layer.merge(Cwd.layer(dir), NodeContext.layer))
+
 const run = <A>(eff: Effect.Effect<A, Error, ConfigService>, dir: string = projectDir) =>
-  Effect.runPromise(eff.pipe(Effect.provide(Layer.provide(ConfigService.Live, Cwd.layer(dir)))))
+  Effect.runPromise(eff.pipe(Effect.provide(layer(dir))))
 
 const runExit = <A>(eff: Effect.Effect<A, Error, ConfigService>, dir: string = projectDir) =>
-  Effect.runPromiseExit(eff.pipe(Effect.provide(Layer.provide(ConfigService.Live, Cwd.layer(dir)))))
+  Effect.runPromiseExit(eff.pipe(Effect.provide(layer(dir))))
 
 let projectDir: string
 
 beforeEach(() => {
   projectDir = mkdtempSync(join(tmpdir(), "gtd-config-"))
+  // Auto-init writes AND commits `.gtdrc.json`, so the temp dir must be a git
+  // repo with a usable identity. Keep the identity repo-local (no global git
+  // mutation).
+  const git = (...args: Array<string>) =>
+    execFileSync("git", args, { cwd: projectDir, stdio: "ignore" })
+  git("init")
+  git("config", "user.name", "gtd-test")
+  git("config", "user.email", "gtd-test@example.com")
 })
 
 afterEach(() => {
@@ -256,6 +271,46 @@ describe("ConfigService", () => {
     expect(cfg.resolveModel("fixing")).toBe("state-fixer")
     expect(cfg.resolveModel("agentic-review")).toBe("state-reviewer")
     expect(cfg.resolveModel("clean")).toBe("state-cleaner")
+  })
+
+  it("auto-init: with no config, creates and commits `.gtdrc.json` at the root with the $schema URL", async () => {
+    await run(Effect.flatMap(ConfigService, (c) => Effect.succeed(c)))
+
+    const rcPath = join(projectDir, ".gtdrc.json")
+    expect(existsSync(rcPath)).toBe(true)
+    const written = JSON.parse(readFileSync(rcPath, "utf8"))
+    expect(written.$schema).toBe("https://raw.githubusercontent.com/pmelab/gtd/main/schema.json")
+  })
+
+  it("strip: a config carrying $schema decodes without an excess-property error", async () => {
+    writeFileSync(
+      join(projectDir, ".gtdrc.json"),
+      JSON.stringify({
+        $schema: "https://raw.githubusercontent.com/pmelab/gtd/main/schema.json",
+        testCommand: "x",
+      }),
+    )
+
+    const exit = await runExit(Effect.flatMap(ConfigService, (c) => Effect.succeed(c)))
+
+    expect(Exit.isSuccess(exit)).toBe(true)
+    if (Exit.isSuccess(exit)) {
+      expect(exit.value.testCommand).toBe("x")
+    }
+  })
+
+  it("idempotency: loading twice succeeds without an `Invalid gtd config` error on excess $schema", async () => {
+    // First load auto-inits (or reads) the stub.
+    const first = await runExit(Effect.flatMap(ConfigService, (c) => Effect.succeed(c)))
+    expect(Exit.isSuccess(first)).toBe(true)
+
+    // The `.gtdrc.json` stub now exists and carries $schema; a second load must
+    // decode it cleanly rather than fail on the excess property.
+    const second = await runExit(Effect.flatMap(ConfigService, (c) => Effect.succeed(c)))
+    expect(Exit.isSuccess(second)).toBe(true)
+    if (Exit.isFailure(second)) {
+      expect(String(second.cause)).not.toMatch(/Invalid gtd config/)
+    }
   })
 
   it("new model state keys decode without excess-property error", async () => {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,8 +1,9 @@
 import { homedir } from "node:os"
-import { dirname } from "node:path"
+import { dirname, join } from "node:path"
 import { cosmiconfig } from "cosmiconfig"
 import { parse as parseYaml } from "yaml"
 import { Context, Effect, Layer, Schema } from "effect"
+import { Command, CommandExecutor } from "@effect/platform"
 import { Cwd } from "./Cwd.js"
 import { ArrayFormatter, ParseError } from "effect/ParseResult"
 
@@ -66,7 +67,7 @@ const ModelsSchema = Schema.Struct({
   states: Schema.optional(ModelStatesSchema),
 })
 
-const ConfigSchema = Schema.Struct({
+export const ConfigSchema = Schema.Struct({
   testCommand: Schema.optional(Schema.String),
   models: Schema.optional(ModelsSchema),
   agenticReview: Schema.optional(Schema.Boolean),
@@ -209,6 +210,51 @@ const loadMerged = (root: string): Effect.Effect<Record<string, unknown>, Error>
     catch: (e) => (e instanceof Error ? e : new Error(String(e))),
   })
 
+const SCHEMA_URL = "https://raw.githubusercontent.com/pmelab/gtd/main/schema.json"
+
+const SCHEMA_STUB = `${JSON.stringify({ $schema: SCHEMA_URL }, null, 2)}\n`
+
+/**
+ * Reuses the same `walkUp` + `searchStrategy: "none"` cosmiconfig explorer as
+ * `loadMerged` to detect whether ANY level of the cwd→root walk carries a gtd
+ * config. Returns `true` on the first non-empty `search(dir)` result.
+ */
+const anyConfigPresent = (root: string): Effect.Effect<boolean, Error> =>
+  Effect.tryPromise({
+    try: async () => {
+      const home = homedir()
+      const chain = walkUp(root, home)
+
+      const explorer = cosmiconfig("gtd", {
+        searchPlaces: SEARCH_PLACES,
+        searchStrategy: "none",
+        loaders: {
+          noExt: yamlLoader,
+          ".json": jsonLoader,
+          ".yaml": yamlLoader,
+          ".yml": yamlLoader,
+        },
+      })
+
+      for (const dir of chain) {
+        const result = await explorer.search(dir)
+        if (result && !result.isEmpty) return true
+      }
+      return false
+    },
+    catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+  })
+
+/**
+ * Write a `.gtdrc.json` stub at `root` containing only the `$schema` key, so
+ * editors get schema validation/autocompletion out of the box.
+ */
+const writeSchemaStub = (root: string): Effect.Effect<void, Error, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    yield* fs.writeFileString(join(root, ".gtdrc.json"), SCHEMA_STUB)
+  }).pipe(Effect.mapError((e) => (e instanceof Error ? e : new Error(String(e)))))
+
 const toOperations = (decoded: DecodedConfig): ConfigOperations => {
   const resolveModel = (state: ModelState): string => {
     const stateOverride = decoded.models?.states?.[state]
@@ -244,8 +290,36 @@ export class ConfigService extends Context.Tag("ConfigService")<ConfigService, C
     ConfigService,
     Effect.gen(function* () {
       const { root } = yield* Cwd
+
+      const present = yield* anyConfigPresent(root)
+      if (!present) {
+        const executor = yield* CommandExecutor.CommandExecutor
+        const git = (...args: Array<string>) =>
+          executor.exitCode(Command.make("git", ...args).pipe(Command.workingDirectory(root)))
+
+        // Never disturb a `gtd: transport` HEAD. Transport is precedence-0 and
+        // means "consume/mixed-reset this exact HEAD". Auto-committing a config
+        // stub on top of it (or writing one into the tree it carries) would
+        // corrupt the primitive: the transport commit would no longer be HEAD,
+        // and — when transport is the repo root — the auto-commit silently masks
+        // the "cannot reset transport commit" error the machine must surface.
+        // Skip auto-init entirely here; it fires normally on a later run once the
+        // transport HEAD has been consumed.
+        const headSubject = yield* Command.make("git", "log", "-1", "--pretty=%s")
+          .pipe(Command.workingDirectory(root), Command.string)
+          .pipe(Effect.map((s) => s.trim()))
+          .pipe(Effect.catchAll(() => Effect.succeed("")))
+
+        if (headSubject !== "gtd: transport") {
+          yield* writeSchemaStub(root)
+          yield* git("add", ".gtdrc.json")
+          yield* git("commit", "-m", "chore: add .gtdrc.json")
+        }
+      }
+
       const merged = yield* loadMerged(root)
-      const decoded = yield* Schema.decodeUnknown(ConfigSchema)(merged, {
+      const { $schema: _schema, ...cleaned } = merged
+      const decoded = yield* Schema.decodeUnknown(ConfigSchema)(cleaned, {
         onExcessProperty: "error",
       })
         .pipe(Effect.mapError(formatSchemaError))

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path"
 import { cosmiconfig } from "cosmiconfig"
 import { parse as parseYaml } from "yaml"
 import { Context, Effect, Layer, Schema } from "effect"
-import { Command, CommandExecutor } from "@effect/platform"
+import { Command, CommandExecutor, FileSystem } from "@effect/platform"
 import { Cwd } from "./Cwd.js"
 import { ArrayFormatter, ParseError } from "effect/ParseResult"
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -297,20 +297,16 @@ export class ConfigService extends Context.Tag("ConfigService")<ConfigService, C
         const git = (...args: Array<string>) =>
           executor.exitCode(Command.make("git", ...args).pipe(Command.workingDirectory(root)))
 
-        // Never disturb a `gtd: transport` HEAD. Transport is precedence-0 and
-        // means "consume/mixed-reset this exact HEAD". Auto-committing a config
-        // stub on top of it (or writing one into the tree it carries) would
-        // corrupt the primitive: the transport commit would no longer be HEAD,
-        // and — when transport is the repo root — the auto-commit silently masks
-        // the "cannot reset transport commit" error the machine must surface.
-        // Skip auto-init entirely here; it fires normally on a later run once the
-        // transport HEAD has been consumed.
+        // Never disturb a repo that's already mid-workflow. Any `gtd:` HEAD means
+        // the machine owns the commit history; auto-committing a stub on top would
+        // produce an unrecognized HEAD and corrupt the state machine. Skip here —
+        // the stub can be added manually or on the next idle run.
         const headSubject = yield* Command.make("git", "log", "-1", "--pretty=%s")
           .pipe(Command.workingDirectory(root), Command.string)
           .pipe(Effect.map((s) => s.trim()))
           .pipe(Effect.catchAll(() => Effect.succeed("")))
 
-        if (headSubject !== "gtd: transport") {
+        if (!headSubject.startsWith("gtd:")) {
           yield* writeSchemaStub(root)
           yield* git("add", ".gtdrc.json")
           yield* git("commit", "-m", "chore: add .gtdrc.json")

--- a/src/ConfigSchemaStub.test.ts
+++ b/src/ConfigSchemaStub.test.ts
@@ -1,0 +1,98 @@
+import { execFileSync } from "node:child_process"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { NodeContext } from "@effect/platform-node"
+import { Effect, Exit, Layer } from "effect"
+import { ConfigService } from "./Config.js"
+import { Cwd } from "./Cwd.js"
+
+// ConfigService.Live now requires FileSystem + CommandExecutor (satisfied by
+// NodeContext.layer, exactly as main.ts provides them) alongside Cwd.
+const liveLayer = (dir: string) =>
+  Layer.provide(ConfigService.Live, Layer.merge(Cwd.layer(dir), NodeContext.layer))
+
+const runExit = <A>(eff: Effect.Effect<A, Error, ConfigService>, dir: string) =>
+  Effect.runPromiseExit(eff.pipe(Effect.provide(liveLayer(dir))))
+
+const getConfig = (dir: string) =>
+  runExit(
+    Effect.flatMap(ConfigService, (c) => Effect.succeed(c)),
+    dir,
+  )
+
+let projectDir: string
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "gtd-schema-"))
+  // Make it a real git repo so the stub commit path can be exercised.
+  execFileSync("git", ["init", "-q"], { cwd: projectDir })
+  execFileSync("git", ["config", "user.email", "t@t.test"], { cwd: projectDir })
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: projectDir })
+})
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true })
+})
+
+describe("ConfigService $schema + stub", () => {
+  it("decodes a config containing a $schema key without an excess-property error", async () => {
+    writeFileSync(
+      join(projectDir, ".gtdrc.json"),
+      JSON.stringify({ $schema: "https://example.com/schema.json", testCommand: "with schema" }),
+    )
+
+    const exit = await getConfig(projectDir)
+
+    expect(Exit.isSuccess(exit)).toBe(true)
+    if (Exit.isSuccess(exit)) {
+      expect(exit.value.testCommand).toBe("with schema")
+    }
+  })
+
+  it("creates a .gtdrc.json stub with the exact $schema content when no config exists", async () => {
+    const exit = await getConfig(projectDir)
+
+    expect(Exit.isSuccess(exit)).toBe(true)
+    const stubPath = join(projectDir, ".gtdrc.json")
+    expect(existsSync(stubPath)).toBe(true)
+    expect(readFileSync(stubPath, "utf8")).toBe(
+      `{\n  "$schema": "https://raw.githubusercontent.com/pmelab/gtd/main/schema.json"\n}\n`,
+    )
+  })
+
+  it("commits the stub with a path-scoped add and the chore message", async () => {
+    await getConfig(projectDir)
+
+    const subject = execFileSync("git", ["log", "-1", "--pretty=%s"], {
+      cwd: projectDir,
+    })
+      .toString()
+      .trim()
+    expect(subject).toBe("chore: add .gtdrc.json")
+
+    // Only the stub was staged/committed — path-scoped add, not `git add -A`.
+    const committedFiles = execFileSync(
+      "git",
+      ["show", "--name-only", "--pretty=format:", "HEAD"],
+      { cwd: projectDir },
+    )
+      .toString()
+      .trim()
+    expect(committedFiles).toBe(".gtdrc.json")
+  })
+
+  it("does not write or commit a stub when a config already exists", async () => {
+    writeFileSync(join(projectDir, ".gtdrc.yaml"), `testCommand: "existing"\n`)
+
+    const exit = await getConfig(projectDir)
+
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(existsSync(join(projectDir, ".gtdrc.json"))).toBe(false)
+    // No commit was created (fresh repo has no HEAD).
+    expect(() =>
+      execFileSync("git", ["rev-parse", "HEAD"], { cwd: projectDir, stdio: "ignore" }),
+    ).toThrow()
+  })
+})

--- a/tests/integration/features/config.feature
+++ b/tests/integration/features/config.feature
@@ -332,6 +332,30 @@ Feature: .gtdrc config system
     And stderr contains ".gtdrc"
 
   @live
+  Scenario: A clean project auto-creates .gtdrc.json with a $schema link
+    Given a test project
+    And a commit "docs: seed plan" that adds "TODO.md" with:
+      """
+      Build the multiply function.
+      """
+    When I run gtd
+    Then it succeeds
+    And the file ".gtdrc.json" exists
+    And the file ".gtdrc.json" contains "https://raw.githubusercontent.com/pmelab/gtd/main/schema.json"
+
+  @live
+  Scenario: A second gtd run does not reject the auto-created .gtdrc.json
+    Given a test project
+    And a commit "docs: seed plan" that adds "TODO.md" with:
+      """
+      Build the multiply function.
+      """
+    When I run gtd
+    And I run gtd
+    Then it succeeds
+    And stderr does not contain "Invalid gtd config"
+
+  @live
   Scenario: A config in a shared parent directory cascades down to a repo beneath it
     # Only the shared (non-git-root) parent carries a .gtdrc; the repo has none.
     # The ancestor's planning model must still reach the decompose prompt, proving

--- a/tests/integration/features/environment.feature
+++ b/tests/integration/features/environment.feature
@@ -61,6 +61,10 @@ Feature: Hostile environments and unusual invocations
   # no destructive action — on the default branch it settles Idle.
   Scenario: A merge commit at HEAD degrades gracefully
     Given a test project
+    And a gtd config file at "." with:
+      """
+      testCommand: npm run test
+      """
     And a merge commit merging a branch with a commit "feat: side work" that adds "src/side.ts" with:
       """
       export const side = () => 1

--- a/tests/integration/features/steering-misuse.feature
+++ b/tests/integration/features/steering-misuse.feature
@@ -63,6 +63,10 @@ Feature: Manual steering-file misuse and odd .gtd contents
   @live
   Scenario: An empty .gtd directory does not crash the build loop
     Given a test project
+    And a gtd config file at "." with:
+      """
+      testCommand: npm run test
+      """
     And a commit "gtd: planning"
     And a directory ".gtd"
     When I run gtd

--- a/tests/integration/features/transport.feature
+++ b/tests/integration/features/transport.feature
@@ -18,6 +18,9 @@ Feature: Transport — mixed-reset a hand-made gtd: transport HEAD, then re-deri
     # The transport commit is gone (mixed-reset); the carried work re-derived as a
     # fresh feature seed and advanced into grilling.
     And the git log does not contain "gtd: transport"
+    # Config auto-init is skipped on a transport HEAD, so no stub commit is
+    # planted on top of the handoff commit.
+    And the git log does not contain "chore: add .gtdrc.json"
     And the git log contains "gtd: new task"
     And the last commit subject is "gtd: grilling"
     And stdout contains "holds the plan under development"


### PR DESCRIPTION
## Summary

- Converts gtd from an agent-skill script bundle to a proper npm CLI package (`@pmelab/gtd`)
- Adds JSON Schema generation and auto-init (`.gtdrc.json` committed on first run, with `$schema` for editor autocompletion)
- `$schema` key stripped before validation so editors can annotate configs without excess-property errors
- OIDC npm publishing via GitHub Actions

## Test plan

- [ ] `npm run build` succeeds
- [ ] `npm run test` passes
- [ ] First run in a project without `.gtdrc` auto-creates and commits `.gtdrc.json`
- [ ] Second run does not reject the auto-created config