### PR TITLE
test: pin codeDirty-independence of review-lifecycle routing

### DIFF
--- a/src/Machine.test.ts
+++ b/src/Machine.test.ts
@@ -404,6 +404,17 @@ describe("rule 4 — review lifecycle", () => {
     // (`reviewCommitted` needs a clean tree, checkbox-only is excluded here).
   })
 
+  it("committed REVIEW + dirty source code (REVIEW.md itself clean) → accept-review, seedAcceptReview", () => {
+    const res = r({
+      reviewPresent: true,
+      reviewDirty: true,
+      codeDirty: true,
+    })
+    expect(res.state).toBe("accept-review")
+    expect(res.autoAdvance).toBe(true)
+    expect(res.edgeAction).toEqual({ kind: "seedAcceptReview" })
+  })
+
   it("reviewDirty + reviewCheckboxOnly → done, auto, done", () => {
     const res = r({
       reviewPresent: true,


### PR DESCRIPTION
## What

Adds one unit test to `src/Machine.test.ts` pinning that `resolveReviewLifecycle`'s routing to `accept-review` + `seedAcceptReview` is **independent of `codeDirty`**.

## Why

`resolveReviewLifecycle` routes a committed-but-dirty review situation based only on `head`, `reviewCommitted`, `reviewDirty`, and `reviewCheckboxOnly` — it never reads `codeDirty`. The existing unit test only exercised the "REVIEW.md itself dirty" variant (`codeDirty` at its default `false`), so a regression gating the feedback branch on `codeDirty` (e.g. `if (p.reviewDirty && !p.codeDirty)`) would still pass at the unit level; only the slower integration test (`review.feature:179`) would catch it. This test closes that gap.

## Notes

- No production code change — machine and edge computation were verified correct.
- No new cucumber scenario — behavioral coverage already exists end-to-end at `review.feature:179`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)