### PR TITLE
feat(review): surface the pending review diff in editors via a review checkout window

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,11 @@
       "Bash(npm run typecheck)",
       "Bash(npm run format:check)",
       "Bash(npm run test:unit)",
-      "Bash(npx vitest run --project unit *)"
+      "Bash(npm run test:e2e)",
+      "Bash(npm test)",
+      "Bash(npx tsc --noEmit)",
+      "Bash(npx vitest run --project unit *)",
+      "Bash(npx vitest run --project e2e *)"
     ],
     "deny": ["Bash(npm run test:mutation)", "Bash(npx stryker run)", "Bash(stryker run)"]
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,17 @@ Same pattern for the `invoker` actor (`"human" | "agent" | "none"`,
 because it's a pure-decision input consumed by the resolver's turn guards
 (`applyTurnTaking`), not something every side effect needs to see.
 
+### Review Checkout Window (Program-Edge Concern)
+
+The review checkout window (`src/ReviewWindow.ts` — HEAD/index rewound to the
+review base while `gtd: awaiting review` rests, so editors surface the diff) is
+wired ONLY in `src/program.ts`: closed before `ConfigInit.ensure` and every
+`gatherEvents`, re-armed after dispatch (success AND failure paths). The
+machine, `gatherEvents`, and `perform` must never know it exists — no
+`ResolvePayload` field, no `GtdState`, no Context tag. Anything that reads git
+state through a new entry point must run AFTER the close hook, or it will
+classify against the rewound HEAD.
+
 ### Agentic Cycle Count Fold
 
 `testFixCount` / `reviewFixCount` / `healthFixCount` are **folded in the

--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ to cwd, so it refuses with a clear error if invoked from a subdirectory.
 `--jsn`) is rejected with a usage error rather than silently ignored, so a
 mistyped flag can never degrade a JSON caller to plain-text mode.
 
+One nuance to "(no mutation)": `next` and `status` never author commits or
+change workflow state, but while a human review is pending they do maintain the
+review checkout window (closing it to read state, re-arming it on the way out —
+see [Human review gate](#human-review-gate)), which transiently moves HEAD and
+the index. The working tree is never touched.
+
 ### `gtd step` / `gtd step-agent`
 
 Both drive the **same fixpoint loop** — gather → resolve → perform the returned
@@ -547,11 +553,38 @@ Once `.gtd/` is fully closed, the machine writes `.gtd/REVIEW.md` and rests at
   plus routing `gtd: done`.
 - Flipping only `- [ ]` → `- [x]` checkboxes in `.gtd/REVIEW.md` — checkbox-only
   edits are also treated as clean approval.
+- Deleting `.gtd/REVIEW.md` outright.
 
 Any **substantive** edit — to `.gtd/REVIEW.md` prose, or to the reviewed code
 itself — is feedback: `gtd(human): review` plus routing `gtd: review feedback`,
 `.gtd/REVIEW.md` removed, and `gtd next` re-emits a grilling prompt to the agent
 that inlines the human's finding.
+
+**The review diff lives in your editor.** While the gate is pending, gtd holds
+open a _review checkout window_: it saves the real head to
+`refs/gtd/review-head`, then rewinds HEAD and the index to the review base with
+`git reset --mixed`, leaving the working tree untouched. Every editor's standard
+git integration now shows the entire reviewable diff as ordinary uncommitted
+changes — SCM panel, gutter marks, per-file diffs. Review it there:
+
+- **Edit** anything (code or `.gtd/REVIEW.md` prose) → feedback.
+- **Discard a hunk** in the editor → that reversion IS the feedback: the agent
+  is re-grilled with it.
+- **Delete a surfaced file** → reject-this-file feedback.
+- Touch nothing (or tick checkboxes / delete `.gtd/REVIEW.md`) → approval.
+
+Any gtd invocation closes the window first (restoring HEAD/index exactly, so
+only your own edits remain dirty — they land as their own separate
+`gtd(human): review` commit, never mixed into the reviewed work), and
+`gtd next`/`gtd status` re-arm it on their way out. The mechanics are
+crash-safe; details and invariants in STATES.md ("The review checkout window").
+
+Caveats while a review is pending: don't push (the branch tip rests at the
+review base — the real head is safe under `refs/gtd/review-head`); commits you
+make manually survive as working-tree content and become review feedback, but
+their commit message is discarded; linked `git worktree` checkouts are
+unsupported. If you switch branches mid-review, gtd refuses to touch the foreign
+branch and prints the manual recovery command.
 
 ### Squash
 

--- a/STATES.md
+++ b/STATES.md
@@ -123,7 +123,7 @@ ladder, not by subject alone):
 | `gtd: tests green`      | rest or mid-chain  | `.gtd` present: force-approved → mid-chain `closePackage` → `close-package`, agent; not force-approved → rest `agentic-review`, agent. No `.gtd` (health path): squash-after-green → mid-chain `writeSquashTemplate`; else rest `idle`, human. |
 | `gtd: errors`           | rest               | `.gtd/ERRORS.md` present → `escalate`, human; else → `fixing`, agent                                                                                                                                                                           |
 | `gtd: package done`     | — (ladder)         | remaining packages → `building`, agent; else reviewable diff → `review`, agent; else idle/health                                                                                                                                               |
-| `gtd: awaiting review`  | rest               | `await-review`, human                                                                                                                                                                                                                          |
+| `gtd: awaiting review`  | rest               | `await-review`, human — while an invocation rests here, the program edge opens the review checkout window (see `await-review`, §4)                                                                                                             |
 | `gtd: review feedback`  | rest               | `grilling`, agent                                                                                                                                                                                                                              |
 | `gtd: done`             | rest or mid-chain  | squash enabled + squash base present → mid-chain `writeSquashTemplate`; else rest `idle`, human                                                                                                                                                |
 | `gtd: squash template`  | rest               | `squashing`, agent                                                                                                                                                                                                                             |
@@ -635,6 +635,47 @@ substantiveness as described under `review` above: non-substantive mid-chains to
 `commitRouting "gtd: done"` → **done**; substantive mid-chains to
 `commitRouting "gtd: review feedback"` → the review-feedback re-grill
 (**grilling**).
+
+**The review checkout window** (`src/ReviewWindow.ts`) — a driver/IO concern
+layered on this rest, invisible to the machine. Editors' standard git
+integration only surfaces _uncommitted_ changes, and at this rest everything is
+committed — so whenever a gtd invocation finishes resting at
+`gtd: awaiting review`, the program edge (`src/program.ts`) opens a window:
+
+1. Save HEAD to `refs/gtd/review-head` and the review base to
+   `refs/gtd/review-base`. The base mirrors the review-scope rules
+   (`reviewWindowBase`, with HEAD itself excluded so rule 2 means the _previous_
+   round's `gtd: awaiting review`).
+2. `git reset --mixed <base>` — HEAD/index at the base, working tree untouched →
+   the whole reviewable diff shows as uncommitted changes in any editor.
+3. Pin `.gtd/` index entries back to the saved head (plumbing stays out of the
+   unstaged view) and intent-to-add untracked files (added files render as
+   content diffs, and editor "discard" is a coherent reject-this-file gesture).
+
+Every gtd invocation **closes** the window first (keyed on ref existence, before
+`ConfigInit.ensure` and any `gatherEvents`):
+`git reset --mixed refs/gtd/review-head` restores HEAD/index exactly and deletes
+the refs, leaving only the reviewer's own edits dirty. Read-only commands
+(`gtd next`, `gtd status`) and refused invocations re-arm the window on their
+way out.
+
+Invariants:
+
+- The machine never observes an open window, and the working tree is never
+  touched — so the reviewer's edits (including editor "discard hunk" reversions
+  and plain file deletions) are captured as their own separate
+  `gtd(human): review` turn commit, never mixed into the package commits, and
+  substantiveness classification is unchanged.
+- Every open/close step is idempotent under re-entry: a crash at any point is
+  recovered by the next invocation's close, and `refs/gtd/review-head` keeps the
+  real head GC-reachable throughout.
+- Manual commits made during the window survive as working-tree content (they
+  become review feedback); the commit object and its message are discarded.
+- If HEAD leaves the reviewed branch while a window is open (the saved base is
+  no longer an ancestor of HEAD), the close fails loudly with recovery
+  instructions and leaves the refs in place rather than resetting a foreign
+  branch. Linked worktrees are unsupported (the refs are repo-global; HEAD and
+  index are per-worktree).
 
 ### `done`
 

