### PR TITLE
feat: add a learning phase before the squash

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,13 @@
       "Bash(npm test)",
       "Bash(npx tsc --noEmit)",
       "Bash(npx vitest run --project unit *)",
-      "Bash(npx vitest run --project e2e *)"
+      "Bash(npx vitest run --project e2e *)",
+      "Bash(npm run typecheck *)",
+      "Bash(npm run lint *)",
+      "Bash(npm run test:unit *)",
+      "Bash(npx vitest run *)",
+      "Bash(npx fallow health *)",
+      "Bash(npx fallow --summary *)"
     ],
     "deny": ["Bash(npm run test:mutation)", "Bash(npx stryker run)", "Bash(stryker run)"]
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,9 @@ cleanup), trace **every** reference before deleting:
 - `src/Events.ts` (`gatherEvents` flag derivation, `perform`)
 - `src/program.ts` dispatch
 - `src/Prompt.ts` (`isPromptState`, `MODEL_STATE`, templates)
+- `src/State.ts` (`edgeActionHandlers` — a total map over `EdgeAction["kind"]`,
+  so it won't fail to compile on a removed/added variant the way an
+  exhaustive-switch-free table can silently drift)
 - STATES.md / README.md
 - All feature files
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 A git-aware CLI that drives a turn-taking loop between a human and an autonomous
 coding agent: capture an idea, grill it into a plan, decompose it into work
 packages, execute with parallel subagents, test, agentically review each
-package, and finally walk a human through a review — squashing the whole cycle
-into one conventional-commits commit at the end.
+package, walk a human through a review, distill durable lessons from the cycle
+into the project's own docs, and finally squash the whole cycle into one
+conventional-commits commit at the end.
 
 Internally, gtd is a **pure fold** over git history. The decision core
 (`src/Machine.ts`) is a single IO-free function, `resolve(events)` — **no
@@ -18,7 +19,7 @@ merge-base with the default branch (whole-history fallback when there is no
 default branch, when HEAD equals the merge-base, or when there is no merge-base)
 plus the working tree, turns them into a `COMMIT[]` + single terminal `RESOLVE`
 event stream, and folds them through the machine. The fold lands on exactly
-**one** of 16 states, plus which actor (human or agent) is awaited there. A
+**one** of 20 states, plus which actor (human or agent) is awaited there. A
 single call resolves to a single state.
 
 Steering is entirely **machine-authored commit subjects** — there are no marker
@@ -29,12 +30,12 @@ the machine performs itself between turns) looks like `gtd: tests green`.
 
 All workflow state lives under **`.gtd/`**: the plan (`.gtd/TODO.md`), work
 packages (`.gtd/01-…/`), review records (`.gtd/REVIEW.md`, `.gtd/FEEDBACK.md`),
-and loop bookkeeping (`.gtd/ERRORS.md`, `.gtd/HEALTH.md`, `.gtd/SQUASH_MSG.md`).
-One rule follows for every agent in the loop: **never touch `.gtd/`** except the
-single file a prompt explicitly grants. A `TODO.md` or `REVIEW.md` at the
-repository root is the project's own file — gtd never reads, consumes, or
-deletes it. (Corollary: don't gitignore `.gtd/` — the workflow commits its state
-through it.)
+and loop bookkeeping (`.gtd/ERRORS.md`, `.gtd/HEALTH.md`, `.gtd/LEARNINGS.md`,
+`.gtd/SQUASH_MSG.md`). One rule follows for every agent in the loop: **never
+touch `.gtd/`** except the single file a prompt explicitly grants. A `TODO.md`
+or `REVIEW.md` at the repository root is the project's own file — gtd never
+reads, consumes, or deletes it. (Corollary: don't gitignore `.gtd/` — the
+workflow commits its state through it.)
 
 ## Quick start: the two-beat loop
 
@@ -428,12 +429,14 @@ GTD_LOOP_AGENT_CMD='my-agent-cli --prompt "$GTD_LOOP_PROMPT"' gtd-loop
 
 ## States & subjects overview
 
-`resolve()` lands on exactly one of **16 states**: `grilling`, `grilled`,
+`resolve()` lands on exactly one of **20 states**: `grilling`, `grilled`,
 `planning`, `building`, `testing`, `fixing`, `escalate`, `agentic-review`,
-`close-package`, `review`, `await-review`, `done`, `squashing`, `idle`,
-`health-check`, `health-fixing`. Each state has a fixed awaited actor (see
-`awaitedActor` in `src/Machine.ts`): `idle`, `escalate`, and `await-review`
-await the **human**; every other state awaits the **agent**.
+`close-package`, `review`, `await-review`, `done`, `learning`,
+`await-learning-review`, `learning-apply`, `learning-applied`, `squashing`,
+`idle`, `health-check`, `health-fixing`. Each state has a fixed awaited actor
+(see `awaitedActor` in `src/Machine.ts`): `idle`, `escalate`, `await-review`,
+and `await-learning-review` await the **human**; every other state awaits the
+**agent**.
 
 For the full precedence ladder, illegal combinations, and the counter folds that
 drive the fix loops, see [STATES.md](STATES.md) — this section is a summary.
@@ -452,6 +455,8 @@ The closed set of gates:
 | `agentic-review` | agent (writes .gtd/FEEDBACK.md verdict)                            |
 | `review`         | agent (writes .gtd/REVIEW.md) / human (approves or gives feedback) |
 | `squashing`      | agent (overwrites .gtd/SQUASH_MSG.md)                              |
+| `learning`       | agent (overwrites .gtd/LEARNINGS.md) / human (accepts or edits)    |
+| `learning-apply` | agent (integrates .gtd/LEARNINGS.md into CLAUDE.md/AGENTS.md/docs) |
 | `health-fixing`  | agent (idle health-check repair)                                   |
 | `escalate`       | human (deletes .gtd/ERRORS.md to resume)                           |
 
@@ -462,7 +467,8 @@ agent "wins": `gtd: grilled`, `gtd: planning`, `gtd: tests green`,
 `gtd: errors`, `gtd: package done`, `gtd: awaiting review`,
 `gtd: review feedback`, `gtd: done`, `gtd: squash template`,
 `gtd: reviewing <hash>` (parameterized, from `gtd review`), `gtd: health-check`,
-`gtd: health-fix`.
+`gtd: health-fix`, `gtd: learning template`, `gtd: learning drafted`,
+`gtd: learning approved`, `gtd: learning applied`.
 
 Everything else — any non-`gtd` subject, and any `gtd: *` subject outside this
 closed set — is a **boundary commit**: inert as far as the machine's grammar is
@@ -526,23 +532,25 @@ the threshold simply closes the package as usual.) Setting
 
 A **do-nothing agent invocation** — `gtd step-agent` on a clean tree at ANY
 agent-awaited rest whose move is a file artifact (`grilling`, `grilled`,
-`building`, `fixing`, `agentic-review`, `review`, and `squashing` while
-`.gtd/SQUASH_MSG.md` still holds the unmodified template) — is inert: zero
-commits, no state consumed; `gtd next` re-emits the same prompt. This is
-load-bearing for the loop protocol, whose every iteration opens with
-`gtd step-agent` before the agent has acted: without the guard that opening beat
-would author junk empty turns — and worse, consume workflow state (an empty
-decompose turn would delete `.gtd/TODO.md` with no packages written; an empty
-squashing turn would squash the cycle under the placeholder template). The same
-guards hold at the classification layer for histories that already carry such
-turns: a `gtd(agent): grilled` HEAD only routes to `gtd: planning` when packages
-exist, a `gtd(agent): review` HEAD only routes to `gtd: awaiting review` when
-`.gtd/REVIEW.md` exists, and a squashing turn only squashes once the template
-has been overwritten. The one deliberate exception is `health-fixing`, whose
-empty turn is meaningful (the failure may have been environmental — the machine
-removes `.gtd/HEALTH.md` and re-tests). Human gates are unaffected: an empty
-**human** turn stays a signal (accept-defaults at grilling, clean approval at
-review).
+`building`, `fixing`, `agentic-review`, `review`, `squashing` while
+`.gtd/SQUASH_MSG.md` still holds the unmodified template, `learning` while
+`.gtd/LEARNINGS.md` still holds the unmodified template, and `learning-apply`
+unconditionally) — is inert: zero commits, no state consumed; `gtd next`
+re-emits the same prompt. This is load-bearing for the loop protocol, whose
+every iteration opens with `gtd step-agent` before the agent has acted: without
+the guard that opening beat would author junk empty turns — and worse, consume
+workflow state (an empty decompose turn would delete `.gtd/TODO.md` with no
+packages written; an empty squashing turn would squash the cycle under the
+placeholder template). The same guards hold at the classification layer for
+histories that already carry such turns: a `gtd(agent): grilled` HEAD only
+routes to `gtd: planning` when packages exist, a `gtd(agent): review` HEAD only
+routes to `gtd: awaiting review` when `.gtd/REVIEW.md` exists, and a squashing
+(or learning) turn only proceeds once its template has been overwritten. The one
+deliberate exception is `health-fixing`, whose empty turn is meaningful (the
+failure may have been environmental — the machine removes `.gtd/HEALTH.md` and
+re-tests). Human gates are unaffected: an empty **human** turn stays a signal
+(accept-defaults at grilling, clean approval at review, accept-the-draft-as-is
+at the learning review gate).
 
 ### Human review gate
 
@@ -586,22 +594,46 @@ their commit message is discarded; linked `git worktree` checkouts are
 unsupported. If you switch branches mid-review, gtd refuses to touch the foreign
 branch and prints the manual recovery command.
 
+### Learning
+
+With `learning: true` (the default), `gtd: done` (or the health-fix path's green
+re-test) is **not** a rest — the chain continues straight to
+`gtd: learning template`, writing and committing a `.gtd/LEARNINGS.md` template,
+running _before_ the squash decision so it still sees the pre-squash history.
+`gtd next` then emits the learning prompt: the agent walks the cycle's test
+failures, review feedback, and health-check rounds, keeps only
+durable/generalizable lessons, and overwrites `.gtd/LEARNINGS.md` with them.
+Once `gtd step-agent` captures that draft (`gtd(agent): learning`), it rests at
+**await-learning-review** for a human — who either accepts the draft as-is (an
+empty turn) or edits it; there is no reject path, so the very next `gtd step`
+always proceeds (`gtd(human): learning` → `gtd: learning approved`), resting at
+**learning-apply** for the agent. The agent integrates the approved learnings
+into the project's own docs (`CLAUDE.md`/`AGENTS.md`/wherever fits, its
+judgment); its turn (`gtd(agent): learning-apply`) removes `.gtd/LEARNINGS.md`
+and lands at `gtd: learning applied`, which then runs the same squash decision
+`gtd: done` runs today. With `learning: false`, `gtd: done` behaves exactly as
+it does without this section: no `.gtd/LEARNINGS.md` is ever written. Learning
+and squash are independent flags — either can be on without the other.
+
 ### Squash
 
-With `squash: true` (the default), `gtd: done` is **not** a rest — the same
-chain continues straight to `gtd: squash template`, writing and committing a
-`.gtd/SQUASH_MSG.md` template. `gtd next` then emits the squashing prompt: the
-agent overwrites `.gtd/SQUASH_MSG.md` with a real conventional-commits message
-(drawing on grilling-round decisions from history) and finishes its turn.
-`gtd step-agent` then performs the squash itself: `git reset --soft <base>` +
-`git commit`, collapsing every intermediate `gtd: *` commit of the cycle into
-one — including any review-feedback detours: the squash base is the cycle's
-ORIGINAL start (the first grilling run since the previous `gtd: done` boundary,
-or the `gtd: reviewing <hash>` anchor for an ad-hoc review cycle), not the most
-recent re-grilling round — the collapse folds the whole cycle into one, using
-the overwritten message's content verbatim (turn position, not message content,
-triggers the squash). With `squash: false`, `gtd: done` is the resting boundary
-and no template is ever written.
+With `squash: true` (the default), `gtd: done` (or, once learning has run,
+`gtd: learning applied`) is **not** a rest — the same chain continues straight
+to `gtd: squash template`, writing and committing a `.gtd/SQUASH_MSG.md`
+template. `gtd next` then emits the squashing prompt: the agent overwrites
+`.gtd/SQUASH_MSG.md` with a real conventional-commits message (drawing on
+grilling-round decisions from history) and finishes its turn. `gtd step-agent`
+then performs the squash itself: `git reset --soft <base>` + `git commit`,
+collapsing every intermediate `gtd: *` commit of the cycle into one — including
+any review-feedback detours, and the learning phase's own commits if learning
+ran: the squash base is the cycle's ORIGINAL start (the first grilling run since
+the previous `gtd: done` boundary, or the `gtd: reviewing <hash>` anchor for an
+ad-hoc review cycle), not the most recent re-grilling round — the collapse folds
+the whole cycle into one, using the overwritten message's content verbatim (turn
+position, not message content, triggers the squash). Doc edits made during
+`learning-apply` survive in the squashed tree, not as their own commit. With
+`squash: false`, `gtd: done` (or `gtd: learning applied`) is the resting
+boundary and no template is ever written.
 
 ### Health check
 
@@ -610,9 +642,9 @@ runs `testCommand` as a health check rather than settling immediately. Green
 settles idle with zero commits. Red below `fixAttemptCap` writes
 `.gtd/HEALTH.md` and rests at **Health Fixing** for the agent; the fixer's own
 turn (`gtd(agent): health-fixing`) removes `.gtd/HEALTH.md` and re-tests in the
-same chain — a green re-test continues to squash (if enabled) or idle; red
-repeats the health-fix loop; red at the cap writes `.gtd/ERRORS.md` and
-escalates.
+same chain — a green re-test continues to learning (if enabled), then squash (if
+enabled), or idle; red repeats the health-fix loop; red at the cap writes
+`.gtd/ERRORS.md` and escalates.
 
 ### Escalate / budget reset
 
@@ -624,24 +656,28 @@ fix-attempt budget to zero.
 
 ## States & subjects: overview table
 
-| State            | Awaits         | Turn/routing subject at rest                                     |
-| ---------------- | -------------- | ---------------------------------------------------------------- |
-| `grilling`       | human or agent | `gtd(human): grilling` / `gtd(agent): grilling`                  |
-| `grilled`        | agent          | `gtd: grilled`                                                   |
-| `planning`       | agent          | `.gtd/` modified                                                 |
-| `building`       | agent          | `gtd: planning` / `gtd: package done`                            |
-| `testing`        | — (edge-only)  | mid-chain only                                                   |
-| `fixing`         | agent          | `gtd: errors`                                                    |
-| `escalate`       | human          | `.gtd/ERRORS.md` present                                         |
-| `agentic-review` | agent          | `gtd: tests green`                                               |
-| `close-package`  | — (edge-only)  | mid-chain only                                                   |
-| `review`         | agent          | `gtd: package done` (no more packages) / `gtd: reviewing <hash>` |
-| `await-review`   | human          | `gtd: awaiting review`                                           |
-| `done`           | — (edge-only)  | `gtd: done`                                                      |
-| `squashing`      | agent          | `gtd: squash template`                                           |
-| `idle`           | human          | no steering files, green health check                            |
-| `health-check`   | — (edge-only)  | mid-chain only                                                   |
-| `health-fixing`  | agent          | `.gtd/HEALTH.md` present                                         |
+| State                   | Awaits         | Turn/routing subject at rest                                     |
+| ----------------------- | -------------- | ---------------------------------------------------------------- |
+| `grilling`              | human or agent | `gtd(human): grilling` / `gtd(agent): grilling`                  |
+| `grilled`               | agent          | `gtd: grilled`                                                   |
+| `planning`              | agent          | `.gtd/` modified                                                 |
+| `building`              | agent          | `gtd: planning` / `gtd: package done`                            |
+| `testing`               | — (edge-only)  | mid-chain only                                                   |
+| `fixing`                | agent          | `gtd: errors`                                                    |
+| `escalate`              | human          | `.gtd/ERRORS.md` present                                         |
+| `agentic-review`        | agent          | `gtd: tests green`                                               |
+| `close-package`         | — (edge-only)  | mid-chain only                                                   |
+| `review`                | agent          | `gtd: package done` (no more packages) / `gtd: reviewing <hash>` |
+| `await-review`          | human          | `gtd: awaiting review`                                           |
+| `done`                  | — (edge-only)  | `gtd: done`                                                      |
+| `learning`              | agent          | `gtd: learning template`                                         |
+| `await-learning-review` | human          | `gtd: learning drafted`                                          |
+| `learning-apply`        | agent          | `gtd: learning approved`                                         |
+| `learning-applied`      | — (edge-only)  | `gtd: learning applied`                                          |
+| `squashing`             | agent          | `gtd: squash template`                                           |
+| `idle`                  | human          | no steering files, green health check                            |
+| `health-check`          | — (edge-only)  | mid-chain only                                                   |
+| `health-fixing`         | agent          | `.gtd/HEALTH.md` present                                         |
 
 See [STATES.md](STATES.md) for the full precedence ladder, the counter folds,
 and every illegal steering-file combination.
@@ -674,13 +710,19 @@ built-in defaults apply. Supported filenames (searched in this order):
 - **`agenticReview`** (boolean, default `true`) — kill-switch for the
   per-package Agentic Review gate. Set `false` to force-approve every package
   and proceed directly to human review.
