### PR TITLE
feat(cli): add read-only `gtd status` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,6 +759,7 @@ Commands:
   (default)        Run the gtd driver loop — detect state, emit next prompt
   format <file>    Format a markdown file in place
   review <target>  Ad-hoc human review against a git ref or branch
+  status           Print current state, next state, and pending edge actions (no actions, no prompt)
 
 Options:
   --json           Output structured JSON instead of plain text
@@ -773,7 +774,7 @@ repository-state work — they run outside a repo and in any repo state.
 
 ## Subcommands
 
-gtd ships two subcommands: `format` and `review`.
+gtd ships three subcommands: `format`, `review`, and `status`.
 
 ## Review subcommand
 
@@ -811,6 +812,82 @@ All errors exit with **code 1** and write a message to **stderr**:
 - **Empty diff** — the merge-base diff between `<target>` and HEAD is empty
   (nothing to review):
   `gtd review: nothing to review (<target> diff is empty after filtering)`
+
+## Status subcommand
+
+```bash
+gtd status
+```
+
+Pure, read-only introspection. Prints the current machine state, the state the
+next real `gtd` run would stop at, and a short summary of the edge actions the
+next run would perform. Performs **nothing** (no commit, reset, or file write)
+and prints **no prompt** — guaranteed side-effect free.
+
+### Fields
+
+| Field             | Description                                                       |
+| ----------------- | ----------------------------------------------------------------- |
+| `state`           | Current machine state                                             |
+| `nextState`       | State the next `gtd` run would stop at, or `null` for edge-only   |
+| `willAutoAdvance` | `true` when the current state is edge-only (auto-advances on run) |
+| `edgeActions`     | List of edge actions the next run would perform before prompting  |
+
+### One-hop semantics
+
+`status` runs the same read-only gather+resolve the driver's first iteration
+does, then reports it without looping or performing.
+
+- A **prompt-bearing / human / terminal** current state reports itself as
+  `nextState`. The next run performs any pending edge action, then prompts
+  there.
+- An **edge-only** current state reports `nextState: null` and
+  `willAutoAdvance: true`, naming the immediate edge action. Because the landing
+  state after auto-advance depends on side effects (test pass/fail, commits)
+  that `status` refuses to run, it honestly reports the current state rather
+  than guessing a landing state. There is **no** multi-hop simulation.
+
+### Output
+
+Default (human-readable) — `building` example:
+
+```
+State:      building
+Next state: building (next run prompts here)
+Edge actions:
+  - commit pending changes as "gtd: building"
+```
+
+With `--json` — same example:
+
+```json
+{
+  "state": "building",
+  "nextState": "building",
+  "willAutoAdvance": false,
+  "edgeActions": ["commit pending changes as \"gtd: building\""]
+}
+```
+
+Edge-only example (`testing` state):
+
+```json
+{
+  "state": "testing",
+  "nextState": null,
+  "willAutoAdvance": true,
+  "edgeActions": ["run the test suite (attempt 1)"]
+}
+```
+
+The JSON envelope contains no `prompt` field — this distinguishes it from the
+default `gtd` run and `gtd review` JSON output.
+
+### Requirements
+
+- Must be run from the **repository root** (same cwd guard as other repo
+  commands).
+- Takes **no arguments** — extra args are rejected with an error.
 
 ## Format subcommand
 

--- a/src/State.test.ts
+++ b/src/State.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
-import type { GtdState } from "./Machine.js"
-import { EDGE_ONLY_STATES, isEdgeOnly } from "./State.js"
+import type { GtdState, ResolveContext } from "./Machine.js"
+import { EDGE_ONLY_STATES, describeStatus, isEdgeOnly } from "./State.js"
 
 // The driver's auto-advance-vs-prompt decision hinges entirely on this set: it
 // must stay identical to `Prompt.ts`'s (private) `EDGE_ONLY_STATES`, i.e. the