--- a/src/Git.test.ts
+++ b/src/Git.test.ts
@@ -640,6 +640,123 @@ for (const [tierName, makeTier] of tiers) {
     })
 
     // -----------------------------------------------------------------------
+    describe("updateRef / readRefOption / deleteRef", () => {
+      it("roundtrips a repo-local ref", async () => {
+        const headHash = t.resolveRef("HEAD")
+
+        await t.run(
+          Effect.flatMap(GitService, (g) => g.updateRef("refs/gtd/review-head", headHash)),
+        )
+        const read = await t.run(
+          Effect.flatMap(GitService, (g) => g.readRefOption("refs/gtd/review-head")),
+        )
+
+        expect(Option.isSome(read)).toBe(true)
+        expect(Option.getOrThrow(read)).toBe(headHash)
+      })
+
+      it("readRefOption returns none for a missing ref", async () => {
+        const read = await t.run(
+          Effect.flatMap(GitService, (g) => g.readRefOption("refs/gtd/does-not-exist")),
+        )
+        expect(Option.isNone(read)).toBe(true)
+      })
+
+      it("deleteRef removes the ref and is idempotent when it is already gone", async () => {
+        const headHash = t.resolveRef("HEAD")
+        await t.run(
+          Effect.flatMap(GitService, (g) => g.updateRef("refs/gtd/review-head", headHash)),
+        )
+
+        await t.run(Effect.flatMap(GitService, (g) => g.deleteRef("refs/gtd/review-head")))
+        const read = await t.run(
+          Effect.flatMap(GitService, (g) => g.readRefOption("refs/gtd/review-head")),
+        )
+        expect(Option.isNone(read)).toBe(true)
+
+        // Second delete of the now-missing ref must not fail.
+        await t.run(Effect.flatMap(GitService, (g) => g.deleteRef("refs/gtd/review-head")))
+      })
+    })
+
+    // -----------------------------------------------------------------------
+    describe("mixedResetTo", () => {
+      it("moves HEAD and index to the target, keeping the worktree", async () => {
+        const firstHash = t.resolveRef("HEAD")
+        t.commit("feat: second", { "second.txt": "second content" })
+        t.writeFile("readme.txt", "edited after second")
+
+        await t.run(Effect.flatMap(GitService, (g) => g.mixedResetTo(firstHash)))
+
+        expect(t.resolveRef("HEAD")).toBe(firstHash)
+        const status = t.statusPorcelain()
+        // second.txt: in worktree, not in the reset index → untracked
+        expect(status).toContain("?? second.txt")
+        // readme.txt: worktree edit vs the reset index → unstaged modification
+        expect(status).toContain("readme.txt")
+      })
+
+      it("resolves a repo-local ref as the target", async () => {
+        const firstHash = t.resolveRef("HEAD")
+        t.commit("feat: second", { "second.txt": "second content" })
+        await t.run(Effect.flatMap(GitService, (g) => g.updateRef("refs/gtd/base", firstHash)))
+
+        await t.run(Effect.flatMap(GitService, (g) => g.mixedResetTo("refs/gtd/base")))
+
+        expect(t.resolveRef("HEAD")).toBe(firstHash)
+      })
+    })
+
+    // -----------------------------------------------------------------------
+    describe("restoreStagedFrom", () => {
+      it("copies the source tree's entries under the pathspec into the index", async () => {
+        const firstHash = t.resolveRef("HEAD")
+        t.writeFileDeep(".gtd/REVIEW.md", "# Review")
+        t.writeFile("code.ts", "export const x = 1")
+        t.stageAndCommit("feat: work")
+        const headHash = t.resolveRef("HEAD")
+
+        // Rewind index to the first commit, then restore only .gtd from HEAD's ref.
+        await t.run(Effect.flatMap(GitService, (g) => g.updateRef("refs/gtd/saved", headHash)))
+        await t.run(Effect.flatMap(GitService, (g) => g.mixedResetTo(firstHash)))
+        await t.run(
+          Effect.flatMap(GitService, (g) => g.restoreStagedFrom("refs/gtd/saved", [".gtd"])),
+        )
+
+        const status = t.statusPorcelain()
+        // .gtd/REVIEW.md matches the index again → no untracked entry, only a
+        // staged addition vs the rewound HEAD (the live helper's porcelain has
+        // no -uall, so the untracked-dir form would collapse to `?? .gtd/`).
+        expect(status).not.toContain("?? .gtd/")
+        expect(status).toContain("A  .gtd/REVIEW.md")
+        // code.ts stays untracked (outside the pathspec).
+        expect(status).toContain("?? code.ts")
+      })
+
+      it("is a no-op when the pathspec matches nothing on either side", async () => {
+        await t.run(Effect.flatMap(GitService, (g) => g.restoreStagedFrom("HEAD", [".gtd"])))
+        expect(t.statusPorcelain().trim()).toBe("")
+      })
+    })
+
+    // -----------------------------------------------------------------------
+    describe("addIntentToAdd", () => {
+      it("registers untracked files so they no longer show as ??", async () => {
+        const firstHash = t.resolveRef("HEAD")
+        t.commit("feat: second", { "second.txt": "second content" })
+
+        await t.run(Effect.flatMap(GitService, (g) => g.mixedResetTo(firstHash)))
+        await t.run(Effect.flatMap(GitService, (g) => g.addIntentToAdd()))
+
+        const status = t.statusPorcelain()
+        // Exact XY codes differ between real git (` A`, intent-to-add) and the
+        // in-memory placeholder (`AM`); both agree the file is no longer ??.
+        expect(status).toContain("second.txt")
+        expect(status).not.toContain("?? second.txt")
+      })
+    })
+
+    // -----------------------------------------------------------------------
     describe("mixedResetHead on root commit", () => {
       it("fails with an error when HEAD is the root commit", async () => {
         // Create a fresh repo with only one commit

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -25,6 +25,12 @@ export interface GitReaderOperations {
   readonly diffRef: (ref: string, exclude?: ReadonlyArray<string>) => Effect.Effect<string, Error>
   readonly diffPath: (path: string) => Effect.Effect<string, Error>
   readonly resolveRef: (ref: string) => Effect.Effect<string, Error>
+  /**
+   * `git rev-parse --verify --quiet <ref>` as a probe: `Option.some(hash)`
+   * when the ref exists, `Option.none()` when it doesn't (unlike `resolveRef`,
+   * which fails). Used for optional repo-local refs like `refs/gtd/*`.
+   */
+  readonly readRefOption: (ref: string) => Effect.Effect<Option.Option<string>, Error>
   /** `git rev-parse --show-toplevel` — the working-tree root; fails outside a repository. */
   readonly topLevel: () => Effect.Effect<string, Error>
   readonly resolveDefaultBranch: () => Effect.Effect<Option.Option<string>, Error>
@@ -80,6 +86,27 @@ export interface GitWriterOperations {
    */
   readonly commitAllWithPrefix: (prefix: string) => Effect.Effect<void, Error>
   readonly softResetTo: (ref: string) => Effect.Effect<void, Error>
+  /** `git update-ref <ref> <hash>` — create or move a repo-local ref (e.g. `refs/gtd/*`). */
+  readonly updateRef: (ref: string, hash: string) => Effect.Effect<void, Error>
+  /** `git update-ref -d <ref>` — idempotent: deleting a missing ref is a no-op. */
+  readonly deleteRef: (ref: string) => Effect.Effect<void, Error>
+  /** `git reset --mixed <ref>` — HEAD and index move to `ref`, the working tree is untouched. */
+  readonly mixedResetTo: (ref: string) => Effect.Effect<void, Error>
+  /**
+   * `git restore --staged --source=<source> -- <paths…>` — set the index
+   * entries under each path to their state at `source` (including removals),
+   * leaving HEAD and the working tree untouched. Tolerant when no path matches.
+   */
+  readonly restoreStagedFrom: (
+    source: string,
+    paths: ReadonlyArray<string>,
+  ) => Effect.Effect<void, Error>
+  /**
+   * `git add --intent-to-add .` — register untracked files in the index with
+   * an empty placeholder so they render as additions (with content hunks) in
+   * `git diff` and editor SCM views, without staging their content.
+   */
+  readonly addIntentToAdd: () => Effect.Effect<void, Error>
   /** `git reset HEAD~1` (mixed) — undoes the last commit, keeping changes in the working tree. */
   readonly mixedResetHead: () => Effect.Effect<void, Error>
   /**
@@ -398,6 +425,12 @@ const makeGitImpl = (executor: CommandExecutor.CommandExecutor, root: string): G
         ),
       ),
 
+    readRefOption: (ref: string) =>
+      exec("git", "rev-parse", "--verify", "--quiet", ref).pipe(
+        Effect.map((s) => Option.some(s.trim())),
+        Effect.catchAll(() => Effect.succeed(Option.none<string>())),
+      ),
+
     topLevel: () => exec("git", "rev-parse", "--show-toplevel").pipe(Effect.map((s) => s.trim())),
 
     resolveDefaultBranch: () =>
@@ -571,6 +604,29 @@ const makeGitImpl = (executor: CommandExecutor.CommandExecutor, root: string): G
       }).pipe(Effect.asVoid),
 
     softResetTo: (ref: string) => exec("git", "reset", "--soft", ref).pipe(Effect.asVoid),
+
+    updateRef: (ref: string, hash: string) =>
+      exec("git", "update-ref", ref, hash).pipe(Effect.asVoid),
+
+    deleteRef: (ref: string) =>
+      exec("git", "update-ref", "-d", ref).pipe(
+        Effect.asVoid,
+        Effect.catchAll(() => Effect.void),
+      ),
+
+    mixedResetTo: (ref: string) => exec("git", "reset", "--mixed", ref).pipe(Effect.asVoid),
+
+    restoreStagedFrom: (source: string, paths: ReadonlyArray<string>) =>
+      paths.length === 0
+        ? Effect.void
+        : exec("git", "restore", "--staged", `--source=${source}`, "--", ...paths).pipe(
+            Effect.asVoid,
+            // `git restore` errors when a pathspec matches nothing at either
+            // side — for an optional dir like `.gtd/` that's a no-op, not a failure.
+            Effect.catchAll(() => Effect.void),
+          ),
+
+    addIntentToAdd: () => exec("git", "add", "--intent-to-add", ".").pipe(Effect.asVoid),
   }
 }
 

--- a/src/ReviewWindow.test.ts
+++ b/src/ReviewWindow.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest"
+import { Effect } from "effect"
+import { GitService } from "./Git.js"
+import {
+  closeReviewWindow,
+  openReviewWindow,
+  reviewWindowBase,
+  REVIEW_BASE_REF,
+  REVIEW_HEAD_REF,
+} from "./ReviewWindow.js"
+import { InMemRepo } from "../tests/integration/support/inmem/Repo.js"
+import { makeGitServiceLayer } from "../tests/integration/support/inmem/layers.js"
+
+// ---------------------------------------------------------------------------
+// reviewWindowBase — pure base picker over synthetic histories
+// ---------------------------------------------------------------------------
+
+const ANCHOR_HASH = "a".repeat(40)
+
+const entry = (hash: string, message: string) => ({ hash, message })
+
+describe("reviewWindowBase", () => {
+  it("picks the first grilling turn of the cycle when no review round happened yet", () => {
+    const base = reviewWindowBase([
+      entry("h1", "chore: boundary"),
+      entry("h2", "gtd(human): grilling"),
+      entry("h3", "gtd(agent): grilled"),
+      entry("h4", "gtd(agent): building"),
+      entry("h5", "gtd: awaiting review"), // HEAD — excluded
+    ])
+    expect(base).toBe("h2")
+  })
+
+  it("prefers the previous awaiting-review over the first grilling turn", () => {
+    const base = reviewWindowBase([
+      entry("h1", "gtd(human): grilling"),
+      entry("h2", "gtd: awaiting review"),
+      entry("h3", "gtd: review feedback"),
+      entry("h4", "gtd(agent): grilling"),
+      entry("h5", "gtd: awaiting review"), // HEAD — excluded
+    ])
+    expect(base).toBe("h2")
+  })
+
+  it("prefers a gtd: reviewing anchor over both other rules", () => {
+    const base = reviewWindowBase([
+      entry("h1", "gtd(human): grilling"),
+      entry("h2", "gtd: awaiting review"),
+      entry("h3", `gtd: reviewing ${ANCHOR_HASH}`),
+      entry("h4", "gtd(agent): review"),
+      entry("h5", "gtd: awaiting review"), // HEAD — excluded
+    ])
+    expect(base).toBe(ANCHOR_HASH)
+  })
+
+  it("resets the cycle at the last gtd: done", () => {
+    const base = reviewWindowBase([
+      entry("h1", "gtd(human): grilling"),
+      entry("h2", "gtd: awaiting review"),
+      entry("h3", "gtd: done"),
+      entry("h4", "gtd(human): grilling"),
+      entry("h5", "gtd: awaiting review"), // HEAD — excluded
+    ])
+    expect(base).toBe("h4")
+  })
+
+  it("returns undefined outside a process (no anchor, no grilling, no prior round)", () => {
+    const base = reviewWindowBase([
+      entry("h1", "chore: boundary"),
+      entry("h2", "gtd: awaiting review"), // HEAD — excluded
+    ])
+    expect(base).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// open/close against the in-memory GitService
+// ---------------------------------------------------------------------------
+
+const runWith = <A>(repo: InMemRepo, eff: Effect.Effect<A, Error, GitService>): Promise<A> =>
+  Effect.runPromise(eff.pipe(Effect.provide(makeGitServiceLayer(repo))))
+
+const runWithEither = <A>(repo: InMemRepo, eff: Effect.Effect<A, Error, GitService>) =>
+  Effect.runPromise(eff.pipe(Effect.provide(makeGitServiceLayer(repo)), Effect.either))
+
+/** A minimal cycle ending at `gtd: awaiting review` (HEAD). */
+const makeReviewRepo = (): InMemRepo => {
+  const repo = new InMemRepo()
+  repo.writeFile("readme.txt", "hello")
+  repo.commitAllWithPrefix("init: first commit")
+  repo.writeFile(".gtd/TODO.md", "# Plan")
+  repo.commitAllWithPrefix("gtd(human): grilling")
+  repo.writeFile("src/code.ts", "export const x = 1")
+  repo.commitAllWithPrefix("gtd(agent): building")
+  repo.deleteFile(".gtd/TODO.md")
+  repo.writeFile(".gtd/REVIEW.md", "# Review\n- [ ] chunk")
+  repo.commitAllWithPrefix("gtd(agent): review")
+  repo.commitAllWithPrefix("gtd: awaiting review")
+  return repo
+}
+
+describe("openReviewWindow", () => {
+  it("is a no-op when HEAD is not gtd: awaiting review", async () => {
+    const repo = new InMemRepo()
+    repo.writeFile("readme.txt", "hello")
+    repo.commitAllWithPrefix("init: first commit")
+
+    const { opened } = await runWith(repo, openReviewWindow)
+
+    expect(opened).toBe(false)
+    expect(repo.resolveRef(REVIEW_HEAD_REF)).toBeNull()
+  })
+
+  it("rewinds HEAD/index to the base and saves both refs", async () => {
+    const repo = makeReviewRepo()
+    const headBefore = repo.resolveRef("HEAD")!
+    const grillingHash = repo.commitHistory().find((c) => c.message.startsWith("gtd(human)"))!.hash
+
+    const { opened } = await runWith(repo, openReviewWindow)
+
+    expect(opened).toBe(true)
+    expect(repo.resolveRef("HEAD")).toBe(grillingHash)
+    expect(repo.resolveRef(REVIEW_HEAD_REF)).toBe(headBefore)
+    expect(repo.resolveRef(REVIEW_BASE_REF)).toBe(grillingHash)
+    // The package diff is dirty (worktree still holds the built code)…
+    expect(repo.statusPorcelain()).toContain("src/code.ts")
+    // …but .gtd is pinned back to the saved head: no unstaged noise for it.
+    const gtdLines = repo
+      .statusPorcelain()
+      .split("\n")
+      .filter((l) => l.includes(".gtd/"))
+    expect(gtdLines.every((l) => !l.startsWith("??") && l[1] === " ")).toBe(true)
+  })
+})
+
+describe("closeReviewWindow", () => {
+  it("is a no-op without a saved ref", async () => {
+    const repo = makeReviewRepo()
+    const { closed } = await runWith(repo, closeReviewWindow)
+    expect(closed).toBe(false)
+  })
+
+  it("restores the saved head, deletes the refs, and leaves reviewer edits dirty", async () => {
+    const repo = makeReviewRepo()
+    const headBefore = repo.resolveRef("HEAD")!
+    await runWith(repo, openReviewWindow)
+    // The reviewer edits one file on top of the surfaced diff.
+    repo.writeFile("src/code.ts", "export const x = 2")
+
+    const { closed } = await runWith(repo, closeReviewWindow)
+
+    expect(closed).toBe(true)
+    expect(repo.resolveRef("HEAD")).toBe(headBefore)
+    expect(repo.resolveRef(REVIEW_HEAD_REF)).toBeNull()
+    expect(repo.resolveRef(REVIEW_BASE_REF)).toBeNull()
+    // Only the reviewer's own edit remains dirty.
+    expect(repo.statusPorcelain().trim()).toBe("M src/code.ts")
+  })
+
+  it("recovers a crash remnant where HEAD never moved off the saved head", async () => {
+    const repo = makeReviewRepo()
+    const headBefore = repo.resolveRef("HEAD")!
+    const grillingHash = repo.commitHistory().find((c) => c.message.startsWith("gtd(human)"))!.hash
+    // Simulate a crash between the ref writes and the mixed reset.
+    repo.updateRef(REVIEW_BASE_REF, grillingHash)
+    repo.updateRef(REVIEW_HEAD_REF, headBefore)
+
+    const { closed } = await runWith(repo, closeReviewWindow)
+
+    expect(closed).toBe(true)
+    expect(repo.resolveRef("HEAD")).toBe(headBefore)
+    expect(repo.statusPorcelain().trim()).toBe("")
+  })
+
+  it("fails loudly and keeps the refs when HEAD left the reviewed branch", async () => {
+    const repo = makeReviewRepo()
+    const headBefore = repo.resolveRef("HEAD")!
+    await runWith(repo, openReviewWindow)
+    // Simulate a checkout to an unrelated point: the base is no longer an
+    // ancestor of HEAD (the root commit predates the base).
+    repo.softResetTo(repo.commitHistory()[0]!.hash)
+
+    const result = await runWithEither(repo, closeReviewWindow)
+
+    expect(result._tag).toBe("Left")
+    if (result._tag === "Left") {
+      expect(result.left.message).toContain("review checkout window")
+    }
+    expect(repo.resolveRef(REVIEW_HEAD_REF)).toBe(headBefore)
+  })
+})

--- a/src/ReviewWindow.ts
+++ b/src/ReviewWindow.ts
@@ -1,0 +1,158 @@
+/**
+ * The review checkout window: while the workflow rests at the human review
+ * gate (`gtd: awaiting review`), HEAD and the index are temporarily rewound to
+ * the review base with the working tree untouched, so the entire
+ * `reviewBase..HEAD` diff surfaces as ordinary uncommitted changes in any
+ * editor's standard git integration (SCM panel, gutters, per-file diffs,
+ * discard-hunk).
+ *
+ * Lifecycle — driven exclusively from the program edge (`src/program.ts`):
+ *
+ * - `openReviewWindow` runs AFTER a gtd invocation finishes and self-guards on
+ *   HEAD being exactly `gtd: awaiting review`: it saves HEAD to
+ *   `refs/gtd/review-head` (plus the base to `refs/gtd/review-base`), then
+ *   `git reset --mixed <base>`. The same call re-arms the window after
+ *   read-only commands (`gtd next` / `gtd status`) and refused invocations.
+ * - `closeReviewWindow` runs BEFORE every dispatched invocation, keyed on ref
+ *   existence: `git reset --mixed refs/gtd/review-head` restores HEAD/index
+ *   exactly, leaving only the reviewer's own edits dirty.
+ *
+ * Invariants: the pure machine never observes an open window (the close hook
+ * precedes every `gatherEvents`), the working tree is never touched, and the
+ * reviewer's edits land as their own separate `gtd(human): review` turn commit
+ * — never mixed into the reviewed package commits. Every step of open/close is
+ * idempotent under re-entry, so a crash at any point is recovered by the next
+ * invocation's close (the saved ref also keeps the real head GC-reachable for
+ * the window's whole lifetime).
+ */
+
+import { Effect, Option } from "effect"
+import { GitService } from "./Git.js"
+import { parseSubject, ROUTING_SUBJECT } from "./Subjects.js"
+
+export const REVIEW_HEAD_REF = "refs/gtd/review-head"
+export const REVIEW_BASE_REF = "refs/gtd/review-base"
+
+const AWAITING_REVIEW_SUBJECT = ROUTING_SUBJECT["awaiting-review"]
+
+const subjectOf = (message: string): string => message.split("\n")[0] ?? ""
+
+/**
+ * Pick the window's base commit from full first-parent history
+ * (oldest→newest, HEAD last). Mirrors the review-scope rules of
+ * `gatherEvents` (`src/Events.ts`) — newest `gtd: reviewing <hash>` anchor →
+ * last `gtd: awaiting review` → first grilling turn, all within the current
+ * cycle (after the last `gtd: done`) — but EXCLUDES HEAD itself: at open
+ * time HEAD is the `gtd: awaiting review` that triggered the window, and
+ * rule 2's "last awaiting review" must mean the PREVIOUS round's, exactly
+ * the base the agent's review record was written against. Returns undefined
+ * when no rule applies (no window to open).
+ */
+export const reviewWindowBase = (
+  history: ReadonlyArray<{ readonly hash: string; readonly message: string }>,
+): string | undefined => {
+  // Exclude HEAD (the awaiting-review routing commit that triggered the open).
+  const beforeHead = history.slice(0, -1)
+
+  let lastDoneIdx = -1
+  for (let i = 0; i < beforeHead.length; i++) {
+    if (subjectOf(beforeHead[i]!.message) === ROUTING_SUBJECT.done) lastDoneIdx = i
+  }
+  const currentCycle = beforeHead.slice(lastDoneIdx + 1)
+
+  let anchor: string | undefined
+  let lastAwaitingReview: string | undefined
+  let firstGrilling: string | undefined
+  for (const c of currentCycle) {
+    const parsed = parseSubject(subjectOf(c.message))
+    if (parsed.kind === "routing" && parsed.phase === "reviewing" && parsed.param !== undefined) {
+      anchor = parsed.param
+    }
+    if (parsed.kind === "routing" && parsed.phase === "awaiting-review") {
+      lastAwaitingReview = c.hash
+    }
+    if (parsed.kind === "turn" && parsed.gate === "grilling" && firstGrilling === undefined) {
+      firstGrilling = c.hash
+    }
+  }
+
+  return anchor ?? lastAwaitingReview ?? firstGrilling
+}
+
+/**
+ * Restore the real head if a review checkout window is open; no-op otherwise.
+ * Keyed on `refs/gtd/review-head` existence, NOT on any config or machine
+ * state, so it always runs first and the machine never sees the window.
+ *
+ * Fails loudly — refs left in place — when HEAD is no longer on the reviewed
+ * branch (the base is not an ancestor of HEAD, e.g. after a branch switch):
+ * a mixed reset there would rewrite the wrong branch's tip. Manual commits on
+ * top of the base pass the guard: the reset keeps their content in the
+ * working tree, where the next turn capture picks it up as review feedback.
+ */
+export const closeReviewWindow: Effect.Effect<{ closed: boolean }, Error, GitService> = Effect.gen(
+  function* () {
+    const git = yield* GitService
+    const savedHead = yield* git.readRefOption(REVIEW_HEAD_REF)
+    if (Option.isNone(savedHead)) return { closed: false }
+
+    const base = yield* git.readRefOption(REVIEW_BASE_REF)
+    if (Option.isSome(base)) {
+      const onReviewedBranch = yield* git.isAncestor(base.value, "HEAD")
+      if (!onReviewedBranch) {
+        return yield* Effect.fail(
+          new Error(
+            "a gtd review checkout window is open but HEAD has moved off the reviewed branch — " +
+              "return to it, or restore manually with " +
+              "`git reset --mixed refs/gtd/review-head && git update-ref -d refs/gtd/review-head && git update-ref -d refs/gtd/review-base`",
+          ),
+        )
+      }
+    }
+
+    yield* git.mixedResetTo(REVIEW_HEAD_REF)
+    yield* git.deleteRef(REVIEW_HEAD_REF)
+    yield* git.deleteRef(REVIEW_BASE_REF)
+    return { closed: true }
+  },
+)
+
+/**
+ * Open (or re-arm) the review checkout window. Self-guarded: a no-op unless
+ * HEAD's subject is exactly `gtd: awaiting review` and a review base can be
+ * derived from history, so the caller invokes it unconditionally after every
+ * dispatched subcommand.
+ *
+ * Ordering is crash-safe: base ref → head ref → mixed reset → `.gtd/` index
+ * restore → intent-to-add. A crash before the head-ref write leaves only a
+ * stale base ref (overwritten on the next open); a crash after it leaves
+ * HEAD == review-head, which the next invocation's close restores as a no-op.
+ */
+export const openReviewWindow: Effect.Effect<{ opened: boolean }, Error, GitService> = Effect.gen(
+  function* () {
+    const git = yield* GitService
+    const hasCommits = yield* git.hasCommits()
+    if (!hasCommits) return { opened: false }
+    const subject = yield* git.lastCommitSubject()
+    if (subject !== AWAITING_REVIEW_SUBJECT) return { opened: false }
+
+    const history = yield* git.commitHistory()
+    const base = reviewWindowBase(history)
+    if (base === undefined) return { opened: false }
+    const headHash = yield* git.resolveRef("HEAD")
+    if (base === headHash) return { opened: false }
+
+    yield* git.updateRef(REVIEW_BASE_REF, base)
+    yield* git.updateRef(REVIEW_HEAD_REF, headHash)
+    yield* git.mixedResetTo(base)
+    // `.gtd/` (REVIEW.md, base-era plan files) is workflow plumbing, not part
+    // of the reviewable diff — pin its index entries back to the saved head so
+    // the editor's unstaged view shows only the code changes.
+    yield* git.restoreStagedFrom(REVIEW_HEAD_REF, [".gtd"])
+    // Files added since the base would otherwise show as untracked; register
+    // them so editors render proper content diffs (and "discard" stays a
+    // coherent reject-this-file gesture).
+    yield* git.addIntentToAdd()
+    return { opened: true }
+  },
+)

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -24,6 +24,7 @@ const failingGitLayer = Layer.succeed(GitService, {
   lastCommitSubject: () =>
     Effect.fail(new Error("GitService must not be called for --version/--help")),
   resolveRef: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
+  readRefOption: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   topLevel: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   resolveDefaultBranch: () =>
     Effect.fail(new Error("GitService must not be called for --version/--help")),
@@ -39,6 +40,13 @@ const failingGitLayer = Layer.succeed(GitService, {
   commitAllWithPrefix: () =>
     Effect.fail(new Error("GitService must not be called for --version/--help")),
   softResetTo: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
+  updateRef: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
+  deleteRef: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
+  mixedResetTo: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
+  restoreStagedFrom: () =>
+    Effect.fail(new Error("GitService must not be called for --version/--help")),
+  addIntentToAdd: () =>
+    Effect.fail(new Error("GitService must not be called for --version/--help")),
   mixedResetHead: () =>
     Effect.fail(new Error("GitService must not be called for --version/--help")),
   resetHard: () => Effect.fail(new Error("GitService must not be called for --version/--help")),

--- a/src/program.ts
+++ b/src/program.ts
@@ -8,6 +8,7 @@ import * as Format from "./Format.js"
 import { GitService, type GitOperations } from "./Git.js"
 import { predictTurn, resolve, type EdgeAction, type GtdEvent, type Result } from "./Machine.js"
 import { buildPrompt } from "./Prompt.js"
+import { closeReviewWindow, openReviewWindow } from "./ReviewWindow.js"
 import { reviewingSubject } from "./Subjects.js"
 import { describeEdgeAction, describeStatus } from "./State.js"
 import { TestRunner } from "./TestRunner.js"
@@ -623,13 +624,27 @@ export function makeProgram(
     const git = yield* GitService
     const fs = yield* FileSystem.FileSystem
     yield* assertRunningFromRepoRoot(git, fs)
+    // A pending review checkout window (HEAD/index rewound to the review base
+    // so editors surface the diff — see src/ReviewWindow.ts) is closed before
+    // ANYTHING reads or mutates state: `gatherEvents` must only ever see the
+    // real head, and ConfigInit's auto-init amend below must never rewrite the
+    // base commit the window rests on.
+    yield* closeReviewWindow
     // Auto-init runs here and ONLY here: past the version/help short-circuit,
     // the format branch, the known-subcommand guard, and the repo-root guard —
     // a refused or rejected invocation must never mutate the repository.
     yield* (yield* ConfigInit).ensure
     const config = yield* ConfigService
 
-    yield* dispatchKnownSubcommand(sub, argv, git, config, json, write)
+    // Re-open the window after the invocation finishes — including failed
+    // ones (a `step-agent` refusal at the human gate, `next`'s dirty-tree
+    // guard): `openReviewWindow` self-guards on HEAD being exactly
+    // `gtd: awaiting review`, so this is a no-op everywhere else and the
+    // reviewer's editor keeps showing the diff until the review resolves.
+    yield* dispatchKnownSubcommand(sub, argv, git, config, json, write).pipe(
+      Effect.tap(() => openReviewWindow),
+      Effect.tapError(() => openReviewWindow.pipe(Effect.ignore)),
+    )
   }).pipe(
     json
       ? Effect.catchAll((error) =>

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -55,11 +55,17 @@ Feature: gtd-loop — the packaged reference loop driver
     When I run gtd-loop
     Then it succeeds
     And stdout contains "--- Your turn (await-review) ---"
-    And the git log contains "gtd(agent): building"
-    And the git log contains "gtd: tests green"
-    And the git log contains "gtd: package done"
-    And the git log contains "gtd(agent): review"
-    And the last commit subject is "gtd: awaiting review"
+    # The loop halts with the review checkout window open: HEAD/index rest at
+    # the review base so the whole package diff shows as uncommitted changes in
+    # the reviewer's editor; the real head sits in refs/gtd/review-head.
+    And the git ref "refs/gtd/review-head" exists
+    And the last commit subject is "gtd(agent): grilling"
+    And the git log at "refs/gtd/review-head" contains "gtd(agent): building"
+    And the git log at "refs/gtd/review-head" contains "gtd: tests green"
+    And the git log at "refs/gtd/review-head" contains "gtd: package done"
+    And the git log at "refs/gtd/review-head" contains "gtd(agent): review"
+    And the git log at "refs/gtd/review-head" contains "gtd: awaiting review"
+    And the git status contains "src/calc.ts"
 
   Scenario: Rerunning after an uncommitted human edit picks it up and continues
     Given a test project
@@ -107,14 +113,16 @@ Feature: gtd-loop — the packaged reference loop driver
       """
     When I run gtd-loop
     Then it succeeds
-    And the last commit subject is "gtd: awaiting review"
+    And the git ref "refs/gtd/review-head" exists
+    And the git log at "refs/gtd/review-head" contains "gtd: awaiting review"
     # The human approves the review by deleting REVIEW.md, without committing —
     # exactly the "edit, don't commit, just rerun" workflow gtd-loop supports.
-    Given a deleted committed file ".gtd/REVIEW.md"
+    Given the file ".gtd/REVIEW.md" is deleted
     When I run gtd-loop
     Then it succeeds
     And the git log contains "gtd(human): review"
     And the git log contains "gtd: done"
+    And the git ref "refs/gtd/review-head" does not exist
     And stdout contains "--- Your turn (idle) ---"
 
   Scenario: Stops instead of spinning when the agent's turn makes no progress

--- a/tests/integration/features/journeys.feature
+++ b/tests/integration/features/journeys.feature
@@ -94,18 +94,29 @@ Feature: Full lifecycle journeys — the step-first two-beat loop end to end
       """
     When I run gtd step-agent
     Then it succeeds
-    And the git log contains "gtd(agent): review"
-    And the last commit subject is "gtd: awaiting review"
+    # The review checkout window is now open: HEAD and index rest at the review
+    # base (the cycle's first grilling turn) while the worktree still holds the
+    # finished work, so any editor's git integration shows the whole package
+    # diff as uncommitted changes. The real head is preserved under
+    # refs/gtd/review-head until the review resolves.
+    And the git ref "refs/gtd/review-head" exists
+    And the last commit subject is "gtd(human): grilling"
+    And the git log at "refs/gtd/review-head" contains "gtd(agent): review"
+    And the git log at "refs/gtd/review-head" contains "gtd: awaiting review"
+    And the git status contains "src/calc.ts"
     When I run gtd next
     Then it succeeds
     And stdout contains ".gtd/REVIEW.md"
-    # The human approves by deleting REVIEW.md.
-    Given a deleted committed file ".gtd/REVIEW.md"
+    # Read-only commands re-arm the window on their way out.
+    And the git ref "refs/gtd/review-head" exists
+    # The human approves by deleting REVIEW.md (a plain worktree deletion).
+    Given the file ".gtd/REVIEW.md" is deleted
     When I run gtd step
     Then it succeeds
     And the git log contains "gtd(human): review"
     And the last commit subject is "gtd: done"
     And the file ".gtd/REVIEW.md" does not exist
+    And the git ref "refs/gtd/review-head" does not exist
     And the commit subjects from oldest to newest are:
       """
       chore: initial commit
@@ -181,8 +192,12 @@ Feature: Full lifecycle journeys — the step-first two-beat loop end to end
       """
     When I run gtd step-agent
     Then it succeeds
-    And the last commit subject is "gtd: awaiting review"
-    Given a deleted committed file ".gtd/REVIEW.md"
+    # The review checkout window opens at the human gate: HEAD rests at the
+    # base, the real head is preserved under refs/gtd/review-head.
+    And the git ref "refs/gtd/review-head" exists
+    And the last commit subject is "gtd(human): grilling"
+    And the git log at "refs/gtd/review-head" contains "gtd: awaiting review"
+    Given the file ".gtd/REVIEW.md" is deleted
     # Squash on: gtd: done is not a rest — the chain continues straight to the
     # squash template in the same human-turn invocation.
     When I run gtd step

--- a/tests/integration/features/review-checkout.feature
+++ b/tests/integration/features/review-checkout.feature
@@ -1,0 +1,182 @@
+@inmem
+Feature: Review checkout window — the pending review diff surfaces in the editor
+
+  While the workflow rests at the human review gate (`gtd: awaiting review`),
+  gtd rewinds HEAD and the index to the review base with the working tree
+  untouched, so the whole reviewable diff shows up as ordinary uncommitted
+  changes in any editor's standard git integration. The real head is preserved
+  under `refs/gtd/review-head` (the base under `refs/gtd/review-base`); every
+  gtd invocation restores it before reading or mutating state, so the machine
+  never sees the window and the reviewer's own edits are captured as their own
+  separate `gtd(human): review` feedback commit — never mixed into the
+  reviewed package commits.
+
+  Background:
+    Given a test project
+    And a commit "chore: add config" that adds ".gtdrc" with:
+      """
+      testCommand: "true"
+      agenticReview: false
+      squash: false
+      """
+    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      Implement a calculator.
+      """
+    And a commit "gtd: planning" that deletes ".gtd/TODO.md"
+    And a commit "gtd(agent): building" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd(agent): building" that adds "src/other.ts" with:
+      """
+      export const untouched = () => true
+      """
+    And a commit "gtd: package done"
+    And a commit "gtd(agent): review" that adds ".gtd/REVIEW.md" with:
+      """
+      # Review
+
+      - [ ] ./src/calc.ts#1 — new add function
+      """
+    And a commit "gtd: awaiting review"
+
+  Scenario: Resting at the gate opens the window — HEAD at the base, the diff dirty
+    When I run gtd next
+    Then it succeeds
+    And the git ref "refs/gtd/review-head" exists
+    And the git ref "refs/gtd/review-base" exists
+    # HEAD rests at the review base: the cycle's first grilling turn.
+    And the last commit subject is "gtd(human): grilling"
+    # The real head is intact behind the ref.
+    And the git log at "refs/gtd/review-head" contains "gtd: awaiting review"
+    # The whole package diff is visible as uncommitted changes…
+    And the git status contains "src/calc.ts"
+    And the git status contains "src/other.ts"
+    # …while `.gtd/` plumbing stays out of the unstaged noise.
+    And the git status does not contain "?? .gtd/"
+
+  Scenario: An empty step approves — the window closes and leaves no trace
+    Given I run gtd next
+    When I run gtd step
+    Then it succeeds
+    And the git log contains "gtd(human): review"
+    And the last commit subject is "gtd: done"
+    And the git ref "refs/gtd/review-head" does not exist
+    And the git ref "refs/gtd/review-base" does not exist
+    And the file ".gtd/REVIEW.md" does not exist
+
+  Scenario: Reviewer edits land as their own separate feedback commit
+    Given I run gtd next
+    And "src/calc.ts" is modified to:
+      """
+      export const add = (a: number, b: number) => a + b
+      // reviewer: please rename to sum
+      """
+    When I run gtd step
+    Then it succeeds
+    And the git log contains "gtd(human): review"
+    And the last commit subject is "gtd: review feedback"
+    And the git ref "refs/gtd/review-head" does not exist
+    # The re-grill prompt inlines exactly the reviewer's edit — the untouched
+    # package file is absent, proving the feedback commit carries only the
+    # reviewer's own change, not the rewound package diff.
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "reviewer: please rename to sum"
+    And stdout does not contain "src/other.ts"
+
+  Scenario: Deleting a surfaced file (editor "discard") is reversion feedback
+    Given I run gtd next
+    And the file "src/calc.ts" is deleted
+    When I run gtd step
+    Then it succeeds
+    And the last commit subject is "gtd: review feedback"
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "src/calc.ts"
+
+  Scenario: Read-only commands re-arm the window on their way out
+    Given I run gtd next
+    When I run gtd status
+    Then it succeeds
+    And the git ref "refs/gtd/review-head" exists
+    And the last commit subject is "gtd(human): grilling"
+    When I run gtd next
+    Then it succeeds
+    And the git ref "refs/gtd/review-head" exists
+    And the last commit subject is "gtd(human): grilling"
+
+  Scenario: gtd next with pending reviewer edits refuses but keeps the window armed
+    Given I run gtd next
+    And "src/calc.ts" is modified to:
+      """
+      export const add = (a: number, b: number) => a + b
+      // half-finished review note
+      """
+    When I run gtd next
+    Then it fails
+    # Re-armed on the error path: the editor keeps showing the diff and the
+    # reviewer's pending edit survives in the working tree.
+    And the git ref "refs/gtd/review-head" exists
+    And the last commit subject is "gtd(human): grilling"
+    And the file "src/calc.ts" contains "half-finished review note"
+
+  Scenario: gtd step-agent at the human gate refuses and re-arms the window
+    Given I run gtd next
+    When I run gtd step-agent
+    Then it fails
+    And stderr contains "await-review awaits a human turn"
+    And the git ref "refs/gtd/review-head" exists
+    And the last commit subject is "gtd(human): grilling"
+
+  Scenario: A crash between the ref writes and the rewind recovers cleanly
+    Given the git ref "refs/gtd/review-base" points at "HEAD~6"
+    And the git ref "refs/gtd/review-head" points at "HEAD"
+    When I run gtd status
+    Then it succeeds
+    And stdout contains "await-review"
+    # The stale window was closed and a fresh one re-armed.
+    And the git ref "refs/gtd/review-head" exists
+    And the last commit subject is "gtd(human): grilling"
+
+  Scenario: A manual commit during the window becomes feedback; its message is discarded
+    Given I run gtd next
+    And a commit "wip: reviewer tweak" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      // tweak made in a manual commit
+      """
+    When I run gtd step
+    Then it succeeds
+    And the git log does not contain "wip: reviewer tweak"
+    And the last commit subject is "gtd: review feedback"
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "tweak made in a manual commit"
+
+  Scenario: Leaving the reviewed branch refuses loudly and keeps the refs
+    Given I run gtd next
+    And HEAD is soft-reset to "HEAD~1"
+    When I run gtd status
+    Then it fails
+    And stderr contains "review checkout window"
+    And the git ref "refs/gtd/review-head" exists
+    And the git ref "refs/gtd/review-base" exists
+
+  @live
+  Scenario: Live tier — the window opens, surfaces the diff, and closes on approval
+    When I run gtd next
+    Then it succeeds
+    And the git ref "refs/gtd/review-head" exists
+    And the last commit subject is "gtd(human): grilling"
+    And the git log at "refs/gtd/review-head" contains "gtd: awaiting review"
+    And the git status contains "src/calc.ts"
+    When I run gtd step
+    Then it succeeds
+    And the git log contains "gtd(human): review"
+    And the last commit subject is "gtd: done"
+    And the git ref "refs/gtd/review-head" does not exist
+    And the git status is clean

--- a/tests/integration/support/inmem/Repo.ts
+++ b/tests/integration/support/inmem/Repo.ts
@@ -28,6 +28,7 @@ function makeHash(message: string, parent: string | null, tree: Map<string, stri
 export class InMemRepo {
   private commits: Map<string, Commit> = new Map()
   private branches: Map<string, string> = new Map() // branch name → hash
+  private refs: Map<string, string> = new Map() // fully qualified ref (refs/gtd/…) → hash
   private head: string | null = null // current commit hash
   private currentBranch: string = "main"
   private worktree: Map<string, string> = new Map()
@@ -139,6 +140,10 @@ export class InMemRepo {
       return cur
     }
 
+    // Fully qualified repo-local ref (refs/gtd/…)
+    const refHash = this.refs.get(ref)
+    if (refHash !== undefined) return refHash
+
     // Branch name
     return this.branches.get(ref) ?? null
   }
@@ -233,6 +238,17 @@ export class InMemRepo {
     })
   }
 
+  /** One-line log ("<short-hash> <subject>", newest→oldest) starting from `ref`. */
+  logFrom(ref: string): string {
+    const hash = this.resolveRef(ref)
+    if (!hash) throw new Error(`Cannot resolve ref: ${ref}`)
+    return (
+      this.ancestorChain(hash)
+        .map((h) => `${h.slice(0, 7)} ${this.getCommit(h)?.message.split("\n")[0] ?? ""}`)
+        .join("\n") + "\n"
+    )
+  }
+
   fileAtRef(ref: string, path: string): string | null {
     const hash = this.resolveRef(ref)
     if (!hash) return null
@@ -304,6 +320,52 @@ export class InMemRepo {
     this.head = hash
     this.branches.set(this.currentBranch, hash)
     // worktree and index unchanged
+  }
+
+  updateRef(ref: string, hash: string): void {
+    const resolved = this.resolveRef(hash)
+    if (!resolved) throw new Error(`Cannot resolve ref: ${hash}`)
+    this.refs.set(ref, resolved)
+  }
+
+  deleteRef(ref: string): void {
+    // Idempotent, like `git update-ref -d` wrapped tolerantly in src/Git.ts.
+    this.refs.delete(ref)
+  }
+
+  mixedResetTo(ref: string): void {
+    const hash = this.resolveRef(ref)
+    if (!hash) throw new Error(`Cannot resolve ref: ${ref}`)
+    const c = this.getCommit(hash)
+    if (!c) throw new Error(`Commit not found: ${hash}`)
+    this.head = hash
+    this.branches.set(this.currentBranch, hash)
+    // Index resets to the target tree, worktree untouched.
+    this.index = new Map(c.files)
+  }
+
+  restoreStagedFrom(source: string, paths: ReadonlyArray<string>): void {
+    const hash = this.resolveRef(source)
+    if (!hash) throw new Error(`Cannot resolve ref: ${source}`)
+    const tree = this.getCommit(hash)?.files ?? new Map<string, string>()
+    const matchesAny = (path: string): boolean =>
+      paths.some((spec) => path === spec || path.startsWith(spec.endsWith("/") ? spec : `${spec}/`))
+    // Index entries under the pathspecs absent from source → removed…
+    for (const key of [...this.index.keys()]) {
+      if (matchesAny(key) && !tree.has(key)) this.index.delete(key)
+    }
+    // …and source entries under the pathspecs copied in.
+    for (const [key, content] of tree) {
+      if (matchesAny(key)) this.index.set(key, content)
+    }
+  }
+
+  addIntentToAdd(): void {
+    // Real git records an empty placeholder blob for untracked files; the
+    // content diff then shows up as unstaged. An empty string plays that role.
+    for (const path of this.worktree.keys()) {
+      if (!this.index.has(path)) this.index.set(path, "")
+    }
   }
 
   mixedResetHead(): void {

--- a/tests/integration/support/inmem/layers.ts
+++ b/tests/integration/support/inmem/layers.ts
@@ -152,6 +152,11 @@ const makeGitReaderOps = (repo: InMemRepo): GitReaderOperations => ({
       : Effect.fail(new Error(`Cannot resolve ref: ${ref}`))
   },
 
+  readRefOption: (ref: string) => {
+    const hash = repo.resolveRef(ref)
+    return Effect.succeed(hash !== null ? Option.some(hash) : Option.none<string>())
+  },
+
   topLevel: () => Effect.succeed("/repo"),
 
   resolveDefaultBranch: () => {
@@ -224,6 +229,17 @@ const makeGitWriterOps = (repo: InMemRepo): GitWriterOperations => ({
   commitAllWithPrefix: (prefix: string) => tryCatch(() => repo.commitAllWithPrefix(prefix)),
 
   softResetTo: (ref: string) => tryCatch(() => repo.softResetTo(ref)),
+
+  updateRef: (ref: string, hash: string) => tryCatch(() => repo.updateRef(ref, hash)),
+
+  deleteRef: (ref: string) => tryCatch(() => repo.deleteRef(ref)),
+
+  mixedResetTo: (ref: string) => tryCatch(() => repo.mixedResetTo(ref)),
+
+  restoreStagedFrom: (source: string, paths: ReadonlyArray<string>) =>
+    tryCatch(() => repo.restoreStagedFrom(source, paths)),
+
+  addIntentToAdd: () => tryCatch(() => repo.addIntentToAdd()),
 
   mixedResetHead: () => tryCatch(() => repo.mixedResetHead()),
 

--- a/tests/integration/support/steps/common.steps.ts
+++ b/tests/integration/support/steps/common.steps.ts
@@ -84,6 +84,13 @@ Given("{string} has appended {string}", (world: GtdWorld, path: string, text: st
   }
 })
 
+// Plain working-tree deletion — what an editor's "delete file" does. Distinct
+// from "a deleted committed file" (git rm), which refuses when the index entry
+// differs from HEAD, e.g. inside an open review checkout window.
+Given("the file {string} is deleted", (world: GtdWorld, path: string) => {
+  world.deleteWorktreeFile(path)
+})
+
 Given("a directory {string}", (world: GtdWorld, path: string) => {
   if (world.tier === "inmem") {
     // Directories are implicit in the in-memory store; no-op.
@@ -256,6 +263,52 @@ Then("the git log contains {string}", (world: GtdWorld, subject: string) => {
 Then("the git log does not contain {string}", (world: GtdWorld, subject: string) => {
   const log = world.gitLog()
   assert.ok(!log.includes(subject), `Expected git log NOT to contain "${subject}". Got:\n${log}`)
+})
+
+// ── Git refs / status / ref-scoped log ──────────────────────────────────────
+// Observables for the review checkout window (refs/gtd/review-head rewind),
+// generic over any revision so other fixtures can reuse them.
+
+Given("the git ref {string} points at {string}", (world: GtdWorld, ref: string, target: string) => {
+  world.setGitRef(ref, target)
+})
+
+Given("HEAD is soft-reset to {string}", (world: GtdWorld, target: string) => {
+  world.softResetHead(target)
+})
+
+Then("the git ref {string} exists", (world: GtdWorld, ref: string) => {
+  assert.ok(world.resolveRefOrNull(ref) !== null, `Expected git ref "${ref}" to exist.`)
+})
+
+Then("the git ref {string} does not exist", (world: GtdWorld, ref: string) => {
+  assert.ok(world.resolveRefOrNull(ref) === null, `Expected git ref "${ref}" NOT to exist.`)
+})
+
+Then(
+  "the git log at {string} contains {string}",
+  (world: GtdWorld, ref: string, subject: string) => {
+    const log = world.gitLogAt(ref)
+    assert.ok(
+      log.includes(subject),
+      `Expected git log at ${ref} to contain "${subject}". Got:\n${log}`,
+    )
+  },
+)
+
+Then("the git status contains {string}", (world: GtdWorld, text: string) => {
+  const status = world.gitStatus()
+  assert.ok(status.includes(text), `Expected git status to contain "${text}". Got:\n${status}`)
+})
+
+Then("the git status does not contain {string}", (world: GtdWorld, text: string) => {
+  const status = world.gitStatus()
+  assert.ok(!status.includes(text), `Expected git status NOT to contain "${text}". Got:\n${status}`)
+})
+
+Then("the git status is clean", (world: GtdWorld) => {
+  const status = world.gitStatus()
+  assert.strictEqual(status.trim(), "", `Expected a clean git status. Got:\n${status}`)
 })
 
 Then("the file {string} exists", (world: GtdWorld, path: string) => {

--- a/tests/integration/support/world.ts
+++ b/tests/integration/support/world.ts
@@ -6,7 +6,7 @@ import { execSync, execFile as execFileCb } from "node:child_process"
 import { promisify } from "node:util"
 
 const execFile = promisify(execFileCb)
-import { readFileSync, existsSync } from "node:fs"
+import { readFileSync, existsSync, unlinkSync } from "node:fs"
 import { join, resolve } from "node:path"
 import { makeProgram } from "../../../src/program.js"
 import { inMemoryLayers } from "./inmem/layers.js"
@@ -201,6 +201,71 @@ export class GtdWorld extends QuickPickleWorld {
       }).trim(),
       10,
     )
+  }
+
+  /** Resolve any revision (ref, HEAD~N, branch) to a hash, or null when it doesn't resolve. */
+  resolveRefOrNull(ref: string): string | null {
+    if (this.repo !== undefined) {
+      return this.repo.resolveRef(ref)
+    }
+    try {
+      return execSync(`git rev-parse --verify --quiet ${ref}`, {
+        cwd: this.repoDir,
+        encoding: "utf-8",
+        stdio: "pipe",
+      }).trim()
+    } catch {
+      return null
+    }
+  }
+
+  /** Create or move a repo-local ref (e.g. refs/gtd/review-head) to the given revision. */
+  setGitRef(ref: string, target: string): void {
+    if (this.repo !== undefined) {
+      this.repo.updateRef(ref, target)
+      return
+    }
+    execSync(`git update-ref ${ref} ${target}`, { cwd: this.repoDir, stdio: "pipe" })
+  }
+
+  /** Porcelain status with untracked files listed individually. */
+  gitStatus(): string {
+    if (this.repo !== undefined) {
+      return this.repo.statusPorcelain()
+    }
+    return execSync("git status --porcelain -uall", {
+      cwd: this.repoDir,
+      encoding: "utf-8",
+    })
+  }
+
+  /** One-line log starting from an arbitrary revision (not just HEAD). */
+  gitLogAt(ref: string): string {
+    if (this.repo !== undefined) {
+      return this.repo.logFrom(ref)
+    }
+    return execSync(`git log --oneline ${ref}`, {
+      cwd: this.repoDir,
+      encoding: "utf-8",
+    })
+  }
+
+  /** Plain working-tree deletion (no git involvement — what an editor's delete does). */
+  deleteWorktreeFile(path: string): void {
+    if (this.repo !== undefined) {
+      this.repo.deleteFile(path)
+      return
+    }
+    unlinkSync(join(this.repoDir, path))
+  }
+
+  /** Move HEAD (and branch tip) to a revision without touching index or worktree. */
+  softResetHead(target: string): void {
+    if (this.repo !== undefined) {
+      this.repo.softResetTo(target)
+      return
+    }
+    execSync(`git reset -q --soft ${target}`, { cwd: this.repoDir, stdio: "pipe" })
   }
 
   execInRepo(cmd: string, args: string[] = []): string {


### PR DESCRIPTION
While the workflow rests at the human review gate (gtd: awaiting review),
everything is already committed, so editors' standard git integration shows
nothing. Now the program edge opens a "review checkout window" whenever an
invocation ends resting there: it saves HEAD to refs/gtd/review-head (and the
review base to refs/gtd/review-base), then `git reset --mixed <base>` — the
working tree is untouched, so the whole reviewable diff appears as ordinary
uncommitted changes in any editor (SCM panel, gutters, per-file diffs,
discard-hunk). `.gtd/` plumbing is pinned back to the saved head in the index,
and untracked-since-base files are registered with intent-to-add so additions
render as content diffs.

Every gtd invocation closes the window first (keyed on ref existence, before
ConfigInit.ensure and any gatherEvents), restoring HEAD/index exactly so only
the reviewer's own edits remain dirty — they are captured as their own
separate gtd(human): review feedback commit, never mixed into the reviewed
package commits, and the pure machine never observes the window. Read-only
commands (next/status) and refused invocations re-arm it on the way out.
Open/close is idempotent at every step, so a crash at any point is recovered
by the next invocation; leaving the reviewed branch mid-review fails loudly
with recovery instructions instead of resetting a foreign branch.

- src/ReviewWindow.ts: open/close effects + pure reviewWindowBase picker
  (anchor > previous awaiting-review > first grilling turn, per cycle)
- src/Git.ts: readRefOption, updateRef, deleteRef, mixedResetTo,
  restoreStagedFrom, addIntentToAdd (+ in-memory mirrors and unit tests)
- src/program.ts: close-before-ensure, re-arm-after-dispatch wiring
- tests: review-checkout.feature (10 inmem scenarios + 1 live), new generic
  git-ref/status/log-at-ref steps; journeys/gtd-loop scenarios updated for the
  always-on window
- docs: STATES.md window subsection, README reviewer UX + caveats, AGENTS.md
  program-edge rule

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011AGgEReBhy5emziXJY2VYz