### PR TITLE
feat: add gtd-loop, a packaged binary for the reference loop driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ gtd next --json            # ask who's up and what they should do
 See [The reference loop driver](#the-reference-loop-driver) for a full script
 implementing this protocol, and [`skills/loop/SKILL.md`](skills/loop/SKILL.md)
 for the agent-facing instructions that follow the same pinned contract.
+`gtd-loop`, installed alongside `gtd` (see below), is the packaged, ready-to-run
+implementation of that same script for anyone who doesn't want to drive the loop
+by hand.
 
 ## Installation
 
@@ -396,6 +399,26 @@ side can drive — agent rests and agent-driven checkpoints — reports
 `actor: "agent"`, so multiple agent turns and commits (e.g. successive test/fix
 cycles, a force-approved package close) chain without human involvement until an
 actual human gate is hit.
+
+`bin/gtd-loop`, installed as the `gtd-loop` binary, is the packaged
+implementation of this exact script — kept in sync with it the same way
+`skills/loop/SKILL.md` is. It additionally attempts `gtd step` (not just
+`gtd step-agent`) every iteration, so a plain rerun after you've edited a file
+at a human gate (no commit needed) picks up your edit and keeps going, and it
+halts with a diagnostic if the same state and prompt repeat with no progress
+(see `skills/loop/SKILL.md`'s "Stall detection").
+
+### Using a different agent
+
+`gtd-loop` defaults to
+`claude -p "$GTD_LOOP_PROMPT" --dangerously-skip-permissions`, but the agent
+invocation is swappable: set `GTD_LOOP_AGENT_CMD` to any shell command, and it
+runs with the prompt available as `$GTD_LOOP_PROMPT` in its environment. For
+example, to drive a different agent CLI:
+
+```bash
+GTD_LOOP_AGENT_CMD='my-agent-cli --prompt "$GTD_LOOP_PROMPT"' gtd-loop
+```
 
 ## States & subjects overview
 

--- a/bin/gtd-loop
+++ b/bin/gtd-loop
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Drives the two-beat protocol (README.md "The reference loop driver") to a
+# human gate. Both mutators are attempted every iteration, refusal-tolerant:
+# whichever actor is actually awaited claims the turn (captures the human's
+# uncommitted edit after a halt, or the agent's own edit from the previous
+# iteration), the other refuses harmlessly.
+prev_state=""
+prev_prompt=""
+
+while true; do
+  gtd step --json >/dev/null 2>&1 || true
+  gtd step-agent --json >/dev/null 2>&1 || true
+
+  if ! next_json="$(gtd next --json 2>&1)"; then
+    echo "gtd-loop: could not determine the next step:" >&2
+    echo "$next_json" >&2
+    echo "Run \`gtd status\` to inspect the repo." >&2
+    exit 1
+  fi
+
+  actor="$(jq -r .actor <<<"$next_json")"
+  pending="$(jq -r .pending <<<"$next_json")"
+  state="$(jq -r .state <<<"$next_json")"
+  prompt="$(jq -r .prompt <<<"$next_json")"
+
+  if [[ "$actor" != "agent" ]]; then
+    echo "--- Your turn ($state) ---"
+    gtd next
+    exit 0
+  fi
+
+  if [[ "$pending" == "true" ]]; then
+    prev_state=""
+    prev_prompt=""
+    continue
+  fi
+
+  # Stall detection (skills/loop/SKILL.md): the same agent-owned state and
+  # prompt repeating means the last dispatch made no progress — stop rather
+  # than spin on it.
+  if [[ "$state" == "$prev_state" && "$prompt" == "$prev_prompt" ]]; then
+    echo "gtd-loop: no progress at '$state' — the agent's last turn changed nothing. Stopping to avoid spinning." >&2
+    gtd next >&2
+    exit 1
+  fi
+  prev_state="$state"
+  prev_prompt="$prompt"
+
+  # Swappable agent adapter: GTD_LOOP_AGENT_CMD lets any coding agent CLI
+  # stand in for the default, receiving the prompt via $GTD_LOOP_PROMPT.
+  cmd="${GTD_LOOP_AGENT_CMD:-}"
+  if [[ -z "$cmd" ]]; then
+    cmd='claude -p "$GTD_LOOP_PROMPT" --dangerously-skip-permissions'
+  fi
+  GTD_LOOP_PROMPT="$prompt" bash -c "$cmd"
+done

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "private": false,
   "description": "Git-aware CLI that emits the next prompt for an autonomous coding agent based on the current repository state",
   "bin": {
-    "gtd": "dist/gtd.bundle.mjs"
+    "gtd": "dist/gtd.bundle.mjs",
+    "gtd-loop": "bin/gtd-loop"
   },
   "files": [
     "dist/",
+    "bin/",
     "README.md",
     "LICENSE",
     "schema.json"

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -1,0 +1,145 @@
+@live
+Feature: gtd-loop — the packaged reference loop driver
+
+  `bin/gtd-loop` is the installable implementation of the two-beat protocol
+  documented in README.md's "The reference loop driver". These scenarios spawn
+  it as a real subprocess (never the real `claude` CLI — a stub agent script
+  stands in, wired through `GTD_LOOP_AGENT_CMD`) to prove its control flow:
+  chaining agent turns, halting at a human gate, picking up an uncommitted
+  human edit on rerun, and detecting a stalled agent turn.
+
+  Scenario: Chains several agent turns, then halts at the next human gate
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      testCommand: "true"
+      agenticReview: false
+      squash: false
+      """
+    And a commit "gtd(agent): grilling" that adds ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      Implement a calculator with add only, in src/calc.ts.
+      """
+    And a commit "gtd: planning" that deletes ".gtd/TODO.md"
+    And a commit "gtd: planning" that adds ".gtd/01-calc/01-add.md" with:
+      """
+      Implement add() in src/calc.ts.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Build the package described below"*)
+          mkdir -p src
+          cat > src/calc.ts <<'CALC'
+      export const add = (a: number, b: number) => a + b
+      CALC
+          ;;
+        *"help a human to review the changes"*)
+          mkdir -p .gtd
+          cat > .gtd/REVIEW.md <<'REVIEW'
+      # Review
+
+      ## Add calculator
+
+      - [ ] ./src/calc.ts#1
+      REVIEW
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    When I run gtd-loop
+    Then it succeeds
+    And stdout contains "--- Your turn (await-review) ---"
+    And the git log contains "gtd(agent): building"
+    And the git log contains "gtd: tests green"
+    And the git log contains "gtd: package done"
+    And the git log contains "gtd(agent): review"
+    And the last commit subject is "gtd: awaiting review"
+
+  Scenario: Rerunning after an uncommitted human edit picks it up and continues
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      testCommand: "true"
+      agenticReview: false
+      squash: false
+      """
+    And a commit "gtd(agent): grilling" that adds ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      Implement a calculator with add only, in src/calc.ts.
+      """
+    And a commit "gtd: planning" that deletes ".gtd/TODO.md"
+    And a commit "gtd: planning" that adds ".gtd/01-calc/01-add.md" with:
+      """
+      Implement add() in src/calc.ts.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Build the package described below"*)
+          mkdir -p src
+          cat > src/calc.ts <<'CALC'
+      export const add = (a: number, b: number) => a + b
+      CALC
+          ;;
+        *"help a human to review the changes"*)
+          mkdir -p .gtd
+          cat > .gtd/REVIEW.md <<'REVIEW'
+      # Review
+
+      ## Add calculator
+
+      - [ ] ./src/calc.ts#1
+      REVIEW
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    When I run gtd-loop
+    Then it succeeds
+    And the last commit subject is "gtd: awaiting review"
+    # The human approves the review by deleting REVIEW.md, without committing —
+    # exactly the "edit, don't commit, just rerun" workflow gtd-loop supports.
+    Given a deleted committed file ".gtd/REVIEW.md"
+    When I run gtd-loop
+    Then it succeeds
+    And the git log contains "gtd(human): review"
+    And the git log contains "gtd: done"
+    And stdout contains "--- Your turn (idle) ---"
+
+  Scenario: Stops instead of spinning when the agent's turn makes no progress
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      testCommand: "true"
+      agenticReview: false
+      squash: false
+      """
+    And a commit "gtd(agent): grilling" that adds ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      Implement a calculator with add only, in src/calc.ts.
+      """
+    And a commit "gtd: planning" that deletes ".gtd/TODO.md"
+    And a commit "gtd: planning" that adds ".gtd/01-calc/01-add.md" with:
+      """
+      Implement add() in src/calc.ts.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      : # does nothing — the build prompt is never acted on
+      """
+    When I run gtd-loop
+    Then it fails
+    And stderr contains "no progress at 'building'"

--- a/tests/integration/support/steps/gtd-loop.steps.ts
+++ b/tests/integration/support/steps/gtd-loop.steps.ts
@@ -1,0 +1,69 @@
+import { Given, When } from "quickpickle"
+import { execFile as execFileCb } from "node:child_process"
+import { promisify } from "node:util"
+import { writeFileSync, mkdtempSync, chmodSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import type { GtdWorld } from "../world.js"
+
+const execFile = promisify(execFileCb)
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "../../../..")
+const GTD_BIN = join(PROJECT_ROOT, "dist/gtd.bundle.mjs")
+const GTD_LOOP_BIN = join(PROJECT_ROOT, "bin/gtd-loop")
+
+// The stub stands in for a real coding agent CLI: it reads $GTD_LOOP_PROMPT
+// (set by gtd-loop per turn) and reacts however the docstring says to, so the
+// scenario text shows exactly what the "agent" does for each prompt it sees.
+Given("a stub agent script that responds to prompts with:", (world: GtdWorld, script: string) => {
+  const dir = mkdtempSync(join(tmpdir(), "gtd-loop-stub-"))
+  const scriptPath = join(dir, "agent.sh")
+  writeFileSync(scriptPath, `#!/usr/bin/env bash\nset -euo pipefail\n${script}\n`)
+  chmodSync(scriptPath, 0o755)
+  world.stubAgentPath = scriptPath
+})
+
+// A `gtd` shim on PATH — bin/gtd-loop calls bare `gtd`, exactly as it would
+// once installed, rather than the absolute dist path the @live tier's own
+// runGtdLive uses for `gtd` directly.
+function writeGtdShim(): string {
+  const shimDir = mkdtempSync(join(tmpdir(), "gtd-loop-path-"))
+  const gtdShim = join(shimDir, "gtd")
+  writeFileSync(gtdShim, `#!/usr/bin/env bash\nexec node "${GTD_BIN}" "$@"\n`)
+  chmodSync(gtdShim, 0o755)
+  return shimDir
+}
+
+function gtdLoopEnv(world: GtdWorld): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    PATH: `${writeGtdShim()}:${process.env["PATH"]}`,
+  }
+  if (world.stubAgentPath) {
+    env["GTD_LOOP_AGENT_CMD"] = `bash "${world.stubAgentPath}"`
+  }
+  return env
+}
+
+function toFailedResult(err: unknown): { exitCode: number; stdout: string; stderr: string } {
+  const e = err as { code?: unknown; stdout?: string; stderr?: string }
+  const exitCode = typeof e.code === "number" ? e.code : 1
+  return { exitCode, stdout: e.stdout ?? "", stderr: e.stderr ?? "" }
+}
+
+// Spawns the real bin/gtd-loop against the real built gtd.bundle.mjs, exactly
+// like the @live tier's runGtdLive does for `gtd` itself — gtd-loop is its own
+// process, so it can't go through the in-process/inmem tier.
+When("I run gtd-loop", async (world: GtdWorld) => {
+  try {
+    const { stdout, stderr } = await execFile("bash", [GTD_LOOP_BIN], {
+      cwd: world.repoDir,
+      env: gtdLoopEnv(world),
+      encoding: "utf-8",
+      timeout: 30_000,
+    })
+    world.lastResult = { exitCode: 0, stdout, stderr }
+  } catch (err: unknown) {
+    world.lastResult = toFailedResult(err)
+  }
+})

