### PR TITLE
feat: split grilling into product grilling + technical architecting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,11 +87,11 @@ keeping the edge thin.
 ## Turn Capture
 
 - An empty AGENT turn is inert at every gate whose move is a file artifact
-  (`grilling`, `grilled`, `building`, `fixing`, `agentic-review`, `review`, and
-  `squashing` while `SQUASH_MSG.md` is still the template) — the loop protocol
-  opens each iteration with `gtd step-agent` BEFORE the agent acts, so a
-  clean-tree capture there must author nothing. When adding a gate, decide
-  explicitly whether its empty turn is a signal (human accept-defaults,
-  health-fixing's environmental fix) or a no-op, and guard BOTH layers:
-  `applyTurnTaking` (don't capture) and `classifyHead` (don't consume state for
-  historical/crash-recovered empty turns)
+  (`grilling`, `architecting`, `grilled`, `building`, `fixing`,
+  `agentic-review`, `review`, and `squashing` while `SQUASH_MSG.md` is still the
+  template) — the loop protocol opens each iteration with `gtd step-agent`
+  BEFORE the agent acts, so a clean-tree capture there must author nothing. When
+  adding a gate, decide explicitly whether its empty turn is a signal (human
+  accept-defaults, health-fixing's environmental fix) or a no-op, and guard BOTH
+  layers: `applyTurnTaking` (don't capture) and `classifyHead` (don't consume
+  state for historical/crash-recovered empty turns)

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 > in the first place. Now I have something that actually helps me.
 
 A git-aware CLI that drives a turn-taking loop between a human and an autonomous
-coding agent: capture an idea, grill it into a plan, decompose it into work
-packages, execute with parallel subagents, test, agentically review each
-package, and finally walk a human through a review — squashing the whole cycle
-into one conventional-commits commit at the end.
+coding agent: capture an idea, grill it into a product-level plan, grill that
+into a technical architecture, decompose it into work packages, execute with
+parallel subagents, test, agentically review each package, and finally walk a
+human through a review — squashing the whole cycle into one conventional-commits
+commit at the end.
 
 Internally, gtd is a **pure fold** over git history. The decision core
 (`src/Machine.ts`) is a single IO-free function, `resolve(events)` — **no
@@ -18,7 +19,7 @@ merge-base with the default branch (whole-history fallback when there is no
 default branch, when HEAD equals the merge-base, or when there is no merge-base)
 plus the working tree, turns them into a `COMMIT[]` + single terminal `RESOLVE`
 event stream, and folds them through the machine. The fold lands on exactly
-**one** of 16 states, plus which actor (human or agent) is awaited there. A
+**one** of 17 states, plus which actor (human or agent) is awaited there. A
 single call resolves to a single state.
 
 Steering is entirely **machine-authored commit subjects** — there are no marker
@@ -27,7 +28,8 @@ files, sentinels, or auto-advance tails to parse. A turn commit looks like
 the machine performs itself between turns) looks like `gtd: tests green`.
 `src/Subjects.ts` is the closed grammar both the machine and the edge read.
 
-All workflow state lives under **`.gtd/`**: the plan (`.gtd/TODO.md`), work
+All workflow state lives under **`.gtd/`**: the product plan (`.gtd/TODO.md`),
+the technical architecture it converges into (`.gtd/ARCHITECTURE.md`), work
 packages (`.gtd/01-…/`), review records (`.gtd/REVIEW.md`, `.gtd/FEEDBACK.md`),
 and loop bookkeeping (`.gtd/ERRORS.md`, `.gtd/HEALTH.md`, `.gtd/SQUASH_MSG.md`).
 One rule follows for every agent in the loop: **never touch `.gtd/`** except the
@@ -55,9 +57,10 @@ An agent loop is a two-beat protocol repeated forever:
    act, then go back to step 1; at a pending checkpoint (`prompt` is null) go
    straight back to step 1.
 
-A human acts by editing files (answering questions in `.gtd/TODO.md`, annotating
-`.gtd/REVIEW.md`, fixing code) and then running `gtd step` to capture the edit
-as their turn and hand control back to the agent side of the loop.
+A human acts by editing files (answering questions in `.gtd/TODO.md` or
+`.gtd/ARCHITECTURE.md`, annotating `.gtd/REVIEW.md`, fixing code) and then
+running `gtd step` to capture the edit as their turn and hand control back to
+the agent side of the loop.
 
 ```bash
 gtd step-agent            # advance the machine's own bookkeeping
@@ -159,8 +162,8 @@ invocation authored (oldest→newest), then a final `state: <state>` line:
 
 ```
 committed: gtd(human): grilling
-committed: gtd: grilled
-state: grilled
+committed: gtd: architecting
+state: architecting
 ```
 
 `--json` emits `{state, actions, commits}` instead (see
@@ -289,9 +292,9 @@ single-line JSON output instead of plain text.
 
 ```json
 {
-  "state": "grilled",
+  "state": "architecting",
   "actions": ["capture the human turn as \"gtd(human): grilling\""],
-  "commits": ["gtd(human): grilling", "gtd: grilled"]
+  "commits": ["gtd(human): grilling", "gtd: architecting"]
 }
 ```
 
@@ -422,12 +425,12 @@ GTD_LOOP_AGENT_CMD='my-agent-cli --prompt "$GTD_LOOP_PROMPT"' gtd-loop
 
 ## States & subjects overview
 
-`resolve()` lands on exactly one of **16 states**: `grilling`, `grilled`,
-`planning`, `building`, `testing`, `fixing`, `escalate`, `agentic-review`,
-`close-package`, `review`, `await-review`, `done`, `squashing`, `idle`,
-`health-check`, `health-fixing`. Each state has a fixed awaited actor (see
-`awaitedActor` in `src/Machine.ts`): `idle`, `escalate`, and `await-review`
-await the **human**; every other state awaits the **agent**.
+`resolve()` lands on exactly one of **17 states**: `grilling`, `architecting`,
+`grilled`, `planning`, `building`, `testing`, `fixing`, `escalate`,
+`agentic-review`, `close-package`, `review`, `await-review`, `done`,
+`squashing`, `idle`, `health-check`, `health-fixing`. Each state has a fixed
+awaited actor (see `awaitedActor` in `src/Machine.ts`): `idle`, `escalate`, and
+`await-review` await the **human**; every other state awaits the **agent**.
 
 For the full precedence ladder, illegal combinations, and the counter folds that
 drive the fix loops, see [STATES.md](STATES.md) — this section is a summary.
@@ -439,7 +442,8 @@ The closed set of gates:
 
 | Gate             | Authored by                                                        |
 | ---------------- | ------------------------------------------------------------------ |
-| `grilling`       | human (answers) / agent (plan iteration)                           |
+| `grilling`       | human (answers) / agent (product-plan iteration)                   |
+| `architecting`   | human (answers) / agent (architecture iteration)                   |
 | `grilled`        | agent (converged, ready to decompose)                              |
 | `building`       | agent (package work, or human feedback while agent is out of turn) |
 | `fixing`         | agent (test-fix or review-fix round)                               |
@@ -452,8 +456,8 @@ The closed set of gates:
 ### Routing commits — `gtd: <phase>`
 
 Bookkeeping the machine authors itself between turns, never a turn a human or
-agent "wins": `gtd: grilled`, `gtd: planning`, `gtd: tests green`,
-`gtd: errors`, `gtd: package done`, `gtd: awaiting review`,
+agent "wins": `gtd: architecting`, `gtd: grilled`, `gtd: planning`,
+`gtd: tests green`, `gtd: errors`, `gtd: package done`, `gtd: awaiting review`,
 `gtd: review feedback`, `gtd: done`, `gtd: squash template`,
 `gtd: reviewing <hash>` (parameterized, from `gtd review`), `gtd: health-check`,
 `gtd: health-fix`.
@@ -465,24 +469,38 @@ this matters on upgrade.
 
 ## Workflow walkthroughs
 
-### Grilling
+### Grilling: two phases, product then architecture
 
 A dirty tree at a boundary HEAD (a fresh idea, sketched in a file or just left
 as pending code) is captured in **one** human turn: `gtd step` commits
 everything pending as `gtd(human): grilling` — nothing is reverted or seeded,
 the captured files stay in history. `gtd next` hands the agent that turn's diff;
-the agent develops `.gtd/TODO.md` into a concrete plan **in one turn**,
-proposing a **suggested default** for every open question, and leaves
-`.gtd/TODO.md` uncommitted for `gtd(agent): grilling`.
+the agent develops `.gtd/TODO.md` into a concrete **product-level** plan **in
+one turn** — user-facing decisions only, no architecture — proposing a
+**suggested default** for every open question, and leaves `.gtd/TODO.md`
+uncommitted for `gtd(agent): grilling`.
 
 There are no markers to answer — the human either:
 
 - **Accepts the suggested defaults**: runs a clean `gtd step` at the answer
-  gate. An empty `gtd(human): grilling` turn plus routing `gtd: grilled` lands
-  automatically, and `gtd next` emits the decompose prompt.
+  gate. An empty `gtd(human): grilling` turn plus routing `gtd: architecting`
+  lands automatically — `.gtd/ARCHITECTURE.md` is seeded from the converged
+  `.gtd/TODO.md` content and `.gtd/TODO.md` is deleted, in that one commit.
 - **Edits `.gtd/TODO.md`** with real answers, then runs `gtd step`, which
   captures the edit as a fresh `gtd(human): grilling` turn and hands it back to
   the agent for another round.
+
+Technical architecting works exactly the same way, one file later: the agent
+develops `.gtd/ARCHITECTURE.md` into a concrete **technical** plan — file/module
+structure, data model, tech-stack choices — and the human answers or accepts
+defaults at the `architecting` gate. Accepting converges to `gtd: grilled` and
+`gtd next` emits the decompose prompt (which now reads `.gtd/ARCHITECTURE.md`).
+
+**Escape hatch for already-technical input:** if the human's initial dirty tree
+already contains `.gtd/ARCHITECTURE.md` (their own technical sketch), `gtd step`
+captures the entry turn as `gtd(human): architecting` directly, skipping product
+grilling for that cycle entirely — no CLI flag needed, it's driven purely by
+which steering file is present.
 
 ### Build lifecycle: budgets
 
@@ -519,24 +537,24 @@ the threshold simply closes the package as usual.) Setting
 `agenticReview: false` force-approves every package immediately.
 
 A **do-nothing agent invocation** — `gtd step-agent` on a clean tree at ANY
-agent-awaited rest whose move is a file artifact (`grilling`, `grilled`,
-`building`, `fixing`, `agentic-review`, `review`, and `squashing` while
-`.gtd/SQUASH_MSG.md` still holds the unmodified template) — is inert: zero
+agent-awaited rest whose move is a file artifact (`grilling`, `architecting`,
+`grilled`, `building`, `fixing`, `agentic-review`, `review`, and `squashing`
+while `.gtd/SQUASH_MSG.md` still holds the unmodified template) — is inert: zero
 commits, no state consumed; `gtd next` re-emits the same prompt. This is
 load-bearing for the loop protocol, whose every iteration opens with
 `gtd step-agent` before the agent has acted: without the guard that opening beat
 would author junk empty turns — and worse, consume workflow state (an empty
-decompose turn would delete `.gtd/TODO.md` with no packages written; an empty
-squashing turn would squash the cycle under the placeholder template). The same
-guards hold at the classification layer for histories that already carry such
-turns: a `gtd(agent): grilled` HEAD only routes to `gtd: planning` when packages
-exist, a `gtd(agent): review` HEAD only routes to `gtd: awaiting review` when
-`.gtd/REVIEW.md` exists, and a squashing turn only squashes once the template
-has been overwritten. The one deliberate exception is `health-fixing`, whose
-empty turn is meaningful (the failure may have been environmental — the machine
-removes `.gtd/HEALTH.md` and re-tests). Human gates are unaffected: an empty
-**human** turn stays a signal (accept-defaults at grilling, clean approval at
-review).
+decompose turn would delete `.gtd/ARCHITECTURE.md` with no packages written; an
+empty squashing turn would squash the cycle under the placeholder template). The
+same guards hold at the classification layer for histories that already carry
+such turns: a `gtd(agent): grilled` HEAD only routes to `gtd: planning` when
+packages exist, a `gtd(agent): review` HEAD only routes to
+`gtd: awaiting review` when `.gtd/REVIEW.md` exists, and a squashing turn only
+squashes once the template has been overwritten. The one deliberate exception is
+`health-fixing`, whose empty turn is meaningful (the failure may have been
+environmental — the machine removes `.gtd/HEALTH.md` and re-tests). Human gates
+are unaffected: an empty **human** turn stays a signal (accept-defaults at
+grilling/architecting, clean approval at review).
 
 ### Human review gate
 
@@ -559,14 +577,15 @@ With `squash: true` (the default), `gtd: done` is **not** a rest — the same
 chain continues straight to `gtd: squash template`, writing and committing a
 `.gtd/SQUASH_MSG.md` template. `gtd next` then emits the squashing prompt: the
 agent overwrites `.gtd/SQUASH_MSG.md` with a real conventional-commits message
-(drawing on grilling-round decisions from history) and finishes its turn.
-`gtd step-agent` then performs the squash itself: `git reset --soft <base>` +
-`git commit`, collapsing every intermediate `gtd: *` commit of the cycle into
-one — including any review-feedback detours: the squash base is the cycle's
-ORIGINAL start (the first grilling run since the previous `gtd: done` boundary,
-or the `gtd: reviewing <hash>` anchor for an ad-hoc review cycle), not the most
-recent re-grilling round — the collapse folds the whole cycle into one, using
-the overwritten message's content verbatim (turn position, not message content,
+(drawing on grilling- and architecting-round decisions from history) and
+finishes its turn. `gtd step-agent` then performs the squash itself:
+`git reset --soft <base>` + `git commit`, collapsing every intermediate `gtd: *`
+commit of the cycle into one — including any review-feedback detours: the squash
+base is the cycle's ORIGINAL start (the first grilling or, via the escape hatch,
+architecting turn since the previous `gtd: done` boundary, or the
+`gtd: reviewing <hash>` anchor for an ad-hoc review cycle), not the most recent
+re-grilling round — the collapse folds the whole cycle into one, using the
+overwritten message's content verbatim (turn position, not message content,
 triggers the squash). With `squash: false`, `gtd: done` is the resting boundary
 and no template is ever written.
 
@@ -594,6 +613,7 @@ fix-attempt budget to zero.
 | State            | Awaits         | Turn/routing subject at rest                                     |
 | ---------------- | -------------- | ---------------------------------------------------------------- |
 | `grilling`       | human or agent | `gtd(human): grilling` / `gtd(agent): grilling`                  |
+| `architecting`   | human or agent | `gtd: architecting` / `gtd(agent): architecting`                 |
 | `grilled`        | agent          | `gtd: grilled`                                                   |
 | `planning`       | agent          | `.gtd/` modified                                                 |
 | `building`       | agent          | `gtd: planning` / `gtd: package done`                            |
@@ -646,13 +666,13 @@ built-in defaults apply. Supported filenames (searched in this order):
   `false` to keep the granular history.
 - **`models`** — model selection for the subagent-spawning states:
   - `planning` — high-reasoning tier (default `claude-opus-4-8`), used by
-    `decompose` (the `grilled`/`planning` states), `grilling`, `agentic-review`,
-    and `clean` (the `review`/`squashing` states).
+    `decompose` (the `grilled`/`planning` states), `grilling`, `architecting`,
+    `agentic-review`, and `clean` (the `review`/`squashing` states).
   - `execution` — everyday tier (default `claude-sonnet-4-8`), used by
     `building` and `fixing`.
   - `states.*` — per-state overrides keyed by `decompose`, `grilling`,
-    `building`, `fixing`, `agentic-review`, `clean`. Unknown `states` keys are
-    **rejected**.
+    `architecting`, `building`, `fixing`, `agentic-review`, `clean`. Unknown
+    `states` keys are **rejected**.
 - **`$schema`** (string, optional) — stripped before validation, so it never
   counts as an unknown key. Point it at the published schema for editor-backed
   autocompletion. A `schema.json` is generated from the config schema at build
@@ -739,7 +759,7 @@ models:
 ### Decompose
 
 The Grilled/Planning states spawn a planning-model subagent that breaks
-`.gtd/TODO.md` into executable work packages under `.gtd/`:
+`.gtd/ARCHITECTURE.md` into executable work packages under `.gtd/`:
 
 ```
 .gtd/

--- a/STATES.md
+++ b/STATES.md
@@ -32,9 +32,9 @@ A transition is a pure function of four inputs, nothing else:
 2. **whether the working tree is dirty or clean**
 3. **the class of HEAD's commit subject** — turn commit, routing commit, or
    boundary commit (§2)
-4. **which steering files are present** (`.gtd/TODO.md`, `.gtd/NN-…/` work
-   packages, `.gtd/REVIEW.md`, `.gtd/FEEDBACK.md`, `.gtd/ERRORS.md`,
-   `.gtd/HEALTH.md`, `.gtd/SQUASH_MSG.md`)
+4. **which steering files are present** (`.gtd/TODO.md`, `.gtd/ARCHITECTURE.md`,
+   `.gtd/NN-…/` work packages, `.gtd/REVIEW.md`, `.gtd/FEEDBACK.md`,
+   `.gtd/ERRORS.md`, `.gtd/HEALTH.md`, `.gtd/SQUASH_MSG.md`)
 
 All steering files live under `.gtd/` — the directory is the workflow's
 namespace, and everything outside it is project code. A root-level `TODO.md` or
@@ -98,15 +98,15 @@ machine-authored namespaces, plus a catch-all:
 ### 2.1 Turn gates (`TurnGate`)
 
 ```
-grilling | grilled | building | fixing | agentic-review | review
+grilling | architecting | grilled | building | fixing | agentic-review | review
 | squashing | health-fixing | escalate
 ```
 
 `turnSubject(actor, gate)` produces `gtd(${actor}): ${gate}`. Not every
 `(actor, gate)` pair is reachable: turns are strictly separated (§3), so a gate
 is only ever authored by its awaited actor — there is no `gtd(human): building`
-at all, and `gtd(human)` appears only at the human gates (`grilling`'s entry and
-answer turns, `review`, `escalate`).
+at all, and `gtd(human)` appears only at the human gates (`grilling`'s and
+`architecting`'s entry and answer turns, `review`, `escalate`).
 
 ### 2.2 Routing phases (`RoutingPhase`) and their awaited actor
 
@@ -118,6 +118,7 @@ ladder, not by subject alone):
 
 | Subject                 | Class at that HEAD | Lands at (state, actor)                                                                                                                                                                                                                        |
 | ----------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gtd: architecting`     | rest               | `architecting`, agent                                                                                                                                                                                                                          |
 | `gtd: grilled`          | rest               | `grilled`, agent                                                                                                                                                                                                                               |
 | `gtd: planning`         | rest               | `building`, agent                                                                                                                                                                                                                              |
 | `gtd: tests green`      | rest or mid-chain  | `.gtd` present: force-approved → mid-chain `closePackage` → `close-package`, agent; not force-approved → rest `agentic-review`, agent. No `.gtd` (health path): squash-after-green → mid-chain `writeSquashTemplate`; else rest `idle`, human. |
@@ -142,8 +143,10 @@ ordinary review-scope rules (§4, Review).
 | Turn commit                  | Class                                      | Lands at                                                                                                                                                                                           |
 | ---------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `gtd(agent): grilling`       | empty diff → rest; non-empty → rest        | `grilling`, agent (empty, re-emit) or `grilling`, human (non-empty, answer gate)                                                                                                                   |
-| `gtd(human): grilling`       | empty diff → mid-chain; non-empty → rest   | empty → `commitRouting "gtd: grilled"` → `grilling`/agent picture; non-empty → rest `grilling`, agent                                                                                              |
-| `gtd(agent): grilled`        | mid-chain                                  | `commitRouting "gtd: planning"` (removes .gtd/TODO.md)                                                                                                                                             |
+| `gtd(human): grilling`       | empty diff → mid-chain; non-empty → rest   | empty → `commitRouting "gtd: architecting", seedArchitectureFromTodo: true` → `architecting`/agent; non-empty → rest `grilling`, agent                                                             |
+| `gtd(agent): architecting`   | empty diff → rest; non-empty → rest        | `architecting`, agent (empty, re-emit) or `architecting`, human (non-empty, answer gate)                                                                                                           |
+| `gtd(human): architecting`   | empty diff → mid-chain; non-empty → rest   | empty → `commitRouting "gtd: grilled"` → `grilled`/agent; non-empty → rest `architecting`, agent                                                                                                   |
+| `gtd(agent): grilled`        | mid-chain                                  | `commitRouting "gtd: planning"` (removes .gtd/ARCHITECTURE.md)                                                                                                                                     |
 | `gtd(agent): building`       | mid-chain                                  | `runTest`                                                                                                                                                                                          |
 | `gtd(agent): fixing`         | empty diff → rest; non-empty → mid-chain   | empty → rest `fixing`, agent (re-emit); non-empty → `runTest`                                                                                                                                      |
 | `gtd(agent): agentic-review` | rest                                       | `agentic-review`, agent (only reached when .gtd/FEEDBACK.md was never written at all — the .gtd/FEEDBACK.md-present cases are handled by the steering-file precedence check that runs before this) |
@@ -332,17 +335,19 @@ committed.
 
 ## 4. Per-state documentation
 
-The 16 frozen `GtdState`s (`src/Machine.ts`). 11 are prompt-bearing
-(`isPromptState` in `src/Prompt.ts`): `grilling`, `grilled`, `building`,
-`fixing`, `agentic-review`, `review`, `await-review`, `squashing`, `escalate`,
-`idle`, `health-fixing`. The other 5 — `testing`, `planning`, `close-package`,
-`done`, `health-check` — are performed entirely by the driver/edge and must
-never reach `buildPrompt` (it throws if they do).
+The 17 frozen `GtdState`s (`src/Machine.ts`). 12 are prompt-bearing
+(`isPromptState` in `src/Prompt.ts`): `grilling`, `architecting`, `grilled`,
+`building`, `fixing`, `agentic-review`, `review`, `await-review`, `squashing`,
+`escalate`, `idle`, `health-fixing`. The other 5 — `testing`, `planning`,
+`close-package`, `done`, `health-check` — are performed entirely by the
+driver/edge and must never reach `buildPrompt` (it throws if they do).
 
 ### `grilling`
 
-**Means:** developing a plan (`.gtd/TODO.md`) toward a concrete, implementation-
-ready form, iterating between agent and human.
+**Means:** developing a plan (`.gtd/TODO.md`) toward a concrete, product-level
+form — user-facing/product decisions only, iterating between agent and human.
+Technical/architectural decisions are explicitly out of scope here; they belong
+to the next phase (`architecting`).
 
 **Awaited actor:** `agent` or `human`, depending on which prompt renders —
 `awaitedActor("grilling")` alone only gives the generic default (`"agent"`); the
@@ -353,43 +358,87 @@ agent-develops rest (`@grilling-agent` template).
 **Prompt:**
 
 - `@grilling-agent` (agent awaited) — develop `.gtd/TODO.md` into a concrete
-  plan in one turn, using subagents; every remaining open question must carry a
-  suggested default; leave .gtd/TODO.md uncommitted. Inlines the latest human
-  turn's diff (workflow files excluded) as "feedback, not finished work" when
-  present.
+  product-level plan in one turn, using subagents; every remaining open question
+  must carry a suggested default; leave .gtd/TODO.md uncommitted. Inlines the
+  latest human turn's diff (workflow files excluded) as "feedback, not finished
+  work" when present.
 - `@grilling-answers` (human awaited) — a pure human gate: edit `.gtd/TODO.md`
   in place to answer/annotate, or run `gtd step` with no edits to accept all
   suggested defaults.
 
 **Entry:** a dirty boundary tree with `invoker: "human"` (no steering files, no
-committed .gtd/TODO.md) captures `gtd(human): grilling` — the v2 entry turn
-(`isDirtyBoundaryEntry` in `applyTurnTaking`). `gtd: done` counts as a boundary
-HEAD for this purpose too, even though it parses as `"routing"` — a settled
-cycle is exactly where the next feature's dirty tree lands.
-`gtd: review feedback` also rests here (agent awaited) — the re-grilling entry
-from review feedback (§4, Review-feedback re-grill below).
+committed .gtd/TODO.md, no committed .gtd/ARCHITECTURE.md) captures
+`gtd(human): grilling` — the v2 entry turn (`isDirtyBoundaryEntry` in
+`applyTurnTaking`). `gtd: done` counts as a boundary HEAD for this purpose too,
+even though it parses as `"routing"` — a settled cycle is exactly where the next
+feature's dirty tree lands. `gtd: review feedback` also rests here (agent
+awaited) — the re-grilling entry from review feedback (§4, Review-feedback
+re-grill below).
+
+**Escape hatch:** if the dirty boundary tree already contains
+`.gtd/ARCHITECTURE.md` (an already-technical sketch the human wrote directly),
+the entry turn is captured as `gtd(human): architecting` instead, skipping
+product grilling entirely for this cycle (see `architecting`'s Entry below).
+This is file-_presence_-based routing — the same mechanism every steering-file
+rung in the ladder already uses — not content-based steering.
 
 **Exit:** an empty human turn at the answer gate (`gtd(human): grilling` with an
-empty diff) mid-chains to `commitRouting "gtd: grilled"` → **grilled**.
+empty diff) mid-chains to
+`commitRouting "gtd: architecting", seedArchitectureFromTodo: true` (writes
+`.gtd/ARCHITECTURE.md` from the converged `.gtd/TODO.md` content and deletes
+`.gtd/TODO.md`, in one commit) → **architecting**.
+
+### `architecting`
+
+**Means:** developing the converged product plan (`.gtd/ARCHITECTURE.md`) into a
+concrete, implementation-ready technical/architectural plan — file/module
+structure, data models, tech-stack choices — iterating between agent and human.
+Mechanically an exact mirror of `grilling`, one file and one phase later.
+
+**Awaited actor:** `agent` or `human`, depending on which prompt renders — same
+`Result.actor` distinction as `grilling` (`@architecting-answers` vs.
+`@architecting-agent`).
+
+**Prompt:**
+
+- `@architecting-agent` (agent awaited) — develop `.gtd/ARCHITECTURE.md` into a
+  concrete technical plan in one turn, using subagents; every remaining open
+  question must carry a suggested default; leave .gtd/ARCHITECTURE.md
+  uncommitted. Must not re-open product/user-facing decisions already settled by
+  grilling. Inlines the latest human turn's diff as "feedback, not finished
+  work" when present.
+- `@architecting-answers` (human awaited) — a pure human gate: edit
+  `.gtd/ARCHITECTURE.md` in place to answer/annotate, or run `gtd step` with no
+  edits to accept all suggested defaults.
+
+**Entry:** the routing commit `gtd: architecting` is a rest landing here (agent)
+— reached either from grilling's converged exit (`.gtd/ARCHITECTURE.md` seeded
+from `.gtd/TODO.md`) or directly from the escape-hatch dirty-boundary entry
+(`.gtd/ARCHITECTURE.md` authored by the human from scratch, no `.gtd/TODO.md`
+ever existing).
+
+**Exit:** an empty human turn at the answer gate (`gtd(human): architecting`
+with an empty diff) mid-chains to `commitRouting "gtd: grilled"` → **grilled**.
 
 ### `grilled`
 
-**Means:** the plan has converged (no open questions, nothing pending); ready to
-be decomposed into ordered work packages.
+**Means:** the architecture has converged (no open questions, nothing pending);
+ready to be decomposed into ordered work packages.
 
 **Awaited actor:** agent.
 
-**Prompt:** `@decompose` — decompose `.gtd/TODO.md` into `.gtd/NN-<package>/`
-directories of numbered task `.md` files. Rules inlined in the prompt: packages
-are sequential/dependency-ordered, each package must be green on its own, tasks
-within a package are parallel and file-disjoint, packages are vertical slices,
-task files are self-contained. The subagent must not commit — this runs inside a
-larger orchestration that depends on uncommitted state.
+**Prompt:** `@decompose` — decompose `.gtd/ARCHITECTURE.md` into
+`.gtd/NN-<package>/` directories of numbered task `.md` files. Rules inlined in
+the prompt: packages are sequential/dependency-ordered, each package must be
+green on its own, tasks within a package are parallel and file-disjoint,
+packages are vertical slices, task files are self-contained. The subagent must
+not commit — this runs inside a larger orchestration that depends on uncommitted
+state.
 
 **Entry:** the routing commit `gtd: grilled` is a rest landing here (agent).
 
 **Exit:** `gtd(agent): grilled` mid-chains to `commitRouting "gtd: planning"`
-(also removing `.gtd/TODO.md`) → **planning**.
+(also removing `.gtd/ARCHITECTURE.md`) → **planning**.
 
 **Turn-taking:** `gtd step` (human) is refused here like at every agent-awaited
 rest (§3), and this rest is why the rule matters: the dirty tree is the
@@ -583,9 +632,9 @@ The human gate reached after drafting (`gtd: awaiting review`) is a separate
 - **Outside a process** (any branch, no grilling turn in this cycle) → no base
   is set; the branch review never fires (falls through to idle/health).
 
-Workflow files (`.gtd/TODO.md`, `.gtd/REVIEW.md`, `.gtd/FEEDBACK.md`,
-`.gtd/ERRORS.md`, `.gtd/HEALTH.md`, `.gtd/SQUASH_MSG.md`, `.gtd/`) are excluded
-from every review diff.
+Workflow files (`.gtd/TODO.md`, `.gtd/ARCHITECTURE.md`, `.gtd/REVIEW.md`,
+`.gtd/FEEDBACK.md`, `.gtd/ERRORS.md`, `.gtd/HEALTH.md`, `.gtd/SQUASH_MSG.md`,
+`.gtd/`) are excluded from every review diff.
 
 **Actions/Exit:**
 
@@ -669,9 +718,10 @@ into one conventional-commits message. Two entry points share this state:
    `.gtd/SQUASH_MSG.md` and commit it as `gtd: squash template`. No squash
    happens yet.
 2. `gtd next` at that rest renders `@squashing` — extract key decisions from the
-   grilling rounds' `.gtd/TODO.md` history, draft one conventional-commits
-   message, and **overwrite** `.gtd/SQUASH_MSG.md` with it (leaving it
-   uncommitted). No sentinel text appears anywhere in this prompt.
+   grilling and architecting rounds' `.gtd/TODO.md` and `.gtd/ARCHITECTURE.md`
+   history, draft one conventional-commits message, and **overwrite**
+   `.gtd/SQUASH_MSG.md` with it (leaving it uncommitted). No sentinel text
+   appears anywhere in this prompt.
 3. `gtd(agent): squashing`, once `.gtd/SQUASH_MSG.md` is present, mid-chains to
    `squashCommit`: read `.gtd/SQUASH_MSG.md`'s content, remove the file,
    `git reset --soft <squashBase>`, then commit-all under that content as the
@@ -763,6 +813,11 @@ the more generic single-file one), then the rest:
 .gtd/REVIEW.md + .gtd
 .gtd/REVIEW.md + committed .gtd/TODO.md
 uncommitted .gtd/REVIEW.md + .gtd/TODO.md
+.gtd/REVIEW.md + committed .gtd/ARCHITECTURE.md
+uncommitted .gtd/REVIEW.md + .gtd/ARCHITECTURE.md
+.gtd/TODO.md + .gtd/ARCHITECTURE.md   (the two never legitimately coexist —
+                          TODO.md is always deleted in the same commit that
+                          seeds ARCHITECTURE.md)
 .gtd/FEEDBACK.md + .gtd/REVIEW.md
 .gtd/FEEDBACK.md without .gtd
 .gtd/ERRORS.md + .gtd/FEEDBACK.md
@@ -805,24 +860,30 @@ In order:
 2. HEAD is `gtd: package done` → packages remain → **building**; else reviewable
    → **review**; else → idle/health.
 3. `.gtd/TODO.md` present (any other HEAD) → **grilling** continues.
-4. `.gtd/` exists with a pending package **and** the nearest workflow commit
+4. `.gtd/ARCHITECTURE.md` present (any other HEAD) → **architecting** continues
+   (mirrors rung 3 — the two files never coexist, per the illegal-combination
+   guard, so ordering between rungs 3 and 4 is inert).
+5. `.gtd/` exists with a pending package **and** the nearest workflow commit
    (skipping boundary commits stacked on top) is still `gtd(agent): building` →
    **building** (operational-recovery carve-out: a boundary commit, e.g. a
    config fix, landed on top of the checkpoint after a mid-chain failure, but
    the checkpoint is still the active one). Narrow by design — an unrecognized
    boundary HEAD with no such checkpoint in its history still hard-errors.
-5. No steering files at all, no recognized workflow HEAD → idle/health
+6. No steering files at all, no recognized workflow HEAD → idle/health
    (`resolveIdleOrHealth`): reviewable diff → **review**; else → **idle**,
    human.
-6. Anything else → `corrupt()` — hard error.
+7. Anything else → `corrupt()` — hard error.
 
 ### 5.5 Turn-taking layer (`applyTurnTaking`, always applied last)
 
 Independent of the ladder above, layered on every resolved baseline:
 
 1. **Dirty-boundary entry** (`invoker === "human"`, dirty tree, no committed
-   .gtd/TODO.md, no steering files, boundary/`gtd: done` HEAD) → captures
-   `gtd(human): grilling` unconditionally, short-circuiting everything else.
+   .gtd/TODO.md, no committed .gtd/ARCHITECTURE.md, no other steering files,
+   boundary/`gtd: done` HEAD) → captures `gtd(human): grilling`, short-
+   circuiting everything else — UNLESS the dirty tree already contains
+   `.gtd/ARCHITECTURE.md` (the escape hatch), in which case it captures
+   `gtd(human): architecting` instead, skipping product grilling for this cycle.
 2. **Mid-chain baseline** → `invoker === "none"` reports `pending: true`; any
    other invoker performs the edge action.
 3. **Rest baseline, `invoker === "none"`** → report state/actor, no mutation.
@@ -859,11 +920,14 @@ Mirrors `tests/integration/features/journeys.feature`. All examples below assume
 ```
 <boundary/init>
 gtd(human): grilling        # dirty-boundary entry turn
-gtd(agent): grilling        # agent develops the plan (non-empty)
+gtd(agent): grilling        # agent develops the product plan (non-empty)
 gtd(human): grilling        # human accepts (empty turn)
+gtd: architecting            # routing: .gtd/ARCHITECTURE.md seeded, .gtd/TODO.md removed
+gtd(agent): architecting    # agent develops the architecture (non-empty)
+gtd(human): architecting    # human accepts (empty turn)
 gtd: grilled                # routing: converged
 gtd(agent): grilled         # agent's own-gate turn (immediately mid-chains)
-gtd: planning                # routing: .gtd/TODO.md removed
+gtd: planning                # routing: .gtd/ARCHITECTURE.md removed
 gtd(agent): building        # agent writes code
 gtd: tests green             # routing: test passed
 gtd: package done             # routing: force-approved (agenticReview off)
@@ -911,12 +975,37 @@ gtd(human): grilling          # dirty-boundary entry (notes.md)
 gtd(agent): grilling          # agent leaves an open question with a suggested default
 gtd(human): grilling          # human answers inline in .gtd/TODO.md (non-empty!) — NOT accept
 gtd(agent): grilling          # agent converges, no more markers
-gtd: grilled                   # human's next clean step converges
+gtd: architecting               # human's next clean step converges
 ```
 
 Note the human's answer round is itself a **non-empty** human turn — it does not
 converge on its own; the agent still gets one more round to confirm convergence
-before the clean accept lands `gtd: grilled`.
+before the clean accept lands `gtd: architecting`.
+
+### Architecting round with a human answer
+
+```
+gtd: architecting               # routing: .gtd/ARCHITECTURE.md seeded from converged TODO.md
+gtd(agent): architecting      # agent leaves an open question with a suggested default
+gtd(human): architecting      # human answers inline in .gtd/ARCHITECTURE.md (non-empty!) — NOT accept
+gtd(agent): architecting      # agent converges, no more markers
+gtd: grilled                    # human's next clean step converges
+```
+
+Mechanically identical to the grilling round above, one file and one phase
+later.
+
+### Escape hatch: already-technical input
+
+```
+<boundary/init>
+gtd(human): architecting      # dirty-boundary entry, but the human authored
+                                 # .gtd/ARCHITECTURE.md directly — product
+                                 # grilling is skipped entirely
+gtd(agent): architecting      # agent develops the architecture from that raw input
+gtd(human): architecting      # human accepts (empty turn)
+gtd: grilled                    # routing: converged — .gtd/TODO.md never existed
+```
 
 ### Escalation and recovery
 
@@ -965,8 +1054,8 @@ The step-first two-beat loop an agent (or the `loop` skill) should run to drive
 1. Run `gtd step-agent`.
 2. Run `gtd next`.
 3. If `actor` is `"human"` → **halt** (the human owns the next move: a human
-   gate — answer .gtd/TODO.md questions, review, fix an escalation — or a
-   human-driven pending checkpoint resumed by `gtd step`).
+   gate — answer .gtd/TODO.md or .gtd/ARCHITECTURE.md questions, review, fix an
+   escalation — or a human-driven pending checkpoint resumed by `gtd step`).
 4. Otherwise: if a prompt was emitted, feed it to the agent (spawn the
    subagent(s) the prompt describes, let them make their edits, leave them
    uncommitted per the prompt's instructions); at an agent-driven pending

--- a/schema.json
+++ b/schema.json
@@ -33,6 +33,9 @@
             "grilling": {
               "type": "string"
             },
+            "architecting": {
+              "type": "string"
+            },
             "building": {
               "type": "string"
             },

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -16,6 +16,7 @@ import { ArrayFormatter, ParseError } from "effect/ParseResult"
 export type ModelState =
   | "decompose"
   | "grilling"
+  | "architecting"
   | "building"
   | "fixing"
   | "agentic-review"
@@ -31,6 +32,7 @@ export type ModelTier = "planning" | "execution"
 export const stateTier: Record<ModelState, ModelTier> = {
   decompose: "planning",
   grilling: "planning",
+  architecting: "planning",
   building: "execution",
   fixing: "execution",
   "agentic-review": "planning",
@@ -55,6 +57,7 @@ const DEFAULT_REVIEW_THRESHOLD = 3
 const ModelStatesSchema = Schema.Struct({
   decompose: Schema.optional(Schema.String),
   grilling: Schema.optional(Schema.String),
+  architecting: Schema.optional(Schema.String),
   building: Schema.optional(Schema.String),
   fixing: Schema.optional(Schema.String),
   "agentic-review": Schema.optional(Schema.String),

--- a/src/Events.test.ts
+++ b/src/Events.test.ts
@@ -486,6 +486,21 @@ describe("gatherEvents — RESOLVE payload", { timeout: 30_000 }, () => {
     expect(p.todoCommitted).toBe(false)
   })
 
+  it("architectureCommitted: tracked at HEAD → true (even with pending edits)", async () => {
+    commitFile(turnSubject("agent", "architecting"), ".gtd/ARCHITECTURE.md", "# Architecture\n")
+    writeRepoFile(join(repoDir, ".gtd/ARCHITECTURE.md"), "# Architecture\n\nedited\n")
+    const p = resolveOf(await runGather())
+    expect(p.architectureExists).toBe(true)
+    expect(p.architectureCommitted).toBe(true)
+  })
+
+  it("architectureCommitted: freshly written (untracked) ARCHITECTURE.md → false", async () => {
+    writeRepoFile(join(repoDir, ".gtd/ARCHITECTURE.md"), "# Architecture\n")
+    const p = resolveOf(await runGather())
+    expect(p.architectureExists).toBe(true)
+    expect(p.architectureCommitted).toBe(false)
+  })
+
   it("pendingErrorsDeletion reflects a working-tree ERRORS.md deletion", async () => {
     commitFile("gtd: errors", ".gtd/ERRORS.md", "boom\n")
     rmSync(join(repoDir, ".gtd/ERRORS.md")) // human removes the committed ERRORS.md
@@ -619,6 +634,17 @@ describe("gatherEvents — headTurnDiff / headTurnIsEmpty", { timeout: 30_000 },
     expect(p.headTurnDiff).toContain("code.ts")
     expect(p.headTurnDiff).not.toContain(".gtd/TODO.md")
   })
+
+  it("headTurnDiff includes ARCHITECTURE.md for an architecting turn — it IS the gate's content", async () => {
+    writeRepoFile(join(repoDir, ".gtd/ARCHITECTURE.md"), "# Architecture\ngo with a REST API\n")
+    writeRepoFile(join(repoDir, "code.ts"), "export const c = 1\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", turnSubject("human", "architecting"))
+    const p = resolveOf(await runGather())
+    expect(p.headTurnDiff).toContain("code.ts")
+    expect(p.headTurnDiff).toContain(".gtd/ARCHITECTURE.md")
+    expect(p.headTurnDiff).toContain("REST API")
+  })
 })
 
 // ── gatherEvents: reviewAnchor ────────────────────────────────────────────────
@@ -690,6 +716,17 @@ describe("gatherEvents — review base (reviewBase / refDiff)", { timeout: 30_00
     commitFile("feat: add widget", "widget.ts", "export const widget = 1\n")
     const p = resolveOf(await runGather())
     expect(p.reviewBase).toBe(grillingHash)
+  })
+
+  it("escape hatch: a cycle starting directly at an architecting turn (no grilling at all) still yields the correct review base", async () => {
+    initRepo(false)
+    commitFile(turnSubject("human", "architecting"), ".gtd/ARCHITECTURE.md", "# Architecture\n")
+    const architectingHash = git("rev-parse", "HEAD")
+    git("rm", "-q", ".gtd/ARCHITECTURE.md")
+    git("commit", "-q", "-m", "gtd: planning")
+    commitFile("feat: add widget", "widget.ts", "export const widget = 1\n")
+    const p = resolveOf(await runGather())
+    expect(p.reviewBase).toBe(architectingHash)
   })
 
   // Rule 2: within-process, incremental — `gtd: awaiting review` already
@@ -1044,6 +1081,14 @@ describe("perform — EdgeAction execution", { timeout: 30_000 }, () => {
     expect(git("status", "--porcelain").trim()).toBe("")
   })
 
+  it("captureTurn: formats a pending ARCHITECTURE.md before committing", async () => {
+    writeRepoFile(join(repoDir, ".gtd/ARCHITECTURE.md"), "#    Arch\nunformatted   \n")
+    await runPerform({ kind: "captureTurn", actor: "human", gate: "architecting" })
+    const formatted = readFileSync(join(repoDir, ".gtd/ARCHITECTURE.md"), "utf8")
+    expect(formatted).not.toBe("#    Arch\nunformatted   \n")
+    expect(git("status", "--porcelain").trim()).toBe("")
+  })
+
   it("commitRouting: commits pending changes under the given subject with no removals", async () => {
     writeRepoFile(join(repoDir, "src.ts"), "code\n")
     await runPerform({ kind: "commitRouting", subject: "gtd: grilled" })
@@ -1051,14 +1096,30 @@ describe("perform — EdgeAction execution", { timeout: 30_000 }, () => {
     expect(git("status", "--porcelain").trim()).toBe("")
   })
 
-  it("commitRouting removeTodo: deletes TODO.md and lands its removal in the commit", async () => {
-    commitFile("gtd: grilled", ".gtd/TODO.md", "# Plan\n")
+  it("commitRouting removeArchitecture: deletes ARCHITECTURE.md and lands its removal in the commit", async () => {
+    commitFile("gtd: grilled", ".gtd/ARCHITECTURE.md", "# Architecture\n")
     mkdirSync(join(repoDir, ".gtd", "01-foo"), { recursive: true })
     writeRepoFile(join(repoDir, ".gtd", "01-foo", "01-task.md"), "# Task\n")
-    await runPerform({ kind: "commitRouting", subject: "gtd: planning", removeTodo: true })
-    expect(existsSync(join(repoDir, ".gtd/TODO.md"))).toBe(false)
+    await runPerform({ kind: "commitRouting", subject: "gtd: planning", removeArchitecture: true })
+    expect(existsSync(join(repoDir, ".gtd/ARCHITECTURE.md"))).toBe(false)
     expect(git("log", "-1", "--format=%s")).toBe("gtd: planning")
-    expect(git("show", "--name-status", "--format=", "HEAD")).toContain("D\t.gtd/TODO.md")
+    expect(git("show", "--name-status", "--format=", "HEAD")).toContain("D\t.gtd/ARCHITECTURE.md")
+  })
+
+  it("commitRouting seedArchitectureFromTodo: seeds ARCHITECTURE.md from TODO.md's content and removes TODO.md", async () => {
+    commitFile("gtd(human): grilling", ".gtd/TODO.md", "# Plan\n\ngo with tailwind css\n")
+    await runPerform({
+      kind: "commitRouting",
+      subject: "gtd: architecting",
+      seedArchitectureFromTodo: true,
+    })
+    expect(existsSync(join(repoDir, ".gtd/TODO.md"))).toBe(false)
+    const architecture = readFileSync(join(repoDir, ".gtd/ARCHITECTURE.md"), "utf8")
+    expect(architecture).toContain("go with tailwind css")
+    expect(git("log", "-1", "--format=%s")).toBe("gtd: architecting")
+    const nameStatus = git("show", "--name-status", "--format=", "HEAD")
+    expect(nameStatus).toContain("D\t.gtd/TODO.md")
+    expect(nameStatus).toContain(".gtd/ARCHITECTURE.md")
   })
 
   it("commitRouting removeReview: deletes REVIEW.md and lands its removal in the commit", async () => {

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -37,6 +37,7 @@ import type {
 // code, never steering.
 const GTD_DIR = ".gtd"
 const TODO_FILE = `${GTD_DIR}/TODO.md`
+const ARCHITECTURE_FILE = `${GTD_DIR}/ARCHITECTURE.md`
 const REVIEW_FILE = `${GTD_DIR}/REVIEW.md`
 const FEEDBACK_FILE = `${GTD_DIR}/FEEDBACK.md`
 const ERRORS_FILE = `${GTD_DIR}/ERRORS.md`
@@ -67,6 +68,7 @@ const WORKFLOW_FILE_EXCLUDES: ReadonlyArray<string> = [GTD_DIR]
 // steering file.
 const GATE_OWN_STEERING_FILE: Partial<Record<string, string>> = {
   grilling: TODO_FILE,
+  architecting: ARCHITECTURE_FILE,
   review: REVIEW_FILE,
 }
 
@@ -433,6 +435,7 @@ export const gatherEvents = (
 
     // Steering-file presence (committed and/or pending).
     const todoExists = yield* fs.exists(resolve(TODO_FILE))
+    const architectureExists = yield* fs.exists(resolve(ARCHITECTURE_FILE))
     const reviewPresent = yield* fs.exists(resolve(REVIEW_FILE))
     const feedbackPresent = yield* fs.exists(resolve(FEEDBACK_FILE))
     const errorsPresent = yield* fs.exists(resolve(ERRORS_FILE))
@@ -458,6 +461,8 @@ export const gatherEvents = (
 
     // TODO.md tracked at HEAD.
     const todoCommitted = todoExists && !isUncommitted(TODO_FILE)
+    // ARCHITECTURE.md tracked at HEAD.
+    const architectureCommitted = architectureExists && !isUncommitted(ARCHITECTURE_FILE)
 
     // The working tree deletes a committed ERRORS.md (human resume → fresh
     // budget). A status probe, distinct from the committed `removedErrors` flag.
@@ -543,10 +548,14 @@ export const gatherEvents = (
         }
       }
 
-      // Find first grilling turn commit in the current cycle (task start).
+      // Find first grilling-or-architecting turn commit in the current cycle
+      // (task start) — the escape hatch lets a cycle start directly at
+      // `architecting` (no grilling turn at all), so both gates count.
       const isGrillingTurn = (message: string): boolean => {
         const parsed = parseSubject(subjectOf(message))
-        return parsed.kind === "turn" && parsed.gate === "grilling"
+        return (
+          parsed.kind === "turn" && (parsed.gate === "grilling" || parsed.gate === "architecting")
+        )
       }
       const firstGrilling = currentCycle.find((c) => isGrillingTurn(c.message))
       // Find last `gtd: awaiting review` in the current cycle.
@@ -631,7 +640,9 @@ export const gatherEvents = (
         // entire cycle back to where it actually began.
         const isGrillingTurnSubject = (subject: string): boolean => {
           const parsed = parseSubject(subject)
-          return parsed.kind === "turn" && parsed.gate === "grilling"
+          return (
+            parsed.kind === "turn" && (parsed.gate === "grilling" || parsed.gate === "architecting")
+          )
         }
         const isReviewingAnchor = (subject: string): boolean => {
           const parsed = parseSubject(subject)
@@ -746,6 +757,8 @@ export const gatherEvents = (
       ...(headTurnReviewSubstantive !== undefined ? { headTurnReviewSubstantive } : {}),
       todoExists,
       todoCommitted,
+      architectureExists,
+      architectureCommitted,
       packagesPresent: packages.length > 0,
       reviewPresent,
       feedbackPresent,
@@ -831,6 +844,15 @@ const SQUASH_TEMPLATE = [
 ].join("\n")
 
 /**
+ * A short scaffold banner prefixed to `.gtd/ARCHITECTURE.md` when it is
+ * seeded from the converged `.gtd/TODO.md` (the grilling→architecting
+ * hand-off) — mirrors `SQUASH_TEMPLATE`'s role of orienting the NEXT turn's
+ * agent rather than steering the machine (file content never steers).
+ */
+const ARCHITECTURE_SEED_BANNER =
+  "<!-- gtd: seeded from the converged product plan (.gtd/TODO.md); decide the technical/architectural questions below. -->\n\n"
+
+/**
  * Execute the side effect the machine's `resolve()` chose. The driver performs
  * this, then re-gathers + re-resolves. Each case maps to the primitives in
  * Git.ts / the FileSystem; the machine only decides *which* action.
@@ -862,12 +884,16 @@ export const perform = (
       .pipe(Effect.catchAll(() => Effect.void))
 
     switch (action.kind) {
-      // Capture a human/agent turn: format the pending TODO.md (best-effort),
-      // then commit-all under `gtd(<actor>): <gate>` (--allow-empty).
+      // Capture a human/agent turn: format the pending TODO.md/ARCHITECTURE.md
+      // (best-effort), then commit-all under `gtd(<actor>): <gate>` (--allow-empty).
       case "captureTurn": {
         const todoExists = yield* fs.exists(resolve(TODO_FILE))
         if (todoExists) {
           yield* formatFile(resolve(TODO_FILE)).pipe(Effect.catchAll(() => Effect.void))
+        }
+        const architectureExists = yield* fs.exists(resolve(ARCHITECTURE_FILE))
+        if (architectureExists) {
+          yield* formatFile(resolve(ARCHITECTURE_FILE)).pipe(Effect.catchAll(() => Effect.void))
         }
         yield* git.commitAllWithPrefix(turnSubject(action.actor, action.gate))
         return { stop: false }
@@ -875,9 +901,23 @@ export const perform = (
 
       // Routing bookkeeping: delete the flagged files FIRST so their removal
       // lands in this same commit, then commit-all under `subject`.
+      // `seedArchitectureFromTodo` instead reads TODO.md, writes it (with a
+      // scaffold banner) as ARCHITECTURE.md, and deletes TODO.md — the
+      // grilling→architecting hand-off, in this same commit.
       case "commitRouting": {
-        if (action.removeTodo === true) {
+        if (action.seedArchitectureFromTodo === true) {
+          const todoContent = yield* fs
+            .readFileString(resolve(TODO_FILE))
+            .pipe(Effect.catchAll(() => Effect.succeed("")))
+          yield* ensureGtdDir
+          yield* fs.writeFileString(
+            resolve(ARCHITECTURE_FILE),
+            ARCHITECTURE_SEED_BANNER + todoContent,
+          )
           yield* fs.remove(resolve(TODO_FILE)).pipe(Effect.catchAll(() => Effect.void))
+        }
+        if (action.removeArchitecture === true) {
+          yield* fs.remove(resolve(ARCHITECTURE_FILE)).pipe(Effect.catchAll(() => Effect.void))
         }
         if (action.removeReview === true) {
           yield* fs.remove(resolve(REVIEW_FILE)).pipe(Effect.catchAll(() => Effect.void))

--- a/src/Machine.property.test.ts
+++ b/src/Machine.property.test.ts
@@ -31,6 +31,8 @@ import {
 const TURN_SUBJECTS = [
   "gtd(human): grilling",
   "gtd(agent): grilling",
+  "gtd(human): architecting",
+  "gtd(agent): architecting",
   "gtd(agent): grilled",
   "gtd(agent): building",
   "gtd(agent): fixing",
@@ -43,6 +45,7 @@ const TURN_SUBJECTS = [
 ] as const
 
 const ROUTING_SUBJECTS = [
+  "gtd: architecting",
   "gtd: grilled",
   "gtd: planning",
   "gtd: tests green",
@@ -82,6 +85,8 @@ const arbPayload: fc.Arbitrary<ResolvePayload> = fc
     checkboxOnlyRaw: fc.boolean(),
     todoExists: fc.boolean(),
     todoCommittedRaw: fc.boolean(),
+    architectureExists: fc.boolean(),
+    architectureCommittedRaw: fc.boolean(),
     packagesPresent: fc.boolean(),
     reviewPresent: fc.boolean(),
     reviewTrackedRaw: fc.boolean(),
@@ -116,6 +121,8 @@ const arbPayload: fc.Arbitrary<ResolvePayload> = fc
       headTurnIsEmpty: isTurnHead ? raw.headTurnIsEmpty : false,
       todoExists: raw.todoExists,
       todoCommitted: raw.todoExists && raw.todoCommittedRaw,
+      architectureExists: raw.architectureExists,
+      architectureCommitted: raw.architectureExists && raw.architectureCommittedRaw,
       packagesPresent: raw.packagesPresent,
       reviewPresent: raw.reviewPresent,
       feedbackPresent: raw.feedbackPresent,
@@ -168,6 +175,9 @@ const isIllegal = (p: ResolvePayload): boolean =>
   (p.reviewPresent && p.packagesPresent) ||
   (p.reviewPresent && p.todoCommitted) ||
   (p.reviewPresent && !(p.reviewCommitted || p.reviewDirty) && p.todoExists) ||
+  (p.reviewPresent && p.architectureCommitted) ||
+  (p.reviewPresent && !(p.reviewCommitted || p.reviewDirty) && p.architectureExists) ||
+  (p.todoExists && p.architectureExists) ||
   (p.feedbackPresent && p.reviewPresent) ||
   (p.feedbackPresent && !p.packagesPresent) ||
   (p.errorsPresent && p.feedbackPresent) ||
@@ -182,20 +192,21 @@ const isIllegal = (p: ResolvePayload): boolean =>
 
 /**
  * Scopes property (a) to payloads where HEAD is an agent turn commit with an
- * empty diff AND, specifically, `gtd(agent): grilling` (agentic-review's
- * empty-FEEDBACK case is a legitimate mid-chain close-package, which IS a
- * captured change — so this invariant is scoped to grilling's inert-empty-
- * agent-turn rule specifically), the working tree is clean (a dirty tree at
- * this HEAD is fresh content for the agent to capture, not a repeat of the
- * same empty turn — out of scope for this invariant), and no higher-
- * precedence steering file shadows that HEAD entirely
- * (ERRORS/HEALTH/FEEDBACK/.gtd/REVIEW) — those are legal inputs but not what
- * this invariant is about.
+ * empty diff AND, specifically, `gtd(agent): grilling` or `gtd(agent):
+ * architecting` (agentic-review's empty-FEEDBACK case is a legitimate
+ * mid-chain close-package, which IS a captured change — so this invariant is
+ * scoped to grilling/architecting's inert-empty-agent-turn rule
+ * specifically), the working tree is clean (a dirty tree at this HEAD is
+ * fresh content for the agent to capture, not a repeat of the same empty
+ * turn — out of scope for this invariant), and no higher-precedence steering
+ * file shadows that HEAD entirely (ERRORS/HEALTH/FEEDBACK/.gtd/REVIEW) —
+ * those are legal inputs but not what this invariant is about.
  */
+const INERT_EMPTY_GATES = ["gtd(agent): grilling", "gtd(agent): architecting"] as const
+
 const isInScopeForInertEmptyGrillingTurnInvariant = (payload: ResolvePayload): boolean => {
-  if (!payload.lastCommitSubject.startsWith("gtd(agent): ")) return false
   if (!payload.headTurnIsEmpty) return false
-  if (payload.lastCommitSubject !== "gtd(agent): grilling") return false
+  if (!(INERT_EMPTY_GATES as readonly string[]).includes(payload.lastCommitSubject)) return false
   if (!payload.workingTreeClean) return false
   return !(
     payload.errorsPresent ||
@@ -208,6 +219,7 @@ const isInScopeForInertEmptyGrillingTurnInvariant = (payload: ResolvePayload): b
 
 const ALL_STATES: ReadonlySet<GtdState> = new Set<GtdState>([
   "grilling",
+  "architecting",
   "grilled",
   "planning",
   "building",
@@ -310,9 +322,11 @@ describe("resolve — property sweep over edge-consistent payloads", () => {
         }
         const human = resolve([{ type: "RESOLVE", payload: asHuman }])
         const agent = resolve([{ type: "RESOLVE", payload: asAgent }])
-        expect(none.state).toBe("grilling")
-        expect(human.state).toBe("grilling")
-        expect(agent.state).toBe("grilling")
+        const expectedState =
+          payload.lastCommitSubject === "gtd(agent): architecting" ? "architecting" : "grilling"
+        expect(none.state).toBe(expectedState)
+        expect(human.state).toBe(expectedState)
+        expect(agent.state).toBe(expectedState)
         // The agent re-invoking on its own empty turn never emits a captureTurn
         // (there is no change to capture) — it just re-reports the same prompt.
         expect(agent.edgeAction?.kind).not.toBe("captureTurn")

--- a/src/Machine.test.ts
+++ b/src/Machine.test.ts
@@ -177,6 +177,32 @@ describe("assertLegal / GtdStateError", () => {
       GtdStateError,
     )
   })
+
+  it("throws illegal-combination for REVIEW.md + committed ARCHITECTURE.md", () => {
+    expect(() =>
+      resolve([R({ reviewPresent: true, architectureExists: true, architectureCommitted: true })]),
+    ).toThrow(GtdStateError)
+  })
+
+  it("throws illegal-combination for uncommitted REVIEW.md + ARCHITECTURE.md", () => {
+    expect(() =>
+      resolve([
+        R({
+          reviewPresent: true,
+          reviewCommitted: false,
+          reviewDirty: false,
+          architectureExists: true,
+          architectureCommitted: false,
+        }),
+      ]),
+    ).toThrow(GtdStateError)
+  })
+
+  it("throws illegal-combination for TODO.md + ARCHITECTURE.md coexisting", () => {
+    expect(() => resolve([R({ todoExists: true, architectureExists: true })])).toThrow(
+      GtdStateError,
+    )
+  })
 })
 
 // ── Boundary entry: dirty tree + human invoker → grilling capture ─────────
@@ -187,6 +213,19 @@ describe("dirty boundary entry", () => {
     expect(result.state).toBe("grilling")
     expect(result.actor).toBe("human")
     expect(result.edgeAction).toEqual({ kind: "captureTurn", actor: "human", gate: "grilling" })
+  })
+
+  it("escape hatch: a dirty tree that already contains ARCHITECTURE.md captures gtd(human): architecting instead", () => {
+    const result = resolve([
+      R({ invoker: "human", workingTreeClean: false, architectureExists: true }),
+    ])
+    expect(result.state).toBe("architecting")
+    expect(result.actor).toBe("human")
+    expect(result.edgeAction).toEqual({
+      kind: "captureTurn",
+      actor: "human",
+      gate: "architecting",
+    })
   })
 
   it("agent step-agent on a dirty boundary tree is refused (awaits human)", () => {
@@ -203,8 +242,8 @@ describe("dirty boundary entry", () => {
 
 // ── Empty-turn semantics ────────────────────────────────────────────────────
 
-describe("empty human grilling turn chains to gtd: grilled", () => {
-  it("clean tree under gtd(human): grilling → routes to gtd: grilled", () => {
+describe("empty human grilling turn chains to gtd: architecting", () => {
+  it("clean tree under gtd(human): grilling → routes to gtd: architecting, seeding ARCHITECTURE.md", () => {
     const result = resolve([
       R({
         invoker: "agent",
@@ -215,7 +254,87 @@ describe("empty human grilling turn chains to gtd: grilled", () => {
         workingTreeClean: true,
       }),
     ])
+    expect(result.edgeAction).toEqual({
+      kind: "commitRouting",
+      subject: "gtd: architecting",
+      seedArchitectureFromTodo: true,
+    })
+  })
+})
+
+describe("empty human architecting turn chains to gtd: grilled", () => {
+  it("clean tree under gtd(human): architecting → routes to gtd: grilled", () => {
+    const result = resolve([
+      R({
+        invoker: "agent",
+        lastCommitSubject: "gtd(human): architecting",
+        headTurnIsEmpty: true,
+        architectureExists: true,
+        architectureCommitted: true,
+        workingTreeClean: true,
+      }),
+    ])
     expect(result.edgeAction).toEqual({ kind: "commitRouting", subject: "gtd: grilled" })
+  })
+})
+
+describe("architecting turn-taking", () => {
+  it("empty agent turn at architecting is inert (rest, re-emit)", () => {
+    const result = resolve([
+      R({
+        invoker: "none",
+        lastCommitSubject: "gtd(agent): architecting",
+        headTurnIsEmpty: true,
+        architectureExists: true,
+        architectureCommitted: true,
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.state).toBe("architecting")
+    expect(result.actor).toBe("agent")
+  })
+
+  it("non-empty agent turn at architecting rests at the human answer gate", () => {
+    const result = resolve([
+      R({
+        invoker: "none",
+        lastCommitSubject: "gtd(agent): architecting",
+        headTurnIsEmpty: false,
+        architectureExists: true,
+        architectureCommitted: false,
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.state).toBe("architecting")
+    expect(result.actor).toBe("human")
+  })
+
+  it("non-empty human turn at architecting rests back at the agent", () => {
+    const result = resolve([
+      R({
+        invoker: "none",
+        lastCommitSubject: "gtd(human): architecting",
+        headTurnIsEmpty: false,
+        architectureExists: true,
+        architectureCommitted: false,
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.state).toBe("architecting")
+    expect(result.actor).toBe("agent")
+  })
+
+  it("gtd: architecting routing subject rests at architecting, agent", () => {
+    const result = resolve([
+      R({
+        invoker: "none",
+        lastCommitSubject: "gtd: architecting",
+        architectureExists: true,
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.state).toBe("architecting")
+    expect(result.actor).toBe("agent")
   })
 })
 
@@ -311,8 +430,8 @@ describe("out-of-turn: human step while agent awaited", () => {
       R({
         invoker: "human",
         lastCommitSubject: "gtd: grilled",
-        todoExists: true,
-        todoCommitted: true,
+        architectureExists: true,
+        architectureCommitted: true,
         packagesPresent: true,
         gtdModified: true,
         workingTreeClean: false,
@@ -328,13 +447,49 @@ describe("out-of-turn: human step while agent awaited", () => {
       R({
         invoker: "human",
         lastCommitSubject: "gtd: grilled",
-        todoExists: true,
-        todoCommitted: true,
+        architectureExists: true,
+        architectureCommitted: true,
         workingTreeClean: true,
       }),
     ])
     expect(result.state).toBe("grilled")
     expect(result.refusal).toContain("run `gtd step-agent`")
+    expect(result.edgeAction).toBeUndefined()
+  })
+})
+
+describe("gtd(agent): grilled mid-chains to gtd: planning", () => {
+  it("with packages present, routes to planning and removes ARCHITECTURE.md", () => {
+    const result = resolve([
+      R({
+        invoker: "agent",
+        lastCommitSubject: "gtd(agent): grilled",
+        architectureExists: true,
+        architectureCommitted: false,
+        packagesPresent: true,
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.edgeAction).toEqual({
+      kind: "commitRouting",
+      subject: "gtd: planning",
+      removeArchitecture: true,
+    })
+  })
+
+  it("with no packages yet, rests so gtd next re-emits the decompose prompt", () => {
+    const result = resolve([
+      R({
+        invoker: "none",
+        lastCommitSubject: "gtd(agent): grilled",
+        architectureExists: true,
+        architectureCommitted: false,
+        packagesPresent: false,
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.state).toBe("grilled")
+    expect(result.actor).toBe("agent")
     expect(result.edgeAction).toBeUndefined()
   })
 })
@@ -396,7 +551,14 @@ describe("predictTurn", () => {
         workingTreeClean: true,
       }),
     ])
-    expect(prediction.subject).toBe("gtd: grilled")
+    expect(prediction.subject).toBe("gtd: architecting")
+  })
+
+  it("escape hatch: predicts the human architecting capture when ARCHITECTURE.md is already in the dirty tree", () => {
+    const prediction = predictTurn([R({ workingTreeClean: false, architectureExists: true })])
+    expect(prediction.actor).toBe("human")
+    expect(prediction.subject).toBe("gtd(human): architecting")
+    expect(prediction.state).toBe("architecting")
   })
 
   it("predicts null at a settled rest (idle, health check is not a commit-predicting action)", () => {

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -24,9 +24,10 @@
 import type { Actor, TurnGate } from "./Subjects.js"
 import { parseSubject } from "./Subjects.js"
 
-/** The 16 resolved states (frozen contract). `Result.state` is one of these. */
+/** The 17 resolved states (frozen contract). `Result.state` is one of these. */
 export type GtdState =
   | "grilling"
+  | "architecting"
   | "grilled"
   | "planning"
   | "building"
@@ -117,6 +118,10 @@ export interface ResolvePayload {
   readonly todoExists: boolean
   /** The present `TODO.md` is tracked at HEAD. */
   readonly todoCommitted: boolean
+  /** `ARCHITECTURE.md` exists (committed or pending). */
+  readonly architectureExists: boolean
+  /** The present `ARCHITECTURE.md` is tracked at HEAD. */
+  readonly architectureCommitted: boolean
   /** Numbered work packages exist under `.gtd/` (committed or pending). NOT "the directory exists" — steering files share `.gtd/`, so bare dir presence means nothing. */
   readonly packagesPresent: boolean
   /** `REVIEW.md` is present (committed and/or pending). */
@@ -194,10 +199,15 @@ export interface ResolvePayload {
  *                          `git add -A` + `git commit --allow-empty` with
  *                          subject `gtd(<actor>): <gate>`.
  *   - `commitRouting`    — machine bookkeeping commit with a fixed `subject`
- *                          (one of the routing subjects). `removeTodo` /
+ *                          (one of the routing subjects). `removeArchitecture` /
  *                          `removeReview` / `removeFeedback` / `removeHealth`
  *                          delete the named steering file first so its
  *                          removal lands in this commit.
+ *                          `seedArchitectureFromTodo` instead reads the
+ *                          present `TODO.md`, writes its content (with a
+ *                          short scaffold banner) as `ARCHITECTURE.md`, and
+ *                          deletes `TODO.md` — the grilling→architecting
+ *                          hand-off, all in this one commit.
  *   - `runTest`          — run the configured test command; on red write
  *                          FEEDBACK (below cap) or ERRORS (`capReached`),
  *                          commit `gtd: errors`; on green commit
@@ -220,7 +230,8 @@ export type EdgeAction =
   | {
       readonly kind: "commitRouting"
       readonly subject: string
-      readonly removeTodo?: boolean
+      readonly seedArchitectureFromTodo?: boolean
+      readonly removeArchitecture?: boolean
       readonly removeReview?: boolean
       readonly removeFeedback?: boolean
       readonly removeHealth?: boolean
@@ -382,6 +393,8 @@ export const DEFAULT_PAYLOAD: ResolvePayload = {
   headTurnIsEmpty: false,
   todoExists: false,
   todoCommitted: false,
+  architectureExists: false,
+  architectureCommitted: false,
   packagesPresent: false,
   reviewPresent: false,
   feedbackPresent: false,
@@ -467,6 +480,16 @@ const isReviewCommittedTodoConflict = (p: ResolvePayload): boolean =>
 const isUncommittedReviewWithTodoConflict = (p: ResolvePayload): boolean =>
   p.reviewPresent && !(p.reviewCommitted || p.reviewDirty) && p.todoExists
 
+const isReviewCommittedArchitectureConflict = (p: ResolvePayload): boolean =>
+  p.reviewPresent && p.architectureCommitted
+
+const isUncommittedReviewWithArchitectureConflict = (p: ResolvePayload): boolean =>
+  p.reviewPresent && !(p.reviewCommitted || p.reviewDirty) && p.architectureExists
+
+/** TODO.md and ARCHITECTURE.md are two lifecycle stages of the same document — they never legitimately coexist. */
+const isTodoArchitectureConflict = (p: ResolvePayload): boolean =>
+  p.todoExists && p.architectureExists
+
 const isFeedbackReviewConflict = (p: ResolvePayload): boolean =>
   p.feedbackPresent && p.reviewPresent
 
@@ -493,6 +516,15 @@ const reviewAndFeedbackRules: readonly IllegalCombinationRule[] = [
     isViolated: isUncommittedReviewWithTodoConflict,
     message: "uncommitted .gtd/REVIEW.md + .gtd/TODO.md",
   },
+  {
+    isViolated: isReviewCommittedArchitectureConflict,
+    message: ".gtd/REVIEW.md + committed .gtd/ARCHITECTURE.md",
+  },
+  {
+    isViolated: isUncommittedReviewWithArchitectureConflict,
+    message: "uncommitted .gtd/REVIEW.md + .gtd/ARCHITECTURE.md",
+  },
+  { isViolated: isTodoArchitectureConflict, message: ".gtd/TODO.md + .gtd/ARCHITECTURE.md" },
   { isViolated: isFeedbackReviewConflict, message: ".gtd/FEEDBACK.md + .gtd/REVIEW.md" },
   { isViolated: isFeedbackWithoutPackages, message: ".gtd/FEEDBACK.md without packages" },
   { isViolated: isErrorsFeedbackConflict, message: ".gtd/ERRORS.md + .gtd/FEEDBACK.md" },
@@ -578,25 +610,47 @@ const classifyHead = (subject: string, flags: ClassifyFlags): HeadClass | null =
             kind: "mid-chain",
             state: "grilling",
             actor: "agent",
-            action: { kind: "commitRouting", subject: "gtd: grilled" },
+            action: {
+              kind: "commitRouting",
+              subject: "gtd: architecting",
+              seedArchitectureFromTodo: true,
+            },
           }
         : { kind: "rest", state: "grilling", actor: "agent" }
     }
 
+    if (gate === "architecting") {
+      if (actor === "agent") {
+        // Non-empty → human answer gate. Empty → inert re-emit of the same prompt.
+        return flags.headTurnIsEmpty
+          ? { kind: "rest", state: "architecting", actor: "agent" }
+          : { kind: "rest", state: "architecting", actor: "human" }
+      }
+      // actor === "human"
+      return flags.headTurnIsEmpty
+        ? {
+            kind: "mid-chain",
+            state: "architecting",
+            actor: "agent",
+            action: { kind: "commitRouting", subject: "gtd: grilled" },
+          }
+        : { kind: "rest", state: "architecting", actor: "agent" }
+    }
+
     if (actor === "agent" && gate === "grilled") {
       // The decompose turn must actually have produced packages before the
-      // machine consumes the plan: routing to `gtd: planning` removes
-      // `.gtd/TODO.md`, and doing that for a turn WITHOUT packages (e.g. a
-      // loop driver's opening `gtd step-agent` captured before the agent
-      // acted) would destroy the plan and drop the cycle into a package-less
-      // building state that silently skips every review gate. No packages →
-      // rest so `gtd next` re-emits the decompose prompt.
+      // machine consumes the architecture: routing to `gtd: planning` removes
+      // `.gtd/ARCHITECTURE.md`, and doing that for a turn WITHOUT packages
+      // (e.g. a loop driver's opening `gtd step-agent` captured before the
+      // agent acted) would destroy the architecture and drop the cycle into a
+      // package-less building state that silently skips every review gate. No
+      // packages → rest so `gtd next` re-emits the decompose prompt.
       return flags.hasPackages
         ? {
             kind: "mid-chain",
             state: "grilled",
             actor: "agent",
-            action: { kind: "commitRouting", subject: "gtd: planning", removeTodo: true },
+            action: { kind: "commitRouting", subject: "gtd: planning", removeArchitecture: true },
           }
         : { kind: "rest", state: "grilled", actor: "agent" }
     }
@@ -708,6 +762,8 @@ const classifyHead = (subject: string, flags: ClassifyFlags): HeadClass | null =
 
   if (parsed.kind === "routing") {
     switch (parsed.phase) {
+      case "architecting":
+        return { kind: "rest", state: "architecting", actor: "agent" }
       case "grilled":
         return { kind: "rest", state: "grilled", actor: "agent" }
       case "planning":
@@ -782,6 +838,7 @@ const classifyHead = (subject: string, flags: ClassifyFlags): HeadClass | null =
  */
 const STATE_IS_OWN_GATE: ReadonlySet<GtdState> = new Set<GtdState>([
   "grilling",
+  "architecting",
   "grilled",
   "building",
   "fixing",
@@ -808,6 +865,7 @@ const gateForState = (state: GtdState): TurnGate =>
  */
 const INERT_EMPTY_AGENT_GATES: ReadonlySet<GtdState> = new Set([
   "grilling",
+  "architecting",
   "grilled",
   "building",
   "fixing",
@@ -1018,6 +1076,13 @@ const resolveBaseline = (
     return { kind: "rest", state: "grilling", actor: "agent" }
   }
 
+  // ARCHITECTURE.md present, boundary/other HEAD — architecting continues.
+  // Mirrors the TODO.md rung above; the two never coexist (assertLegal
+  // guards it), so ordering between the two rungs is inert.
+  if (p.architectureExists) {
+    return { kind: "rest", state: "architecting", actor: "agent" }
+  }
+
   // `.gtd/` exists with a pending package, and the nearest workflow commit
   // (skipping any boundary commits on top of it) is still the
   // `gtd(agent): building` checkpoint — an operational recovery commit (e.g. a
@@ -1053,7 +1118,8 @@ const resolveBaseline = (
     !p.feedbackPresent &&
     !p.errorsPresent &&
     !p.healthPresent &&
-    !p.todoExists
+    !p.todoExists &&
+    !p.architectureExists
   ) {
     return resolveIdleOrHealth(p)
   }
@@ -1085,19 +1151,29 @@ const applyTurnTaking = (
   const context = buildContext(p, counters)
   const invoker = p.invoker
 
-  // Dirty boundary + invoker human, no steering files, no COMMITTED TODO, HEAD
-  // is not itself a turn commit — the v2 entry turn. Checks `todoCommitted`
-  // rather than `todoExists`: a TODO.md the human just wrote as part of THIS
-  // dirty tree (uncommitted) is exactly what gets captured by this turn (a
-  // pre-existing coincidentally-named file must not be mistaken for an
-  // already-in-progress grilling process — only a TODO.md already tracked at
-  // HEAD indicates that). `gtd: done` counts as a boundary HEAD here too (a
-  // settled cycle is exactly where the next feature's dirty tree lands), even
-  // though it parses as a `"routing"` subject in the general taxonomy.
+  // Dirty boundary + invoker human, no steering files, no COMMITTED TODO/
+  // ARCHITECTURE, HEAD is not itself a turn commit — the v2 entry turn.
+  // Checks `todoCommitted`/`architectureCommitted` rather than
+  // `todoExists`/`architectureExists`: a steering file the human just wrote
+  // as part of THIS dirty tree (uncommitted) is exactly what gets captured
+  // by this turn (a pre-existing coincidentally-named file must not be
+  // mistaken for an already-in-progress grilling/architecting process — only
+  // a file already tracked at HEAD indicates that). `gtd: done` counts as a
+  // boundary HEAD here too (a settled cycle is exactly where the next
+  // feature's dirty tree lands), even though it parses as a `"routing"`
+  // subject in the general taxonomy.
+  //
+  // Escape hatch: which gate the entry turn is captured under depends on
+  // whether the human's dirty tree already contains `.gtd/ARCHITECTURE.md`
+  // — an already-technical sketch skips product grilling entirely and enters
+  // directly at `architecting` (file *presence*, never content, decides
+  // this — the same mechanism every other steering-file rung in this
+  // ladder already uses).
   const isDirtyBoundaryEntry =
     invoker === "human" &&
     !p.workingTreeClean &&
     !p.todoCommitted &&
+    !p.architectureCommitted &&
     !p.packagesPresent &&
     !p.reviewPresent &&
     !p.feedbackPresent &&
@@ -1106,11 +1182,12 @@ const applyTurnTaking = (
     (parseSubject(head).kind === "boundary" || head === "gtd: done")
 
   if (isDirtyBoundaryEntry) {
+    const entryGate: TurnGate = p.architectureExists ? "architecting" : "grilling"
     return {
-      state: "grilling",
+      state: entryGate as GtdState,
       actor: "human",
       pending: false,
-      edgeAction: { kind: "captureTurn", actor: "human", gate: "grilling" },
+      edgeAction: { kind: "captureTurn", actor: "human", gate: entryGate },
       context,
     }
   }
@@ -1346,6 +1423,7 @@ export const predictTurn = (events: readonly GtdEvent[]): TurnPrediction => {
   const isDirtyBoundaryEntry =
     !payload.workingTreeClean &&
     !payload.todoCommitted &&
+    !payload.architectureCommitted &&
     !payload.packagesPresent &&
     !payload.reviewPresent &&
     !payload.feedbackPresent &&
@@ -1353,7 +1431,12 @@ export const predictTurn = (events: readonly GtdEvent[]): TurnPrediction => {
     !payload.healthPresent &&
     (parseSubject(head).kind === "boundary" || head === "gtd: done")
   if (isDirtyBoundaryEntry) {
-    return { actor: "human", subject: "gtd(human): grilling", state: "grilling" }
+    const entryGate: TurnGate = payload.architectureExists ? "architecting" : "grilling"
+    return {
+      actor: "human",
+      subject: `gtd(human): ${entryGate}`,
+      state: entryGate as GtdState,
+    }
   }
 
   if (baseline.state === "idle") {

--- a/src/Prompt.snapshot.test.ts
+++ b/src/Prompt.snapshot.test.ts
@@ -118,6 +118,47 @@ describe("buildPrompt snapshots", () => {
     ).toMatchSnapshot()
   })
 
+  // ── architecting ─────────────────────────────────────────────────────────
+
+  it("architecting agent plain", () => {
+    expect(
+      buildPrompt(result("architecting", { actor: "agent" }), resolveModel, "plain"),
+    ).toMatchSnapshot()
+  })
+
+  it("architecting agent json", () => {
+    expect(
+      buildPrompt(result("architecting", { actor: "agent" }), resolveModel, "json"),
+    ).toMatchSnapshot()
+  })
+
+  it("architecting agent with turnDiff plain", () => {
+    expect(
+      buildPrompt(
+        result("architecting", {
+          actor: "agent",
+          context: {
+            turnDiff: "diff --git a/ARCHITECTURE.md b/ARCHITECTURE.md\n+- answer: use option A\n",
+          },
+        }),
+        resolveModel,
+        "plain",
+      ),
+    ).toMatchSnapshot()
+  })
+
+  it("architecting human plain", () => {
+    expect(
+      buildPrompt(result("architecting", { actor: "human" }), resolveModel, "plain"),
+    ).toMatchSnapshot()
+  })
+
+  it("architecting human json", () => {
+    expect(
+      buildPrompt(result("architecting", { actor: "human" }), resolveModel, "json"),
+    ).toMatchSnapshot()
+  })
+
   // ── grilled ───────────────────────────────────────────────────────────────
 
   it("grilled plain", () => {

--- a/src/Prompt.test.ts
+++ b/src/Prompt.test.ts
@@ -37,6 +37,7 @@ const EXECUTION_MODEL = "claude-sonnet-4-8"
 
 const PROMPT_STATES: ReadonlyArray<GtdState> = [
   "grilling",
+  "architecting",
   "grilled",
   "building",
   "fixing",
@@ -58,7 +59,7 @@ const EDGE_ONLY_STATES: ReadonlyArray<GtdState> = [
 ]
 
 describe("isPromptState", () => {
-  it("matches exactly the pinned 11-state set", () => {
+  it("matches exactly the pinned 12-state set", () => {
     for (const state of PROMPT_STATES) expect(isPromptState(state)).toBe(true)
     for (const state of EDGE_ONLY_STATES) expect(isPromptState(state)).toBe(false)
   })
@@ -85,6 +86,16 @@ describe("buildPrompt", () => {
 
     it("grilling (human) renders the grilling-answers section", () => {
       const out = buildPrompt(result("grilling", { actor: "human" }))
+      expect(out).toContain("nothing for the agent to do")
+    })
+
+    it("architecting (agent) renders the architecting-agent section", () => {
+      const out = buildPrompt(result("architecting", { actor: "agent" }))
+      expect(out).toContain("Develop it into a concrete")
+    })
+
+    it("architecting (human) renders the architecting-answers section", () => {
+      const out = buildPrompt(result("architecting", { actor: "human" }))
       expect(out).toContain("nothing for the agent to do")
     })
 
@@ -178,6 +189,12 @@ describe("buildPrompt", () => {
       expect(out).not.toContain("{{MODEL}}")
     })
 
+    it("architecting (agent) injects the planning model and leaves no {{MODEL}}", () => {
+      const out = buildPrompt(result("architecting", { actor: "agent" }))
+      expect(out).toContain(PLANNING_MODEL)
+      expect(out).not.toContain("{{MODEL}}")
+    })
+
     it("agentic-review injects the planning model and leaves no {{MODEL}}", () => {
       const out = buildPrompt(withPackage("agentic-review"))
       expect(out).toContain(PLANNING_MODEL)
@@ -200,6 +217,9 @@ describe("buildPrompt", () => {
       const custom = (s: string): string => `MODEL-FOR-${s}`
       expect(buildPrompt(result("grilling", { actor: "agent" }), custom)).toContain(
         "MODEL-FOR-grilling",
+      )
+      expect(buildPrompt(result("architecting", { actor: "agent" }), custom)).toContain(
+        "MODEL-FOR-architecting",
       )
       expect(buildPrompt(result("grilled"), custom)).toContain("MODEL-FOR-decompose")
       expect(buildPrompt(withPackage("building"), custom)).toContain("MODEL-FOR-building")
@@ -224,6 +244,7 @@ describe("buildPrompt", () => {
     it("plain agent prompts end with the exact turn-ending tail", () => {
       const cases: ReadonlyArray<Result> = [
         result("grilling", { actor: "agent" }),
+        result("architecting", { actor: "agent" }),
         result("grilled"),
         withPackage("building"),
         result("fixing"),
@@ -245,6 +266,7 @@ describe("buildPrompt", () => {
     it("plain human prompts have no tail", () => {
       const cases: ReadonlyArray<Result> = [
         result("grilling", { actor: "human" }),
+        result("architecting", { actor: "human" }),
         result("await-review", { actor: "human" }),
         result("escalate", { actor: "human" }),
         result("idle", { actor: "human" }),
@@ -270,6 +292,8 @@ describe("buildPrompt", () => {
     const allPromptResults = (): ReadonlyArray<Result> => [
       result("grilling", { actor: "agent" }),
       result("grilling", { actor: "human" }),
+      result("architecting", { actor: "agent" }),
+      result("architecting", { actor: "human" }),
       result("grilled"),
       withPackage("building"),
       result("fixing"),
@@ -311,6 +335,25 @@ describe("buildPrompt", () => {
 
     it("omits the diff block when turnDiff is absent", () => {
       const out = buildPrompt(result("grilling", { actor: "agent" }))
+      expect(out).not.toContain("```diff")
+    })
+  })
+
+  describe("architecting-agent turnDiff inlining", () => {
+    it("inlines context.turnDiff as a fenced diff with the reading rules when present", () => {
+      const out = buildPrompt(
+        result("architecting", {
+          actor: "agent",
+          context: { turnDiff: "diff --git a/x b/x\n+hello\n" },
+        }),
+      )
+      expect(out).toContain("```diff")
+      expect(out).toContain("+hello")
+      expect(out).toContain("feedback, not finished work")
+    })
+
+    it("omits the diff block when turnDiff is absent", () => {
+      const out = buildPrompt(result("architecting", { actor: "agent" }))
       expect(out).not.toContain("```diff")
     })
   })