@@ -59,5 +59,56 @@ describe("edge-only state classification", () => {
     for (const state of promptBearing) {
       expect(isEdgeOnly(state)).toBe(false)
     }
+  })
+})
+
+const minContext: ResolveContext = {
+  testFixCount: 0,
+  reviewFixCount: 0,
+  packages: [],
+  diff: "",
+  lastCommitSubject: "",
+  workingTreeClean: true,
+  feedbackContent: "",
+}
+
+describe("describeStatus", () => {
+  it("prompt-bearing result: state=building, no edgeAction", () => {
+    const result = {
+      state: "building" as GtdState,
+      autoAdvance: false,
+      context: minContext,
+    }
+    expect(describeStatus(result)).toEqual({
+      state: "building",
+      nextState: "building",
+      willAutoAdvance: false,
+      edgeActions: [],
+    })
+  })
+
+  it("edge-only result: state=testing, runTest edgeAction", () => {
+    const result = {
+      state: "testing" as GtdState,
+      autoAdvance: true,
+      edgeAction: { kind: "runTest" as const, errorCount: 0, capReached: false },
+      context: minContext,
+    }
+    const summary = describeStatus(result)
+    expect(summary.nextState).toBeNull()
+    expect(summary.willAutoAdvance).toBe(true)
+    expect(summary.edgeActions[0]).toBe("run the test suite (attempt 1)")
+  })
+
+  it("commitPending with removeTodo=true", () => {
+    const result = {
+      state: "planning" as GtdState,
+      autoAdvance: false,
+      edgeAction: { kind: "commitPending" as const, prefix: "gtd: planning", removeTodo: true },
+      context: minContext,
+    }
+    expect(describeStatus(result).edgeActions[0]).toBe(
+      'commit pending changes as "gtd: planning" (removing TODO.md)',
+    )
   })
 })

--- a/src/State.ts
+++ b/src/State.ts
@@ -4,7 +4,7 @@ import type { ConfigService } from "./Config.js"
 import { gatherEvents } from "./Events.js"
 import type { GitService } from "./Git.js"
 import { Cwd } from "./Cwd.js"
-import { type GtdState, resolve, type Result } from "./Machine.js"
+import { type EdgeAction, type GtdState, resolve, type Result } from "./Machine.js"
 
 /**
  * The thin decision core the driver loop in `main.ts` calls. There is no
@@ -45,6 +45,58 @@ export const EDGE_ONLY_STATES: ReadonlySet<GtdState> = new Set<GtdState>([
 
 /** True when the driver must auto-advance (re-gather + re-resolve) past `state` rather than prompt. */
 export const isEdgeOnly = (state: GtdState): boolean => EDGE_ONLY_STATES.has(state)
+
+/** A pure, IO-free summary of the current gtd state derived from a resolved `Result`. */
+export interface StatusSummary {
+  readonly state: GtdState
+  readonly nextState: GtdState | null
+  readonly willAutoAdvance: boolean
+  readonly edgeActions: readonly string[]
+}
+
+type EdgeActionHandlers = {
+  readonly [K in EdgeAction["kind"]]: (a: Extract<EdgeAction, { kind: K }>) => string
+}
+
+/** Renders one human-readable phrase for each `EdgeAction` variant. */
+const edgeActionHandlers: EdgeActionHandlers = {
+  transportReset: () => "reset the working tree to the gtd: transport parent",
+  seedNewFeature: () => "seed a new feature (write the initial TODO.md)",
+  seedAcceptReview: () => "seed the accept-review step",
+  captureGrillingEdits: () => "capture pending grilling edits into TODO.md",
+  runTest: (a) =>
+    `run the test suite (attempt ${a.errorCount + 1}${a.capReached ? ", cap reached" : ""})`,
+  commitPending: (a) => {
+    let msg = `commit pending changes as "${a.prefix}"`
+    if (a.removeTodo) msg += " (removing TODO.md)"
+    if (a.removeFeedback) msg += " (removing FEEDBACK.md)"
+    if (a.removeHealth) msg += " (removing HEALTH.md)"
+    return msg
+  },
+  runHealthCheck: (a) =>
+    `run the health check${a.commitErrorsReset ? " (resetting the error budget)" : ""}`,
+  closePackage: () => "close the active package (commit gtd: package done)",
+  commitReview: () => "commit the review record (REVIEW.md)",
+  done: () => "finalize the review cycle (commit gtd: done)",
+  squashCommit: (a) => `squash the cycle onto ${a.squashBase}`,
+  removeHealthSentinel: () =>
+    "remove the health-squash sentinel before prompting for a squash message",
+  removeStraySquashMsg: () => "remove a stray SQUASH_MSG.md",
+}
+
+const describeEdgeAction = (a: EdgeAction): string =>
+  (edgeActionHandlers[a.kind] as (a: EdgeAction) => string)(a)
+
+/** Pure fold of a resolved `Result` into a `StatusSummary`. Performs no IO. */
+export const describeStatus = (result: Result): StatusSummary => {
+  const willAutoAdvance = isEdgeOnly(result.state)
+  return {
+    state: result.state,
+    nextState: willAutoAdvance ? null : result.state,
+    willAutoAdvance,
+    edgeActions: result.edgeAction ? [describeEdgeAction(result.edgeAction)] : [],
+  }
+}
 
 /**
  * Gather every git/filesystem fact (the only IO, in `Events.gatherEvents`) and

--- a/src/program.ts
+++ b/src/program.ts
@@ -9,7 +9,8 @@ import { GitService } from "./Git.js"
 import type { Result } from "./Machine.js"
 import { cleanResult, DEFAULT_PAYLOAD } from "./Machine.js"
 import { buildPrompt } from "./Prompt.js"
-import { detect, isEdgeOnly } from "./State.js"
+import { describeStatus, detect, isEdgeOnly } from "./State.js"
+import type { StatusSummary } from "./State.js"
 import { TestRunner } from "./TestRunner.js"
 
 const _require = createRequire(import.meta.url)
@@ -21,6 +22,7 @@ Commands:
   (default)        Run the gtd driver loop — detect state, emit next prompt
   format <file>    Format a markdown file in place
   review <target>  Ad-hoc human review against a git ref or branch
+  status           Print current state, next state, and pending edge actions (no actions, no prompt)
 
 Options:
   --json           Output structured JSON instead of plain text
@@ -54,6 +56,29 @@ const IDLE_RESULT: Result = {
  * machine/edge bug — fail loudly rather than spin forever.
  */
 const MAX_EDGE_HOPS = 100