-- **`squash`** (boolean, default `true`) — after `gtd: done`, collapse the
-  cycle's `gtd: *` commits into a single conventional-commits commit. Set
-  `false` to keep the granular history.
+- **`squash`** (boolean, default `true`) — after `gtd: done` (or, once learning
+  has run, `gtd: learning applied`), collapse the cycle's `gtd: *` commits into
+  a single conventional-commits commit. Set `false` to keep the granular
+  history.
+- **`learning`** (boolean, default `true`) — after `gtd: done` (or the
+  health-fix path's green re-test), distill durable lessons from the cycle into
+  `.gtd/LEARNINGS.md`, have a human review them, then integrate them into the
+  project's own docs before the squash decision runs. Set `false` to skip the
+  phase entirely — independent of `squash`.
 - **`models`** — model selection for the subagent-spawning states:
   - `planning` — high-reasoning tier (default `claude-opus-4-8`), used by
     `decompose` (the `grilled`/`planning` states), `grilling`, `agentic-review`,
-    and `clean` (the `review`/`squashing` states).
+    and `clean` (the `review`/`squashing`/`learning`/`learning-apply` states).
   - `execution` — everyday tier (default `claude-sonnet-4-8`), used by
     `building` and `fixing`.
   - `states.*` — per-state overrides keyed by `decompose`, `grilling`,
@@ -739,6 +781,7 @@ fixAttemptCap: 3
 reviewThreshold: 3
 agenticReview: true
 squash: true
+learning: true
 models:
   planning: claude-opus-4-8
   execution: claude-sonnet-4-8

--- a/STATES.md
+++ b/STATES.md
@@ -8,7 +8,7 @@ history + a working-tree snapshot) to a `Result`; all git/filesystem IO lives at
 the edge (`src/Events.ts`).
 
 This document is the design reference for that machine: the turn-taking model,
-the commit-subject grammar, the command surface, the 16 states, the precedence
+the commit-subject grammar, the command surface, the 20 states, the precedence
 ladder, canonical transcripts, and the loop protocol an agent should follow to
 drive it. It documents the shipped v2 engine — `gtd step` / `gtd step-agent` /
 `gtd next` — not the earlier single-mutating-command design. Where this document
@@ -50,6 +50,12 @@ file their turn explicitly grants.
 - **.gtd/REVIEW.md checkbox-only diffs** — a pending `.gtd/REVIEW.md` edit that
   is purely `- [ ]` ↔ `- [x]` flips (and nothing else dirty) is an approval
   signal, not review feedback (`isCheckboxOnlyDiff` in `src/Events.ts`).
+
+`.gtd/LEARNINGS.md` and `.gtd/SQUASH_MSG.md` are the two exceptions to this rule
+at a different layer: their content becomes the human-review draft / the final
+squash commit message verbatim, but neither ever _steers_ a routing decision —
+only their **presence** and (for the machine-written template) whether they
+still hold the unmodified template do.
 
 Every other piece of content — .gtd/TODO.md prose, .gtd/FEEDBACK.md's actual
 findings text, .gtd/REVIEW.md's prose, code diffs — is inlined into prompts for
@@ -99,14 +105,16 @@ machine-authored namespaces, plus a catch-all:
 
 ```
 grilling | grilled | building | fixing | agentic-review | review
-| squashing | health-fixing | escalate
+| squashing | health-fixing | escalate | learning | learning-apply
 ```
 
 `turnSubject(actor, gate)` produces `gtd(${actor}): ${gate}`. Not every
 `(actor, gate)` pair is reachable: turns are strictly separated (§3), so a gate
 is only ever authored by its awaited actor — there is no `gtd(human): building`
 at all, and `gtd(human)` appears only at the human gates (`grilling`'s entry and
-answer turns, `review`, `escalate`).
+answer turns, `review`, `escalate`, and — mirroring `review` — `learning`, whose
+human turn (at the `await-learning-review` rest) shares the agent draft turn's
+gate name rather than getting its own).
 
 ### 2.2 Routing phases (`RoutingPhase`) and their awaited actor
 
@@ -116,20 +124,24 @@ in `src/Subjects.ts`). The table below transcribes the classification
 and the actor it lands on (`"—"` = the row is resolved by the payload-dependent
 ladder, not by subject alone):
 