--- a/tests/integration/support/world.ts
+++ b/tests/integration/support/world.ts
@@ -34,6 +34,8 @@ export class GtdWorld extends QuickPickleWorld {
     stderr: "",
   }
   savedCommitCount: number | undefined = undefined
+  /** Path to a stub agent script for `gtd-loop` scenarios (@live only). */
+  stubAgentPath: string | undefined = undefined
 
   /** Directory the next `runGtd` uses as cwd; defaults to the repo root. */
   runCwd: string | undefined = undefined

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
             "./tests/integration/support/steps/environment.steps.ts",
             "./tests/integration/support/steps/formatting.steps.ts",
             "./tests/integration/support/steps/gtd-state.steps.ts",
+            "./tests/integration/support/steps/gtd-loop.steps.ts",
           ],
           testTimeout: 300_000,
         },


### PR DESCRIPTION
Packages README.md's documented "reference loop driver" bash script as an
installable bin/gtd-loop, so running the agentic loop end to end is a single
command instead of hand-copying the snippet.

Beyond the documented protocol, gtd-loop also attempts `gtd step` (not just
`gtd step-agent`) every iteration, so rerunning after editing a file at a
human gate — with no commit — picks up the edit and keeps going. It halts
with a diagnostic when the same state and prompt repeat with no progress
(the stall rule already documented in skills/loop/SKILL.md but never
implemented), and the agent invocation is swappable via GTD_LOOP_AGENT_CMD
so other coding agent CLIs can drive it too.