@@ -437,6 +480,8 @@ describe("buildPrompt", () => {
     for (const [label, res] of [
       ["grilling (agent)", result("grilling", { actor: "agent" })],
       ["grilling (human)", result("grilling", { actor: "human" })],
+      ["architecting (agent)", result("architecting", { actor: "agent" })],
+      ["architecting (human)", result("architecting", { actor: "human" })],
       ["grilled", result("grilled")],
       ["building", withPackage("building")],
       ["fixing", result("fixing")],

--- a/src/Prompt.ts
+++ b/src/Prompt.ts
@@ -6,6 +6,8 @@ import packageMd from "./prompts/partials/package.md"
 import agentTurnMd from "./prompts/partials/agent-turn.md"
 import grillingAgentMd from "./prompts/grilling-agent.md"
 import grillingAnswersMd from "./prompts/grilling-answers.md"
+import architectingAgentMd from "./prompts/architecting-agent.md"
+import architectingAnswersMd from "./prompts/architecting-answers.md"
 import decomposeMd from "./prompts/decompose.md"
 import buildingMd from "./prompts/building.md"
 import fixingMd from "./prompts/fixing.md"
@@ -20,7 +22,7 @@ import { builtinTierDefault, stateTier, type ModelState } from "./Config.js"
 import type { GtdState, Result } from "./Machine.js"
 
 /**
- * The 11 prompt-bearing states (frozen contract) — `src/State.ts` consumes
+ * The 12 prompt-bearing states (frozen contract) — `src/State.ts` consumes
  * this single classification instead of duplicating an edge-only set.
  * `buildPrompt` throws for the other five (testing, planning, close-package,
  * done, health-check), which are performed by the driver and must never
@@ -28,6 +30,7 @@ import type { GtdState, Result } from "./Machine.js"
  */
 const PROMPT_STATES: ReadonlySet<GtdState> = new Set<GtdState>([
   "grilling",
+  "architecting",
   "grilled",
   "building",
   "fixing",
@@ -45,6 +48,7 @@ export const isPromptState = (state: GtdState): boolean => PROMPT_STATES.has(sta
 /** The prompt-bearing states `buildPrompt` renders a section for. */
 type PromptState =
   | "grilling"
+  | "architecting"
   | "grilled"
   | "building"
   | "fixing"
@@ -64,6 +68,7 @@ type PromptState =
  */
 const MODEL_STATE: Partial<Record<PromptState, ModelState>> = {
   grilling: "grilling",
+  architecting: "architecting",
   grilled: "decompose",
   building: "building",
   fixing: "fixing",
@@ -112,6 +117,8 @@ eta.loadTemplate("@agent-turn", agentTurnMd)
 // Register state templates
 eta.loadTemplate("@grilling-agent", grillingAgentMd)
 eta.loadTemplate("@grilling-answers", grillingAnswersMd)
+eta.loadTemplate("@architecting-agent", architectingAgentMd)
+eta.loadTemplate("@architecting-answers", architectingAnswersMd)
 eta.loadTemplate("@decompose", decomposeMd)
 eta.loadTemplate("@building", buildingMd)
 eta.loadTemplate("@fixing", fixingMd)
@@ -129,8 +136,8 @@ eta.loadTemplate("@idle", idleMd)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ;(eta as any).resolvePath = null
 
-/** Maps each non-grilling PromptState to its registered template name. */
-const STATE_TEMPLATE: Record<Exclude<PromptState, "grilling">, string> = {
+/** Maps each non-grilling/architecting PromptState to its registered template name. */
+const STATE_TEMPLATE: Record<Exclude<PromptState, "grilling" | "architecting">, string> = {
   grilled: "@decompose",
   building: "@building",
   fixing: "@fixing",
@@ -171,11 +178,13 @@ export const buildPrompt = (
   // human turns and any --json output carry no tail at all.
   const tail = output === "plain" && result.actor === "agent" ? "@agent-turn" : undefined
 
-  // Select the state template. For `grilling`, which prompt renders depends
-  // on which actor the resolver is awaiting at this rest.
+  // Select the state template. For `grilling`/`architecting`, which prompt
+  // renders depends on which actor the resolver is awaiting at this rest.
   let templateName: string
   if (promptState === "grilling") {
     templateName = result.actor === "human" ? "@grilling-answers" : "@grilling-agent"
+  } else if (promptState === "architecting") {
+    templateName = result.actor === "human" ? "@architecting-answers" : "@architecting-agent"
   } else {
     templateName = STATE_TEMPLATE[promptState]
   }

--- a/src/State.test.ts
+++ b/src/State.test.ts
@@ -72,10 +72,22 @@ describe("describeEdgeAction (exhaustive over EdgeAction)", () => {
       describeEdgeAction({
         kind: "commitRouting",
         subject: "gtd: package done",
-        removeTodo: true,
+        removeArchitecture: true,
         removeFeedback: true,
       }),
-    ).toBe('commit routing as "gtd: package done" (removing .gtd/TODO.md, .gtd/FEEDBACK.md)')
+    ).toBe(
+      'commit routing as "gtd: package done" (removing .gtd/ARCHITECTURE.md, .gtd/FEEDBACK.md)',
+    )
+  })
+
+  it("commitRouting notes the seedArchitectureFromTodo hand-off", () => {
+    expect(
+      describeEdgeAction({
+        kind: "commitRouting",
+        subject: "gtd: architecting",
+        seedArchitectureFromTodo: true,
+      }),
+    ).toBe('commit routing as "gtd: architecting" (seeding .gtd/ARCHITECTURE.md from .gtd/TODO.md)')
   })
 
   it("runTest reports the 1-indexed attempt number", () => {

--- a/src/State.ts
+++ b/src/State.ts
@@ -25,8 +25,11 @@ const edgeActionHandlers: EdgeActionHandlers = {
   captureTurn: (a) => `capture the ${a.actor} turn as "gtd(${a.actor}): ${a.gate}"`,
   commitRouting: (a) => {
     let msg = `commit routing as "${a.subject}"`
+    if (a.seedArchitectureFromTodo) {
+      msg += " (seeding .gtd/ARCHITECTURE.md from .gtd/TODO.md)"
+    }
     const removed: string[] = []
-    if (a.removeTodo) removed.push(".gtd/TODO.md")
+    if (a.removeArchitecture) removed.push(".gtd/ARCHITECTURE.md")
     if (a.removeReview) removed.push(".gtd/REVIEW.md")
     if (a.removeFeedback) removed.push(".gtd/FEEDBACK.md")
     if (a.removeHealth) removed.push(".gtd/HEALTH.md")

--- a/src/Subjects.test.ts
+++ b/src/Subjects.test.ts
@@ -20,6 +20,7 @@ describe("turn subject round-trip", () => {
   const actors: ReadonlyArray<Actor> = ["human", "agent"]
   const gates: ReadonlyArray<TurnGate> = [
     "grilling",
+    "architecting",
     "grilled",
     "building",
     "fixing",

--- a/src/Subjects.ts
+++ b/src/Subjects.ts
@@ -37,6 +37,7 @@ export type Actor = "human" | "agent"
 /** The closed set of gate labels a turn commit can carry. */
 export type TurnGate =
   | "grilling"
+  | "architecting"
   | "grilled"
   | "building"
   | "fixing"
@@ -51,6 +52,7 @@ export const turnSubject = (actor: Actor, gate: TurnGate): string => `gtd(${acto
 
 /** The closed set of routing phases the machine can author as bookkeeping. */
 export type RoutingPhase =
+  | "architecting"
   | "grilled"
   | "planning"
   | "tests-green"
@@ -66,6 +68,7 @@ export type RoutingPhase =
 
 /** Literal subjects for the non-parameterized routing phases. */
 export const ROUTING_SUBJECT: Record<Exclude<RoutingPhase, "reviewing">, string> = {
+  architecting: "gtd: architecting",
   grilled: "gtd: grilled",
   planning: "gtd: planning",
   "tests-green": "gtd: tests green",
@@ -100,6 +103,7 @@ const TURN_RE = /^gtd\((human|agent)\): (.+)$/
 
 const TURN_GATES: ReadonlySet<string> = new Set<TurnGate>([
   "grilling",
+  "architecting",
   "grilled",
   "building",
   "fixing",

--- a/src/__snapshots__/Prompt.snapshot.test.ts.snap
+++ b/src/__snapshots__/Prompt.snapshot.test.ts.snap
@@ -153,6 +153,214 @@ agent); when it awaits the human, stop and hand off.
 "
 `;
 
+exports[`buildPrompt snapshots > architecting agent json 1`] = `
+"You are an autonomous coding agent orchestrating work on the user's repo.
+
+The \`.gtd/\` directory is the workflow's own state (plans, task specs, review
+records). Never create, edit, delete, or reference files under \`.gtd/\` — and
+never instruct a subagent to — except the specific \`.gtd/\` file this prompt
+explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
+*outside* \`.gtd/\` is ordinary project code, not workflow state.
+
+\`.gtd/ARCHITECTURE.md\` holds the technical plan under development — seeded
+from the converged product plan, or, if this is the very first turn on
+already-technical input, written directly by the human. Develop it into a concrete,
+implementation-ready technical plan **in this one turn** — use subagents /
+internal iteration to go as deep as needed; there is no further agent-only
+round after this one.
+
+**Scope: technical/architectural decisions only.** Decide file/module
+structure, data models, module boundaries, library or tech-stack choices, and
+error-handling/concurrency strategy — the *how*, building on the *what*
+already settled in this file's product content. Do not re-open or re-litigate
+product/user-facing decisions from the prior phase; treat them as settled
+context.
+
+### Develop the architecture
+
+Spawn a **planning-model subagent** using model \`MODEL-architecting\` to develop the
+architecture. The subagent works entirely by editing \`.gtd/ARCHITECTURE.md\`:
+
+1. **Explore the codebase before asking anything** — read the relevant files,
+   tests, and docs so every question below is one the codebase genuinely
+   cannot answer.
+2. **Replace the seeded/captured content with a real architecture** — the
+   files to change, module/data-model structure, and why, grounded in the
+   codebase.
+3. **Iterate internally** (spawn further subagents, reconsider, cross-check)
+   until the architecture is as complete as it can get without human input.
+   Do not leave this to a future round — there isn't one before the human is
+   asked.
+4. For every remaining open question, write it near the top of the file with
+   a **suggested default** — your best-guess answer, stated plainly, that the
+   human can accept as-is. A question with no suggested default is incomplete.
+5. Leave \`.gtd/ARCHITECTURE.md\` **uncommitted** — the human's turn (\`gtd step\`)
+   reads it next.
+"
+`;
+
+exports[`buildPrompt snapshots > architecting agent plain 1`] = `
+"You are an autonomous coding agent orchestrating work on the user's repo.
+
+The \`.gtd/\` directory is the workflow's own state (plans, task specs, review
+records). Never create, edit, delete, or reference files under \`.gtd/\` — and
+never instruct a subagent to — except the specific \`.gtd/\` file this prompt
+explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
+*outside* \`.gtd/\` is ordinary project code, not workflow state.
+
+\`.gtd/ARCHITECTURE.md\` holds the technical plan under development — seeded
+from the converged product plan, or, if this is the very first turn on
+already-technical input, written directly by the human. Develop it into a concrete,
+implementation-ready technical plan **in this one turn** — use subagents /
+internal iteration to go as deep as needed; there is no further agent-only
+round after this one.
+
+**Scope: technical/architectural decisions only.** Decide file/module
+structure, data models, module boundaries, library or tech-stack choices, and
+error-handling/concurrency strategy — the *how*, building on the *what*
+already settled in this file's product content. Do not re-open or re-litigate
+product/user-facing decisions from the prior phase; treat them as settled
+context.
+
+### Develop the architecture
+
+Spawn a **planning-model subagent** using model \`MODEL-architecting\` to develop the
+architecture. The subagent works entirely by editing \`.gtd/ARCHITECTURE.md\`:
+
+1. **Explore the codebase before asking anything** — read the relevant files,
+   tests, and docs so every question below is one the codebase genuinely
+   cannot answer.
+2. **Replace the seeded/captured content with a real architecture** — the
+   files to change, module/data-model structure, and why, grounded in the
+   codebase.
+3. **Iterate internally** (spawn further subagents, reconsider, cross-check)
+   until the architecture is as complete as it can get without human input.
+   Do not leave this to a future round — there isn't one before the human is
+   asked.
+4. For every remaining open question, write it near the top of the file with
+   a **suggested default** — your best-guess answer, stated plainly, that the
+   human can accept as-is. A question with no suggested default is incomplete.
+5. Leave \`.gtd/ARCHITECTURE.md\` **uncommitted** — the human's turn (\`gtd step\`)
+   reads it next.
+
+Finish your turn by running \`gtd step-agent\`. Then run \`gtd next\` and follow
+its output — repeat this cycle as long as the output is addressed to you (the
+agent); when it awaits the human, stop and hand off.
+"
+`;
+
+exports[`buildPrompt snapshots > architecting agent with turnDiff plain 1`] = `
+"You are an autonomous coding agent orchestrating work on the user's repo.
+
+The \`.gtd/\` directory is the workflow's own state (plans, task specs, review
+records). Never create, edit, delete, or reference files under \`.gtd/\` — and
+never instruct a subagent to — except the specific \`.gtd/\` file this prompt
+explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
+*outside* \`.gtd/\` is ordinary project code, not workflow state.
+
+\`.gtd/ARCHITECTURE.md\` holds the technical plan under development — seeded
+from the converged product plan, or, if this is the very first turn on
+already-technical input, written directly by the human. Develop it into a concrete,
+implementation-ready technical plan **in this one turn** — use subagents /
+internal iteration to go as deep as needed; there is no further agent-only
+round after this one.
+
+**Scope: technical/architectural decisions only.** Decide file/module
+structure, data models, module boundaries, library or tech-stack choices, and
+error-handling/concurrency strategy — the *how*, building on the *what*
+already settled in this file's product content. Do not re-open or re-litigate
+product/user-facing decisions from the prior phase; treat them as settled
+context.
+
+### Develop the architecture
+
+Spawn a **planning-model subagent** using model \`MODEL-architecting\` to develop the
+architecture. The subagent works entirely by editing \`.gtd/ARCHITECTURE.md\`:
+
+1. **Explore the codebase before asking anything** — read the relevant files,
+   tests, and docs so every question below is one the codebase genuinely
+   cannot answer.
+2. **Replace the seeded/captured content with a real architecture** — the
+   files to change, module/data-model structure, and why, grounded in the
+   codebase.
+3. **Iterate internally** (spawn further subagents, reconsider, cross-check)
+   until the architecture is as complete as it can get without human input.
+   Do not leave this to a future round — there isn't one before the human is
+   asked.
+4. For every remaining open question, write it near the top of the file with
+   a **suggested default** — your best-guess answer, stated plainly, that the
+   human can accept as-is. A question with no suggested default is incomplete.
+5. Leave \`.gtd/ARCHITECTURE.md\` **uncommitted** — the human's turn (\`gtd step\`)
+   reads it next.
+
+### Latest human input (answers / sketch / review feedback)
+
+\`\`\`diff
+diff --git a/ARCHITECTURE.md b/ARCHITECTURE.md
++- answer: use option A
+\`\`\`
+
+Read the diff above as **feedback, not finished work**:
+
+- Code changes are suggestions — fold them into the architecture and
+  re-implement them properly, including test coverage, rather than restoring
+  them verbatim.
+- Code comments are positional feedback about the code at that location.
+- Plan-text changes are global feedback on the architecture (or the reviewed
+  work) as a whole.
+
+Finish your turn by running \`gtd step-agent\`. Then run \`gtd next\` and follow
+its output — repeat this cycle as long as the output is addressed to you (the
+agent); when it awaits the human, stop and hand off.
+"
+`;
+
+exports[`buildPrompt snapshots > architecting human json 1`] = `
+"You are an autonomous coding agent orchestrating work on the user's repo.
+
+The \`.gtd/\` directory is the workflow's own state (plans, task specs, review
+records). Never create, edit, delete, or reference files under \`.gtd/\` — and
+never instruct a subagent to — except the specific \`.gtd/\` file this prompt
+explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
+*outside* \`.gtd/\` is ordinary project code, not workflow state.
+
+\`.gtd/ARCHITECTURE.md\` holds the technical plan under development, with open
+questions written near the top — each one carrying a suggested default.
+
+This is a human gate; there is nothing for the agent to do.
+
+Tell the user:
+
+- To answer a question, edit \`.gtd/ARCHITECTURE.md\` in place (replace the
+  question's text with your answer, or annotate it), then run \`gtd step\`.
+- To accept **all** suggested defaults as-is, run \`gtd step\` with **no
+  edits** — this converges the architecture and moves on to decomposition.
+"
+`;
+
+exports[`buildPrompt snapshots > architecting human plain 1`] = `
+"You are an autonomous coding agent orchestrating work on the user's repo.
+
+The \`.gtd/\` directory is the workflow's own state (plans, task specs, review
+records). Never create, edit, delete, or reference files under \`.gtd/\` — and
+never instruct a subagent to — except the specific \`.gtd/\` file this prompt
+explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
+*outside* \`.gtd/\` is ordinary project code, not workflow state.
+
+\`.gtd/ARCHITECTURE.md\` holds the technical plan under development, with open
+questions written near the top — each one carrying a suggested default.
+
+This is a human gate; there is nothing for the agent to do.
+
+Tell the user:
+
+- To answer a question, edit \`.gtd/ARCHITECTURE.md\` in place (replace the
+  question's text with your answer, or annotate it), then run \`gtd step\`.
+- To accept **all** suggested defaults as-is, run \`gtd step\` with **no
+  edits** — this converges the architecture and moves on to decomposition.
+"
+`;
+
 exports[`buildPrompt snapshots > await-review json 1`] = `
 "You are an autonomous coding agent orchestrating work on the user's repo.
 
@@ -468,9 +676,10 @@ never instruct a subagent to — except the specific \`.gtd/\` file this prompt
 explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
 *outside* \`.gtd/\` is ordinary project code, not workflow state.
 
-\`.gtd/TODO.md\` contains an implementation plan. Decompose it into an ordered set of
-executable work packages stored in the \`.gtd/\` directory. If \`.gtd/\` already
-holds packages from an earlier turn, immediately abort and raise an error.
+\`.gtd/ARCHITECTURE.md\` contains a converged architecture/technical plan.
+Decompose it into an ordered set of executable work packages stored in the
+\`.gtd/\` directory. If \`.gtd/\` already holds packages from an earlier turn,
+immediately abort and raise an error.
 
 Spawn a **planning-model subagent** using model \`MODEL-decompose\` to perform the
 decomposition. It creates numbered package directories, each holding numbered
@@ -511,8 +720,8 @@ task files:
    cases. It is the only context building agents will receive to work on the
    task.
 
-6. **Specs must never reference \`.gtd/\` files** — \`.gtd/TODO.md\` is consumed
-   and **deleted** the moment decomposition completes, and every other file
+6. **Specs must never reference \`.gtd/\` files** — \`.gtd/ARCHITECTURE.md\` is
+   consumed and **deleted** the moment decomposition completes, and every other file
    under \`.gtd/\` (including these task specs) is machine-managed workflow
    state. No task description, acceptance criterion, or constraint may require
    creating, preserving, updating, or checking any \`.gtd/\` file — such a
@@ -532,9 +741,10 @@ never instruct a subagent to — except the specific \`.gtd/\` file this prompt
 explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
 *outside* \`.gtd/\` is ordinary project code, not workflow state.
 
-\`.gtd/TODO.md\` contains an implementation plan. Decompose it into an ordered set of
-executable work packages stored in the \`.gtd/\` directory. If \`.gtd/\` already
-holds packages from an earlier turn, immediately abort and raise an error.
+\`.gtd/ARCHITECTURE.md\` contains a converged architecture/technical plan.
+Decompose it into an ordered set of executable work packages stored in the
+\`.gtd/\` directory. If \`.gtd/\` already holds packages from an earlier turn,
+immediately abort and raise an error.
 
 Spawn a **planning-model subagent** using model \`MODEL-decompose\` to perform the
 decomposition. It creates numbered package directories, each holding numbered
@@ -575,8 +785,8 @@ task files:
    cases. It is the only context building agents will receive to work on the
    task.
 
-6. **Specs must never reference \`.gtd/\` files** — \`.gtd/TODO.md\` is consumed
-   and **deleted** the moment decomposition completes, and every other file
+6. **Specs must never reference \`.gtd/\` files** — \`.gtd/ARCHITECTURE.md\` is
+   consumed and **deleted** the moment decomposition completes, and every other file
    under \`.gtd/\` (including these task specs) is machine-managed workflow
    state. No task description, acceptance criterion, or constraint may require
    creating, preserving, updating, or checking any \`.gtd/\` file — such a
@@ -601,9 +811,14 @@ explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
 *outside* \`.gtd/\` is ordinary project code, not workflow state.
 
 \`.gtd/TODO.md\` holds the plan under development. Develop it into a concrete,
-implementation-ready plan **in this one turn** — use subagents / internal
-iteration to go as deep as needed; there is no further agent-only round after
-this one.
+product-level plan **in this one turn** — use subagents / internal iteration
+to go as deep as needed; there is no further agent-only round after this one.
+
+**Scope: product and user-facing decisions only.** Do not decide
+implementation details in this file — file/module structure, data models,
+library or tech-stack choices, and other architecture questions belong to the
+next phase (\`.gtd/ARCHITECTURE.md\`) and must not be treated as open questions
+here.
 
 ### Develop the plan
 
@@ -613,9 +828,9 @@ The subagent works entirely by editing \`.gtd/TODO.md\`:
 1. **Explore the codebase before asking anything** — read the relevant files,
    tests, and docs so every question below is one the codebase genuinely
    cannot answer.
-2. **Replace the captured input / seed template with a real implementation
-   plan** — the files to change, exactly what changes, and why, grounded in
-   the codebase.
+2. **Replace the captured input / seed template with a real product plan** —
+   what to build and why, and the user-facing behavior it should have,
+   grounded in the codebase. Leave *how* to build it for the next phase.
 3. **Iterate internally** (spawn further subagents, reconsider, cross-check)
    until the plan is as complete as it can get without human input. Do not
    leave this to a future round — there isn't one before the human is asked.
@@ -637,9 +852,14 @@ explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
 *outside* \`.gtd/\` is ordinary project code, not workflow state.
 
 \`.gtd/TODO.md\` holds the plan under development. Develop it into a concrete,
-implementation-ready plan **in this one turn** — use subagents / internal
-iteration to go as deep as needed; there is no further agent-only round after
-this one.
+product-level plan **in this one turn** — use subagents / internal iteration
+to go as deep as needed; there is no further agent-only round after this one.
+
+**Scope: product and user-facing decisions only.** Do not decide
+implementation details in this file — file/module structure, data models,
+library or tech-stack choices, and other architecture questions belong to the
+next phase (\`.gtd/ARCHITECTURE.md\`) and must not be treated as open questions
+here.
 
 ### Develop the plan
 
@@ -649,9 +869,9 @@ The subagent works entirely by editing \`.gtd/TODO.md\`:
 1. **Explore the codebase before asking anything** — read the relevant files,
    tests, and docs so every question below is one the codebase genuinely
    cannot answer.
-2. **Replace the captured input / seed template with a real implementation
-   plan** — the files to change, exactly what changes, and why, grounded in
-   the codebase.
+2. **Replace the captured input / seed template with a real product plan** —
+   what to build and why, and the user-facing behavior it should have,
+   grounded in the codebase. Leave *how* to build it for the next phase.
 3. **Iterate internally** (spawn further subagents, reconsider, cross-check)
    until the plan is as complete as it can get without human input. Do not
    leave this to a future round — there isn't one before the human is asked.
@@ -677,9 +897,14 @@ explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
 *outside* \`.gtd/\` is ordinary project code, not workflow state.
 
 \`.gtd/TODO.md\` holds the plan under development. Develop it into a concrete,
-implementation-ready plan **in this one turn** — use subagents / internal
-iteration to go as deep as needed; there is no further agent-only round after
-this one.
+product-level plan **in this one turn** — use subagents / internal iteration
+to go as deep as needed; there is no further agent-only round after this one.
+
+**Scope: product and user-facing decisions only.** Do not decide
+implementation details in this file — file/module structure, data models,
+library or tech-stack choices, and other architecture questions belong to the
+next phase (\`.gtd/ARCHITECTURE.md\`) and must not be treated as open questions
+here.
 
 ### Develop the plan
 
@@ -689,9 +914,9 @@ The subagent works entirely by editing \`.gtd/TODO.md\`:
 1. **Explore the codebase before asking anything** — read the relevant files,
    tests, and docs so every question below is one the codebase genuinely
    cannot answer.
-2. **Replace the captured input / seed template with a real implementation
-   plan** — the files to change, exactly what changes, and why, grounded in
-   the codebase.
+2. **Replace the captured input / seed template with a real product plan** —
+   what to build and why, and the user-facing behavior it should have,
+   grounded in the codebase. Leave *how* to build it for the next phase.
 3. **Iterate internally** (spawn further subagents, reconsider, cross-check)
    until the plan is as complete as it can get without human input. Do not
    leave this to a future round — there isn't one before the human is asked.
@@ -741,7 +966,7 @@ Tell the user:
 - To answer a question, edit \`.gtd/TODO.md\` in place (replace the question's text
   with your answer, or annotate it), then run \`gtd step\`.
 - To accept **all** suggested defaults as-is, run \`gtd step\` with **no
-  edits** — this converges the plan and moves on to decomposition.
+  edits** — this converges the plan and moves on to technical architecting.
 "
 `;
 
@@ -764,7 +989,7 @@ Tell the user:
 - To answer a question, edit \`.gtd/TODO.md\` in place (replace the question's text
   with your answer, or annotate it), then run \`gtd step\`.
 - To accept **all** suggested defaults as-is, run \`gtd step\` with **no
-  edits** — this converges the plan and moves on to decomposition.
+  edits** — this converges the plan and moves on to technical architecting.
 "
 `;
 
@@ -1052,10 +1277,11 @@ conventional-commits squash message and finish your turn.
 ### Step 1 — Extract decisions from grilling rounds
 
 Scan the git history of recent \`gtd: ...\` / \`gtd(agent): ...\` /
-\`gtd(human): ...\` commits. Look for changes to \`.gtd/TODO.md\` — specifically the
-\`## Captured input\` sections and any edits to plan text. Extract **key
-decisions, trade-offs, and design choices** made during grilling rounds. These
-will appear in the commit body so the history is self-documenting.
+\`gtd(human): ...\` commits. Look for changes to \`.gtd/TODO.md\` and
+\`.gtd/ARCHITECTURE.md\` — specifically the \`## Captured input\` sections and any
+edits to plan/architecture text. Extract **key decisions, trade-offs, and
+design choices** made during grilling and architecting rounds. These will
+appear in the commit body so the history is self-documenting.
 
 ### Step 2 — Draft the commit message
 
@@ -1106,10 +1332,11 @@ conventional-commits squash message and finish your turn.
 ### Step 1 — Extract decisions from grilling rounds
 
 Scan the git history of recent \`gtd: ...\` / \`gtd(agent): ...\` /
-\`gtd(human): ...\` commits. Look for changes to \`.gtd/TODO.md\` — specifically the
-\`## Captured input\` sections and any edits to plan text. Extract **key
-decisions, trade-offs, and design choices** made during grilling rounds. These
-will appear in the commit body so the history is self-documenting.
+\`gtd(human): ...\` commits. Look for changes to \`.gtd/TODO.md\` and
+\`.gtd/ARCHITECTURE.md\` — specifically the \`## Captured input\` sections and any
+edits to plan/architecture text. Extract **key decisions, trade-offs, and
+design choices** made during grilling and architecting rounds. These will
+appear in the commit body so the history is self-documenting.
 
 ### Step 2 — Draft the commit message
 

--- a/src/prompts/architecting-agent.md
+++ b/src/prompts/architecting-agent.md
@@ -1,0 +1,52 @@
+<%~ include("@header") %>
+
+`.gtd/ARCHITECTURE.md` holds the technical plan under development — seeded
+from the converged product plan, or, if this is the very first turn on
+already-technical input, written directly by the human. Develop it into a concrete,
+implementation-ready technical plan **in this one turn** — use subagents /
+internal iteration to go as deep as needed; there is no further agent-only
+round after this one.
+
+**Scope: technical/architectural decisions only.** Decide file/module
+structure, data models, module boundaries, library or tech-stack choices, and
+error-handling/concurrency strategy — the *how*, building on the *what*
+already settled in this file's product content. Do not re-open or re-litigate
+product/user-facing decisions from the prior phase; treat them as settled
+context.
+
+### Develop the architecture
+
+Spawn a **planning-model subagent** using model `<%= it.model %>` to develop the
+architecture. The subagent works entirely by editing `.gtd/ARCHITECTURE.md`:
+
+1. **Explore the codebase before asking anything** — read the relevant files,
+   tests, and docs so every question below is one the codebase genuinely
+   cannot answer.
+2. **Replace the seeded/captured content with a real architecture** — the
+   files to change, module/data-model structure, and why, grounded in the
+   codebase.
+3. **Iterate internally** (spawn further subagents, reconsider, cross-check)
+   until the architecture is as complete as it can get without human input.
+   Do not leave this to a future round — there isn't one before the human is
+   asked.
+4. For every remaining open question, write it near the top of the file with
+   a **suggested default** — your best-guess answer, stated plainly, that the
+   human can accept as-is. A question with no suggested default is incomplete.
+5. Leave `.gtd/ARCHITECTURE.md` **uncommitted** — the human's turn (`gtd step`)
+   reads it next.
+<% if (it.context.turnDiff && it.context.turnDiff.trim()) { %>
+<%~ include("@diff", { heading: "Latest human input (answers / sketch / review feedback)", diff: it.context.turnDiff, fenceFor: it.fenceFor }) %>
+
+Read the diff above as **feedback, not finished work**:
+
+- Code changes are suggestions — fold them into the architecture and
+  re-implement them properly, including test coverage, rather than restoring
+  them verbatim.
+- Code comments are positional feedback about the code at that location.
+- Plan-text changes are global feedback on the architecture (or the reviewed
+  work) as a whole.
+<% } %>
+
+<% if (it.tail) { %>
+<%~ include(it.tail) %>
+<% } %>

--- a/src/prompts/architecting-answers.md
+++ b/src/prompts/architecting-answers.md
@@ -1,0 +1,17 @@
+<%~ include("@header") %>
+
+`.gtd/ARCHITECTURE.md` holds the technical plan under development, with open
+questions written near the top — each one carrying a suggested default.
+
+This is a human gate; there is nothing for the agent to do.
+
+Tell the user:
+
+- To answer a question, edit `.gtd/ARCHITECTURE.md` in place (replace the
+  question's text with your answer, or annotate it), then run `gtd step`.
+- To accept **all** suggested defaults as-is, run `gtd step` with **no
+  edits** — this converges the architecture and moves on to decomposition.
+
+<% if (it.tail) { %>
+<%~ include(it.tail) %>
+<% } %>

--- a/src/prompts/decompose.md
+++ b/src/prompts/decompose.md
@@ -1,8 +1,9 @@
 <%~ include("@header") %>
 
-`.gtd/TODO.md` contains an implementation plan. Decompose it into an ordered set of
-executable work packages stored in the `.gtd/` directory. If `.gtd/` already
-holds packages from an earlier turn, immediately abort and raise an error.
+`.gtd/ARCHITECTURE.md` contains a converged architecture/technical plan.
+Decompose it into an ordered set of executable work packages stored in the
+`.gtd/` directory. If `.gtd/` already holds packages from an earlier turn,
+immediately abort and raise an error.
 
 Spawn a **planning-model subagent** using model `<%= it.model %>` to perform the
 decomposition. It creates numbered package directories, each holding numbered
@@ -43,8 +44,8 @@ task files:
    cases. It is the only context building agents will receive to work on the
    task.
 
-6. **Specs must never reference `.gtd/` files** — `.gtd/TODO.md` is consumed
-   and **deleted** the moment decomposition completes, and every other file
+6. **Specs must never reference `.gtd/` files** — `.gtd/ARCHITECTURE.md` is
+   consumed and **deleted** the moment decomposition completes, and every other file
    under `.gtd/` (including these task specs) is machine-managed workflow
    state. No task description, acceptance criterion, or constraint may require
    creating, preserving, updating, or checking any `.gtd/` file — such a

--- a/src/prompts/grilling-agent.md
+++ b/src/prompts/grilling-agent.md
@@ -1,9 +1,14 @@
 <%~ include("@header") %>
 
 `.gtd/TODO.md` holds the plan under development. Develop it into a concrete,
-implementation-ready plan **in this one turn** — use subagents / internal
-iteration to go as deep as needed; there is no further agent-only round after
-this one.
+product-level plan **in this one turn** — use subagents / internal iteration
+to go as deep as needed; there is no further agent-only round after this one.
+
+**Scope: product and user-facing decisions only.** Do not decide
+implementation details in this file — file/module structure, data models,
+library or tech-stack choices, and other architecture questions belong to the
+next phase (`.gtd/ARCHITECTURE.md`) and must not be treated as open questions
+here.
 
 ### Develop the plan
 
@@ -13,9 +18,9 @@ The subagent works entirely by editing `.gtd/TODO.md`:
 1. **Explore the codebase before asking anything** — read the relevant files,
    tests, and docs so every question below is one the codebase genuinely
    cannot answer.
-2. **Replace the captured input / seed template with a real implementation
-   plan** — the files to change, exactly what changes, and why, grounded in
-   the codebase.
+2. **Replace the captured input / seed template with a real product plan** —
+   what to build and why, and the user-facing behavior it should have,
+   grounded in the codebase. Leave *how* to build it for the next phase.
 3. **Iterate internally** (spawn further subagents, reconsider, cross-check)
    until the plan is as complete as it can get without human input. Do not
    leave this to a future round — there isn't one before the human is asked.

--- a/src/prompts/grilling-answers.md
+++ b/src/prompts/grilling-answers.md
@@ -10,7 +10,7 @@ Tell the user:
 - To answer a question, edit `.gtd/TODO.md` in place (replace the question's text
   with your answer, or annotate it), then run `gtd step`.
 - To accept **all** suggested defaults as-is, run `gtd step` with **no
-  edits** — this converges the plan and moves on to decomposition.
+  edits** — this converges the plan and moves on to technical architecting.
 
 <% if (it.tail) { %>
 <%~ include(it.tail) %>

--- a/src/prompts/squashing.md
+++ b/src/prompts/squashing.md
@@ -7,10 +7,11 @@ conventional-commits squash message and finish your turn.
 ### Step 1 — Extract decisions from grilling rounds
 
 Scan the git history of recent `gtd: ...` / `gtd(agent): ...` /
-`gtd(human): ...` commits. Look for changes to `.gtd/TODO.md` — specifically the
-`## Captured input` sections and any edits to plan text. Extract **key
-decisions, trade-offs, and design choices** made during grilling rounds. These
-will appear in the commit body so the history is self-documenting.
+`gtd(human): ...` commits. Look for changes to `.gtd/TODO.md` and
+`.gtd/ARCHITECTURE.md` — specifically the `## Captured input` sections and any
+edits to plan/architecture text. Extract **key decisions, trade-offs, and
+design choices** made during grilling and architecting rounds. These will
+appear in the commit body so the history is self-documenting.
 
 ### Step 2 — Draft the commit message
 

--- a/tests/integration/features/architecting.feature
+++ b/tests/integration/features/architecting.feature
@@ -1,0 +1,165 @@
+@inmem
+Feature: Architecting — technical grilling on the converged product plan
+
+  Architecting is grilling's second phase, mechanically identical to it: the
+  agent develops `.gtd/ARCHITECTURE.md` into a concrete technical plan
+  (file/module structure, data model, tech-stack choices) and the human either
+  answers inline or accepts the suggested defaults with a clean `gtd step`.
+  Normally `.gtd/ARCHITECTURE.md` is seeded from the converged `.gtd/TODO.md`
+  at the end of product grilling (see `grilling.feature`'s convergence
+  scenario). But the entry itself is file-presence-driven, not history-driven:
+  if a human's very first dirty tree already contains `.gtd/ARCHITECTURE.md`
+  (their own already-technical sketch), `gtd step` captures the entry turn
+  directly as `gtd(human): architecting` — product grilling is skipped
+  entirely, and `.gtd/TODO.md` never exists for that cycle. A clean `gtd step`
+  at architecting's answer gate converges to `gtd: grilled` and prompts
+  decompose.
+
+  Scenario: The escape hatch — a dirty tree seeded with ARCHITECTURE.md enters architecting directly, skipping product grilling
+    Given a test project
+    And a file ".gtd/ARCHITECTURE.md" with:
+      """
+      # Architecture
+
+      Refactor the calculator module to use a strategy pattern.
+      """
+    When I run gtd step
+    Then it succeeds
+    And the last commit subject is "gtd(human): architecting"
+    And the file ".gtd/ARCHITECTURE.md" exists
+    And the file ".gtd/ARCHITECTURE.md" contains "Refactor the calculator module to use a strategy pattern."
+    And the file ".gtd/TODO.md" does not exist
+    And the git log does not contain "gtd(human): grilling"
+    And stdout contains "committed: gtd(human): architecting"
+
+  Scenario: gtd next hands the agent the human's turn diff at the escape-hatch entry
+    Given a test project
+    And a file ".gtd/ARCHITECTURE.md" with:
+      """
+      # Architecture
+
+      Refactor the calculator module to use a strategy pattern.
+      """
+    And I run gtd step
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"actor\":\"agent\""
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "Finish your turn by running `gtd step-agent`."
+
+  Scenario: The agent's architecture turn gates on a human to answer inline
+    Given a test project
+    And a commit "gtd: architecting" that adds ".gtd/ARCHITECTURE.md" with:
+      """
+      # Architecture
+
+      Build a calculator.
+      """
+    And ".gtd/ARCHITECTURE.md" is modified to:
+      """
+      # Architecture
+
+      Build a calculator.
+
+      ## Which language runtime?
+
+      Suggested default: TypeScript on Node.js.
+      """
+    When I run gtd step-agent
+    Then it succeeds
+    And the last commit subject is "gtd(agent): architecting"
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"actor\":\"human\""
+    And stdout contains ".gtd/ARCHITECTURE.md"
+
+  Scenario: Human answers in ARCHITECTURE.md and the agent architecting prompt carries the answer diff
+    Given a test project
+    And a commit "gtd: architecting" that adds ".gtd/ARCHITECTURE.md" with:
+      """
+      # Architecture
+
+      Build a calculator.
+      """
+    And ".gtd/ARCHITECTURE.md" is modified to:
+      """
+      # Architecture
+
+      Build a calculator.
+
+      ## Which language runtime?
+
+      Suggested default: TypeScript on Node.js.
+      """
+    And I run gtd step-agent
+    And "code.ts" is modified to:
+      """
+      export const c = 1
+      """
+    And ".gtd/ARCHITECTURE.md" is modified to:
+      """
+      # Architecture
+
+      Build a calculator.
+
+      ## Which language runtime?
+
+      Answer: TypeScript on Deno.
+      """
+    When I run gtd step
+    Then it succeeds
+    And the last commit subject is "gtd(human): architecting"
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"actor\":\"agent\""
+    And stdout contains "TypeScript on Deno"
+
+  Scenario: A clean step at the answer gate converges to Grilled and prompts decompose
+    Given a test project
+    And a commit "gtd: architecting" that adds ".gtd/ARCHITECTURE.md" with:
+      """
+      # Architecture
+
+      Build a calculator with add and subtract.
+      """
+    And ".gtd/ARCHITECTURE.md" is modified to:
+      """
+      # Architecture
+
+      Build a calculator with add and subtract.
+
+      ## Which language runtime?
+
+      Suggested default: TypeScript on Node.js.
+      """
+    And I run gtd step-agent
+    When I run gtd step
+    Then it succeeds
+    And the last commit subject is "gtd: grilled"
+    And the file ".gtd/ARCHITECTURE.md" exists
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"actor\":\"agent\""
+    And stdout contains "Decompose it into an ordered set of"
+
+  Scenario: A do-nothing agent invocation at the architecting rest is inert and re-emits the same prompt
+    Given a test project
+    And a file ".gtd/ARCHITECTURE.md" with:
+      """
+      # Architecture
+
+      Build a calculator with add and subtract.
+      """
+    And I run gtd step
+    And I record the commit count
+    When I run gtd step-agent
+    Then it succeeds
+    And the commit count is unchanged
+    And the last commit subject is "gtd(human): architecting"
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"actor\":\"agent\""
+    When I run gtd step-agent
+    Then it succeeds
+    And the commit count is unchanged

--- a/tests/integration/features/config.feature
+++ b/tests/integration/features/config.feature
@@ -50,7 +50,7 @@ Feature: .gtdrc config system
         planning: my-planner-model
         execution: my-executor-model
       """
-    And a commit "gtd: grilled" that adds ".gtd/TODO.md" with:
+    And a commit "gtd: grilled" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Build the multiply function.
       """
@@ -89,7 +89,7 @@ Feature: .gtdrc config system
         states:
           decompose: state-decompose-model
       """
-    And a commit "gtd: grilled" that adds ".gtd/TODO.md" with:
+    And a commit "gtd: grilled" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Build the multiply function.
       """
@@ -102,7 +102,7 @@ Feature: .gtdrc config system
   @inmem
   Scenario: Built-in planning default applies with no config present
     Given a test project
-    And a commit "gtd: grilled" that adds ".gtd/TODO.md" with:
+    And a commit "gtd: grilled" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Build the multiply function.
       """
@@ -210,7 +210,7 @@ Feature: .gtdrc config system
         planning: ancestor-planner-model
         execution: ancestor-executor-model
       """
-    And a commit "gtd: grilled" that adds ".gtd/TODO.md" with:
+    And a commit "gtd: grilled" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Build the multiply function.
       """
@@ -227,7 +227,7 @@ Feature: .gtdrc config system
       """
       fixAttemptCap: -1
       """
-    And a commit "gtd: grilled" that adds ".gtd/TODO.md" with:
+    And a commit "gtd: grilled" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Build the multiply function.
       """
@@ -242,7 +242,7 @@ Feature: .gtdrc config system
       """
       fixAttemptCap: 1.5
       """
-    And a commit "gtd: grilled" that adds ".gtd/TODO.md" with:
+    And a commit "gtd: grilled" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Build the multiply function.
       """
@@ -257,7 +257,7 @@ Feature: .gtdrc config system
       """
       reviewThreshold: 0
       """
-    And a commit "gtd: grilled" that adds ".gtd/TODO.md" with:
+    And a commit "gtd: grilled" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Build the multiply function.
       """
@@ -286,7 +286,7 @@ Feature: .gtdrc config system
       """
       testCommand: [unclosed
       """
-    And a commit "gtd: grilled" that adds ".gtd/TODO.md" with:
+    And a commit "gtd: grilled" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Build the multiply function.
       """
@@ -302,7 +302,7 @@ Feature: .gtdrc config system
       - item1
       - item2
       """
-    And a commit "gtd: grilled" that adds ".gtd/TODO.md" with:
+    And a commit "gtd: grilled" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Build the multiply function.
       """
@@ -317,7 +317,7 @@ Feature: .gtdrc config system
       """
       bogusKey: 1
       """
-    And a commit "gtd: grilled" that adds ".gtd/TODO.md" with:
+    And a commit "gtd: grilled" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Build the multiply function.
       """
@@ -333,7 +333,7 @@ Feature: .gtdrc config system
       """
       null
       """
-    And a commit "gtd: grilled" that adds ".gtd/TODO.md" with:
+    And a commit "gtd: grilled" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Build the multiply function.
       """
@@ -344,7 +344,7 @@ Feature: .gtdrc config system
   @live
   Scenario: A clean project auto-creates .gtdrc.json with a $schema link
     Given a test project
-    And a commit "gtd: grilled" that adds ".gtd/TODO.md" with:
+    And a commit "gtd: grilled" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Build the multiply function.
       """
@@ -356,7 +356,7 @@ Feature: .gtdrc config system
   @live
   Scenario: A second gtd run does not reject the auto-created .gtdrc.json
     Given a test project
-    And a commit "gtd: grilled" that adds ".gtd/TODO.md" with:
+    And a commit "gtd: grilled" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Build the multiply function.
       """
@@ -376,7 +376,7 @@ Feature: .gtdrc config system
       models:
         planning: shared-parent-planner
       """
-    And a commit "gtd: grilled" that adds ".gtd/TODO.md" with:
+    And a commit "gtd: grilled" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Build the multiply function.
       """

--- a/tests/integration/features/grilling.feature
+++ b/tests/integration/features/grilling.feature
@@ -9,8 +9,10 @@ Feature: Grilling — human sketch, agent plan, human answers, clean-step conver
   `gtd step-agent`s a `gtd(agent): grilling` turn, which gates on a human to
   answer inline in TODO.md (or accept defaults). A clean `gtd step` at that gate
   is the sole convergence signal — no marker text is ever parsed — landing an
-  empty `gtd(human): grilling` plus routing `gtd: grilled` and prompting
-  decompose.
+  empty `gtd(human): grilling` plus routing `gtd: architecting`, which seeds
+  `.gtd/ARCHITECTURE.md` from the converged TODO.md content, removes TODO.md,
+  and prompts the architecting agent (see `architecting.feature` for that
+  phase's own contract).
 
   Scenario: A dirty boundary tree becomes one human grilling turn, nothing reverted
     Given a test project
@@ -112,7 +114,7 @@ Feature: Grilling — human sketch, agent plan, human answers, clean-step conver
     And stdout contains "\"actor\":\"agent\""
     And stdout contains "add, subtract, and multiply"
 
-  Scenario: A clean step at the answer gate converges to Grilled and prompts decompose
+  Scenario: A clean step at the answer gate converges to Architecting, seeding ARCHITECTURE.md from TODO.md
     Given a test project
     And a file "notes.md" with:
       """
@@ -133,11 +135,14 @@ Feature: Grilling — human sketch, agent plan, human answers, clean-step conver
     When I run gtd step
     Then it succeeds
     And the git log contains "gtd(human): grilling"
-    And the last commit subject is "gtd: grilled"
+    And the last commit subject is "gtd: architecting"
+    And the file ".gtd/TODO.md" does not exist
+    And the file ".gtd/ARCHITECTURE.md" exists
+    And the file ".gtd/ARCHITECTURE.md" contains "Build a calculator with add and subtract."
     When I run gtd next with "--json"
     Then it succeeds
     And stdout contains "\"actor\":\"agent\""
-    And stdout contains "Decompose it into an ordered set of"
+    And stdout contains "Develop it into a concrete"
 
   Scenario: The literal marker text is inert — it no longer stops for the user
     Given a test project
@@ -157,11 +162,11 @@ Feature: Grilling — human sketch, agent plan, human answers, clean-step conver
     And I run gtd step-agent
     When I run gtd step
     Then it succeeds
-    And the last commit subject is "gtd: grilled"
+    And the last commit subject is "gtd: architecting"
     When I run gtd next with "--json"
     Then it succeeds
     And stdout contains "\"actor\":\"agent\""
-    And stdout contains "Decompose it into an ordered set of"
+    And stdout contains "Develop it into a concrete"
 
   Scenario: A do-nothing agent invocation at the grilling rest is inert and re-emits the same prompt
     Given a test project

--- a/tests/integration/features/journeys.feature
+++ b/tests/integration/features/journeys.feature
@@ -46,6 +46,27 @@ Feature: Full lifecycle journeys — the step-first two-beat loop end to end
     When I run gtd step-agent
     Then it succeeds
     And the last commit subject is "gtd(agent): grilling"
+    # A clean human step accepts (empty turn) and converges to gtd: architecting,
+    # seeding ARCHITECTURE.md from the converged plan and removing TODO.md.
+    When I run gtd step
+    Then it succeeds
+    And the last commit subject is "gtd: architecting"
+    And stdout contains "state: architecting"
+    And the file ".gtd/TODO.md" does not exist
+    And the file ".gtd/ARCHITECTURE.md" exists
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "Develop it into a concrete"
+    # The agent develops the architecture to convergence and accepts defaults.
+    When a file ".gtd/ARCHITECTURE.md" with:
+      """
+      # Architecture
+
+      Implement add() as a plain function export in src/calc.ts.
+      """
+    When I run gtd step-agent
+    Then it succeeds
+    And the last commit subject is "gtd(agent): architecting"
     # A clean human step accepts (empty turn) and converges to gtd: grilled.
     When I run gtd step
     Then it succeeds
@@ -54,7 +75,7 @@ Feature: Full lifecycle journeys — the step-first two-beat loop end to end
     When I run gtd next
     Then it succeeds
     And stdout contains "Decompose it into an ordered set of"
-    # The agent decomposes into one package; TODO.md is left for the machine to remove.
+    # The agent decomposes into one package; ARCHITECTURE.md is left for the machine to remove.
     When a file ".gtd/01-calc/01-add.md" with:
       """
       Implement add() in src/calc.ts.
@@ -62,7 +83,7 @@ Feature: Full lifecycle journeys — the step-first two-beat loop end to end
     When I run gtd step-agent
     Then it succeeds
     And the last commit subject is "gtd: planning"
-    And the file ".gtd/TODO.md" does not exist
+    And the file ".gtd/ARCHITECTURE.md" does not exist
     When I run gtd next
     Then it succeeds
     And stdout contains "Build the package described below"
@@ -113,6 +134,9 @@ Feature: Full lifecycle journeys — the step-first two-beat loop end to end
       gtd(human): grilling
       gtd(agent): grilling
       gtd(human): grilling
+      gtd: architecting
+      gtd(agent): architecting
+      gtd(human): architecting
       gtd: grilled
       gtd(agent): grilled
       gtd: planning
@@ -151,6 +175,17 @@ Feature: Full lifecycle journeys — the step-first two-beat loop end to end
       # Plan
 
       Implement a calculator with add only, in src/calc.ts.
+      """
+    When I run gtd step-agent
+    Then it succeeds
+    When I run gtd step
+    Then it succeeds
+    And the last commit subject is "gtd: architecting"
+    When a file ".gtd/ARCHITECTURE.md" with:
+      """
+      # Architecture
+
+      Implement add() as a plain function export in src/calc.ts.
       """
     When I run gtd step-agent
     Then it succeeds
@@ -207,6 +242,9 @@ Feature: Full lifecycle journeys — the step-first two-beat loop end to end
     And the git log does not contain "gtd: grilling"
     And the git log does not contain "gtd(human): grilling"
     And the git log does not contain "gtd(agent): grilling"
+    And the git log does not contain "gtd: architecting"
+    And the git log does not contain "gtd(agent): architecting"
+    And the git log does not contain "gtd(human): architecting"
     And the git log does not contain "gtd: grilled"
     And the git log does not contain "gtd: planning"
     And the git log does not contain "gtd(agent): building"
@@ -352,6 +390,20 @@ Feature: Full lifecycle journeys — the step-first two-beat loop end to end
     When I run gtd step-agent
     Then it succeeds
     And the last commit subject is "gtd(agent): grilling"
+    # A clean human step (accept) converges to architecting.
+    When I run gtd step
+    Then it succeeds
+    And the last commit subject is "gtd: architecting"
+    # The architecting agent converges immediately, with no open questions.
+    When a file ".gtd/ARCHITECTURE.md" with:
+      """
+      # Architecture
+
+      Implement add, subtract, and multiply as plain function exports in src/calc.ts.
+      """
+    When I run gtd step-agent
+    Then it succeeds
+    And the last commit subject is "gtd(agent): architecting"
     # A clean human step (accept) converges to grilled.
     When I run gtd step
     Then it succeeds

--- a/tests/integration/features/step-agent.feature
+++ b/tests/integration/features/step-agent.feature
@@ -75,11 +75,11 @@ Feature: gtd step-agent — the agent mutator
     And stderr contains "awaits a human turn"
     And the commit count is unchanged
 
-  Scenario: A do-nothing agent invocation at the grilled rest never consumes the plan
+  Scenario: A do-nothing agent invocation at the grilled rest never consumes the architecture
     Given a test project
-    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+    And a commit "gtd(human): architecting" that adds ".gtd/ARCHITECTURE.md" with:
       """
-      # Plan
+      # Architecture
 
       Build a calculator.
       """
@@ -88,17 +88,17 @@ Feature: gtd step-agent — the agent mutator
     When I run gtd step-agent
     Then it succeeds
     And the commit count is unchanged
-    And the file ".gtd/TODO.md" exists
+    And the file ".gtd/ARCHITECTURE.md" exists
     And the git log does not contain "gtd: planning"
     When I run gtd next
     Then it succeeds
     And stdout contains "Decompose it into an ordered set of"
 
-  Scenario: A historical decompose turn without packages rests instead of deleting the plan
+  Scenario: A historical decompose turn without packages rests instead of deleting the architecture
     Given a test project
-    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+    And a commit "gtd(human): architecting" that adds ".gtd/ARCHITECTURE.md" with:
       """
-      # Plan
+      # Architecture
 
       Build a calculator.
       """
@@ -108,7 +108,7 @@ Feature: gtd step-agent — the agent mutator
     When I run gtd step-agent
     Then it succeeds
     And the commit count is unchanged
-    And the file ".gtd/TODO.md" exists
+    And the file ".gtd/ARCHITECTURE.md" exists
     And the git log does not contain "gtd: planning"
 
   Scenario: A do-nothing agent invocation at the planning rest never skips the build

--- a/tests/integration/features/step.feature
+++ b/tests/integration/features/step.feature
@@ -46,7 +46,7 @@ Feature: gtd step — the human mutator
     And stderr contains "awaits an agent turn"
     And the commit count is unchanged
 
-  Scenario: An empty human turn at the grilling answer gate accepts and advances to gtd: grilled
+  Scenario: An empty human turn at the grilling answer gate accepts and advances to gtd: architecting
     Given a test project
     And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
       """
@@ -74,14 +74,16 @@ Feature: gtd step — the human mutator
       gtd(human): grilling
       gtd(agent): grilling
       gtd(human): grilling
-      gtd: grilled
+      gtd: architecting
       """
+    And the file ".gtd/TODO.md" does not exist
+    And the file ".gtd/ARCHITECTURE.md" exists
 
   Scenario: Human step at the grilled rest is refused — the decompose window belongs to the agent
     Given a test project
-    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+    And a commit "gtd(human): architecting" that adds ".gtd/ARCHITECTURE.md" with:
       """
-      # Plan
+      # Architecture
 
       Build a calculator with add and subtract.
       """
@@ -100,13 +102,13 @@ Feature: gtd step — the human mutator
     Then it fails
     And stderr contains "run `gtd step-agent`"
     And the commit count is unchanged
-    And the file ".gtd/TODO.md" exists
+    And the file ".gtd/ARCHITECTURE.md" exists
     # The agent step is the only legal move: it commits the decomposition and
-    # removes TODO.md in one chain.
+    # removes ARCHITECTURE.md in one chain.
     When I run gtd step-agent
     Then it succeeds
     And the last commit subject is "gtd: planning"
-    And the file ".gtd/TODO.md" does not exist
+    And the file ".gtd/ARCHITECTURE.md" does not exist
 
   Scenario: Out-of-turn human step while the agent is awaited is refused on a clean tree
     Given a test project


### PR DESCRIPTION
Adds a new "architecting" turn gate/state mirroring today's grilling
mechanics one file later: grilling now scopes to product/user-facing
decisions only, converges into .gtd/ARCHITECTURE.md (seeded from the
converged .gtd/TODO.md), and architecting handles technical/architecture
decisions before decompose consumes .gtd/ARCHITECTURE.md into packages.

Also adds a file-presence-driven escape hatch: a dirty entry tree that
already contains .gtd/ARCHITECTURE.md enters directly at architecting,
skipping product grilling for already-technical input.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GYGTvdaeKFAy6a42vcCMdG