-| Subject                 | Class at that HEAD | Lands at (state, actor)                                                                                                                                                                                                                        |
-| ----------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `gtd: grilled`          | rest               | `grilled`, agent                                                                                                                                                                                                                               |
-| `gtd: planning`         | rest               | `building`, agent                                                                                                                                                                                                                              |
-| `gtd: tests green`      | rest or mid-chain  | `.gtd` present: force-approved → mid-chain `closePackage` → `close-package`, agent; not force-approved → rest `agentic-review`, agent. No `.gtd` (health path): squash-after-green → mid-chain `writeSquashTemplate`; else rest `idle`, human. |
-| `gtd: errors`           | rest               | `.gtd/ERRORS.md` present → `escalate`, human; else → `fixing`, agent                                                                                                                                                                           |
-| `gtd: package done`     | — (ladder)         | remaining packages → `building`, agent; else reviewable diff → `review`, agent; else idle/health                                                                                                                                               |
-| `gtd: awaiting review`  | rest               | `await-review`, human — while an invocation rests here, the program edge opens the review checkout window (see `await-review`, §4)                                                                                                             |
-| `gtd: review feedback`  | rest               | `grilling`, agent                                                                                                                                                                                                                              |
-| `gtd: done`             | rest or mid-chain  | squash enabled + squash base present → mid-chain `writeSquashTemplate`; else rest `idle`, human                                                                                                                                                |
-| `gtd: squash template`  | rest               | `squashing`, agent                                                                                                                                                                                                                             |
-| `gtd: reviewing <hash>` | rest               | `review`, agent                                                                                                                                                                                                                                |
-| `gtd: health-check`     | rest               | `.gtd/ERRORS.md` present → `escalate`, human; else → `health-fixing`, agent                                                                                                                                                                    |
-| `gtd: health-fix`       | rest (usually)     | `idle`, human — see the health-fix re-test carve-out below                                                                                                                                                                                     |
+| Subject                  | Class at that HEAD | Lands at (state, actor)                                                                                                                                                                                                                                                                               |
+| ------------------------ | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gtd: grilled`           | rest               | `grilled`, agent                                                                                                                                                                                                                                                                                      |
+| `gtd: planning`          | rest               | `building`, agent                                                                                                                                                                                                                                                                                     |
+| `gtd: tests green`       | rest or mid-chain  | `.gtd` present: force-approved → mid-chain `closePackage` → `close-package`, agent; not force-approved → rest `agentic-review`, agent. No `.gtd` (health path): learning enabled → mid-chain `writeLearningTemplate`; else squash enabled → mid-chain `writeSquashTemplate`; else rest `idle`, human. |
+| `gtd: errors`            | rest               | `.gtd/ERRORS.md` present → `escalate`, human; else → `fixing`, agent                                                                                                                                                                                                                                  |
+| `gtd: package done`      | — (ladder)         | remaining packages → `building`, agent; else reviewable diff → `review`, agent; else idle/health                                                                                                                                                                                                      |
+| `gtd: awaiting review`   | rest               | `await-review`, human — while an invocation rests here, the program edge opens the review checkout window (see `await-review`, §4)                                                                                                                                                                    |
+| `gtd: review feedback`   | rest               | `grilling`, agent                                                                                                                                                                                                                                                                                     |
+| `gtd: done`              | rest or mid-chain  | learning enabled + squash base present → mid-chain `writeLearningTemplate`; else squash enabled + squash base present → mid-chain `writeSquashTemplate`; else rest `idle`, human                                                                                                                      |
+| `gtd: squash template`   | rest               | `squashing`, agent                                                                                                                                                                                                                                                                                    |
+| `gtd: reviewing <hash>`  | rest               | `review`, agent                                                                                                                                                                                                                                                                                       |
+| `gtd: health-check`      | rest               | `.gtd/ERRORS.md` present → `escalate`, human; else → `health-fixing`, agent                                                                                                                                                                                                                           |
+| `gtd: health-fix`        | rest (usually)     | `idle`, human — see the health-fix re-test carve-out below                                                                                                                                                                                                                                            |
+| `gtd: learning template` | rest               | `learning`, agent                                                                                                                                                                                                                                                                                     |
+| `gtd: learning drafted`  | rest               | `await-learning-review`, human                                                                                                                                                                                                                                                                        |
+| `gtd: learning approved` | rest               | `learning-apply`, agent                                                                                                                                                                                                                                                                               |
+| `gtd: learning applied`  | rest or mid-chain  | squash enabled + squash base present → mid-chain `writeSquashTemplate`; else rest `idle`, human                                                                                                                                                                                                       |
 
 The parameterized anchor `gtd: reviewing <hash>` (`reviewingSubject` in
 `src/Subjects.ts`) is written only by `gtd review <target>` (§3); `<hash>` is
@@ -139,19 +151,22 @@ ordinary review-scope rules (§4, Review).
 **Turn-commit classification** (the other half of `classifyHead`, keyed on
 `(actor, gate)`):
 
-| Turn commit                  | Class                                      | Lands at                                                                                                                                                                                           |
-| ---------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `gtd(agent): grilling`       | empty diff → rest; non-empty → rest        | `grilling`, agent (empty, re-emit) or `grilling`, human (non-empty, answer gate)                                                                                                                   |
-| `gtd(human): grilling`       | empty diff → mid-chain; non-empty → rest   | empty → `commitRouting "gtd: grilled"` → `grilling`/agent picture; non-empty → rest `grilling`, agent                                                                                              |
-| `gtd(agent): grilled`        | mid-chain                                  | `commitRouting "gtd: planning"` (removes .gtd/TODO.md)                                                                                                                                             |
-| `gtd(agent): building`       | mid-chain                                  | `runTest`                                                                                                                                                                                          |
-| `gtd(agent): fixing`         | empty diff → rest; non-empty → mid-chain   | empty → rest `fixing`, agent (re-emit); non-empty → `runTest`                                                                                                                                      |
-| `gtd(agent): agentic-review` | rest                                       | `agentic-review`, agent (only reached when .gtd/FEEDBACK.md was never written at all — the .gtd/FEEDBACK.md-present cases are handled by the steering-file precedence check that runs before this) |
-| `gtd(agent): review`         | mid-chain                                  | `commitRouting "gtd: awaiting review"`                                                                                                                                                             |
-| `gtd(human): review`         | mid-chain                                  | substantive → `commitRouting "gtd: review feedback"` (removes .gtd/REVIEW.md); non-substantive (clean or checkbox-only) → `commitRouting "gtd: done"` (removes .gtd/REVIEW.md)                     |
-| `gtd(agent): squashing`      | squash base present → mid-chain; else rest | mid-chain → `squashCommit`; rest → `squashing`, agent                                                                                                                                              |
-| `gtd(agent): health-fixing`  | mid-chain                                  | `commitRouting "gtd: health-fix"` (removes .gtd/HEALTH.md)                                                                                                                                         |
-| `gtd(human): escalate`       | mid-chain                                  | `runTest` (re-test after the human's fix)                                                                                                                                                          |
+| Turn commit                  | Class                                                     | Lands at                                                                                                                                                                                           |
+| ---------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gtd(agent): grilling`       | empty diff → rest; non-empty → rest                       | `grilling`, agent (empty, re-emit) or `grilling`, human (non-empty, answer gate)                                                                                                                   |
+| `gtd(human): grilling`       | empty diff → mid-chain; non-empty → rest                  | empty → `commitRouting "gtd: grilled"` → `grilling`/agent picture; non-empty → rest `grilling`, agent                                                                                              |
+| `gtd(agent): grilled`        | mid-chain                                                 | `commitRouting "gtd: planning"` (removes .gtd/TODO.md)                                                                                                                                             |
+| `gtd(agent): building`       | mid-chain                                                 | `runTest`                                                                                                                                                                                          |
+| `gtd(agent): fixing`         | empty diff → rest; non-empty → mid-chain                  | empty → rest `fixing`, agent (re-emit); non-empty → `runTest`                                                                                                                                      |
+| `gtd(agent): agentic-review` | rest                                                      | `agentic-review`, agent (only reached when .gtd/FEEDBACK.md was never written at all — the .gtd/FEEDBACK.md-present cases are handled by the steering-file precedence check that runs before this) |
+| `gtd(agent): review`         | mid-chain                                                 | `commitRouting "gtd: awaiting review"`                                                                                                                                                             |
+| `gtd(human): review`         | mid-chain                                                 | substantive → `commitRouting "gtd: review feedback"` (removes .gtd/REVIEW.md); non-substantive (clean or checkbox-only) → `commitRouting "gtd: done"` (removes .gtd/REVIEW.md)                     |
+| `gtd(agent): squashing`      | squash base present → mid-chain; else rest                | mid-chain → `squashCommit`; rest → `squashing`, agent                                                                                                                                              |
+| `gtd(agent): health-fixing`  | mid-chain                                                 | `commitRouting "gtd: health-fix"` (removes .gtd/HEALTH.md)                                                                                                                                         |
+| `gtd(human): escalate`       | mid-chain                                                 | `runTest` (re-test after the human's fix)                                                                                                                                                          |
+| `gtd(agent): learning`       | squash base present + non-template → mid-chain; else rest | mid-chain → `commitRouting "gtd: learning drafted"`; rest → `learning`, agent (re-emit until the agent overwrites the template)                                                                    |
+| `gtd(human): learning`       | mid-chain (unconditional — no reject path)                | `commitRouting "gtd: learning approved"`                                                                                                                                                           |
+| `gtd(agent): learning-apply` | mid-chain                                                 | `commitRouting "gtd: learning applied"` (removes .gtd/LEARNINGS.md)                                                                                                                                |
 
 **The health-fix re-test carve-out.** `gtd: health-fix` classifies as a plain
 rest (`idle`, human) for `gtd next` / `gtd status` — a clean tree there
@@ -332,12 +347,13 @@ committed.
 
 ## 4. Per-state documentation
 
-The 16 frozen `GtdState`s (`src/Machine.ts`). 11 are prompt-bearing
+The 20 frozen `GtdState`s (`src/Machine.ts`). 14 are prompt-bearing
 (`isPromptState` in `src/Prompt.ts`): `grilling`, `grilled`, `building`,
-`fixing`, `agentic-review`, `review`, `await-review`, `squashing`, `escalate`,
-`idle`, `health-fixing`. The other 5 — `testing`, `planning`, `close-package`,
-`done`, `health-check` — are performed entirely by the driver/edge and must
-never reach `buildPrompt` (it throws if they do).
+`fixing`, `agentic-review`, `review`, `await-review`, `squashing`, `learning`,
+`await-learning-review`, `learning-apply`, `escalate`, `idle`, `health-fixing`.
+The other 6 — `testing`, `planning`, `close-package`, `done`, `health-check`,
+`learning-applied` — are performed entirely by the driver/edge and must never
+reach `buildPrompt` (it throws if they do).
 
 ### `grilling`
 
@@ -681,14 +697,104 @@ Invariants:
 
 **Means:** the review approved; the cycle is closing. Edge-only.
 
-**Awaited actor:** agent (mid-chain) when squash is queued, otherwise this
-routing subject rests at **idle** (human) directly.
+**Awaited actor:** agent (mid-chain) when learning or squash is queued,
+otherwise this routing subject rests at **idle** (human) directly.
 
 **Actions:** none of its own beyond having been committed by the review's
 mid-chain hop (`commitRouting "gtd: done"`, removing .gtd/REVIEW.md).
 
-**Exit:** squash enabled and a squash base is present → mid-chain
+**Exit:** learning enabled and a squash base is present → mid-chain
+`writeLearningTemplate` → **learning** (the learning phase runs before the
+squash decision, since it needs the same pre-squash history the squash base
+covers). Otherwise, squash enabled and a squash base is present → mid-chain
 `writeSquashTemplate` → **squashing**. Otherwise → rest at **idle**.
+
+### `learning`
+
+**Means:** the cycle is approved and (if squash is also on) headed for a squash
+— before that history collapses, the agent distills durable lessons from it into
+`.gtd/LEARNINGS.md`. Reached from the same two entry points as squashing (a
+feature cycle's `gtd: done`, or a health-fix cycle's green re-test), reusing the
+identical squash base/diff.
+
+**Awaited actor:** agent.
+
+**Actions (two-hop flow, mirrors `squashing`):**
+
+1. `writeLearningTemplate` — write a fixed skeleton to `.gtd/LEARNINGS.md` and
+   commit it as `gtd: learning template`. Nothing is drafted yet.
+2. `gtd next` at that rest renders `@learning` — walk the cycle's
+   `gtd: .../gtd(agent): .../gtd(human): ...` history (test failures and fixes,
+   review feedback, health-check rounds, grilling decisions), keep only
+   durable/generalizable lessons, and **overwrite** `.gtd/LEARNINGS.md` with
+   them (leaving it uncommitted).
+3. `gtd(agent): learning`, once `.gtd/LEARNINGS.md` no longer holds the
+   unmodified template, mid-chains to `commitRouting "gtd: learning drafted"` →
+   **await-learning-review**. While the template is still unmodified, this turn
+   is inert (re-emits the same prompt), exactly like `squashing`'s own template
+   guard.
+
+**Exit:** `commitRouting "gtd: learning drafted"` → **await-learning-review**.
+
+### `await-learning-review`
+
+**Means:** a human gate — the agent's `.gtd/LEARNINGS.md` draft is ready for
+review. There is no reject/redo path here: the human either accepts the draft
+as-is or edits it in place, and either way the very next `gtd step` proceeds
+forward. This is a deliberate simplification from `review`'s dual-branch
+(approve vs. feedback) — refining what gets kept is not the same kind of
+decision as approving finished work.
+
+**Awaited actor:** human.
+
+**Prompt:** `@await-learning-review` — read `.gtd/LEARNINGS.md`, delete anything
+not worth keeping or add anything missed, then run `gtd step` (with or without
+edits).
+
+**Actions:** `gtd(human): learning` unconditionally mid-chains to
+`commitRouting "gtd: learning approved"` — an empty human turn here is a signal
+("accept as-is"), not a no-op, same as an empty turn at `review`/ `grilling`'s
+answer gate.
+
+**Exit:** `commitRouting "gtd: learning approved"` → **learning-apply**.
+
+### `learning-apply`
+
+**Means:** the human-approved learnings are ready to be integrated into the
+project's own memory — `CLAUDE.md`, `AGENTS.md`, or whichever doc fits, agent's
+judgment. `.gtd/LEARNINGS.md` itself is never the final home; it's deleted once
+this turn lands.
+
+**Awaited actor:** agent.
+
+**Prompt:** `@learning-apply` — read the approved `.gtd/LEARNINGS.md`, integrate
+its points into the relevant project doc(s), leave uncommitted. Never edit or
+delete `.gtd/LEARNINGS.md` directly — the machine removes it.
+
+**Actions:** `gtd(agent): learning-apply` mid-chains to
+`commitRouting "gtd: learning applied"`, removing `.gtd/LEARNINGS.md`. A clean
+tree here is a plain do-nothing agent turn (no doc edits to capture) —
+unconditionally inert, unlike `health-fixing`'s meaningful empty turn.
+
+**Exit:** `commitRouting "gtd: learning applied"` → **learning-applied**.
+
+### `learning-applied`
+
+**Means:** the learning phase is done; `.gtd/LEARNINGS.md` is gone, and the
+project's docs carry whatever survived review. Edge-only — runs the exact same
+squash decision `done` runs, now that learning has already had its turn.
+
+**Awaited actor:** agent (mid-chain) when squash is queued, otherwise this
+routing subject rests at **idle** (human) directly.
+
+**Actions:** none of its own beyond having been committed by `learning-apply`'s
+mid-chain hop.
+
+**Exit:** squash enabled and a squash base is present → mid-chain
+`writeSquashTemplate` → **squashing**. Otherwise → rest at **idle**. The doc
+edits landed in `gtd(agent): learning-apply` are folded into the eventual squash
+commit's tree (they survive there, not as their own commit) when squash is also
+on.
 
 ### `squashing`
 
@@ -768,15 +874,17 @@ discipline as `fixing`/`.gtd/FEEDBACK.md`.
 **Exit:** the fixer's own turn commit `gtd(agent): health-fixing` mid-chains
 straight into removing .gtd/HEALTH.md and committing `gtd: health-fix`. The next
 resolve at `gtd: health-fix` (same invocation, mid-chain — §2's carve-out)
-re-runs `testCommand`: green with squash queued → commit `gtd: tests green` →
-continues into the squash template chain; green with no squash queued → stop
-with zero further commits (a plain idle rest); red below cap → write a fresh
-`.gtd/HEALTH.md`, commit `gtd: health-check`, loop again; red at cap → write
-`.gtd/ERRORS.md`, commit `gtd: health-check` → **escalate**.
+re-runs `testCommand`: green with learning or squash queued → commit
+`gtd: tests green` → continues into the learning template chain (if learning is
+on) or straight into the squash template chain (learning off, squash on); green
+with neither queued → stop with zero further commits (a plain idle rest); red
+below cap → write a fresh `.gtd/HEALTH.md`, commit `gtd: health-check`, loop
+again; red at cap → write `.gtd/ERRORS.md`, commit `gtd: health-check` →
+**escalate**.
 
 ### `health-check`
 
-One of the 16 frozen `GtdState`s, but no code path in `resolve` ever reports
+One of the 20 frozen `GtdState`s, but no code path in `resolve` ever reports
 `state: "health-check"` — it never appears as a `Result.state`. The health check
 itself runs as the internal `runHealthCheck` edge action, invoked from
 **idle**'s carve-out or from the `gtd: health-fix` re-test hop; its output is
@@ -792,15 +900,22 @@ wins; anything matching nothing is `corruption` — a hard error, never a guess.
 
 ### 5.1 Illegal-combination guard (`assertLegal`, before anything else)
 
-Checked in two passes — .gtd/HEALTH.md-specific rules first (so a
+Checked in three passes — .gtd/HEALTH.md-specific rules first (so a
 .gtd/HEALTH.md + .gtd/FEEDBACK.md, say, gets the two-file diagnosis rather than
-the more generic single-file one), then the rest:
+the more generic single-file one), then .gtd/LEARNINGS.md-specific rules, then
+the rest:
 
 ```
 .gtd/HEALTH.md + .gtd
 .gtd/HEALTH.md + .gtd/REVIEW.md
 .gtd/HEALTH.md + .gtd/FEEDBACK.md
 .gtd/HEALTH.md + .gtd/ERRORS.md
+.gtd/LEARNINGS.md + .gtd
+.gtd/LEARNINGS.md + .gtd/REVIEW.md
+.gtd/LEARNINGS.md + .gtd/FEEDBACK.md
+.gtd/LEARNINGS.md + .gtd/ERRORS.md
+.gtd/LEARNINGS.md + .gtd/HEALTH.md
+.gtd/LEARNINGS.md + .gtd/SQUASH_MSG.md
 .gtd/REVIEW.md + .gtd
 .gtd/REVIEW.md + committed .gtd/TODO.md
 uncommitted .gtd/REVIEW.md + .gtd/TODO.md
@@ -811,6 +926,12 @@ uncommitted .gtd/REVIEW.md + .gtd/TODO.md
                           .gtd/ERRORS.md briefly outlives .gtd during the health-check
                           cap escalation)
 ```
+
+The `.gtd/LEARNINGS.md` rules are defensive, not load-bearing: unlike
+`.gtd/HEALTH.md`, `.gtd/LEARNINGS.md`'s presence never drives a routing decision
+on its own (§5.2 doesn't mention it) — only `classifyHead`'s `learning` gate
+branch reads it, and none of these six combinations can arise on a legal
+history.
 
 Each is a predicate over `ResolvePayload` paired with the exact diagnosis string
 `GtdStateError` throws.
@@ -893,7 +1014,7 @@ subject and tree cleanliness in its message. Never guessed past.
 ## 6. Canonical transcripts
 
 Mirrors `tests/integration/features/journeys.feature`. All examples below assume
-`agenticReview: false` and `squash: false` unless noted.
+`agenticReview: false`, `squash: false`, and `learning: false` unless noted.
 
 ### Happy path (no detours)
 
@@ -932,6 +1053,28 @@ gtd: squash template          # writeSquashTemplate
 whose subject is the message's first line (e.g.
 `feat: add calculator with add support`). None of the intermediate `gtd: *` /
 `gtd(actor): *` subjects survive in the final log.
+
+### Happy path with learning on
+
+Same sequence through `gtd: done`, but the same invocation continues straight to
+the learning phase first — before the squash decision, if squash is also on:
+
+```
+gtd: learning template          # writeLearningTemplate
+<gtd next → learning prompt with the full-process diff>
+gtd(agent): learning            # agent drafts .gtd/LEARNINGS.md (non-template)
+gtd: learning drafted           # routing: rest for the human
+gtd(human): learning            # human accepts as-is or edits — no reject path
+gtd: learning approved          # routing: rest for the agent
+gtd(agent): learning-apply      # agent integrates into CLAUDE.md/AGENTS.md/docs
+gtd: learning applied           # routing: .gtd/LEARNINGS.md removed
+```
+
+From `gtd: learning applied`, the exact same squash decision `gtd: done` makes
+runs again: squash on continues to `gtd: squash template` (§"Happy path with
+squash on"); squash off rests at **idle**. When both are on, the doc edits
+landed in `gtd(agent): learning-apply` are folded into the eventual squash
+commit's tree — they survive there, not as a separate commit.
 
 ### Red-then-fixed detour (build/test/fix loop)
 
@@ -992,8 +1135,9 @@ cleanly.
 gtd: health-check                # red below cap: .gtd/HEALTH.md written
 gtd(agent): health-fixing       # fixer's own turn
 gtd: health-fix                   # .gtd/HEALTH.md removed; re-tests in the same chain
-# green, squash off → stop, plain idle rest, zero further commits
-# green, squash on  → gtd: tests green → gtd: squash template → ... → one squash commit
+# green, learning off, squash off → stop, plain idle rest, zero further commits
+# green, learning on               → gtd: tests green → gtd: learning template → ... (learning phase, then the squash decision)
+# green, learning off, squash on  → gtd: tests green → gtd: squash template → ... → one squash commit
 # red, below cap    → gtd: health-check again (loop)
 # red, at cap       → .gtd/ERRORS.md written, gtd: health-check → escalate
 ```

--- a/schema.json
+++ b/schema.json
@@ -57,6 +57,9 @@
     "squash": {
       "type": "boolean"
     },
+    "learning": {
+      "type": "boolean"
+    },
     "fixAttemptCap": {
       "$ref": "#/$defs/Int",
       "description": "a non-negative number",

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -46,6 +46,7 @@ export const builtinTierDefault: Record<ModelTier, string> = {
 const DEFAULT_TEST_COMMAND = "npm run test"
 const DEFAULT_AGENTIC_REVIEW = true
 const DEFAULT_SQUASH = true
+const DEFAULT_LEARNING = true
 const DEFAULT_FIX_ATTEMPT_CAP = 3
 const DEFAULT_REVIEW_THRESHOLD = 3
 
@@ -72,6 +73,7 @@ export const ConfigSchema = Schema.Struct({
   models: Schema.optional(ModelsSchema),
   agenticReview: Schema.optional(Schema.Boolean),
   squash: Schema.optional(Schema.Boolean),
+  learning: Schema.optional(Schema.Boolean),
   fixAttemptCap: Schema.optional(Schema.Int.pipe(Schema.greaterThanOrEqualTo(0))),
   reviewThreshold: Schema.optional(Schema.Int.pipe(Schema.greaterThanOrEqualTo(1))),
 })
@@ -83,6 +85,7 @@ export interface ConfigOperations {
   readonly resolveModel: (state: ModelState) => string
   readonly agenticReview: boolean
   readonly squash: boolean
+  readonly learning: boolean
   readonly fixAttemptCap: number
   readonly reviewThreshold: number
 }
@@ -262,6 +265,7 @@ const toOperations = (decoded: DecodedConfig): ConfigOperations => {
     resolveModel,
     agenticReview: decoded.agenticReview ?? DEFAULT_AGENTIC_REVIEW,
     squash: decoded.squash ?? DEFAULT_SQUASH,
+    learning: decoded.learning ?? DEFAULT_LEARNING,
     fixAttemptCap: decoded.fixAttemptCap ?? DEFAULT_FIX_ATTEMPT_CAP,
     reviewThreshold: decoded.reviewThreshold ?? DEFAULT_REVIEW_THRESHOLD,
   }

--- a/src/Events.test.ts
+++ b/src/Events.test.ts
@@ -66,6 +66,9 @@ const fakeConfig = (o: Partial<ConfigOperations> = {}): ConfigOperations => ({
   resolveModel: () => "claude-opus-4-8",
   agenticReview: true,
   squash: true,
+  // Isolated from squash-specific tests below by default — learning has its
+  // own describe block that opts back in via the `o` override.
+  learning: false,
   fixAttemptCap: 3,
   reviewThreshold: 3,
   ...o,
@@ -107,6 +110,7 @@ const runPerform = (
           resolveModel: () => "stub",
           agenticReview: true,
           squash: true,
+          learning: false,
           fixAttemptCap: 3,
           reviewThreshold: 3,
         }),
@@ -1209,10 +1213,10 @@ describe("perform — EdgeAction execution", { timeout: 30_000 }, () => {
     expect(result.stop).toBe(false)
   })
 
-  it("runHealthCheck green, no squash chain queued → no commit, stop: true", async () => {
+  it("runHealthCheck green, no learning/squash chain queued → no commit, stop: true", async () => {
     const countBefore = git("rev-list", "--count", "HEAD")
     const result = await runPerform(
-      { kind: "runHealthCheck", errorCount: 0, capReached: false, squashAfterGreen: false },
+      { kind: "runHealthCheck", errorCount: 0, capReached: false, chainAfterGreen: false },
       { exitCode: 0, output: "all good" },
     )
     expect(result.stop).toBe(true)
@@ -1220,10 +1224,10 @@ describe("perform — EdgeAction execution", { timeout: 30_000 }, () => {
     expect(existsSync(join(repoDir, ".gtd/HEALTH.md"))).toBe(false)
   })
 
-  it("runHealthCheck green, squashAfterGreen → commits gtd: tests green, stop: false", async () => {
+  it("runHealthCheck green, chainAfterGreen → commits gtd: tests green, stop: false", async () => {
     const countBefore = Number(git("rev-list", "--count", "HEAD"))
     const result = await runPerform(
-      { kind: "runHealthCheck", errorCount: 1, capReached: false, squashAfterGreen: true },
+      { kind: "runHealthCheck", errorCount: 1, capReached: false, chainAfterGreen: true },
       { exitCode: 0, output: "all good" },
     )
     expect(result.stop).toBe(false)
@@ -1235,7 +1239,7 @@ describe("perform — EdgeAction execution", { timeout: 30_000 }, () => {
 
   it("runHealthCheck red below cap → writes HEALTH.md, commits gtd: health-check, stop: false", async () => {
     const result = await runPerform(
-      { kind: "runHealthCheck", errorCount: 1, capReached: false, squashAfterGreen: false },
+      { kind: "runHealthCheck", errorCount: 1, capReached: false, chainAfterGreen: false },
       { exitCode: 1, output: "FAIL: test boom\n" },
     )
     expect(result.stop).toBe(false)
@@ -1249,7 +1253,7 @@ describe("perform — EdgeAction execution", { timeout: 30_000 }, () => {
 
   it("runHealthCheck red at cap → writes ERRORS.md, commits gtd: health-check, stop: false", async () => {
     const result = await runPerform(
-      { kind: "runHealthCheck", errorCount: 3, capReached: true, squashAfterGreen: false },
+      { kind: "runHealthCheck", errorCount: 3, capReached: true, chainAfterGreen: false },
       { exitCode: 1, output: "FAIL: persistent\n" },
     )
     expect(result.stop).toBe(false)

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -42,6 +42,7 @@ const FEEDBACK_FILE = `${GTD_DIR}/FEEDBACK.md`
 const ERRORS_FILE = `${GTD_DIR}/ERRORS.md`
 const HEALTH_FILE = `${GTD_DIR}/HEALTH.md`
 const SQUASH_MSG_FILE = `${GTD_DIR}/SQUASH_MSG.md`
+const LEARNINGS_FILE = `${GTD_DIR}/LEARNINGS.md`
 // Pre-namespace history wrote FEEDBACK.md at the repo root. Recognized for
 // COMMIT-event classification only (isFeedback), never for diffs or
 // working-tree probes — a root FEEDBACK.md in the tree today is project code.
@@ -69,6 +70,24 @@ const GATE_OWN_STEERING_FILE: Partial<Record<string, string>> = {
   grilling: TODO_FILE,
   review: REVIEW_FILE,
 }
+
+// Routing phases and turn gates spanning the squash/learning chain
+// (`gtd: done` → … → `gtd(agent): squashing`) — used to decide when
+// `squashBase`/`squashDiff` must stay computed so the range is stable across
+// the whole chain, including the learning phase now spliced in front of the
+// squash template write.
+const SQUASH_OR_LEARNING_ROUTING_PHASES: ReadonlySet<string> = new Set([
+  "squash-template",
+  "learning-template",
+  "learning-drafted",
+  "learning-approved",
+  "learning-applied",
+])
+const SQUASH_OR_LEARNING_TURN_GATES: ReadonlySet<string> = new Set([
+  "squashing",
+  "learning",
+  "learning-apply",
+])
 
 const turnDiffExcludes = (gate: string): ReadonlyArray<string> => {
   const ownFile = GATE_OWN_STEERING_FILE[gate]
@@ -585,23 +604,25 @@ export const gatherEvents = (
     }
 
     // --- Squash base + diff (squashing after gtd: done) ----------------------
-    // Computed whenever HEAD is `gtd: done` or anywhere in the squash chain
-    // `gtd: done` → `gtd: squash template` → `gtd(agent): squashing` triggers
-    // (squash is enabled): the mid-chain `squashCommit` action performed at
-    // the `gtd(agent): squashing` HEAD needs `squashBase` on THAT hop, by
-    // which point HEAD has moved past `gtd: done` itself. The squash range is
+    // Computed whenever HEAD is `gtd: done` or anywhere in the squash/learning
+    // chain `gtd: done` → [learning phase] → `gtd: squash template` →
+    // `gtd(agent): squashing` (squash and/or learning enabled): every
+    // mid-chain hop across that whole range needs `squashBase` stable and
+    // available — in particular the learning-draft agent turn (`gtd(agent):
+    // learning`), which would otherwise never see `hasSquashBase` true and
+    // livelock re-capturing an empty turn forever. The squash range is
     // the cycle ENDING at the last `gtd: done` found in history (not
     // necessarily HEAD), not `currentCycle` which is empty once HEAD is past it.
     let squashBase: string | undefined
     let squashDiff: string | undefined
     const headParsedForSquash = parseSubject(lastCommitSubject)
-    const inSquashChain =
+    const inSquashOrLearningChain =
       lastCommitSubject === DONE_SUBJECT ||
-      (headParsedForSquash.kind === "routing" && headParsedForSquash.phase === "squash-template") ||
+      (headParsedForSquash.kind === "routing" &&
+        SQUASH_OR_LEARNING_ROUTING_PHASES.has(headParsedForSquash.phase)) ||
       (headParsedForSquash.kind === "turn" &&
-        headParsedForSquash.actor === "agent" &&
-        headParsedForSquash.gate === "squashing")
-    if (hasCommits && inSquashChain && config.squash) {
+        SQUASH_OR_LEARNING_TURN_GATES.has(headParsedForSquash.gate))
+    if (hasCommits && inSquashOrLearningChain && (config.squash || config.learning)) {
       // Scan `history` (merge-base..HEAD on a feature branch), NOT the whole
       // history: commits below the merge-base exist on the default branch, and
       // a squash reset must never rewrite them. On trunk (no merge-base),
@@ -681,18 +702,27 @@ export const gatherEvents = (
       squashMsgPresent &&
       (yield* fs.readFileString(resolve(SQUASH_MSG_FILE))).trim() === SQUASH_TEMPLATE.trim()
 
+    // --- LEARNINGS.md presence (learning template written+overwritten) -------
+    const learningMsgPresent = yield* fs.exists(resolve(LEARNINGS_FILE))
+    // Unmodified template → the machine must not mid-chain the agent's draft
+    // turn yet (mirrors squashMsgIsTemplate).
+    const learningMsgIsTemplate =
+      learningMsgPresent &&
+      (yield* fs.readFileString(resolve(LEARNINGS_FILE))).trim() === LEARNING_TEMPLATE.trim()
+
     // --- HEALTH.md presence (health-check output written by runHealthCheck) -----
     const healthPresent = yield* fs.exists(resolve(HEALTH_FILE))
     const healthContent = healthPresent ? yield* fs.readFileString(resolve(HEALTH_FILE)) : ""
     const healthCommitted = healthPresent && !isUncommitted(HEALTH_FILE)
 
-    // --- Health squash base (squash after green health-fix run) ------------------
-    // Only computed when squash is enabled. Mirrors foldCounters: scans all of
-    // history forward, resetting on isPackageStart/removedErrors events,
-    // tracking the FIRST `gtd: health-check` of the current health run.
-    // healthFixBase is the parent of that first health-check commit.
+    // --- Health squash base (squash/learning after green health-fix run) --------
+    // Only computed when squash and/or learning is enabled. Mirrors
+    // foldCounters: scans all of history forward, resetting on
+    // isPackageStart/removedErrors events, tracking the FIRST
+    // `gtd: health-check` of the current health run. healthFixBase is the
+    // parent of that first health-check commit.
     let healthFixBase: string | undefined
-    if (config.squash) {
+    if (config.squash || config.learning) {
       let firstHealthCheckHash: string | undefined
       let healthCheckCount = 0
       for (const commit of commitEvents) {
@@ -779,6 +809,9 @@ export const gatherEvents = (
       healthContent,
       healthCommitted,
       ...(healthFixBase !== undefined ? { healthFixBase } : {}),
+      learningEnabled: config.learning,
+      learningMsgPresent,
+      learningMsgIsTemplate,
     }
 
     const resolveEvent: GtdEvent = { type: "RESOLVE", payload }
@@ -827,6 +860,20 @@ const SQUASH_TEMPLATE = [
   "type: short summary",
   "",
   "Longer description of the change, if needed.",
+  "",
+].join("\n")
+
+/**
+ * A short skeleton written by `writeLearningTemplate`, instructing the
+ * learning agent to replace it with the real distilled learnings.
+ */
+const LEARNING_TEMPLATE = [
+  "<!-- gtd: replace this file's content with the actual distilled learnings for this cycle. -->",
+  "<!-- Keep only durable, generalizable lessons — delete anything that's a one-off detail. -->",
+  "",
+  "## Learnings",
+  "",
+  "- ...",
   "",
 ].join("\n")
 
@@ -888,6 +935,9 @@ export const perform = (
         if (action.removeHealth === true) {
           yield* fs.remove(resolve(HEALTH_FILE)).pipe(Effect.catchAll(() => Effect.void))
         }
+        if (action.removeLearning === true) {
+          yield* fs.remove(resolve(LEARNINGS_FILE)).pipe(Effect.catchAll(() => Effect.void))
+        }
         yield* git.commitAllWithPrefix(action.subject)
         return { stop: false }
       }
@@ -941,6 +991,15 @@ export const perform = (
         return { stop: false }
       }
 
+      // Write the LEARNINGS.md template (a durable-lessons skeleton) and
+      // commit routing `gtd: learning template`.
+      case "writeLearningTemplate": {
+        yield* ensureGtdDir
+        yield* fs.writeFileString(resolve(LEARNINGS_FILE), LEARNING_TEMPLATE)
+        yield* git.commitAllWithPrefix("gtd: learning template")
+        return { stop: false }
+      }
+
       // Squash: read SQUASH_MSG.md content (the real message authored by the
       // squashing turn), rm it, soft-reset to squashBase, commit-all under the
       // file's content as the message.
@@ -955,10 +1014,11 @@ export const perform = (
       }
 
       // Health check: run tests on an idle/clean tree.
-      // Green, no squash-after chain queued → stop immediately, no commit/write.
-      // Green, `squashAfterGreen` → commit routing `gtd: tests green` (the
+      // Green, no learning/squash-after chain queued → stop immediately, no
+      //   commit/write.
+      // Green, `chainAfterGreen` → commit routing `gtd: tests green` (the
       //   observable green marker) and continue — the resolver chains
-      //   `writeSquashTemplate` at that HEAD next.
+      //   `writeLearningTemplate` or `writeSquashTemplate` at that HEAD next.
       // Red below cap → write HEALTH.md, commit routing `gtd: health-check` (the
       //   always-clean invariant: write-and-commit in the same chain).
       // Red at cap → write ERRORS.md, commit routing `gtd: health-check`.
@@ -966,7 +1026,7 @@ export const perform = (
         const runner = yield* TestRunner
         const result = yield* runner.run()
         if (result.exitCode === 0) {
-          if (action.squashAfterGreen) {
+          if (action.chainAfterGreen) {
             yield* git.commitAllWithPrefix("gtd: tests green")
             return { stop: false }
           }

--- a/src/Machine.property.test.ts
+++ b/src/Machine.property.test.ts
@@ -40,6 +40,9 @@ const TURN_SUBJECTS = [
   "gtd(agent): squashing",
   "gtd(agent): health-fixing",
   "gtd(human): escalate",
+  "gtd(agent): learning",
+  "gtd(human): learning",
+  "gtd(agent): learning-apply",
 ] as const
 
 const ROUTING_SUBJECTS = [
@@ -54,6 +57,10 @@ const ROUTING_SUBJECTS = [
   "gtd: squash template",
   "gtd: health-check",
   "gtd: health-fix",
+  "gtd: learning template",
+  "gtd: learning drafted",
+  "gtd: learning approved",
+  "gtd: learning applied",
 ] as const
 
 const BOUNDARY_SUBJECTS = [
@@ -98,6 +105,7 @@ const arbPayload: fc.Arbitrary<ResolvePayload> = fc
     healthCommittedRaw: fc.boolean(),
     squashEnabled: fc.boolean(),
     hasSquashBase: fc.boolean(),
+    learningEnabled: fc.boolean(),
   })
   // fallow-ignore-next-line complexity
   .map((raw): ResolvePayload => {
@@ -145,6 +153,9 @@ const arbPayload: fc.Arbitrary<ResolvePayload> = fc
       healthContent: raw.healthPresent ? "health finding" : "",
       healthCommitted: raw.healthPresent && raw.healthCommittedRaw,
       ...(raw.hasSquashBase ? { squashBase: "def456", squashDiff: "diff" } : {}),
+      learningEnabled: raw.learningEnabled,
+      learningMsgPresent: false,
+      learningMsgIsTemplate: false,
     }
   })
 
@@ -219,6 +230,10 @@ const ALL_STATES: ReadonlySet<GtdState> = new Set<GtdState>([
   "review",
   "await-review",
   "done",
+  "learning",
+  "await-learning-review",
+  "learning-apply",
+  "learning-applied",
   "squashing",
   "idle",
   "health-check",

--- a/src/Machine.test.ts
+++ b/src/Machine.test.ts
@@ -143,12 +143,22 @@ describe("awaitedActor", () => {
     expect(awaitedActor("await-review")).toBe("human")
   })
 
+  it("is human for await-learning-review", () => {
+    expect(awaitedActor("await-learning-review")).toBe("human")
+  })
+
   it("is agent for building, fixing, agentic-review, squashing, health-fixing", () => {
     expect(awaitedActor("building")).toBe("agent")
     expect(awaitedActor("fixing")).toBe("agent")
     expect(awaitedActor("agentic-review")).toBe("agent")
     expect(awaitedActor("squashing")).toBe("agent")
     expect(awaitedActor("health-fixing")).toBe("agent")
+  })
+
+  it("is agent for learning, learning-apply, learning-applied", () => {
+    expect(awaitedActor("learning")).toBe("agent")
+    expect(awaitedActor("learning-apply")).toBe("agent")
+    expect(awaitedActor("learning-applied")).toBe("agent")
   })
 })
 
@@ -374,6 +384,182 @@ describe("squash chain", () => {
       }),
     ])
     expect(result.edgeAction).toEqual({ kind: "squashCommit", squashBase: "abc123" })
+  })
+
+  it("gtd: done + squash enabled + learning enabled + squashBase → writeLearningTemplate (learning runs first)", () => {
+    const result = resolve([
+      R({
+        invoker: "agent",
+        lastCommitSubject: "gtd: done",
+        squashEnabled: true,
+        learningEnabled: true,
+        squashBase: "abc123",
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.edgeAction).toEqual({ kind: "writeLearningTemplate" })
+  })
+
+  it("gtd: done + learning enabled + squash disabled + squashBase → writeLearningTemplate (orthogonal to squash)", () => {
+    const result = resolve([
+      R({
+        invoker: "agent",
+        lastCommitSubject: "gtd: done",
+        squashEnabled: false,
+        learningEnabled: true,
+        squashBase: "abc123",
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.edgeAction).toEqual({ kind: "writeLearningTemplate" })
+  })
+})
+
+// ── Learning chain ────────────────────────────────────────────────────────
+
+describe("learning chain", () => {
+  it("gtd: learning template → rest learning prompt for agent", () => {
+    const result = resolve([
+      R({ invoker: "none", lastCommitSubject: "gtd: learning template", workingTreeClean: true }),
+    ])
+    expect(result.state).toBe("learning")
+    expect(result.actor).toBe("agent")
+    expect(result.edgeAction).toBeUndefined()
+  })
+
+  it("unmodified LEARNINGS.md template never mid-chains — rests until the agent drafts real content", () => {
+    const result = resolve([
+      R({
+        invoker: "agent",
+        lastCommitSubject: "gtd(agent): learning",
+        squashBase: "abc123",
+        learningMsgIsTemplate: true,
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.state).toBe("learning")
+    expect(result.actor).toBe("agent")
+    expect(result.edgeAction).toBeUndefined()
+  })
+
+  it("gtd(agent): learning with real content → commitRouting gtd: learning drafted", () => {
+    const result = resolve([
+      R({
+        invoker: "agent",
+        lastCommitSubject: "gtd(agent): learning",
+        squashBase: "abc123",
+        learningMsgIsTemplate: false,
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.edgeAction).toEqual({
+      kind: "commitRouting",
+      subject: "gtd: learning drafted",
+    })
+  })
+
+  it("gtd: learning drafted → rest await-learning-review prompt for human", () => {
+    const result = resolve([
+      R({ invoker: "none", lastCommitSubject: "gtd: learning drafted", workingTreeClean: true }),
+    ])
+    expect(result.state).toBe("await-learning-review")
+    expect(result.actor).toBe("human")
+    expect(result.edgeAction).toBeUndefined()
+  })
+
+  it("gtd(human): learning (even empty — accept as-is) → commitRouting gtd: learning approved", () => {
+    const result = resolve([
+      R({
+        invoker: "human",
+        lastCommitSubject: "gtd(human): learning",
+        headTurnIsEmpty: true,
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.edgeAction).toEqual({
+      kind: "commitRouting",
+      subject: "gtd: learning approved",
+    })
+  })
+
+  it("gtd: learning approved → rest learning-apply prompt for agent", () => {
+    const result = resolve([
+      R({ invoker: "none", lastCommitSubject: "gtd: learning approved", workingTreeClean: true }),
+    ])
+    expect(result.state).toBe("learning-apply")
+    expect(result.actor).toBe("agent")
+    expect(result.edgeAction).toBeUndefined()
+  })
+
+  it("a clean tree at learning-apply is inert (no doc edits to capture)", () => {
+    const result = resolve([
+      R({
+        invoker: "agent",
+        lastCommitSubject: "gtd: learning approved",
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.state).toBe("learning-apply")
+    expect(result.actor).toBe("agent")
+    expect(result.edgeAction).toBeUndefined()
+  })
+
+  it("gtd(agent): learning-apply → commitRouting gtd: learning applied, removeLearning", () => {
+    const result = resolve([
+      R({
+        invoker: "agent",
+        lastCommitSubject: "gtd(agent): learning-apply",
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.edgeAction).toEqual({
+      kind: "commitRouting",
+      subject: "gtd: learning applied",
+      removeLearning: true,
+    })
+  })
+
+  it("gtd: learning applied + squash enabled + squashBase → writeSquashTemplate", () => {
+    const result = resolve([
+      R({
+        invoker: "agent",
+        lastCommitSubject: "gtd: learning applied",
+        squashEnabled: true,
+        squashBase: "abc123",
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.edgeAction).toEqual({ kind: "writeSquashTemplate" })
+  })
+
+  it("gtd: learning applied + squash disabled → rest idle for human", () => {
+    const result = resolve([
+      R({
+        invoker: "none",
+        lastCommitSubject: "gtd: learning applied",
+        squashEnabled: false,
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.state).toBe("idle")
+    expect(result.actor).toBe("human")
+    expect(result.edgeAction).toBeUndefined()
+  })
+
+  it('human turn authored at await-learning-review captures under gate "learning", not "review"', () => {
+    const result = resolve([
+      R({
+        invoker: "human",
+        lastCommitSubject: "gtd: learning drafted",
+        workingTreeClean: false,
+        codeDirty: true,
+      }),
+    ])
+    expect(result.edgeAction).toEqual({
+      kind: "captureTurn",
+      actor: "human",
+      gate: "learning",
+    })
   })
 })
 

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -24,7 +24,7 @@
 import type { Actor, TurnGate } from "./Subjects.js"
 import { parseSubject } from "./Subjects.js"
 
-/** The 16 resolved states (frozen contract). `Result.state` is one of these. */
+/** The 20 resolved states (frozen contract). `Result.state` is one of these. */
 export type GtdState =
   | "grilling"
   | "grilled"
@@ -38,6 +38,10 @@ export type GtdState =
   | "review"
   | "await-review"
   | "done"
+  | "learning"
+  | "await-learning-review"
+  | "learning-apply"
+  | "learning-applied"
   | "squashing"
   | "idle"
   | "health-check"
@@ -185,6 +189,17 @@ export interface ResolvePayload {
   readonly healthCommitted: boolean
   /** Parent commit of the first persisting health-fix cycle commit. */
   readonly healthFixBase?: string
+  /** Learning phase enabled (config kill-switch). */
+  readonly learningEnabled: boolean
+  /** `.gtd/LEARNINGS.md` is present (committed or pending). */
+  readonly learningMsgPresent: boolean
+  /**
+   * `LEARNINGS.md` still holds the unmodified template written by
+   * `writeLearningTemplate` (or is absent). Mirrors `squashMsgIsTemplate`:
+   * guards the agent's draft turn so the machine never mid-chains on an
+   * unmodified placeholder.
+   */
+  readonly learningMsgIsTemplate: boolean
 }
 
 /**
@@ -208,12 +223,14 @@ export interface ResolvePayload {
  *   - `writeSquashTemplate` — write + commit SQUASH_MSG.md `gtd: squash template`.
  *   - `squashCommit`     — soft-reset to `squashBase`, then `gtd(agent): squashing`
  *                          reads SQUASH_MSG.md at perform time for the message.
+ *   - `writeLearningTemplate` — write + commit LEARNINGS.md `gtd: learning template`.
  *   - `runHealthCheck`   — run the configured test command; on red write
  *                          HEALTH.md (below cap) or ERRORS.md (`capReached`),
  *                          commit `gtd: health-check`; on green with prior
- *                          fixes and `squashAfterGreen`, commit
- *                          `gtd: tests green` to chain into the squash
- *                          template; otherwise stop idle with zero commits.
+ *                          fixes and `chainAfterGreen` (squash and/or learning
+ *                          enabled), commit `gtd: tests green` to chain into
+ *                          the learning/squash template; otherwise stop idle
+ *                          with zero commits.
  */
 export type EdgeAction =
   | { readonly kind: "captureTurn"; readonly actor: Actor; readonly gate: TurnGate }
@@ -224,16 +241,18 @@ export type EdgeAction =
       readonly removeReview?: boolean
       readonly removeFeedback?: boolean
       readonly removeHealth?: boolean
+      readonly removeLearning?: boolean
     }
   | { readonly kind: "runTest"; readonly errorCount: number; readonly capReached: boolean }
   | { readonly kind: "closePackage" }
   | { readonly kind: "writeSquashTemplate" }
   | { readonly kind: "squashCommit"; readonly squashBase: string }
+  | { readonly kind: "writeLearningTemplate" }
   | {
       readonly kind: "runHealthCheck"
       readonly errorCount: number
       readonly capReached: boolean
-      readonly squashAfterGreen: boolean
+      readonly chainAfterGreen: boolean
     }
 
 /** The folded prompt context carried on every `Result`. */
@@ -409,6 +428,9 @@ export const DEFAULT_PAYLOAD: ResolvePayload = {
   healthPresent: false,
   healthContent: "",
   healthCommitted: false,
+  learningEnabled: false,
+  learningMsgPresent: false,
+  learningMsgIsTemplate: false,
 }
 
 /** Build the prompt context from the payload passthrough + the folded counters. */
@@ -455,6 +477,39 @@ const healthFileConflictRules: readonly IllegalCombinationRule[] = [
   {
     isViolated: (p) => p.healthPresent && p.errorsPresent,
     message: ".gtd/HEALTH.md + .gtd/ERRORS.md",
+  },
+]
+
+// LEARNINGS.md, like SQUASH_MSG.md, is HEAD-classification-driven, not
+// precedence-driven — none of these can fire on a legal history (packages,
+// REVIEW.md, FEEDBACK.md, ERRORS.md, and TODO.md are all gone by `gtd: done`;
+// HEALTH.md is removed before tests-green; SQUASH_MSG.md is only written
+// after `gtd: learning applied` removes LEARNINGS.md). Defensive only: refuse
+// to guess on a corrupted repo rather than silently mis-resolve.
+const learningFileConflictRules: readonly IllegalCombinationRule[] = [
+  {
+    isViolated: (p) => p.learningMsgPresent && p.packagesPresent,
+    message: ".gtd/LEARNINGS.md + packages",
+  },
+  {
+    isViolated: (p) => p.learningMsgPresent && p.reviewPresent,
+    message: ".gtd/LEARNINGS.md + .gtd/REVIEW.md",
+  },
+  {
+    isViolated: (p) => p.learningMsgPresent && p.feedbackPresent,
+    message: ".gtd/LEARNINGS.md + .gtd/FEEDBACK.md",
+  },
+  {
+    isViolated: (p) => p.learningMsgPresent && p.errorsPresent,
+    message: ".gtd/LEARNINGS.md + .gtd/ERRORS.md",
+  },
+  {
+    isViolated: (p) => p.learningMsgPresent && p.healthPresent,
+    message: ".gtd/LEARNINGS.md + .gtd/HEALTH.md",
+  },
+  {
+    isViolated: (p) => p.learningMsgPresent && p.squashMsgPresent,
+    message: ".gtd/LEARNINGS.md + .gtd/SQUASH_MSG.md",
   },
 ]
 
@@ -508,7 +563,11 @@ const reviewAndFeedbackRules: readonly IllegalCombinationRule[] = [
  * documented precedence order.
  */
 const assertLegal = (p: ResolvePayload): void => {
-  for (const rule of [...healthFileConflictRules, ...reviewAndFeedbackRules]) {
+  for (const rule of [
+    ...healthFileConflictRules,
+    ...learningFileConflictRules,
+    ...reviewAndFeedbackRules,
+  ]) {
     if (rule.isViolated(p)) {
       throw new GtdStateError("illegal-combination", `illegal combination: ${rule.message}`)
     }
@@ -538,6 +597,26 @@ type HeadClass =
       readonly action: EdgeAction
     }
 
+/**
+ * The learning/squash decision shared by `gtd: done`, `gtd: tests green`
+ * (health path, no packages), and `gtd: learning applied`: learning first
+ * (when it hasn't already run), then squash, else rest at idle. `state` is
+ * the label the mid-chain hop reports (mirrors the just-consumed routing
+ * phase's own name, e.g. "done" for the `gtd: done` case).
+ */
+const nextAfterReviewOrLearning = (
+  flags: ClassifyFlags,
+  state: GtdState,
+  learningAlreadyRan: boolean,
+): HeadClass => {
+  if (!learningAlreadyRan && flags.learningEnabled && flags.hasSquashBase) {
+    return { kind: "mid-chain", state, actor: "agent", action: { kind: "writeLearningTemplate" } }
+  }
+  return flags.squashEnabled && flags.hasSquashBase
+    ? { kind: "mid-chain", state, actor: "agent", action: { kind: "writeSquashTemplate" } }
+    : { kind: "rest", state: "idle", actor: "human" }
+}
+
 /** The small set of config/content-dependent facts a subject-only classification still needs. */
 interface ClassifyFlags {
   readonly headTurnIsEmpty: boolean
@@ -545,11 +624,63 @@ interface ClassifyFlags {
   readonly agenticReviewForceApproved: boolean
   readonly squashEnabled: boolean
   readonly hasSquashBase: boolean
-  readonly squashAfterGreen: boolean
+  readonly learningEnabled: boolean
+  readonly learningMsgIsTemplate: boolean
   readonly reviewSubstantive: boolean
   readonly errorsPresent: boolean
   readonly reviewPresent: boolean
   readonly squashMsgIsTemplate: boolean
+}
+
+/**
+ * Classify a learning-gate turn commit — `gtd(agent): learning` (draft),
+ * `gtd(human): learning` (review), or `gtd(agent): learning-apply` (doc
+ * integration). Returns `null` for any other `(actor, gate)` pair, mirroring
+ * `classifyHead`'s own null-means-"not handled here" convention, so the
+ * caller can fall through to its remaining branches unchanged.
+ */
+const classifyLearningTurn = (
+  actor: Actor,
+  gate: string,
+  flags: ClassifyFlags,
+): HeadClass | null => {
+  if (actor === "agent" && gate === "learning") {
+    // Mirrors squashing: never mid-chain while `.gtd/LEARNINGS.md` still
+    // holds the unmodified template — rest so `gtd next` re-emits the same
+    // prompt until the agent actually drafts real learnings.
+    return flags.hasSquashBase && !flags.learningMsgIsTemplate
+      ? {
+          kind: "mid-chain",
+          state: "learning",
+          actor: "agent",
+          action: { kind: "commitRouting", subject: "gtd: learning drafted" },
+        }
+      : { kind: "rest", state: "learning", actor: "agent" }
+  }
+  if (actor === "human" && gate === "learning") {
+    // No reject/redo path: any human turn here — even an empty one, meaning
+    // "accept the draft as-is" — always proceeds forward to the agent's
+    // apply turn.
+    return {
+      kind: "mid-chain",
+      state: "learning",
+      actor: "human",
+      action: { kind: "commitRouting", subject: "gtd: learning approved" },
+    }
+  }
+  if (actor === "agent" && gate === "learning-apply") {
+    return {
+      kind: "mid-chain",
+      state: "learning-apply",
+      actor: "agent",
+      action: {
+        kind: "commitRouting",
+        subject: "gtd: learning applied",
+        removeLearning: true,
+      },
+    }
+  }
+  return null
 }
 
 /**
@@ -685,6 +816,9 @@ const classifyHead = (subject: string, flags: ClassifyFlags): HeadClass | null =
         : { kind: "rest", state: "squashing", actor: "agent" }
     }
 
+    const learningTurn = classifyLearningTurn(actor, gate, flags)
+    if (learningTurn !== null) return learningTurn
+
     if (actor === "agent" && gate === "health-fixing") {
       return {
         kind: "mid-chain",
@@ -723,14 +857,7 @@ const classifyHead = (subject: string, flags: ClassifyFlags): HeadClass | null =
               }
             : { kind: "rest", state: "agentic-review", actor: "agent" }
         }
-        return flags.squashEnabled && flags.squashAfterGreen
-          ? {
-              kind: "mid-chain",
-              state: "testing",
-              actor: "agent",
-              action: { kind: "writeSquashTemplate" },
-            }
-          : { kind: "rest", state: "idle", actor: "human" }
+        return nextAfterReviewOrLearning(flags, "testing", false)
       case "errors":
         return flags.errorsPresent
           ? { kind: "rest", state: "escalate", actor: "human" }
@@ -743,18 +870,19 @@ const classifyHead = (subject: string, flags: ClassifyFlags): HeadClass | null =
       case "review-feedback":
         return { kind: "rest", state: "grilling", actor: "agent" }
       case "done":
-        return flags.squashEnabled && flags.hasSquashBase
-          ? {
-              kind: "mid-chain",
-              state: "done",
-              actor: "agent",
-              action: { kind: "writeSquashTemplate" },
-            }
-          : { kind: "rest", state: "idle", actor: "human" }
+        return nextAfterReviewOrLearning(flags, "done", false)
       case "squash-template":
         return { kind: "rest", state: "squashing", actor: "agent" }
       case "reviewing":
         return { kind: "rest", state: "review", actor: "agent" }
+      case "learning-template":
+        return { kind: "rest", state: "learning", actor: "agent" }
+      case "learning-drafted":
+        return { kind: "rest", state: "await-learning-review", actor: "human" }
+      case "learning-approved":
+        return { kind: "rest", state: "learning-apply", actor: "agent" }
+      case "learning-applied":
+        return nextAfterReviewOrLearning(flags, "learning-applied", true)
       case "health-check":
         return flags.errorsPresent
           ? { kind: "rest", state: "escalate", actor: "human" }
@@ -777,8 +905,9 @@ const classifyHead = (subject: string, flags: ClassifyFlags): HeadClass | null =
 /**
  * States that author a turn under their own same-named gate. Every other
  * `GtdState` (planning, testing, close-package, await-review, done, idle,
- * health-check — none of which are themselves turn gates) falls through to
- * "review", `gateForState`'s documented default.
+ * health-check, learning-applied — none of which are themselves turn gates)
+ * falls through to "review", `gateForState`'s documented default, unless
+ * overridden by `GATE_OVERRIDES` below.
  */
 const STATE_IS_OWN_GATE: ReadonlySet<GtdState> = new Set<GtdState>([
   "grilling",
@@ -790,11 +919,24 @@ const STATE_IS_OWN_GATE: ReadonlySet<GtdState> = new Set<GtdState>([
   "squashing",
   "health-fixing",
   "escalate",
+  "learning",
+  "learning-apply",
 ])
+
+/**
+ * Explicit gate overrides for non-own-gate states whose turn gate is neither
+ * their own state name nor the hardcoded "review" default. `await-review`
+ * doesn't need one (it genuinely reuses "review"); `await-learning-review`
+ * does, since its human turn is authored under gate `"learning"` (shared
+ * with the agent's draft turn), not `"review"`.
+ */
+const GATE_OVERRIDES: Partial<Record<GtdState, TurnGate>> = {
+  "await-learning-review": "learning",
+}
 
 /** Map a state to the turn gate an invocation at that state's rest would author. */
 const gateForState = (state: GtdState): TurnGate =>
-  STATE_IS_OWN_GATE.has(state) ? (state as TurnGate) : "review"
+  STATE_IS_OWN_GATE.has(state) ? (state as TurnGate) : (GATE_OVERRIDES[state] ?? "review")
 
 /**
  * Agent-awaited rests whose move is a file artifact (a developed plan,
@@ -802,9 +944,12 @@ const gateForState = (state: GtdState): TurnGate =>
  * dirties the tree, so a clean tree here is a do-nothing invocation.
  * `squashing` joins the set only while `.gtd/SQUASH_MSG.md` still holds the
  * unmodified template — squashing then would stamp the placeholder text onto
- * the collapsed cycle. `health-fixing` is deliberately absent: its empty turn
- * is meaningful (environmental fix; the machine removes HEALTH.md and
- * re-tests).
+ * the collapsed cycle. `learning` joins the same way, guarded by
+ * `learningMsgIsTemplate` instead. `learning-apply`'s move is a doc edit
+ * (CLAUDE.md/AGENTS.md/docs), so it's unconditionally inert on a clean tree,
+ * same as `building`/`fixing`. `health-fixing` is deliberately absent: its
+ * empty turn is meaningful (environmental fix; the machine removes
+ * HEALTH.md and re-tests).
  */
 const INERT_EMPTY_AGENT_GATES: ReadonlySet<GtdState> = new Set([
   "grilling",
@@ -813,6 +958,7 @@ const INERT_EMPTY_AGENT_GATES: ReadonlySet<GtdState> = new Set([
   "fixing",
   "agentic-review",
   "review",
+  "learning-apply",
 ])
 
 /**
@@ -822,7 +968,9 @@ const INERT_EMPTY_AGENT_GATES: ReadonlySet<GtdState> = new Set([
  */
 const isInertEmptyAgentRest = (state: GtdState, p: ResolvePayload): boolean =>
   p.workingTreeClean &&
-  (INERT_EMPTY_AGENT_GATES.has(state) || (state === "squashing" && p.squashMsgIsTemplate))
+  (INERT_EMPTY_AGENT_GATES.has(state) ||
+    (state === "squashing" && p.squashMsgIsTemplate) ||
+    (state === "learning" && p.learningMsgIsTemplate))
 
 /**
  * The baseline decision: classify HEAD, falling through to the payload-driven
@@ -921,8 +1069,6 @@ const resolveBaseline = (
       : { kind: "rest", state: "fixing", actor: "agent" }
   }
 
-  const squashAfterGreen =
-    p.squashEnabled && counters.healthFixCount > 0 && p.healthFixBase !== undefined
   // Prefer the turn commit's own diff (set only when HEAD is the
   // `gtd(human): review` turn commit being classified right now) over live
   // working-tree dirtiness, which is already clean by the time this mid-chain
@@ -938,7 +1084,8 @@ const resolveBaseline = (
     agenticReviewForceApproved: forceApprove,
     squashEnabled: p.squashEnabled,
     hasSquashBase: p.squashBase !== undefined,
-    squashAfterGreen,
+    learningEnabled: p.learningEnabled,
+    learningMsgIsTemplate: p.learningMsgIsTemplate,
     reviewSubstantive,
     // A pending (uncommitted) deletion of ERRORS.md still counts as "ERRORS.md
     // was committed at this HEAD" for classification purposes: `fs.exists`
@@ -988,7 +1135,7 @@ const resolveBaseline = (
           kind: "runHealthCheck",
           errorCount: counters.healthFixCount,
           capReached: counters.healthFixCount >= p.fixAttemptCap,
-          squashAfterGreen: classified.action.squashAfterGreen,
+          chainAfterGreen: classified.action.chainAfterGreen,
         },
       }
     }
@@ -1157,8 +1304,10 @@ const applyTurnTaking = (
     (head === "gtd: health-fix" && baseline.state === "idle") ||
     (healthCheckCapReached && baseline.state === "health-fixing")
   ) {
-    const squashAfterGreenAtHealthFix =
-      p.squashEnabled && counters.healthFixCount > 0 && p.healthFixBase !== undefined
+    const chainAfterGreenAtHealthFix =
+      (p.squashEnabled || p.learningEnabled) &&
+      counters.healthFixCount > 0 &&
+      p.healthFixBase !== undefined
     return {
       state: "idle",
       actor: "agent",
@@ -1167,7 +1316,7 @@ const applyTurnTaking = (
         kind: "runHealthCheck",
         errorCount: counters.healthFixCount,
         capReached: counters.healthFixCount >= p.fixAttemptCap,
-        squashAfterGreen: squashAfterGreenAtHealthFix,
+        chainAfterGreen: chainAfterGreenAtHealthFix,
       },
       context,
     }
@@ -1199,8 +1348,10 @@ const applyTurnTaking = (
   // Idle carve-out: a human step at idle always re-runs the health check —
   // never an empty turn commit, and never a plain fixpoint no-op.
   if (baseline.state === "idle" && invoker === "human") {
-    const squashAfterGreen =
-      p.squashEnabled && counters.healthFixCount > 0 && p.healthFixBase !== undefined
+    const chainAfterGreen =
+      (p.squashEnabled || p.learningEnabled) &&
+      counters.healthFixCount > 0 &&
+      p.healthFixBase !== undefined
     return {
       state: "idle",
       actor: "human",
@@ -1209,7 +1360,7 @@ const applyTurnTaking = (
         kind: "runHealthCheck",
         errorCount: counters.healthFixCount,
         capReached: counters.healthFixCount >= p.fixAttemptCap,
-        squashAfterGreen,
+        chainAfterGreen,
       },
       context,
     }
@@ -1386,6 +1537,7 @@ export const awaitedActor = (state: GtdState): Actor => {
     case "idle":
     case "escalate":
     case "await-review":
+    case "await-learning-review":
       return "human"
     default:
       return "agent"

--- a/src/Perf.test.ts
+++ b/src/Perf.test.ts
@@ -70,6 +70,7 @@ describe("performance smoke", { timeout: 180_000 }, () => {
             resolveModel: () => "claude-opus-4-8",
             agenticReview: true,
             squash: true,
+            learning: false,
             fixAttemptCap: 3,
             reviewThreshold: 3,
           }),

--- a/src/Prompt.snapshot.test.ts
+++ b/src/Prompt.snapshot.test.ts
@@ -275,4 +275,56 @@ describe("buildPrompt snapshots", () => {
       ),
     ).toMatchSnapshot()
   })
+
+  // ── learning ──────────────────────────────────────────────────────────────
+
+  it("learning with squashDiff and squashBase plain", () => {
+    expect(
+      buildPrompt(
+        result("learning", {
+          context: {
+            squashDiff: "diff --git a/x b/x\n+hello\n",
+            squashBase: "abc1234",
+          },
+        }),
+        resolveModel,
+        "plain",
+      ),
+    ).toMatchSnapshot()
+  })
+
+  it("learning with squashDiff and squashBase json", () => {
+    expect(
+      buildPrompt(
+        result("learning", {
+          context: {
+            squashDiff: "diff --git a/x b/x\n+hello\n",
+            squashBase: "abc1234",
+          },
+        }),
+        resolveModel,
+        "json",
+      ),
+    ).toMatchSnapshot()
+  })
+
+  it("await-learning-review plain", () => {
+    expect(
+      buildPrompt(result("await-learning-review", { actor: "human" }), resolveModel, "plain"),
+    ).toMatchSnapshot()
+  })
+
+  it("await-learning-review json", () => {
+    expect(
+      buildPrompt(result("await-learning-review", { actor: "human" }), resolveModel, "json"),
+    ).toMatchSnapshot()
+  })
+
+  it("learning-apply plain", () => {
+    expect(buildPrompt(result("learning-apply"), resolveModel, "plain")).toMatchSnapshot()
+  })
+
+  it("learning-apply json", () => {
+    expect(buildPrompt(result("learning-apply"), resolveModel, "json")).toMatchSnapshot()
+  })
 })

--- a/src/Prompt.test.ts
+++ b/src/Prompt.test.ts
@@ -44,6 +44,9 @@ const PROMPT_STATES: ReadonlyArray<GtdState> = [
   "review",
   "await-review",
   "squashing",
+  "learning",
+  "await-learning-review",
+  "learning-apply",
   "escalate",
   "idle",
   "health-fixing",
@@ -55,10 +58,11 @@ const EDGE_ONLY_STATES: ReadonlyArray<GtdState> = [
   "close-package",
   "done",
   "health-check",
+  "learning-applied",
 ]
 
 describe("isPromptState", () => {
-  it("matches exactly the pinned 11-state set", () => {
+  it("matches exactly the pinned 14-state set", () => {
     for (const state of PROMPT_STATES) expect(isPromptState(state)).toBe(true)
     for (const state of EDGE_ONLY_STATES) expect(isPromptState(state)).toBe(false)
   })
@@ -122,6 +126,22 @@ describe("buildPrompt", () => {
     it("squashing renders the squashing section", () => {
       const out = buildPrompt(result("squashing"))
       expect(out).toContain("conventional-commits")
+    })
+
+    it("learning renders the learning section", () => {
+      const out = buildPrompt(result("learning"))
+      expect(out).toContain(".gtd/LEARNINGS.md")
+    })
+
+    it("await-learning-review renders the await-learning-review section", () => {
+      const out = buildPrompt(result("await-learning-review", { actor: "human" }))
+      expect(out).toContain("LEARNINGS.md")
+      expect(out).toMatch(/human\s+gate/)
+    })
+
+    it("learning-apply renders the learning-apply section", () => {
+      const out = buildPrompt(result("learning-apply"))
+      expect(out).toContain("CLAUDE.md")
     })
 
     it("escalate renders the escalate section", () => {
@@ -212,7 +232,7 @@ describe("buildPrompt", () => {
 
     it("human-gated states carry no {{MODEL}} and no injected model", () => {
       const custom = (s: string): string => `SHOULD-NOT-APPEAR-${s}`
-      for (const state of ["escalate", "idle", "await-review"] as const) {
+      for (const state of ["escalate", "idle", "await-review", "await-learning-review"] as const) {
         const out = buildPrompt(result(state, { actor: "human" }), custom)
         expect(out).not.toContain("{{MODEL}}")
         expect(out).not.toContain("SHOULD-NOT-APPEAR")
@@ -230,6 +250,8 @@ describe("buildPrompt", () => {
         withPackage("agentic-review"),
         result("review"),
         result("squashing"),
+        result("learning"),
+        result("learning-apply"),
         result("health-fixing"),
       ]
       const tail =
@@ -246,6 +268,7 @@ describe("buildPrompt", () => {
       const cases: ReadonlyArray<Result> = [
         result("grilling", { actor: "human" }),
         result("await-review", { actor: "human" }),
+        result("await-learning-review", { actor: "human" }),
         result("escalate", { actor: "human" }),
         result("idle", { actor: "human" }),
       ]
@@ -277,6 +300,9 @@ describe("buildPrompt", () => {
       result("review"),
       result("await-review", { actor: "human" }),
       result("squashing"),
+      result("learning"),
+      result("await-learning-review", { actor: "human" }),
+      result("learning-apply"),
       result("escalate", { actor: "human" }),
       result("idle", { actor: "human" }),
       result("health-fixing"),
@@ -426,6 +452,17 @@ describe("buildPrompt", () => {
       )
       expect(out).toContain("abc1234def")
     })
+
+    it("learning inlines squashDiff under a full-process heading", () => {
+      const out = buildPrompt(
+        result("learning", {
+          context: { squashDiff: "diff --git a/x b/x\n+hello\n", squashBase: "abc1234" },
+        }),
+      )
+      expect(out).toContain("Full-process diff")
+      expect(out).toContain("```diff")
+      expect(out).toContain("+hello")
+    })
   })
 
   describe("json output mode", () => {
@@ -444,6 +481,9 @@ describe("buildPrompt", () => {
       ["review", result("review")],
       ["await-review", result("await-review", { actor: "human" })],
       ["squashing", result("squashing")],
+      ["learning", result("learning")],
+      ["await-learning-review", result("await-learning-review", { actor: "human" })],
+      ["learning-apply", result("learning-apply")],
       ["escalate", result("escalate", { actor: "human" })],
       ["idle", result("idle", { actor: "human" })],
     ] as const) {

--- a/src/Prompt.ts
+++ b/src/Prompt.ts
@@ -14,17 +14,20 @@ import agenticReviewMd from "./prompts/agentic-review.md"
 import reviewMd from "./prompts/review.md"
 import awaitReviewMd from "./prompts/await-review.md"
 import squashingMd from "./prompts/squashing.md"
+import learningMd from "./prompts/learning.md"
+import awaitLearningReviewMd from "./prompts/await-learning-review.md"
+import learningApplyMd from "./prompts/learning-apply.md"
 import escalateMd from "./prompts/escalate.md"
 import idleMd from "./prompts/idle.md"
 import { builtinTierDefault, stateTier, type ModelState } from "./Config.js"
 import type { GtdState, Result } from "./Machine.js"
 
 /**
- * The 11 prompt-bearing states (frozen contract) — `src/State.ts` consumes
+ * The 14 prompt-bearing states (frozen contract) — `src/State.ts` consumes
  * this single classification instead of duplicating an edge-only set.
- * `buildPrompt` throws for the other five (testing, planning, close-package,
- * done, health-check), which are performed by the driver and must never
- * render a prompt.
+ * `buildPrompt` throws for the other six (testing, planning, close-package,
+ * done, health-check, learning-applied), which are performed by the driver
+ * and must never render a prompt.
  */
 const PROMPT_STATES: ReadonlySet<GtdState> = new Set<GtdState>([
   "grilling",
@@ -35,6 +38,9 @@ const PROMPT_STATES: ReadonlySet<GtdState> = new Set<GtdState>([
   "review",
   "await-review",
   "squashing",
+  "learning",
+  "await-learning-review",
+  "learning-apply",
   "escalate",
   "idle",
   "health-fixing",
@@ -52,15 +58,19 @@ type PromptState =
   | "review"
   | "await-review"
   | "squashing"
+  | "learning"
+  | "await-learning-review"
+  | "learning-apply"
   | "escalate"
   | "idle"
   | "health-fixing"
 
 /**
  * Which `ModelState` a prompt-bearing state resolves `{{MODEL}}` against.
- * `grilled` shares the `decompose` tier; `review` and `squashing` share the
- * `clean` tier (renamed states, same model tier); the human-gated states
- * (`await-review`, `escalate`, `idle`) spawn no subagent and carry none.
+ * `grilled` shares the `decompose` tier; `review`, `squashing`, `learning`,
+ * and `learning-apply` share the `clean` tier (renamed states, same model
+ * tier); the human-gated states (`await-review`, `await-learning-review`,
+ * `escalate`, `idle`) spawn no subagent and carry none.
  */
 const MODEL_STATE: Partial<Record<PromptState, ModelState>> = {
   grilling: "grilling",
@@ -71,6 +81,8 @@ const MODEL_STATE: Partial<Record<PromptState, ModelState>> = {
   "agentic-review": "agentic-review",
   review: "clean",
   squashing: "clean",
+  learning: "clean",
+  "learning-apply": "clean",
 }
 
 /**
@@ -120,6 +132,9 @@ eta.loadTemplate("@agentic-review", agenticReviewMd)
 eta.loadTemplate("@review", reviewMd)
 eta.loadTemplate("@await-review", awaitReviewMd)
 eta.loadTemplate("@squashing", squashingMd)
+eta.loadTemplate("@learning", learningMd)
+eta.loadTemplate("@await-learning-review", awaitLearningReviewMd)
+eta.loadTemplate("@learning-apply", learningApplyMd)
 eta.loadTemplate("@escalate", escalateMd)
 eta.loadTemplate("@idle", idleMd)
 
@@ -138,6 +153,9 @@ const STATE_TEMPLATE: Record<Exclude<PromptState, "grilling">, string> = {
   review: "@review",
   "await-review": "@await-review",
   squashing: "@squashing",
+  learning: "@learning",
+  "await-learning-review": "@await-learning-review",
+  "learning-apply": "@learning-apply",
   escalate: "@escalate",
   idle: "@idle",
   "health-fixing": "@health-fixing",

--- a/src/State.test.ts
+++ b/src/State.test.ts
@@ -45,7 +45,8 @@ describe("describeEdgeAction (exhaustive over EdgeAction)", () => {
     { kind: "closePackage" },
     { kind: "writeSquashTemplate" },
     { kind: "squashCommit", squashBase: "abc1234" },
-    { kind: "runHealthCheck", errorCount: 0, capReached: false, squashAfterGreen: false },
+    { kind: "writeLearningTemplate" },
+    { kind: "runHealthCheck", errorCount: 0, capReached: false, chainAfterGreen: false },
   ]
 
   it("returns a non-empty phrase for every EdgeAction variant", () => {
@@ -78,6 +79,16 @@ describe("describeEdgeAction (exhaustive over EdgeAction)", () => {
     ).toBe('commit routing as "gtd: package done" (removing .gtd/TODO.md, .gtd/FEEDBACK.md)')
   })
 
+  it("commitRouting lists removeLearning", () => {
+    expect(
+      describeEdgeAction({
+        kind: "commitRouting",
+        subject: "gtd: learning applied",
+        removeLearning: true,
+      }),
+    ).toBe('commit routing as "gtd: learning applied" (removing .gtd/LEARNINGS.md)')
+  })
+
   it("runTest reports the 1-indexed attempt number", () => {
     expect(describeEdgeAction({ kind: "runTest", errorCount: 2, capReached: false })).toBe(
       "run the test suite (attempt 3)",
@@ -96,14 +107,20 @@ describe("describeEdgeAction (exhaustive over EdgeAction)", () => {
     )
   })
 
-  it("runHealthCheck reports attempt, cap, and squash-after-green together", () => {
+  it("writeLearningTemplate returns a fixed phrase", () => {
+    expect(describeEdgeAction({ kind: "writeLearningTemplate" })).toBe(
+      "write the learnings template",
+    )
+  })
+
+  it("runHealthCheck reports attempt, cap, and chain-after-green together", () => {
     expect(
       describeEdgeAction({
         kind: "runHealthCheck",
         errorCount: 0,
         capReached: true,
-        squashAfterGreen: true,
+        chainAfterGreen: true,
       }),
-    ).toBe("run the health check (attempt 1, cap reached, squash after green)")
+    ).toBe("run the health check (attempt 1, cap reached, chain after green)")
   })
 })

--- a/src/State.ts
+++ b/src/State.ts
@@ -30,6 +30,7 @@ const edgeActionHandlers: EdgeActionHandlers = {
     if (a.removeReview) removed.push(".gtd/REVIEW.md")
     if (a.removeFeedback) removed.push(".gtd/FEEDBACK.md")
     if (a.removeHealth) removed.push(".gtd/HEALTH.md")
+    if (a.removeLearning) removed.push(".gtd/LEARNINGS.md")
     if (removed.length > 0) msg += ` (removing ${removed.join(", ")})`
     return msg
   },
@@ -38,9 +39,10 @@ const edgeActionHandlers: EdgeActionHandlers = {
   closePackage: () => "close the active package",
   writeSquashTemplate: () => "write the squash message template",
   squashCommit: (a) => `squash the cycle onto ${a.squashBase}`,
+  writeLearningTemplate: () => "write the learnings template",
   runHealthCheck: (a) =>
     `run the health check (attempt ${a.errorCount + 1}${a.capReached ? ", cap reached" : ""}${
-      a.squashAfterGreen ? ", squash after green" : ""
+      a.chainAfterGreen ? ", chain after green" : ""
     })`,
 }
 

--- a/src/Subjects.test.ts
+++ b/src/Subjects.test.ts
@@ -28,6 +28,8 @@ describe("turn subject round-trip", () => {
     "squashing",
     "health-fixing",
     "escalate",
+    "learning",
+    "learning-apply",
   ]
 
   it("round-trips every actor x gate combination", () => {

--- a/src/Subjects.ts
+++ b/src/Subjects.ts
@@ -45,6 +45,8 @@ export type TurnGate =
   | "squashing"
   | "health-fixing"
   | "escalate"
+  | "learning"
+  | "learning-apply"
 
 /** `gtd(${actor}): ${gate}` — the subject `gtd step`/`gtd step-agent` write. */
 export const turnSubject = (actor: Actor, gate: TurnGate): string => `gtd(${actor}): ${gate}`
@@ -63,6 +65,10 @@ export type RoutingPhase =
   | "reviewing"
   | "health-check"
   | "health-fix"
+  | "learning-template"
+  | "learning-drafted"
+  | "learning-approved"
+  | "learning-applied"
 
 /** Literal subjects for the non-parameterized routing phases. */
 export const ROUTING_SUBJECT: Record<Exclude<RoutingPhase, "reviewing">, string> = {
@@ -77,6 +83,10 @@ export const ROUTING_SUBJECT: Record<Exclude<RoutingPhase, "reviewing">, string>
   "squash-template": "gtd: squash template",
   "health-check": "gtd: health-check",
   "health-fix": "gtd: health-fix",
+  "learning-template": "gtd: learning template",
+  "learning-drafted": "gtd: learning drafted",
+  "learning-approved": "gtd: learning approved",
+  "learning-applied": "gtd: learning applied",
 }
 
 /** `gtd: reviewing ${baseHash}` — the ad-hoc review anchor. */
@@ -108,6 +118,8 @@ const TURN_GATES: ReadonlySet<string> = new Set<TurnGate>([
   "squashing",
   "health-fixing",
   "escalate",
+  "learning",
+  "learning-apply",
 ])
 
 const ROUTING_SUBJECT_TO_PHASE: ReadonlyMap<string, Exclude<RoutingPhase, "reviewing">> = new Map(

--- a/src/__snapshots__/Prompt.snapshot.test.ts.snap
+++ b/src/__snapshots__/Prompt.snapshot.test.ts.snap
@@ -153,6 +153,56 @@ agent); when it awaits the human, stop and hand off.
 "
 `;
 
+exports[`buildPrompt snapshots > await-learning-review json 1`] = `
+"You are an autonomous coding agent orchestrating work on the user's repo.
+
+The \`.gtd/\` directory is the workflow's own state (plans, task specs, review
+records). Never create, edit, delete, or reference files under \`.gtd/\` — and
+never instruct a subagent to — except the specific \`.gtd/\` file this prompt
+explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
+*outside* \`.gtd/\` is ordinary project code, not workflow state.
+
+\`.gtd/LEARNINGS.md\` holds the distilled learnings from this cycle, drafted by
+the agent. This is a human gate; there is nothing for the agent to do.
+
+Tell the user:
+
+- Read \`.gtd/LEARNINGS.md\`.
+- Delete anything not worth keeping, or edit/add anything the draft missed.
+- Run \`gtd step\` — with or without edits, either way proceeds: the agent
+  integrates whatever remains into the project's own memory
+  (CLAUDE.md/AGENTS.md/docs) next.
+
+There is no reject path — this gate only refines what gets kept, it doesn't
+send the cycle back for rework.
+"
+`;
+
+exports[`buildPrompt snapshots > await-learning-review plain 1`] = `
+"You are an autonomous coding agent orchestrating work on the user's repo.
+
+The \`.gtd/\` directory is the workflow's own state (plans, task specs, review
+records). Never create, edit, delete, or reference files under \`.gtd/\` — and
+never instruct a subagent to — except the specific \`.gtd/\` file this prompt
+explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
+*outside* \`.gtd/\` is ordinary project code, not workflow state.
+
+\`.gtd/LEARNINGS.md\` holds the distilled learnings from this cycle, drafted by
+the agent. This is a human gate; there is nothing for the agent to do.
+
+Tell the user:
+
+- Read \`.gtd/LEARNINGS.md\`.
+- Delete anything not worth keeping, or edit/add anything the draft missed.
+- Run \`gtd step\` — with or without edits, either way proceeds: the agent
+  integrates whatever remains into the project's own memory
+  (CLAUDE.md/AGENTS.md/docs) next.
+
+There is no reject path — this gate only refines what gets kept, it doesn't
+send the cycle back for rework.
+"
+`;
+
 exports[`buildPrompt snapshots > await-review json 1`] = `
 "You are an autonomous coding agent orchestrating work on the user's repo.
 
@@ -783,6 +833,194 @@ green. Nothing to do.
 
 Start a new cycle by sketching an idea in the working tree (edit code or add a
 short note, e.g. \`IDEA.md\`) and running \`gtd step\` to capture it.
+"
+`;
+
+exports[`buildPrompt snapshots > learning with squashDiff and squashBase json 1`] = `
+"You are an autonomous coding agent orchestrating work on the user's repo.
+
+The \`.gtd/\` directory is the workflow's own state (plans, task specs, review
+records). Never create, edit, delete, or reference files under \`.gtd/\` — and
+never instruct a subagent to — except the specific \`.gtd/\` file this prompt
+explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
+*outside* \`.gtd/\` is ordinary project code, not workflow state.
+
+The process is **approved and done**, and headed for a squash. Before that
+happens, \`.gtd/LEARNINGS.md\` has been committed with a template — your job is
+to overwrite it with the real, distilled learnings from this cycle so they
+survive the squash even though the granular history won't.
+
+### Step 1 — Walk the cycle's history
+
+Scan the git history back to the cycle's start (the full-process diff is
+inlined below, and \`git log\` over the same range shows every \`gtd: ...\` /
+\`gtd(agent): ...\` / \`gtd(human): ...\` commit). Look specifically for:
+
+- **Test failures and fixes** — each \`gtd: errors\` round and the fix that
+  followed it. What broke, and what actually made it pass?
+- **Review feedback** — human \`.gtd/REVIEW.md\` notes and \`gtd: review
+  feedback\` detours. What did the human have to correct that the agent got
+  wrong on its own?
+- **Health-check rounds** — any \`gtd: health-check\` / \`gtd: health-fix\`
+  cycles. Environmental or systemic issues surfaced outside normal building?
+- **Grilling decisions** — \`.gtd/TODO.md\`'s "## Captured input" sections and
+  plan edits. Trade-offs or conventions the human specified that a future
+  agent should already know.
+
+### Step 2 — Distill, don't transcribe
+
+For each thing you found, ask: is this a **durable, generalizable lesson**
+(a convention, a gotcha, a pattern this project wants followed next time), or
+a **one-off detail** specific to this change? Keep only the former. A future
+agent reading this should learn something that changes how it works on this
+project, not a recap of what happened.
+
+### Step 3 — Overwrite .gtd/LEARNINGS.md
+
+Replace the **entire content** of \`.gtd/LEARNINGS.md\` with your distilled
+learnings (plain markdown, no leftover template scaffolding). If nothing
+durable surfaced this cycle, write a short explicit note saying so — don't
+leave the placeholder text in place. Leave the file uncommitted and finish
+your turn; a human reviews it next before it's integrated into the project's
+own memory (CLAUDE.md/AGENTS.md/docs).
+
+Cycle base: abc1234
+
+### Full-process diff (\`git diff abc1234 HEAD\`)
+
+\`\`\`diff
+diff --git a/x b/x
++hello
+\`\`\`
+"
+`;
+
+exports[`buildPrompt snapshots > learning with squashDiff and squashBase plain 1`] = `
+"You are an autonomous coding agent orchestrating work on the user's repo.
+
+The \`.gtd/\` directory is the workflow's own state (plans, task specs, review
+records). Never create, edit, delete, or reference files under \`.gtd/\` — and
+never instruct a subagent to — except the specific \`.gtd/\` file this prompt
+explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
+*outside* \`.gtd/\` is ordinary project code, not workflow state.
+
+The process is **approved and done**, and headed for a squash. Before that
+happens, \`.gtd/LEARNINGS.md\` has been committed with a template — your job is
+to overwrite it with the real, distilled learnings from this cycle so they
+survive the squash even though the granular history won't.
+
+### Step 1 — Walk the cycle's history
+
+Scan the git history back to the cycle's start (the full-process diff is
+inlined below, and \`git log\` over the same range shows every \`gtd: ...\` /
+\`gtd(agent): ...\` / \`gtd(human): ...\` commit). Look specifically for:
+
+- **Test failures and fixes** — each \`gtd: errors\` round and the fix that
+  followed it. What broke, and what actually made it pass?
+- **Review feedback** — human \`.gtd/REVIEW.md\` notes and \`gtd: review
+  feedback\` detours. What did the human have to correct that the agent got
+  wrong on its own?
+- **Health-check rounds** — any \`gtd: health-check\` / \`gtd: health-fix\`
+  cycles. Environmental or systemic issues surfaced outside normal building?
+- **Grilling decisions** — \`.gtd/TODO.md\`'s "## Captured input" sections and
+  plan edits. Trade-offs or conventions the human specified that a future
+  agent should already know.
+
+### Step 2 — Distill, don't transcribe
+
+For each thing you found, ask: is this a **durable, generalizable lesson**
+(a convention, a gotcha, a pattern this project wants followed next time), or
+a **one-off detail** specific to this change? Keep only the former. A future
+agent reading this should learn something that changes how it works on this
+project, not a recap of what happened.
+
+### Step 3 — Overwrite .gtd/LEARNINGS.md
+
+Replace the **entire content** of \`.gtd/LEARNINGS.md\` with your distilled
+learnings (plain markdown, no leftover template scaffolding). If nothing
+durable surfaced this cycle, write a short explicit note saying so — don't
+leave the placeholder text in place. Leave the file uncommitted and finish
+your turn; a human reviews it next before it's integrated into the project's
+own memory (CLAUDE.md/AGENTS.md/docs).
+
+Cycle base: abc1234
+
+### Full-process diff (\`git diff abc1234 HEAD\`)
+
+\`\`\`diff
+diff --git a/x b/x
++hello
+\`\`\`
+
+Finish your turn by running \`gtd step-agent\`. Then run \`gtd next\` and follow
+its output — repeat this cycle as long as the output is addressed to you (the
+agent); when it awaits the human, stop and hand off.
+"
+`;
+
+exports[`buildPrompt snapshots > learning-apply json 1`] = `
+"You are an autonomous coding agent orchestrating work on the user's repo.
+
+The \`.gtd/\` directory is the workflow's own state (plans, task specs, review
+records). Never create, edit, delete, or reference files under \`.gtd/\` — and
+never instruct a subagent to — except the specific \`.gtd/\` file this prompt
+explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
+*outside* \`.gtd/\` is ordinary project code, not workflow state.
+
+The human has approved (and possibly amended) \`.gtd/LEARNINGS.md\`. Your job is
+to integrate those learnings into the project's own memory, not to touch
+\`.gtd/LEARNINGS.md\` itself.
+
+1. **Read \`.gtd/LEARNINGS.md\`.**
+2. **Pick the right home for each point**, using your judgment and this
+   project's existing convention:
+   - An existing \`CLAUDE.md\` or \`AGENTS.md\` at the repo root (or a directory
+     closer to what the learning concerns) is usually the right place.
+   - If neither exists and the learnings warrant one, create \`AGENTS.md\` at
+     the repo root.
+   - A learning about a specific subsystem may fit better in that
+     subsystem's own docs than a root-level file — use your judgment.
+3. **Integrate, don't just append** — merge each point into the relevant
+   section of the target file(s); rephrase for clarity, dedupe against what's
+   already documented, and keep the existing document's structure and tone.
+4. **Never delete or edit \`.gtd/LEARNINGS.md\`** — the machine removes it once
+   your turn is captured.
+5. **Leave every change uncommitted and finish your turn.**
+"
+`;
+
+exports[`buildPrompt snapshots > learning-apply plain 1`] = `
+"You are an autonomous coding agent orchestrating work on the user's repo.
+
+The \`.gtd/\` directory is the workflow's own state (plans, task specs, review
+records). Never create, edit, delete, or reference files under \`.gtd/\` — and
+never instruct a subagent to — except the specific \`.gtd/\` file this prompt
+explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
+*outside* \`.gtd/\` is ordinary project code, not workflow state.
+
+The human has approved (and possibly amended) \`.gtd/LEARNINGS.md\`. Your job is
+to integrate those learnings into the project's own memory, not to touch
+\`.gtd/LEARNINGS.md\` itself.
+
+1. **Read \`.gtd/LEARNINGS.md\`.**
+2. **Pick the right home for each point**, using your judgment and this
+   project's existing convention:
+   - An existing \`CLAUDE.md\` or \`AGENTS.md\` at the repo root (or a directory
+     closer to what the learning concerns) is usually the right place.
+   - If neither exists and the learnings warrant one, create \`AGENTS.md\` at
+     the repo root.
+   - A learning about a specific subsystem may fit better in that
+     subsystem's own docs than a root-level file — use your judgment.
+3. **Integrate, don't just append** — merge each point into the relevant
+   section of the target file(s); rephrase for clarity, dedupe against what's
+   already documented, and keep the existing document's structure and tone.
+4. **Never delete or edit \`.gtd/LEARNINGS.md\`** — the machine removes it once
+   your turn is captured.
+5. **Leave every change uncommitted and finish your turn.**
+
+Finish your turn by running \`gtd step-agent\`. Then run \`gtd next\` and follow
+its output — repeat this cycle as long as the output is addressed to you (the
+agent); when it awaits the human, stop and hand off.
 "
 `;
 

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -63,6 +63,7 @@ const stubConfigLayer = Layer.succeed(ConfigService, {
   resolveModel: () => "stub",
   agenticReview: false,
   squash: false,
+  learning: false,
   fixAttemptCap: 0,
   reviewThreshold: 0,
 })

--- a/src/prompts/await-learning-review.md
+++ b/src/prompts/await-learning-review.md
@@ -1,0 +1,19 @@
+<%~ include("@header") %>
+
+`.gtd/LEARNINGS.md` holds the distilled learnings from this cycle, drafted by
+the agent. This is a human gate; there is nothing for the agent to do.
+
+Tell the user:
+
+- Read `.gtd/LEARNINGS.md`.
+- Delete anything not worth keeping, or edit/add anything the draft missed.
+- Run `gtd step` — with or without edits, either way proceeds: the agent
+  integrates whatever remains into the project's own memory
+  (CLAUDE.md/AGENTS.md/docs) next.
+
+There is no reject path — this gate only refines what gets kept, it doesn't
+send the cycle back for rework.
+
+<% if (it.tail) { %>
+<%~ include(it.tail) %>
+<% } %>

--- a/src/prompts/learning-apply.md
+++ b/src/prompts/learning-apply.md
@@ -1,0 +1,25 @@
+<%~ include("@header") %>
+
+The human has approved (and possibly amended) `.gtd/LEARNINGS.md`. Your job is
+to integrate those learnings into the project's own memory, not to touch
+`.gtd/LEARNINGS.md` itself.
+
+1. **Read `.gtd/LEARNINGS.md`.**
+2. **Pick the right home for each point**, using your judgment and this
+   project's existing convention:
+   - An existing `CLAUDE.md` or `AGENTS.md` at the repo root (or a directory
+     closer to what the learning concerns) is usually the right place.
+   - If neither exists and the learnings warrant one, create `AGENTS.md` at
+     the repo root.
+   - A learning about a specific subsystem may fit better in that
+     subsystem's own docs than a root-level file — use your judgment.
+3. **Integrate, don't just append** — merge each point into the relevant
+   section of the target file(s); rephrase for clarity, dedupe against what's
+   already documented, and keep the existing document's structure and tone.
+4. **Never delete or edit `.gtd/LEARNINGS.md`** — the machine removes it once
+   your turn is captured.
+5. **Leave every change uncommitted and finish your turn.**
+
+<% if (it.tail) { %>
+<%~ include(it.tail) %>
+<% } %>

--- a/src/prompts/learning.md
+++ b/src/prompts/learning.md
@@ -1,0 +1,48 @@
+<%~ include("@header") %>
+
+The process is **approved and done**, and headed for a squash. Before that
+happens, `.gtd/LEARNINGS.md` has been committed with a template — your job is
+to overwrite it with the real, distilled learnings from this cycle so they
+survive the squash even though the granular history won't.
+
+### Step 1 — Walk the cycle's history
+
+Scan the git history back to the cycle's start (the full-process diff is
+inlined below, and `git log` over the same range shows every `gtd: ...` /
+`gtd(agent): ...` / `gtd(human): ...` commit). Look specifically for:
+
+- **Test failures and fixes** — each `gtd: errors` round and the fix that
+  followed it. What broke, and what actually made it pass?
+- **Review feedback** — human `.gtd/REVIEW.md` notes and `gtd: review
+  feedback` detours. What did the human have to correct that the agent got
+  wrong on its own?
+- **Health-check rounds** — any `gtd: health-check` / `gtd: health-fix`
+  cycles. Environmental or systemic issues surfaced outside normal building?
+- **Grilling decisions** — `.gtd/TODO.md`'s "## Captured input" sections and
+  plan edits. Trade-offs or conventions the human specified that a future
+  agent should already know.
+
+### Step 2 — Distill, don't transcribe
+
+For each thing you found, ask: is this a **durable, generalizable lesson**
+(a convention, a gotcha, a pattern this project wants followed next time), or
+a **one-off detail** specific to this change? Keep only the former. A future
+agent reading this should learn something that changes how it works on this
+project, not a recap of what happened.
+
+### Step 3 — Overwrite .gtd/LEARNINGS.md
+
+Replace the **entire content** of `.gtd/LEARNINGS.md` with your distilled
+learnings (plain markdown, no leftover template scaffolding). If nothing
+durable surfaced this cycle, write a short explicit note saying so — don't
+leave the placeholder text in place. Leave the file uncommitted and finish
+your turn; a human reviews it next before it's integrated into the project's
+own memory (CLAUDE.md/AGENTS.md/docs).
+<% if (it.context.squashDiff && it.context.squashDiff.trim()) { %>
+<%= it.context.squashBase !== undefined ? "\nCycle base: " + it.context.squashBase + "\n" : "" %>
+<%~ include("@diff", { heading: "Full-process diff (`git diff " + (it.context.squashBase !== undefined ? it.context.squashBase : "<squashBase>") + " HEAD`)", diff: it.context.squashDiff, fenceFor: it.fenceFor }) %>
+<% } %>
+
+<% if (it.tail) { %>
+<%~ include(it.tail) %>
+<% } %>

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -74,6 +74,7 @@ Feature: gtd-loop — the packaged reference loop driver
       testCommand: "true"
       agenticReview: false
       squash: false
+      learning: false
       """
     And a commit "gtd(agent): grilling" that adds ".gtd/TODO.md" with:
       """

--- a/tests/integration/features/health-check.feature
+++ b/tests/integration/features/health-check.feature
@@ -64,6 +64,7 @@ Feature: Health check — the idle test loop
       """
       testCommand: bash gate.sh
       squash: true
+      learning: false
       """
     And a commit "feat: initial feature" that adds "src/lib.ts" with:
       """
@@ -98,6 +99,7 @@ Feature: Health check — the idle test loop
       """
       testCommand: bash gate.sh
       squash: false
+      learning: false
       """
     And a commit "feat: initial feature" that adds "src/lib.ts" with:
       """

--- a/tests/integration/features/journeys.feature
+++ b/tests/integration/features/journeys.feature
@@ -21,6 +21,7 @@ Feature: Full lifecycle journeys — the step-first two-beat loop end to end
       testCommand: "true"
       agenticReview: false
       squash: false
+      learning: false
       """
     And a file "src/input.ts" with:
       """
@@ -149,6 +150,7 @@ Feature: Full lifecycle journeys — the step-first two-beat loop end to end
       testCommand: "true"
       agenticReview: false
       squash: true
+      learning: false
       """
     And a file "src/input.ts" with:
       """

--- a/tests/integration/features/learning.feature
+++ b/tests/integration/features/learning.feature
@@ -1,0 +1,379 @@
+@learning
+@inmem
+Feature: Learning phase — distill and persist project memory before the squash
+
+  With learning on, the approval boundary `gtd: done` (or the health-fix path's
+  green re-test) is not a rest: the chain continues straight to
+  `gtd: learning template`, writing and committing a `.gtd/LEARNINGS.md`
+  template. `gtd next` then emits the learning prompt for the agent,
+  instructing it to distill durable lessons from the cycle's test failures,
+  review feedback, and health-check rounds. Once the agent overwrites the
+  template with real content and runs `gtd step-agent`, the draft is captured
+  (`gtd(agent): learning`) and routed to `gtd: learning drafted`, resting at
+  `await-learning-review` for a human. The human either accepts the draft
+  as-is (an empty turn) or edits it — either way there is no reject path, so
+  the very next `gtd step` always proceeds to `gtd: learning approved`,
+  resting at `learning-apply` for the agent. The agent integrates the
+  approved learnings into the project's own docs; its turn
+  (`gtd(agent): learning-apply`) is routed to `gtd: learning applied`, which
+  removes `.gtd/LEARNINGS.md` and then runs the same squash decision `gtd:
+  done` runs today: squash on continues to `gtd: squash template`, squash off
+  rests at idle. Learning and squash are orthogonal — either can be enabled
+  independently. With learning off, `gtd: done` (and the health-fix green
+  re-test) behaves exactly as it does today: no `.gtd/LEARNINGS.md` is ever
+  written.
+
+  Scenario: gtd: done with learning on continues the chain to the learning template
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      learning: true
+      squash: true
+      """
+    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      Build a calculator.
+      """
+    And a commit "gtd: planning" that deletes ".gtd/TODO.md"
+    And a commit "gtd(agent): review" that adds ".gtd/REVIEW.md" with:
+      """
+      # Review
+
+      - [ ] ./src/calc.ts#1
+      """
+    And a commit "gtd: awaiting review"
+    And a commit "gtd(human): review" that deletes ".gtd/REVIEW.md"
+    When I run gtd step
+    Then it succeeds
+    And the git log contains "gtd: done"
+    And the git log contains "gtd: learning template"
+    And the last commit subject is "gtd: learning template"
+    And the file ".gtd/LEARNINGS.md" exists
+
+  Scenario: gtd next at the learning template rest emits the learning prompt with the full-process diff
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      learning: true
+      """
+    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      Build a calculator.
+      """
+    And a commit "gtd: planning" that deletes ".gtd/TODO.md"
+    And a commit "gtd(agent): building" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd: package done"
+    And a commit "gtd(agent): review" that adds ".gtd/REVIEW.md" with:
+      """
+      # Review
+
+      - [ ] ./src/calc.ts#1
+      """
+    And a commit "gtd: awaiting review"
+    And a commit "gtd(human): review" that deletes ".gtd/REVIEW.md"
+    And a commit "gtd: done"
+    And a commit "gtd: learning template" that adds ".gtd/LEARNINGS.md" with:
+      """
+      <!-- gtd: replace this file's content with the actual distilled learnings for this cycle. -->
+
+      ## Learnings
+
+      - ...
+      """
+    When I run gtd next
+    Then it succeeds
+    And stdout contains ".gtd/LEARNINGS.md"
+    And stdout contains "distilled learnings"
+    And stdout contains "src/calc.ts"
+
+  Scenario: The agent overwrites LEARNINGS.md and gtd step-agent captures the draft, resting for human review
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      learning: true
+      """
+    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      Build a calculator.
+      """
+    And a commit "gtd: planning" that deletes ".gtd/TODO.md"
+    And a commit "gtd(agent): review" that adds ".gtd/REVIEW.md" with:
+      """
+      # Review
+
+      - [ ] ./src/calc.ts#1
+      """
+    And a commit "gtd: awaiting review"
+    And a commit "gtd(human): review" that deletes ".gtd/REVIEW.md"
+    And a commit "gtd: done"
+    And a commit "gtd: learning template" that adds ".gtd/LEARNINGS.md" with:
+      """
+      <!-- gtd: replace this file's content with the actual distilled learnings for this cycle. -->
+
+      ## Learnings
+
+      - ...
+      """
+    And ".gtd/LEARNINGS.md" is modified to:
+      """
+      ## Learnings
+
+      - Tests were failing because the helper mutated its input; prefer pure
+        functions in this codebase.
+      """
+    When I run gtd step-agent
+    Then it succeeds
+    And the git log contains "gtd(agent): learning"
+    And the last commit subject is "gtd: learning drafted"
+    And the file ".gtd/LEARNINGS.md" exists
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"actor\":\"human\""
+
+  Scenario: The unmodified LEARNINGS.md template never proceeds — the machine rests until real content is written
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      learning: true
+      """
+    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+      """
+      Build a calculator.
+      """
+    And a commit "gtd: planning" that deletes ".gtd/TODO.md"
+    And a commit "gtd(agent): review" that adds ".gtd/REVIEW.md" with:
+      """
+      - [ ] ./src/calc.ts#1
+      """
+    And a commit "gtd: awaiting review"
+    And a commit "gtd(human): review" that deletes ".gtd/REVIEW.md"
+    And a commit "gtd: done"
+    And a commit "gtd: learning template" that adds ".gtd/LEARNINGS.md" with:
+      """
+      <!-- gtd: replace this file's content with the actual distilled learnings for this cycle. -->
+      <!-- Keep only durable, generalizable lessons — delete anything that's a one-off detail. -->
+
+      ## Learnings
+
+      - ...
+      """
+    Then I record the commit count
+    When I run gtd step-agent
+    Then it succeeds
+    And the commit count is unchanged
+    And the last commit subject is "gtd: learning template"
+    When I run gtd next
+    Then it succeeds
+    And stdout contains ".gtd/LEARNINGS.md"
+
+  Scenario: The human accepts the draft as-is — an empty turn still proceeds to learning-apply
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      learning: true
+      """
+    And a commit "gtd(agent): learning" that adds ".gtd/LEARNINGS.md" with:
+      """
+      ## Learnings
+
+      - Keep fixtures small and composable.
+      """
+    And a commit "gtd: learning drafted"
+    When I run gtd step
+    Then it succeeds
+    And the git log contains "gtd(human): learning"
+    And the last commit subject is "gtd: learning approved"
+    And the file ".gtd/LEARNINGS.md" exists
+
+  Scenario: The human edits LEARNINGS.md — there is no reject path, it still proceeds to learning-apply
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      learning: true
+      """
+    And a commit "gtd(agent): learning" that adds ".gtd/LEARNINGS.md" with:
+      """
+      ## Learnings
+
+      - Keep fixtures small and composable.
+      - Some detail worth dropping.
+      """
+    And a commit "gtd: learning drafted"
+    And ".gtd/LEARNINGS.md" is modified to:
+      """
+      ## Learnings
+
+      - Keep fixtures small and composable.
+      """
+    When I run gtd step
+    Then it succeeds
+    And the git log contains "gtd(human): learning"
+    And the last commit subject is "gtd: learning approved"
+    And the file ".gtd/LEARNINGS.md" contains "Keep fixtures small and composable."
+    And the file ".gtd/LEARNINGS.md" does not contain "Some detail worth dropping."
+
+  Scenario: The agent applies the learnings, removing LEARNINGS.md and continuing to the squash template
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      learning: true
+      squash: true
+      """
+    And a commit "chore: pre-cycle work" that adds "src/existing.ts" with:
+      """
+      export const existing = 1
+      """
+    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+      """
+      Build a calculator.
+      """
+    And a commit "gtd: planning" that deletes ".gtd/TODO.md"
+    And a commit "gtd(agent): building" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd: package done"
+    And a commit "gtd(agent): review" that adds ".gtd/REVIEW.md" with:
+      """
+      - [ ] ./src/calc.ts#1
+      """
+    And a commit "gtd: awaiting review"
+    And a commit "gtd(human): review" that deletes ".gtd/REVIEW.md"
+    And a commit "gtd: done"
+    And a commit "gtd: learning template" that adds ".gtd/LEARNINGS.md" with:
+      """
+      ## Learnings
+
+      - Prefer pure functions for arithmetic helpers.
+      """
+    And a commit "gtd(agent): learning"
+    And a commit "gtd: learning drafted"
+    And a commit "gtd(human): learning"
+    And a commit "gtd: learning approved"
+    And a file "AGENTS.md" with:
+      """
+      Prefer pure functions for arithmetic helpers.
+      """
+    When I run gtd step-agent
+    Then it succeeds
+    And the git log contains "gtd(agent): learning-apply"
+    And the git log contains "gtd: learning applied"
+    And the last commit subject is "gtd: squash template"
+    And the file ".gtd/LEARNINGS.md" does not exist
+    And the file ".gtd/SQUASH_MSG.md" exists
+    And the file "AGENTS.md" contains "Prefer pure functions for arithmetic helpers."
+    And the file "src/calc.ts" exists
+    And the file "src/existing.ts" exists
+
+  Scenario: With squash off, the agent's applied learnings settle at a plain idle rest
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      learning: true
+      squash: false
+      """
+    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+      """
+      Build a calculator.
+      """
+    And a commit "gtd: planning" that deletes ".gtd/TODO.md"
+    And a commit "gtd(agent): review" that adds ".gtd/REVIEW.md" with:
+      """
+      - [ ] ./src/calc.ts#1
+      """
+    And a commit "gtd: awaiting review"
+    And a commit "gtd(human): review" that deletes ".gtd/REVIEW.md"
+    And a commit "gtd: done"
+    And a commit "gtd: learning template" that adds ".gtd/LEARNINGS.md" with:
+      """
+      ## Learnings
+
+      - Nothing durable this cycle.
+      """
+    And a commit "gtd(agent): learning"
+    And a commit "gtd: learning drafted"
+    And a commit "gtd(human): learning"
+    And a commit "gtd: learning approved"
+    And a file "AGENTS.md" with:
+      """
+      Nothing durable this cycle.
+      """
+    When I run gtd step-agent
+    Then it succeeds
+    And the last commit subject is "gtd: learning applied"
+    And the file ".gtd/LEARNINGS.md" does not exist
+    And the file ".gtd/SQUASH_MSG.md" does not exist
+    And the git log does not contain "gtd: squash template"
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"actor\":\"human\""
+
+  Scenario: learning off — gtd: done chains straight to the squash template, no LEARNINGS.md ever written
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      learning: false
+      squash: true
+      """
+    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+      """
+      Build a calculator.
+      """
+    And a commit "gtd: planning" that deletes ".gtd/TODO.md"
+    And a commit "gtd(agent): review" that adds ".gtd/REVIEW.md" with:
+      """
+      - [ ] ./src/calc.ts#1
+      """
+    And a commit "gtd: awaiting review"
+    And a commit "gtd(human): review" that deletes ".gtd/REVIEW.md"
+    When I run gtd step
+    Then it succeeds
+    And the last commit subject is "gtd: squash template"
+    And the git log does not contain "gtd: learning template"
+    And the file ".gtd/LEARNINGS.md" does not exist
+
+  Scenario: The health-fixer's green re-test chains to the learning template before the squash template
+    Given a test project
+    And a commit "chore: test gate" that adds "gate.sh" with:
+      """
+      echo HEALTH_BROKEN
+      exit 1
+      """
+    And a gtd config file at ".gtdrc" with:
+      """
+      testCommand: bash gate.sh
+      learning: true
+      squash: true
+      """
+    And a commit "feat: initial feature" that adds "src/lib.ts" with:
+      """
+      export const lib = 1
+      """
+    And a commit "gtd: health-check" that adds ".gtd/HEALTH.md" with:
+      """
+      SENTINEL_HEALTH_FAILURE
+      """
+    And "gate.sh" is modified to:
+      """
+      echo ALL_GREEN
+      exit 0
+      """
+    When I run gtd step-agent
+    Then it succeeds
+    And the git log contains "gtd(agent): health-fix"
+    And the git log contains "gtd: health-fix"
+    And the git log contains "gtd: tests green"
+    And the git log contains "gtd: learning template"
+    And the last commit subject is "gtd: learning template"
+    And the file ".gtd/HEALTH.md" does not exist
+    And the file ".gtd/LEARNINGS.md" exists
+    And the git log does not contain "gtd: squash template"

--- a/tests/integration/features/review-checkout.feature
+++ b/tests/integration/features/review-checkout.feature
@@ -18,6 +18,7 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
       testCommand: "true"
       agenticReview: false
       squash: false
+      learning: false
       """
     And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
       """

--- a/tests/integration/features/squashing.feature
+++ b/tests/integration/features/squashing.feature
@@ -21,6 +21,7 @@ Feature: Squashing — collapse a cycle into one conventional-commits message
     And a gtd config file at ".gtdrc" with:
       """
       squash: true
+      learning: false
       """
     And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
       """
@@ -49,6 +50,7 @@ Feature: Squashing — collapse a cycle into one conventional-commits message
     And a gtd config file at ".gtdrc" with:
       """
       squash: true
+      learning: false
       """
     And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
       """
@@ -81,6 +83,7 @@ Feature: Squashing — collapse a cycle into one conventional-commits message
     And a gtd config file at ".gtdrc" with:
       """
       squash: true
+      learning: false
       """
     And a commit "chore: pre-cycle work" that adds "src/existing.ts" with:
       """
@@ -131,6 +134,7 @@ Feature: Squashing — collapse a cycle into one conventional-commits message
     And a gtd config file at ".gtdrc" with:
       """
       squash: false
+      learning: false
       """
     And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
       """
@@ -161,6 +165,7 @@ Feature: Squashing — collapse a cycle into one conventional-commits message
     And a gtd config file at ".gtdrc" with:
       """
       squash: true
+      learning: false
       """
     And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
       """
@@ -196,6 +201,7 @@ Feature: Squashing — collapse a cycle into one conventional-commits message
     And a gtd config file at ".gtdrc" with:
       """
       squash: true
+      learning: false
       """
     And a commit "chore: pre-cycle work" that adds "src/existing.ts" with:
       """
@@ -258,6 +264,7 @@ Feature: Squashing — collapse a cycle into one conventional-commits message
     And a gtd config file at ".gtdrc" with:
       """
       squash: true
+      learning: false
       """
     And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
       """

--- a/tests/integration/support/inmem/layers.ts
+++ b/tests/integration/support/inmem/layers.ts
@@ -448,12 +448,22 @@ const parseConfigContent = (filename: string, content: string): Record<string, u
   }
 }
 
+const stringField = (raw: Record<string, unknown>, key: string, fallback: string): string =>
+  typeof raw[key] === "string" ? (raw[key] as string) : fallback
+
+const boolField = (raw: Record<string, unknown>, key: string, fallback: boolean): boolean =>
+  typeof raw[key] === "boolean" ? (raw[key] as boolean) : fallback
+
+const numberField = (raw: Record<string, unknown>, key: string, fallback: number): number =>
+  typeof raw[key] === "number" ? (raw[key] as number) : fallback
+
 const makeConfigOps = (raw: Record<string, unknown>): ConfigOperations => {
-  const testCommand = typeof raw["testCommand"] === "string" ? raw["testCommand"] : "npm run test"
-  const agenticReview = typeof raw["agenticReview"] === "boolean" ? raw["agenticReview"] : true
-  const squash = typeof raw["squash"] === "boolean" ? raw["squash"] : true
-  const fixAttemptCap = typeof raw["fixAttemptCap"] === "number" ? raw["fixAttemptCap"] : 3
-  const reviewThreshold = typeof raw["reviewThreshold"] === "number" ? raw["reviewThreshold"] : 3
+  const testCommand = stringField(raw, "testCommand", "npm run test")
+  const agenticReview = boolField(raw, "agenticReview", true)
+  const squash = boolField(raw, "squash", true)
+  const learning = boolField(raw, "learning", true)
+  const fixAttemptCap = numberField(raw, "fixAttemptCap", 3)
+  const reviewThreshold = numberField(raw, "reviewThreshold", 3)
 
   const modelsRaw = raw["models"]
   const models =
@@ -474,7 +484,15 @@ const makeConfigOps = (raw: Record<string, unknown>): ConfigOperations => {
     return builtinTierDefault[tier]
   }
 
-  return { testCommand, resolveModel, agenticReview, squash, fixAttemptCap, reviewThreshold }
+  return {
+    testCommand,
+    resolveModel,
+    agenticReview,
+    squash,
+    learning,
+    fixAttemptCap,
+    reviewThreshold,
+  }
 }
 
 const makeInMemoryConfigService = (repo: InMemRepo): Layer.Layer<ConfigService> => {


### PR DESCRIPTION
Adds a `learning` gate between `gtd: done` (or a green health-fix re-test)
and the squash: the agent distills durable lessons from the cycle's test
failures, review feedback, and health-check rounds into `.gtd/LEARNINGS.md`;
a human reviews and amends it; the agent then integrates what survives into
the project's own docs (CLAUDE.md/AGENTS.md, its judgment) before the
existing squash decision runs. Learning and squash are orthogonal config
flags (`learning`, default true), so either can run independently.

Extends the closed v2 grammar with 4 new states, 2 turn gates, and 4 routing
phases, mirroring the existing squash/review machinery throughout
Subjects.ts/Machine.ts/Events.ts/State.ts/Prompt.ts, with new prompts and
cucumber coverage, and updates STATES.md/README.md/AGENTS.md accordingly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HEVfcp25NRvEZtz3Mg9jxS