+
+/**
+ * Pure presenter: formats a `StatusSummary` as human-readable text.
+ * Returns a string ending in exactly one trailing newline.
+ */
+const renderStatus = (s: StatusSummary): string => {
+  const lines: string[] = []
+  lines.push(`State:      ${s.state}`)
+  if (s.willAutoAdvance) {
+    lines.push(`Next state: (edge-only — next run performs the action(s) below and auto-advances)`)
+  } else {
+    lines.push(`Next state: ${s.nextState} (next run prompts here)`)
+  }
+  if (s.edgeActions.length === 0) {
+    lines.push(`Edge actions: none`)
+  } else {
+    lines.push(`Edge actions:`)
+    for (const action of s.edgeActions) {
+      lines.push(`  - ${action}`)
+    }
+  }
+  return lines.join("\n") + "\n"
+}
 
 /**
  * Options for the exported `makeProgram` factory.
@@ -196,7 +221,24 @@ export function makeProgram(
       return
     }
 
-    // No escape hatches: gtd takes no command other than `format` or `review`.
+    if (sub === "status") {
+      const args = argv.slice(3).filter((a) => a.length > 0 && !a.startsWith("--"))
+      if (args.length > 0) {
+        return yield* Effect.fail(
+          new Error(`gtd status: too many arguments — expected none, got: ${args.join(", ")}`),
+        )
+      }
+      const result = yield* detect()
+      const summary = describeStatus(result)
+      if (json) {
+        write(JSON.stringify(summary) + "\n")
+      } else {
+        write(renderStatus(summary))
+      }
+      return
+    }
+
+    // No escape hatches: gtd takes no command other than `format`, `review`, or `status`.
     // Anything else (e.g. `transport`, `abort`) is rejected rather than silently ignored.
     if (sub !== undefined) {
       return yield* Effect.fail(new Error(`unknown command '${sub}'`))

--- a/tests/integration/features/status-subcommand.feature
+++ b/tests/integration/features/status-subcommand.feature
@@ -1,0 +1,111 @@
+@inmem
+Feature: gtd status subcommand
+
+  `gtd status` is a pure, read-only introspection command: it reports the
+  current state, the next state, and any pending edge actions. It performs no
+  git operations, runs no tests, writes no files, and emits no prompt. The
+  `--json` flag switches output to a `StatusSummary` object.
+
+  Scenario: Prompt-bearing state reports itself as next state (human-readable)
+    Given a test project
+    And a commit "gtd: grilling" that adds "TODO.md" with:
+      """
+      # Plan
+
+      Build a feature.
+
+      ## What approach?
+
+      <!-- user answers here -->
+      """
+    When I run gtd with args "status"
+    Then it succeeds
+    And stdout contains "State:"
+    And stdout contains "grilling"
+    And stdout contains "Next state:"
+
+  Scenario: Edge-only state reports auto-advance and the edge action
+    Given a test project
+    And a file "REVIEW.md" with:
+      """
+      ## Review
+
+      - [ ] Looks good
+      """
+    When I run gtd with args "status"
+    Then it succeeds
+    And stdout contains "auto-advances"
+    And stdout contains "Edge actions:"
+    And stdout contains "commit the review record"
+
+  Scenario: --json emits the StatusSummary object
+    Given a test project
+    And a commit "gtd: grilling" that adds "TODO.md" with:
+      """
+      # Plan
+
+      Build a feature.
+
+      ## What approach?
+
+      <!-- user answers here -->
+      """
+    When I run gtd with args "status --json"
+    Then it succeeds
+    And stdout contains "\"state\""
+    And stdout contains "\"nextState\""
+    And stdout contains "\"willAutoAdvance\""
+    And stdout contains "\"edgeActions\""
+    And stdout does not contain "\"prompt\""
+
+  Scenario: --json state field matches resolved state name (escalate)
+    Given a test project
+    And a commit "gtd: planning" that adds ".gtd/01-foo/01-task.md" with:
+      """
+      Implement the helper function.
+      """
+    And a commit "gtd: errors" that adds "ERRORS.md" with:
+      """
+      The test suite failed three times: assertion mismatch on line 42.
+      """
+    When I run gtd with args "status --json"
+    Then it succeeds
+    And stdout contains "\"state\":\"escalate\""
+    And stdout contains "\"nextState\":\"escalate\""
+
+  Scenario: status performs no actions and prints no prompt
+    Given a test project
+    And a commit "gtd: planning" that adds ".gtd/01-foo/01-task.md" with:
+      """
+      Implement the helper function.
+      """
+    Then I record the commit count
+    When I run gtd with args "status"
+    Then it succeeds
+    And the commit count is unchanged
+    And stdout does not contain "run `gtd`"
+
+  Scenario: status rejects extra arguments
+    Given a test project
+    When I run gtd with args "status extra"
+    Then it fails
+    And stderr contains "gtd status: too many arguments"
+
+  Scenario: status on an illegal steering-file combination reports the error
+    Given a test project
+    And a commit "gtd: planning" that adds ".gtd/01-foo/01-task.md" with:
+      """
+      Implement the helper function.
+      """
+    And a file "ERRORS.md" with:
+      """
+      test failed
+      """
+    And a file "FEEDBACK.md" with:
+      """
+      a finding
+      """
+    And the working tree is committed as "feat: illegal combination"
+    When I run gtd with args "status --json"
+    Then it fails
+    And stdout contains "\"state\":\"error\""


### PR DESCRIPTION
Closes #63.

Adds a pure, read-only `gtd status` subcommand that prints the current machine state, the state the next `gtd` run would stop at, and a short summary of pending edge actions — **without** performing any edge action or emitting a prompt. Human-readable by default; single-line JSON with `--json`.

## Design

- **One-hop, no side effects.** `status` derives everything purely from the current git + filesystem facts via the existing pure `detect()` (one gather + resolve hop). No multi-hop simulation.
- A **prompt-bearing** current state reports itself as `nextState` (the next run performs any pending edge action, then prompts there).
- An **edge-only** current state reports `nextState: null` + `willAutoAdvance: true` and names the immediate edge action — rather than guessing a landing state that would depend on side effects (test pass/fail, commits) the command refuses to run.
- The JSON envelope intentionally omits the `prompt` field, distinguishing it from the default run and `gtd review` output.
- The edge-action describer uses an exhaustive, typechecked handler map over the `EdgeAction` union, so new variants must be described before they compile.

## Changes

- `src/State.ts` — pure `StatusSummary`, `describeEdgeAction` (handler map), `describeStatus`
- `src/program.ts` — `status` subcommand dispatch, `renderStatus` presenter, HELP_TEXT
- `tests/integration/features/status-subcommand.feature` — 7 `@inmem` scenarios
- `src/State.test.ts` — unit tests for `describeStatus`
- `README.md` — new `## Status subcommand` section + Commands/Subcommands sync

## Testing

Full suite GREEN: `format:check`, `typecheck`, `lint`, unit, e2e, and the `fallow` health check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)