### PR TITLE
feat: enforce and parse structure for grilling/architecting and review docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Commands:
   next             Print the prompt for whichever actor is awaited (no mutation)
   status           Predict the next commit and state from the working tree (no mutation)
   review <target>  Anchor an ad-hoc human review against a git ref or branch
+  questions        List open questions from the active grilling/architecting doc
+  changesets       List changesets/files from the active review doc
   format <file>    Format a markdown file in place
 
 Options:
@@ -273,6 +275,30 @@ Errors (all exit 1, message on stderr):
 - Empty diff:
   `gtd review: nothing to review (<target> diff is empty after filtering)`
 
+### `gtd questions` / `gtd changesets`
+
+Pure, read-only reporters — no dirty-tree check, no mutation — that parse the
+structured content out of the active grilling/architecting and review documents,
+for a future UI:
+
+- **`gtd questions`** reads whichever of `.gtd/TODO.md` / `.gtd/ARCHITECTURE.md`
+  is present and reports its `## Open Questions` list (see
+  [Structured grilling/architecting and review files](#structured-grillingarchitecting-and-review-files)
+  below). Reports an empty list when neither file exists.
+- **`gtd changesets`** reads `.gtd/REVIEW.md`, if present, and reports its
+  chunks/file-pointer list. Reports an empty list when the file doesn't exist.
+
+Both take no arguments and always exit 0 — a malformed file is reported via the
+`errors` field/lines rather than failing the command (the same diagnosis
+`gtd step-agent` would refuse the agent's next turn capture with).
+
+```bash
+gtd questions --json
+# {"file":".gtd/TODO.md","questions":[{"question":"Which operations?","status":"suggested","text":"add and subtract."}],"errors":[]}
+gtd changesets --json
+# {"file":".gtd/REVIEW.md","shortHash":"abc1234","fullHash":"abc1234...","changesets":[...],"errors":[]}
+```
+
 ### `gtd format <file>`
 
 Unchanged from v1: formats a markdown file in place with a bundled prettier
@@ -292,8 +318,9 @@ Errors (all exit 1, message on stderr):
 
 ## JSON schemas
 
-Pass `--json` to `step`, `step-agent`, `next`, or `status` for machine-readable
-single-line JSON output instead of plain text.
+Pass `--json` to `step`, `step-agent`, `next`, `status`, `review`, `questions`,
+or `changesets` for machine-readable single-line JSON output instead of plain
+text.
 
 **`step` / `step-agent`** — `{state, actions, commits}`:
 
@@ -346,6 +373,47 @@ single-line JSON output instead of plain text.
 
 `predictedCommit` is `null` when the next invocation would author nothing (e.g.
 idle with a green health check).
+
+**`questions`** — `{file, questions, errors}`:
+
+```json
+{
+  "file": ".gtd/TODO.md",
+  "questions": [
+    {
+      "question": "Which operations?",
+      "status": "suggested",
+      "text": "add and subtract."
+    }
+  ],
+  "errors": []
+}
+```
+
+`file` is `null` when neither `.gtd/TODO.md` nor `.gtd/ARCHITECTURE.md` is
+present. `errors` lists any structural problems in the file — the same diagnosis
+that would make `gtd step-agent` refuse the agent's next turn capture.
+
+**`changesets`** — `{file, shortHash, fullHash, changesets, errors}`:
+
+```json
+{
+  "file": ".gtd/REVIEW.md",
+  "shortHash": "abc1234",
+  "fullHash": "abc1234def5678901234567890123456789abcd",
+  "changesets": [
+    {
+      "title": "Add calculator",
+      "description": "New add function for the calculator.",
+      "files": [{ "path": "./src/calc.ts", "line": 1, "checked": false }]
+    }
+  ],
+  "errors": []
+}
+```
+
+`file` is `null` when `.gtd/REVIEW.md` doesn't exist. `errors` mirrors
+`questions`' field above.
 
 **Error envelope** — every command, in `--json` mode, reports failures inside
 the JSON object rather than as unstructured text, and still exits 1:
@@ -489,8 +557,10 @@ everything pending as `gtd(human): grilling` — nothing is reverted or seeded,
 the captured files stay in history. `gtd next` hands the agent that turn's diff;
 the agent develops `.gtd/TODO.md` into a concrete **product-level** plan **in
 one turn** — user-facing decisions only, no architecture — proposing a
-**suggested default** for every open question, and leaves `.gtd/TODO.md`
-uncommitted for `gtd(agent): grilling`.
+**suggested default** for every open question under an enforced
+`## Open Questions` structure (see
+[Structured grilling/architecting and review files](#structured-grillingarchitecting-and-review-files)),
+and leaves `.gtd/TODO.md` uncommitted for `gtd(agent): grilling`.
 
 There are no markers to answer — the human either:
 
@@ -513,6 +583,46 @@ already contains `.gtd/ARCHITECTURE.md` (their own technical sketch), `gtd step`
 captures the entry turn as `gtd(human): architecting` directly, skipping product
 grilling for that cycle entirely — no CLI flag needed, it's driven purely by
 which steering file is present.
+
+### Structured grilling/architecting and review files
+
+`.gtd/TODO.md`, `.gtd/ARCHITECTURE.md`, and `.gtd/REVIEW.md` stay plain,
+human-readable markdown, but each follows an enforced structure so the data can
+be parsed out programmatically (`gtd questions` / `gtd changesets`, both
+`--json`-able, for a future UI) instead of staying opaque prose.
+
+**Grilling/architecting** (identical contract, one file and phase apart): an
+OPTIONAL `## Open Questions` section — omitted entirely means zero open
+questions, not an error. Every `###` sub-heading directly under it is one open
+question; its first body line must be `Suggested default: <text>` (the agent's
+proposal) or `Answer: <text>` (a human's answer):
+
+```markdown
+# Plan
+
+Build a calculator that can add and subtract.
+
+## Open Questions
+
+### Which operations?
+
+Suggested default: add and subtract.
+```
+
+**Review**: a `# Review: <short-hash>` header as the first line, an
+`<!-- base: <full-hash> -->` comment, and at least one `##` chunk with a
+non-empty title and at least one `- [ ]` / `- [x]` file-pointer line — the same
+format `@review` already instructs the agent to write (see
+[Human review gate](#human-review-gate) below).
+
+Validation applies ONLY to the **agent's own authored draft** at the gate that
+writes the file — never to a human's free-form edits (their answer at the
+grilling/architecting gate, their feedback/approval at the review gate). When
+the active file is malformed, `gtd step-agent` refuses (zero commits, a stderr
+message listing every structural problem) instead of capturing the turn; the
+agent fixes the file and reruns `gtd step-agent`. `gtd questions --json` /
+`gtd changesets --json` surface the same `errors` without blocking anything, so
+an agent (or a UI) can self-check before committing to a turn.
 
 ### Build lifecycle: budgets
 

--- a/STATES.md
+++ b/STATES.md
@@ -43,7 +43,7 @@ namespace, and everything outside it is project code. A root-level `TODO.md` or
 deletes it, and agents are prompted never to touch `.gtd/` except the single
 file their turn explicitly grants.
 
-**File content never steers**, with exactly two machine-verified exceptions:
+**File content never steers**, with exactly three machine-verified exceptions:
 
 - **.gtd/FEEDBACK.md emptiness** — a whitespace-only `.gtd/FEEDBACK.md` written
   by a fresh agentic review is the approval signal (`feedbackEmpty` in
@@ -51,6 +51,15 @@ file their turn explicitly grants.
 - **.gtd/REVIEW.md checkbox-only diffs** — a pending `.gtd/REVIEW.md` edit that
   is purely `- [ ]` ↔ `- [x]` flips (and nothing else dirty) is an approval
   signal, not review feedback (`isCheckboxOnlyDiff` in `src/Events.ts`).
+- **Structural validation of the AGENT's own draft** at the grilling,
+  architecting, and review gates — `.gtd/TODO.md` / `.gtd/ARCHITECTURE.md`'s
+  `## Open Questions` structure (`src/OpenQuestions.ts`) and `.gtd/REVIEW.md`'s
+  header/base-comment/chunk structure (`src/ReviewDoc.ts`), surfaced as
+  `grillingDocErrors` / `reviewDocErrors` in `ResolvePayload`. This never
+  inspects a HUMAN's own turn (their answer at grilling, their feedback/approval
+  at review) — only the agent's own turn capture can be refused this way
+  (`applyTurnTaking` in `src/Machine.ts`). See "Open questions and review
+  structure" below.
 
 `.gtd/LEARNINGS.md` and `.gtd/SQUASH_MSG.md` are the two exceptions to this rule
 at a different layer: their content becomes the human-review draft / the final
@@ -83,6 +92,36 @@ commit and never plain no-ops: it always re-runs the configured `testCommand` as
 a health check. A green result stops the loop with **zero commits** — idle is a
 true steady state, not a place that accumulates empty-commit noise. A red result
 writes `.gtd/HEALTH.md` and commits it, entering the health-fixing detour (§4).
+
+### Open questions and review structure
+
+`.gtd/TODO.md` / `.gtd/ARCHITECTURE.md` and `.gtd/REVIEW.md` stay plain,
+human-readable markdown, but each has an enforced structure so the data can be
+parsed out (`gtd questions` / `gtd changesets`, §3) instead of staying opaque
+prose:
+
+- **`.gtd/TODO.md` / `.gtd/ARCHITECTURE.md`** (identical contract, mirrored
+  phases, parsed by `parseOpenQuestions` in `src/OpenQuestions.ts`): an OPTIONAL
+  `## Open Questions` section (omitted entirely = zero open questions, not an
+  error). Every `###` sub-heading directly under it is one open question; its
+  body's first non-blank line must be `Suggested default: <text>` (the agent's
+  unanswered default) or `Answer: <text>` (a human's answer). A `###` question
+  with neither is a structural error.
+- **`.gtd/REVIEW.md`** (parsed by `parseReviewDoc` in `src/ReviewDoc.ts`): a
+  `# Review: <short-hash>` header as the document's first line, an
+  `<!-- base: <full-hash> -->` comment, and at least one `##` chunk, each with a
+  non-empty title and at least one `- [ ]` / `- [x]` file-pointer line. A chunk
+  with zero file pointers, or a missing header/base comment, is a structural
+  error.
+
+Validation applies ONLY to the **agent's own authored draft** at the gate that
+writes the file (`gtd(agent): grilling`, `gtd(agent): architecting`,
+`gtd(agent): review`) — never to a human's free-form edits (their answer at the
+grilling/architecting gate, their feedback/approval at the review gate). When
+the active file is malformed, `gtd step-agent` refuses (zero commits, a stderr
+message listing every structural error) instead of capturing the turn — the
+agent fixes the file and reruns `gtd step-agent`. This is the third of the
+narrow, machine-verified exceptions to "file content never steers" above.
 
 ## 2. The commit-subject grammar
 
@@ -300,6 +339,23 @@ commits `gtd: reviewing <hash>`. Refuses on a dirty tree or an empty filtered
 diff. This anchor takes precedence over the ordinary in-process review-scope
 rules (§4, Review) the next time the machine resolves a review.
 
+### `gtd questions` — pure reader
+
+`invoker`-agnostic pure read: no dirty-tree check, no mutation. Reads whichever
+of `.gtd/TODO.md` / `.gtd/ARCHITECTURE.md` is present (they never coexist),
+parses it per "Open questions and review structure" above (§1), and reports the
+open-questions list — plus any structural errors, the same ones that would
+refuse the next `gtd(agent): grilling`/`gtd(agent): architecting` turn capture.
+Reports an empty list (no file, no error) when neither file is present. Rejects
+extra positional arguments. For a future UI.
+
+### `gtd changesets` — pure reader
+
+Mirrors `gtd questions` for the review side: reads `.gtd/REVIEW.md`, if present,
+parses it per §1 above, and reports the changeset/file list plus any structural
+errors. Reports an empty list (no file, no error) when the file is absent.
+Rejects extra positional arguments. For a future UI.
+
 ### `gtd format <file>`
 
 Reformats a single markdown file in place (via the same formatter `gtd` applies
@@ -329,8 +385,8 @@ committed.
 
 ### JSON shapes
 
-`--json` is supported on `step`, `step-agent`, `next`, `status`, and `review`
-(not `format`). Representative shapes:
+`--json` is supported on `step`, `step-agent`, `next`, `status`, `review`,
+`questions`, and `changesets` (not `format`). Representative shapes:
 
 - `step` / `step-agent`: `{ state, actions, commits }` — `actions` is the
   human-readable list of edge actions performed, `commits` the ordered list of
@@ -346,6 +402,15 @@ committed.
 - `status`: `{ state, actor, predictedCommit, predictedState }` —
   `predictedCommit` is `null` when nothing would be committed (e.g. idle).
 - `review`: `{ state: "review", reviewBase, pending: false, prompt: null }`.
+- `questions`: `{ file, questions, errors }` — `file` is `.gtd/TODO.md` /
+  `.gtd/ARCHITECTURE.md` / `null`; `questions` is
+  `{ question, status: "suggested" | "answered", text }[]`; `errors` lists any
+  structural violations found (same diagnosis `gtd step-agent` would refuse the
+  agent's turn capture with).
+- `changesets`: `{ file, shortHash, fullHash, changesets, errors }` — `file` is
+  `.gtd/REVIEW.md` / `null`; `changesets` is
+  `{ title, description, files: { path, line, checked, note }[] }[]`; `errors`
+  mirrors `questions`' field above.
 - Any top-level failure (including inside the Effect pipeline) renders as
   `{ state: "error", prompt: <message> }` before the process exits non-zero.
 
@@ -376,9 +441,10 @@ agent-develops rest (`@grilling-agent` template).
 
 - `@grilling-agent` (agent awaited) — develop `.gtd/TODO.md` into a concrete
   product-level plan in one turn, using subagents; every remaining open question
-  must carry a suggested default; leave .gtd/TODO.md uncommitted. Inlines the
-  latest human turn's diff (workflow files excluded) as "feedback, not finished
-  work" when present.
+  goes under a `## Open Questions` section (§1, "Open questions and review
+  structure") with a suggested default; leave .gtd/TODO.md uncommitted. Inlines
+  the latest human turn's diff (workflow files excluded) as "feedback, not
+  finished work" when present.
 - `@grilling-answers` (human awaited) — a pure human gate: edit `.gtd/TODO.md`
   in place to answer/annotate, or run `gtd step` with no edits to accept all
   suggested defaults.
@@ -420,7 +486,8 @@ Mechanically an exact mirror of `grilling`, one file and one phase later.
 
 - `@architecting-agent` (agent awaited) — develop `.gtd/ARCHITECTURE.md` into a
   concrete technical plan in one turn, using subagents; every remaining open
-  question must carry a suggested default; leave .gtd/ARCHITECTURE.md
+  question goes under a `## Open Questions` section (§1, "Open questions and
+  review structure") with a suggested default; leave .gtd/ARCHITECTURE.md
   uncommitted. Must not re-open product/user-facing decisions already settled by
   grilling. Inlines the latest human turn's diff as "feedback, not finished
   work" when present.
@@ -627,12 +694,12 @@ the `grilling` section's Entry paragraph.)
 
 **Prompt (agent draft, `@review`):** spawn a subagent to read the inlined diff
 (`git diff <reviewBase> HEAD`, workflow files excluded), group hunks
-semantically into chunks, and write `.gtd/REVIEW.md` with a fixed format: a
-`# Review: <short-hash>` header, an HTML-comment `base:` line, and per-chunk
-`- [ ]` file-pointer checkboxes (`./path#line`). Checkboxes are the approval
-mechanism — ticking them with nothing else edited approves; any other edit (to
-.gtd/REVIEW.md or the code) is a change request. Leave `.gtd/REVIEW.md`
-uncommitted.
+semantically into chunks, and write `.gtd/REVIEW.md` with a fixed, enforced
+format (§1, "Open questions and review structure"): a `# Review: <short-hash>`
+header, an HTML-comment `base:` line, and per-chunk `- [ ]` file-pointer
+checkboxes (`./path#line`). Checkboxes are the approval mechanism — ticking them
+with nothing else edited approves; any other edit (to .gtd/REVIEW.md or the
+code) is a change request. Leave `.gtd/REVIEW.md` uncommitted.
 
 The human gate reached after drafting (`gtd: awaiting review`) is a separate
 `GtdState`, `await-review`, with its own `@await-review` prompt — see below.

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -7,6 +7,8 @@ import { Cwd } from "./Cwd.js"
 import { formatFile } from "./Format.js"
 import { TestRunner } from "./TestRunner.js"
 import { parseSubject, turnSubject, type Actor } from "./Subjects.js"
+import { parseOpenQuestions } from "./OpenQuestions.js"
+import { parseReviewDoc } from "./ReviewDoc.js"
 import type {
   CommitEvent,
   EdgeAction,
@@ -483,6 +485,22 @@ export const gatherEvents = (
     // ARCHITECTURE.md tracked at HEAD.
     const architectureCommitted = architectureExists && !isUncommitted(ARCHITECTURE_FILE)
 
+    // Structural validation of whichever grilling-phase file is present (the
+    // two never coexist) and of REVIEW.md, consulted ONLY by the machine when
+    // the AGENT is about to capture a fresh turn at that gate (a human's own
+    // turn is never blocked by this — see `applyTurnTaking`).
+    const grillingDocPath = todoExists
+      ? TODO_FILE
+      : architectureExists
+        ? ARCHITECTURE_FILE
+        : undefined
+    const grillingDocErrors = grillingDocPath
+      ? parseOpenQuestions(yield* fs.readFileString(resolve(grillingDocPath))).errors
+      : []
+    const reviewDocErrors = reviewPresent
+      ? parseReviewDoc(yield* fs.readFileString(resolve(REVIEW_FILE))).errors
+      : []
+
     // The working tree deletes a committed ERRORS.md (human resume → fresh
     // budget). A status probe, distinct from the committed `removedErrors` flag.
     const pendingErrorsDeletion = entries.some(
@@ -801,6 +819,8 @@ export const gatherEvents = (
       reviewCommitted,
       reviewDirty,
       reviewCheckboxOnly,
+      ...(grillingDocErrors.length > 0 ? { grillingDocErrors } : {}),
+      ...(reviewDocErrors.length > 0 ? { reviewDocErrors } : {}),
       pendingErrorsDeletion,
       pendingFeedbackDeletion,
       lastCommitSubject,
@@ -860,6 +880,59 @@ export const reviewAgainst = (
     const refDiff = yield* git.diffRef(mergeBaseHash, WORKFLOW_FILE_EXCLUDES)
     if (refDiff.trim().length === 0) return undefined
     return { reviewBase: mergeBaseHash, refDiff }
+  })
+
+/** The `gtd questions` CLI command's result shape — the file it read (if any) plus the parsed doc. */
+export type OpenQuestionsResult = { file: string | null } & ReturnType<typeof parseOpenQuestions>
+
+/**
+ * Reads and parses whichever of `.gtd/TODO.md` / `.gtd/ARCHITECTURE.md` is
+ * present (the two never coexist) for the `gtd questions` CLI command. Pure
+ * read — no dirty-tree check, no mutation; reports whatever is on disk right
+ * now, well-formed or not.
+ */
+export const readOpenQuestionsDoc = (): Effect.Effect<
+  OpenQuestionsResult,
+  Error,
+  FileSystem.FileSystem | Cwd
+> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const { root } = yield* Cwd
+    const resolve = (p: string) => join(root, p)
+
+    const todoExists = yield* fs.exists(resolve(TODO_FILE))
+    const architectureExists = yield* fs.exists(resolve(ARCHITECTURE_FILE))
+    const file = todoExists ? TODO_FILE : architectureExists ? ARCHITECTURE_FILE : null
+    if (file === null) return { file, questions: [], errors: [] }
+
+    const content = yield* fs.readFileString(resolve(file))
+    return { file, ...parseOpenQuestions(content) }
+  })
+
+/** The `gtd changesets` CLI command's result shape — the file it read (if any) plus the parsed doc. */
+export type ReviewDocResult = { file: string | null } & ReturnType<typeof parseReviewDoc>
+
+/**
+ * Reads and parses `.gtd/REVIEW.md`, if present, for the `gtd changesets` CLI
+ * command. Pure read — no dirty-tree check, no mutation; reports whatever is
+ * on disk right now, well-formed or not.
+ */
+export const readReviewDoc = (): Effect.Effect<
+  ReviewDocResult,
+  Error,
+  FileSystem.FileSystem | Cwd
+> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const { root } = yield* Cwd
+    const resolve = (p: string) => join(root, p)
+
+    const present = yield* fs.exists(resolve(REVIEW_FILE))
+    if (!present) return { file: null, changesets: [], errors: [] }
+
+    const content = yield* fs.readFileString(resolve(REVIEW_FILE))
+    return { file: REVIEW_FILE, ...parseReviewDoc(content) }
   })
 
 /**

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -205,6 +205,23 @@ export interface ResolvePayload {
    * unmodified placeholder.
    */
   readonly learningMsgIsTemplate: boolean
+  /**
+   * Structural-validation errors for whichever of `TODO.md`/`ARCHITECTURE.md`
+   * is present (the two never coexist, so one field covers both phases), from
+   * `parseOpenQuestions` (`src/OpenQuestions.ts`). Empty/absent when the
+   * present file is well-formed or neither file exists. Consulted ONLY when
+   * the AGENT is about to capture a fresh `grilling`/`architecting` turn
+   * (`applyTurnTaking`) — a human's own turn is never blocked by this.
+   */
+  readonly grillingDocErrors?: readonly string[]
+  /**
+   * Structural-validation errors for the present `REVIEW.md`, from
+   * `parseReviewDoc` (`src/ReviewDoc.ts`). Empty/absent when well-formed or
+   * absent. Consulted ONLY when the AGENT is about to capture a fresh
+   * `review` turn (the human's checkbox/feedback turn at `await-review` is
+   * never blocked by this).
+   */
+  readonly reviewDocErrors?: readonly string[]
 }
 
 /**
@@ -1485,6 +1502,38 @@ const applyTurnTaking = (
   //   (accept-defaults at grilling, clean approval at review).
   if (invoker === "agent" && isInertEmptyAgentRest(baseline.state, p)) {
     return { state: baseline.state, actor: awaited, pending: false, context }
+  }
+
+  // A malformed grilling/architecting/review draft blocks the AGENT's own
+  // turn capture — a third narrow content-inspection exception, alongside
+  // FEEDBACK.md emptiness and REVIEW.md checkbox-only diffs (STATES.md §1).
+  // `invoker === "agent"` is what keeps this from ever firing on a HUMAN's
+  // turn capture at these same gate names (their answer at the grilling
+  // gate, their feedback/approval at the review gate) — those are never
+  // structurally validated.
+  if (invoker === "agent") {
+    if (
+      (gate === "grilling" || gate === "architecting") &&
+      (p.grillingDocErrors?.length ?? 0) > 0
+    ) {
+      const file = gate === "grilling" ? ".gtd/TODO.md" : ".gtd/ARCHITECTURE.md"
+      return {
+        state: baseline.state,
+        actor: awaited,
+        pending: false,
+        refusal: `${file} does not match the required structure:\n- ${p.grillingDocErrors!.join("\n- ")}\n\nFix the file and re-run \`gtd step-agent\`.`,
+        context,
+      }
+    }
+    if (gate === "review" && (p.reviewDocErrors?.length ?? 0) > 0) {
+      return {
+        state: baseline.state,
+        actor: awaited,
+        pending: false,
+        refusal: `.gtd/REVIEW.md does not match the required structure:\n- ${p.reviewDocErrors!.join("\n- ")}\n\nFix the file and re-run \`gtd step-agent\`.`,
+        context,
+      }
+    }
   }
 
   return {

--- a/src/OpenQuestions.test.ts
+++ b/src/OpenQuestions.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest"
+import { parseOpenQuestions } from "./OpenQuestions.js"
+
+describe("parseOpenQuestions", () => {
+  it("returns zero questions and zero errors when there is no Open Questions section", () => {
+    expect(parseOpenQuestions("# Plan\n\nBuild a calculator.\n")).toEqual({
+      questions: [],
+      errors: [],
+    })
+  })
+
+  it("returns zero questions and zero errors when the Open Questions section is present but empty", () => {
+    expect(parseOpenQuestions("# Plan\n\nBuild a calculator.\n\n## Open Questions\n")).toEqual({
+      questions: [],
+      errors: [],
+    })
+  })
+
+  it("parses a single well-formed suggested-default question", () => {
+    const content = [
+      "# Plan",
+      "",
+      "Build a calculator.",
+      "",
+      "## Open Questions",
+      "",
+      "### Which operations?",
+      "",
+      "Suggested default: add and subtract.",
+      "",
+    ].join("\n")
+    expect(parseOpenQuestions(content)).toEqual({
+      questions: [
+        { question: "Which operations?", status: "suggested", text: "add and subtract." },
+      ],
+      errors: [],
+    })
+  })
+
+  it("parses an answered question", () => {
+    const content = [
+      "## Open Questions",
+      "",
+      "### Which operations?",
+      "",
+      "Answer: add, subtract, and multiply.",
+      "",
+    ].join("\n")
+    expect(parseOpenQuestions(content)).toEqual({
+      questions: [
+        { question: "Which operations?", status: "answered", text: "add, subtract, and multiply." },
+      ],
+      errors: [],
+    })
+  })
+
+  it("parses multiple questions in one section", () => {
+    const content = [
+      "## Open Questions",
+      "",
+      "### Which operations?",
+      "",
+      "Suggested default: add and subtract.",
+      "",
+      "### What is the target platform?",
+      "",
+      "Answer: web only.",
+      "",
+    ].join("\n")
+    expect(parseOpenQuestions(content).questions).toEqual([
+      { question: "Which operations?", status: "suggested", text: "add and subtract." },
+      { question: "What is the target platform?", status: "answered", text: "web only." },
+    ])
+  })
+
+  it("stops the Open Questions section at the next H2 heading", () => {
+    const content = [
+      "## Open Questions",
+      "",
+      "### Which operations?",
+      "",
+      "Suggested default: add and subtract.",
+      "",
+      "## Implementation Notes",
+      "",
+      "### Not a question",
+      "",
+      "This should be ignored entirely.",
+      "",
+    ].join("\n")
+    expect(parseOpenQuestions(content)).toEqual({
+      questions: [
+        { question: "Which operations?", status: "suggested", text: "add and subtract." },
+      ],
+      errors: [],
+    })
+  })
+
+  it("errors when a question has no Suggested default:/Answer: line", () => {
+    const content = [
+      "## Open Questions",
+      "",
+      "### Which operations?",
+      "",
+      "Not sure yet.",
+      "",
+    ].join("\n")
+    const result = parseOpenQuestions(content)
+    expect(result.questions).toEqual([])
+    expect(result.errors).toEqual([
+      'Open question "Which operations?" is missing a "Suggested default: ..." or "Answer: ..." line',
+    ])
+  })
+
+  it("errors when a question has an empty response line", () => {
+    const content = [
+      "## Open Questions",
+      "",
+      "### Which operations?",
+      "",
+      "Suggested default:",
+      "",
+    ].join("\n")
+    const result = parseOpenQuestions(content)
+    expect(result.questions).toEqual([])
+    expect(result.errors).toHaveLength(1)
+  })
+
+  it("errors when a question has no body at all before the next heading", () => {
+    const content = [
+      "## Open Questions",
+      "",
+      "### Which operations?",
+      "### What is the target platform?",
+      "",
+      "Answer: web only.",
+      "",
+    ].join("\n")
+    const result = parseOpenQuestions(content)
+    expect(result.errors).toEqual([
+      'Open question "Which operations?" is missing a "Suggested default: ..." or "Answer: ..." line',
+    ])
+    expect(result.questions).toEqual([
+      { question: "What is the target platform?", status: "answered", text: "web only." },
+    ])
+  })
+
+  it("collects one error per malformed question and keeps well-formed ones", () => {
+    const content = [
+      "## Open Questions",
+      "",
+      "### First?",
+      "",
+      "no marker here",
+      "",
+      "### Second?",
+      "",
+      "Suggested default: yes.",
+      "",
+      "### Third?",
+      "",
+      "also no marker",
+      "",
+    ].join("\n")
+    const result = parseOpenQuestions(content)
+    expect(result.questions).toEqual([{ question: "Second?", status: "suggested", text: "yes." }])
+    expect(result.errors).toHaveLength(2)
+  })
+})

--- a/src/OpenQuestions.ts
+++ b/src/OpenQuestions.ts
@@ -1,0 +1,133 @@
+/**
+ * Pure parser/validator for the "open questions" structure shared by
+ * `.gtd/TODO.md` (grilling) and `.gtd/ARCHITECTURE.md` (architecting) — the
+ * two phases are mechanically identical, one file and one phase apart, so a
+ * single parser covers both.
+ *
+ * Format: free-form prose, plus an OPTIONAL `## Open Questions` section
+ * (omitted entirely = zero open questions, not an error). Every `###`
+ * sub-heading directly under that section is one open question; its body's
+ * first non-blank line must be `Suggested default: <text>` (the agent's
+ * unanswered default) or `Answer: <text>` (a human's answer, or the agent
+ * folding one in) — anything else is a validation error.
+ *
+ * No git, no filesystem, no Effect — trivially unit-testable and safe to call
+ * from both the IO edge (`Events.ts`) and, indirectly via a payload flag,
+ * consulted by the pure resolver (`Machine.ts`).
+ */
+
+export type OpenQuestionStatus = "suggested" | "answered"
+
+export interface OpenQuestion {
+  readonly question: string
+  readonly status: OpenQuestionStatus
+  readonly text: string
+}
+
+export interface OpenQuestionsDoc {
+  readonly questions: readonly OpenQuestion[]
+  readonly errors: readonly string[]
+}
+
+const OPEN_QUESTIONS_HEADING = "## Open Questions"
+const RESPONSE_RE = /^(Suggested default|Answer):\s*(.*)$/
+
+/** Leading `#` run length of a heading line, or `undefined` if the (trimmed) line isn't a heading. */
+const headingLevel = (line: string): number | undefined => {
+  const match = /^(#{1,6})\s+\S.*$/.exec(line.trim())
+  return match ? match[1]!.length : undefined
+}
+
+/** One `###` heading under `## Open Questions`, with its raw body lines (up to the next heading of any level). */
+interface QuestionBlock {
+  readonly question: string
+  readonly body: readonly string[]
+}
+
+/**
+ * Splits the lines after `## Open Questions` into consecutive `###` blocks.
+ * Stops at the next level-1/2 heading (the end of the section) or EOF; a
+ * heading deeper than level 3, or plain prose, is skipped as filler between
+ * blocks.
+ */
+const splitQuestionBlocks = (lines: readonly string[], start: number): readonly QuestionBlock[] => {
+  const blocks: QuestionBlock[] = []
+  let i = start
+
+  while (i < lines.length) {
+    const level = headingLevel(lines[i]!)
+    if (level !== undefined && level <= 2) break
+
+    if (level !== 3) {
+      i += 1
+      continue
+    }
+
+    const question = lines[i]!.trim()
+      .replace(/^#{3}\s+/, "")
+      .trim()
+    i += 1
+    const body: string[] = []
+    while (i < lines.length && headingLevel(lines[i]!) === undefined) {
+      body.push(lines[i]!)
+      i += 1
+    }
+    blocks.push({ question, body })
+  }
+
+  return blocks
+}
+
+/** Parses one question block into a well-formed `OpenQuestion`, or an error message. */
+const parseQuestionBlock = (block: QuestionBlock): OpenQuestion | { readonly error: string } => {
+  if (block.question.length === 0) {
+    return {
+      error: "An '### ' open-question heading under '## Open Questions' has no question text",
+    }
+  }
+
+  const firstNonBlank = block.body.map((line) => line.trim()).find((line) => line.length > 0)
+  const responseMatch = firstNonBlank ? RESPONSE_RE.exec(firstNonBlank) : undefined
+  const text = responseMatch?.[2]?.trim() ?? ""
+  if (!responseMatch || text.length === 0) {
+    return {
+      error: `Open question "${block.question}" is missing a "Suggested default: ..." or "Answer: ..." line`,
+    }
+  }
+
+  return {
+    question: block.question,
+    status: responseMatch[1] === "Answer" ? "answered" : "suggested",
+    text,
+  }
+}
+
+/**
+ * Parses the open-questions structure out of `content` (the raw text of
+ * `.gtd/TODO.md` or `.gtd/ARCHITECTURE.md`). Total and side-effect-free:
+ * always returns a result, never throws. `errors` is non-empty exactly when
+ * the document violates the required structure (a `###` question under
+ * `## Open Questions` with no recognized response line) — the caller decides
+ * what to do with that (the machine refuses the agent's turn capture; the
+ * `gtd questions` CLI command just reports it alongside whatever parsed).
+ */
+export const parseOpenQuestions = (content: string): OpenQuestionsDoc => {
+  const lines = content.split(/\r?\n/)
+  const headingIndex = lines.findIndex((line) => line.trim() === OPEN_QUESTIONS_HEADING)
+  if (headingIndex === -1) {
+    return { questions: [], errors: [] }
+  }
+
+  const questions: OpenQuestion[] = []
+  const errors: string[] = []
+  for (const block of splitQuestionBlocks(lines, headingIndex + 1)) {
+    const result = parseQuestionBlock(block)
+    if ("error" in result) {
+      errors.push(result.error)
+    } else {
+      questions.push(result)
+    }
+  }
+
+  return { questions, errors }
+}

--- a/src/ReviewDoc.test.ts
+++ b/src/ReviewDoc.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest"
+import { parseReviewDoc } from "./ReviewDoc.js"
+
+describe("parseReviewDoc", () => {
+  it("parses a well-formed review with one chunk", () => {
+    const content = [
+      "# Review: abc1234",
+      "",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add calculator",
+      "",
+      "New add function for the calculator.",
+      "",
+      "- [ ] ./src/calc.ts#1",
+      "- [ ] ./src/calc.ts#5",
+      "",
+    ].join("\n")
+
+    expect(parseReviewDoc(content)).toEqual({
+      shortHash: "abc1234",
+      fullHash: "abc1234def5678901234567890123456789abcd",
+      changesets: [
+        {
+          title: "Add calculator",
+          description: "New add function for the calculator.",
+          files: [
+            { path: "./src/calc.ts", line: 1, checked: false },
+            { path: "./src/calc.ts", line: 5, checked: false },
+          ],
+        },
+      ],
+      errors: [],
+    })
+  })
+
+  it("parses multiple chunks, checked boxes, and trailing notes", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add calculator",
+      "",
+      "- [x] ./src/calc.ts#1 — new add function",
+      "",
+      "## Wire it up",
+      "",
+      "- [ ] ./src/index.ts#10",
+      "",
+    ].join("\n")
+
+    const result = parseReviewDoc(content)
+    expect(result.errors).toEqual([])
+    expect(result.changesets).toEqual([
+      {
+        title: "Add calculator",
+        description: "",
+        files: [{ path: "./src/calc.ts", line: 1, checked: true, note: "new add function" }],
+      },
+      {
+        title: "Wire it up",
+        description: "",
+        files: [{ path: "./src/index.ts", line: 10, checked: false }],
+      },
+    ])
+  })
+
+  it("errors when the header is missing", () => {
+    const content = [
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add calculator",
+      "",
+      "- [ ] ./src/calc.ts#1",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    expect(result.shortHash).toBeUndefined()
+    expect(result.errors).toContain(
+      "Missing or malformed '# Review: <hash>' header as the document's first line",
+    )
+  })
+
+  it("errors when the base comment is missing", () => {
+    const content = [
+      "# Review: abc1234",
+      "",
+      "## Add calculator",
+      "",
+      "- [ ] ./src/calc.ts#1",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    expect(result.fullHash).toBeUndefined()
+    expect(result.errors).toContain("Missing '<!-- base: <hash> -->' comment")
+  })
+
+  it("errors when a chunk has no file pointers", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add calculator",
+      "",
+      "Just prose, no pointers.",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    expect(result.errors).toContain('Chunk "Add calculator" has no file pointers')
+    expect(result.changesets).toEqual([
+      { title: "Add calculator", description: "Just prose, no pointers.", files: [] },
+    ])
+  })
+
+  it("errors when there are no chunks at all", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "Nothing to review.",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    expect(result.errors).toContain("REVIEW.md has no '##' chunks")
+    expect(result.changesets).toEqual([])
+  })
+
+  it("collects all applicable errors at once for a fully malformed document", () => {
+    const result = parseReviewDoc("Just some text\n")
+    expect(result.errors).toEqual([
+      "Missing or malformed '# Review: <hash>' header as the document's first line",
+      "Missing '<!-- base: <hash> -->' comment",
+      "REVIEW.md has no '##' chunks",
+    ])
+  })
+})

--- a/src/ReviewDoc.ts
+++ b/src/ReviewDoc.ts
@@ -1,0 +1,166 @@
+/**
+ * Pure parser/validator for the review structure `.gtd/REVIEW.md` must
+ * follow — formalizing the shape the `@review` prompt template
+ * (`src/prompts/review.md`) already tells the agent to write:
+ *
+ * ```markdown
+ * # Review: <short-hash>
+ *
+ * <!-- base: <full-hash> -->
+ *
+ * ## <Chunk Title>
+ *
+ * <What this chunk changes and why>
+ *
+ * - [ ] ./path/to/file.ts#42
+ * - [ ] ./path/to/file.ts#99
+ * ```
+ *
+ * Required: the `# Review: <hash>` header (as the document's first non-blank
+ * line), the `<!-- base: <hash> -->` comment, and at least one `##` chunk
+ * with a non-empty title and at least one `- [ ]` / `- [x]` file pointer.
+ *
+ * No git, no filesystem, no Effect — trivially unit-testable and safe to call
+ * from both the IO edge (`Events.ts`) and, indirectly via a payload flag,
+ * consulted by the pure resolver (`Machine.ts`).
+ */
+
+export interface ReviewFile {
+  readonly path: string
+  readonly line?: number
+  readonly checked: boolean
+  readonly note?: string
+}
+
+export interface Changeset {
+  readonly title: string
+  readonly description: string
+  readonly files: readonly ReviewFile[]
+}
+
+export interface ReviewDoc {
+  readonly shortHash?: string
+  readonly fullHash?: string
+  readonly changesets: readonly Changeset[]
+  readonly errors: readonly string[]
+}
+
+const HEADER_RE = /^#\s+Review:\s*(\S+)\s*$/
+const BASE_COMMENT_RE = /^<!--\s*base:\s*(\S+)\s*-->$/
+const CHUNK_HEADING_RE = /^##\s+(.+)$/
+const FILE_POINTER_RE = /^-\s*\[([ xX])\]\s*(\.\/\S+?)(?:#(\d+))?(?:\s*[—-]+\s*(.*))?$/
+
+/** The `# Review: <hash>` header, required as the document's first non-blank line. */
+const parseHeader = (lines: readonly string[]): string | undefined => {
+  const firstNonBlank = lines.find((line) => line.trim().length > 0)
+  return firstNonBlank ? HEADER_RE.exec(firstNonBlank.trim())?.[1] : undefined
+}
+
+/** The `<!-- base: <hash> -->` comment, wherever it appears in the document. */
+const parseBaseComment = (lines: readonly string[]): string | undefined => {
+  for (const line of lines) {
+    const match = BASE_COMMENT_RE.exec(line.trim())
+    if (match) return match[1]
+  }
+  return undefined
+}
+
+/** One `- [ ]` / `- [x]` file-pointer line, or `undefined` if `line` isn't one. */
+const parseFilePointer = (line: string): ReviewFile | undefined => {
+  const match = FILE_POINTER_RE.exec(line)
+  if (!match) return undefined
+  return {
+    checked: match[1] !== " ",
+    path: match[2]!,
+    ...(match[3] !== undefined ? { line: Number(match[3]) } : {}),
+    ...(match[4] && match[4].trim().length > 0 ? { note: match[4].trim() } : {}),
+  }
+}
+
+/** Splits one chunk's body lines (up to the next `##` heading) into its file pointers and description prose. */
+const parseChunkBody = (
+  body: readonly string[],
+): { readonly description: string; readonly files: readonly ReviewFile[] } => {
+  const files: ReviewFile[] = []
+  const descriptionLines: string[] = []
+  for (const raw of body) {
+    const line = raw.trim()
+    if (line.length === 0) continue
+    const file = parseFilePointer(line)
+    if (file) {
+      files.push(file)
+    } else {
+      descriptionLines.push(line)
+    }
+  }
+  return { description: descriptionLines.join(" "), files }
+}
+
+/** Splits the document into `##` chunks, each with its title and body lines. */
+const splitChunks = (
+  lines: readonly string[],
+): ReadonlyArray<{ title: string; body: string[] }> => {
+  const chunks: Array<{ title: string; body: string[] }> = []
+  let i = 0
+  while (i < lines.length) {
+    const chunkMatch = CHUNK_HEADING_RE.exec(lines[i]!.trim())
+    if (!chunkMatch) {
+      i += 1
+      continue
+    }
+    const title = chunkMatch[1]!.trim()
+    i += 1
+    const body: string[] = []
+    while (i < lines.length && !CHUNK_HEADING_RE.test(lines[i]!.trim())) {
+      body.push(lines[i]!)
+      i += 1
+    }
+    chunks.push({ title, body })
+  }
+  return chunks
+}
+
+/** Parses every `##` chunk into a `Changeset`, collecting one error per chunk with no file pointers. */
+const parseChangesets = (
+  lines: readonly string[],
+): { readonly changesets: readonly Changeset[]; readonly errors: readonly string[] } => {
+  const changesets: Changeset[] = []
+  const errors: string[] = []
+  for (const { title, body } of splitChunks(lines)) {
+    const { description, files } = parseChunkBody(body)
+    if (files.length === 0) errors.push(`Chunk "${title}" has no file pointers`)
+    changesets.push({ title, description, files })
+  }
+  if (changesets.length === 0) errors.push("REVIEW.md has no '##' chunks")
+  return { changesets, errors }
+}
+
+/**
+ * Parses the review structure out of `content` (the raw text of
+ * `.gtd/REVIEW.md`). Total and side-effect-free: always returns a result,
+ * never throws. `errors` is non-empty exactly when the document violates the
+ * required structure — the caller decides what to do with that (the machine
+ * refuses the agent's turn capture; the `gtd changesets` CLI command just
+ * reports it alongside whatever parsed).
+ */
+export const parseReviewDoc = (content: string): ReviewDoc => {
+  const lines = content.split(/\r?\n/)
+  const shortHash = parseHeader(lines)
+  const fullHash = parseBaseComment(lines)
+  const { changesets, errors: chunkErrors } = parseChangesets(lines)
+
+  const errors = [
+    ...(shortHash
+      ? []
+      : ["Missing or malformed '# Review: <hash>' header as the document's first line"]),
+    ...(fullHash ? [] : ["Missing '<!-- base: <hash> -->' comment"]),
+    ...chunkErrors,
+  ]
+
+  return {
+    ...(shortHash ? { shortHash } : {}),
+    ...(fullHash ? { fullHash } : {}),
+    changesets,
+    errors,
+  }
+}

--- a/src/__snapshots__/Prompt.snapshot.test.ts.snap
+++ b/src/__snapshots__/Prompt.snapshot.test.ts.snap
@@ -191,9 +191,13 @@ architecture. The subagent works entirely by editing \`.gtd/ARCHITECTURE.md\`:
    until the architecture is as complete as it can get without human input.
    Do not leave this to a future round — there isn't one before the human is
    asked.
-4. For every remaining open question, write it near the top of the file with
-   a **suggested default** — your best-guess answer, stated plainly, that the
-   human can accept as-is. A question with no suggested default is incomplete.
+4. For every remaining open question, add it under a \`## Open Questions\`
+   section near the top of the file, one \`### <question>\` sub-heading per
+   question, whose first body line is \`Suggested default: <answer>\` — your
+   best-guess answer, stated plainly, that the human can accept as-is. This
+   structure is enforced: a \`###\` question with no \`Suggested default:\` line
+   blocks your turn — \`gtd step-agent\` refuses until it's fixed. Omit the
+   \`## Open Questions\` section entirely once there are none.
 5. Leave \`.gtd/ARCHITECTURE.md\` **uncommitted** — the human's turn (\`gtd step\`)
    reads it next.
 "
@@ -237,9 +241,13 @@ architecture. The subagent works entirely by editing \`.gtd/ARCHITECTURE.md\`:
    until the architecture is as complete as it can get without human input.
    Do not leave this to a future round — there isn't one before the human is
    asked.
-4. For every remaining open question, write it near the top of the file with
-   a **suggested default** — your best-guess answer, stated plainly, that the
-   human can accept as-is. A question with no suggested default is incomplete.
+4. For every remaining open question, add it under a \`## Open Questions\`
+   section near the top of the file, one \`### <question>\` sub-heading per
+   question, whose first body line is \`Suggested default: <answer>\` — your
+   best-guess answer, stated plainly, that the human can accept as-is. This
+   structure is enforced: a \`###\` question with no \`Suggested default:\` line
+   blocks your turn — \`gtd step-agent\` refuses until it's fixed. Omit the
+   \`## Open Questions\` section entirely once there are none.
 5. Leave \`.gtd/ARCHITECTURE.md\` **uncommitted** — the human's turn (\`gtd step\`)
    reads it next.
 
@@ -287,9 +295,13 @@ architecture. The subagent works entirely by editing \`.gtd/ARCHITECTURE.md\`:
    until the architecture is as complete as it can get without human input.
    Do not leave this to a future round — there isn't one before the human is
    asked.
-4. For every remaining open question, write it near the top of the file with
-   a **suggested default** — your best-guess answer, stated plainly, that the
-   human can accept as-is. A question with no suggested default is incomplete.
+4. For every remaining open question, add it under a \`## Open Questions\`
+   section near the top of the file, one \`### <question>\` sub-heading per
+   question, whose first body line is \`Suggested default: <answer>\` — your
+   best-guess answer, stated plainly, that the human can accept as-is. This
+   structure is enforced: a \`###\` question with no \`Suggested default:\` line
+   blocks your turn — \`gtd step-agent\` refuses until it's fixed. Omit the
+   \`## Open Questions\` section entirely once there are none.
 5. Leave \`.gtd/ARCHITECTURE.md\` **uncommitted** — the human's turn (\`gtd step\`)
    reads it next.
 
@@ -325,14 +337,16 @@ explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
 *outside* \`.gtd/\` is ordinary project code, not workflow state.
 
 \`.gtd/ARCHITECTURE.md\` holds the technical plan under development, with open
-questions written near the top — each one carrying a suggested default.
+questions under a \`## Open Questions\` section — each \`### <question>\`
+carrying a suggested default.
 
 This is a human gate; there is nothing for the agent to do.
 
 Tell the user:
 
-- To answer a question, edit \`.gtd/ARCHITECTURE.md\` in place (replace the
-  question's text with your answer, or annotate it), then run \`gtd step\`.
+- To answer a question, edit its \`### <question>\` entry under \`## Open
+  Questions\` in place — replace the \`Suggested default: ...\` line with
+  \`Answer: ...\` (or annotate it further), then run \`gtd step\`.
 - To accept **all** suggested defaults as-is, run \`gtd step\` with **no
   edits** — this converges the architecture and moves on to decomposition.
 "
@@ -348,14 +362,16 @@ explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
 *outside* \`.gtd/\` is ordinary project code, not workflow state.
 
 \`.gtd/ARCHITECTURE.md\` holds the technical plan under development, with open
-questions written near the top — each one carrying a suggested default.
+questions under a \`## Open Questions\` section — each \`### <question>\`
+carrying a suggested default.
 
 This is a human gate; there is nothing for the agent to do.
 
 Tell the user:
 
-- To answer a question, edit \`.gtd/ARCHITECTURE.md\` in place (replace the
-  question's text with your answer, or annotate it), then run \`gtd step\`.
+- To answer a question, edit its \`### <question>\` entry under \`## Open
+  Questions\` in place — replace the \`Suggested default: ...\` line with
+  \`Answer: ...\` (or annotate it further), then run \`gtd step\`.
 - To accept **all** suggested defaults as-is, run \`gtd step\` with **no
   edits** — this converges the architecture and moves on to decomposition.
 "
@@ -884,9 +900,13 @@ The subagent works entirely by editing \`.gtd/TODO.md\`:
 3. **Iterate internally** (spawn further subagents, reconsider, cross-check)
    until the plan is as complete as it can get without human input. Do not
    leave this to a future round — there isn't one before the human is asked.
-4. For every remaining open question, write it near the top of the file with
-   a **suggested default** — your best-guess answer, stated plainly, that the
-   human can accept as-is. A question with no suggested default is incomplete.
+4. For every remaining open question, add it under a \`## Open Questions\`
+   section near the top of the file, one \`### <question>\` sub-heading per
+   question, whose first body line is \`Suggested default: <answer>\` — your
+   best-guess answer, stated plainly, that the human can accept as-is. This
+   structure is enforced: a \`###\` question with no \`Suggested default:\` line
+   blocks your turn — \`gtd step-agent\` refuses until it's fixed. Omit the
+   \`## Open Questions\` section entirely once there are none.
 5. Leave \`.gtd/TODO.md\` **uncommitted** — the human's turn (\`gtd step\`) reads it
    next.
 "
@@ -925,9 +945,13 @@ The subagent works entirely by editing \`.gtd/TODO.md\`:
 3. **Iterate internally** (spawn further subagents, reconsider, cross-check)
    until the plan is as complete as it can get without human input. Do not
    leave this to a future round — there isn't one before the human is asked.
-4. For every remaining open question, write it near the top of the file with
-   a **suggested default** — your best-guess answer, stated plainly, that the
-   human can accept as-is. A question with no suggested default is incomplete.
+4. For every remaining open question, add it under a \`## Open Questions\`
+   section near the top of the file, one \`### <question>\` sub-heading per
+   question, whose first body line is \`Suggested default: <answer>\` — your
+   best-guess answer, stated plainly, that the human can accept as-is. This
+   structure is enforced: a \`###\` question with no \`Suggested default:\` line
+   blocks your turn — \`gtd step-agent\` refuses until it's fixed. Omit the
+   \`## Open Questions\` section entirely once there are none.
 5. Leave \`.gtd/TODO.md\` **uncommitted** — the human's turn (\`gtd step\`) reads it
    next.
 
@@ -970,9 +994,13 @@ The subagent works entirely by editing \`.gtd/TODO.md\`:
 3. **Iterate internally** (spawn further subagents, reconsider, cross-check)
    until the plan is as complete as it can get without human input. Do not
    leave this to a future round — there isn't one before the human is asked.
-4. For every remaining open question, write it near the top of the file with
-   a **suggested default** — your best-guess answer, stated plainly, that the
-   human can accept as-is. A question with no suggested default is incomplete.
+4. For every remaining open question, add it under a \`## Open Questions\`
+   section near the top of the file, one \`### <question>\` sub-heading per
+   question, whose first body line is \`Suggested default: <answer>\` — your
+   best-guess answer, stated plainly, that the human can accept as-is. This
+   structure is enforced: a \`###\` question with no \`Suggested default:\` line
+   blocks your turn — \`gtd step-agent\` refuses until it's fixed. Omit the
+   \`## Open Questions\` section entirely once there are none.
 5. Leave \`.gtd/TODO.md\` **uncommitted** — the human's turn (\`gtd step\`) reads it
    next.
 
@@ -1006,15 +1034,17 @@ never instruct a subagent to — except the specific \`.gtd/\` file this prompt
 explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
 *outside* \`.gtd/\` is ordinary project code, not workflow state.
 
-\`.gtd/TODO.md\` holds the plan under development, with open questions written near
-the top — each one carrying a suggested default.
+\`.gtd/TODO.md\` holds the plan under development, with open questions under a
+\`## Open Questions\` section — each \`### <question>\` carrying a suggested
+default.
 
 This is a human gate; there is nothing for the agent to do.
 
 Tell the user:
 
-- To answer a question, edit \`.gtd/TODO.md\` in place (replace the question's text
-  with your answer, or annotate it), then run \`gtd step\`.
+- To answer a question, edit its \`### <question>\` entry under \`## Open
+  Questions\` in place — replace the \`Suggested default: ...\` line with
+  \`Answer: ...\` (or annotate it further), then run \`gtd step\`.
 - To accept **all** suggested defaults as-is, run \`gtd step\` with **no
   edits** — this converges the plan and moves on to technical architecting.
 "
@@ -1029,15 +1059,17 @@ never instruct a subagent to — except the specific \`.gtd/\` file this prompt
 explicitly tells you to work on. A \`TODO.md\`, \`REVIEW.md\`, or similar file
 *outside* \`.gtd/\` is ordinary project code, not workflow state.
 
-\`.gtd/TODO.md\` holds the plan under development, with open questions written near
-the top — each one carrying a suggested default.
+\`.gtd/TODO.md\` holds the plan under development, with open questions under a
+\`## Open Questions\` section — each \`### <question>\` carrying a suggested
+default.
 
 This is a human gate; there is nothing for the agent to do.
 
 Tell the user:
 
-- To answer a question, edit \`.gtd/TODO.md\` in place (replace the question's text
-  with your answer, or annotate it), then run \`gtd step\`.
+- To answer a question, edit its \`### <question>\` entry under \`## Open
+  Questions\` in place — replace the \`Suggested default: ...\` line with
+  \`Answer: ...\` (or annotate it further), then run \`gtd step\`.
 - To accept **all** suggested defaults as-is, run \`gtd step\` with **no
   edits** — this converges the plan and moves on to technical architecting.
 "
@@ -1299,6 +1331,10 @@ Spawn a **planning-model subagent** using model \`MODEL-clean\` to author a
      \`.gtd/REVIEW.md\` (or any code edits) are treated as a change-request.
    - The user checks off or edits items in place as they work through the
      review; there is no separate Resolved section.
+   - This structure is enforced: the \`# Review: <hash>\` header, the
+     \`<!-- base: ... -->\` comment, and at least one file pointer per chunk
+     are all required — a missing one blocks your turn (\`gtd step-agent\`
+     refuses until it's fixed).
 
 4. Leave \`.gtd/REVIEW.md\` **uncommitted** and finish your turn — the human reviews
    it next.
@@ -1355,6 +1391,10 @@ Spawn a **planning-model subagent** using model \`MODEL-clean\` to author a
      \`.gtd/REVIEW.md\` (or any code edits) are treated as a change-request.
    - The user checks off or edits items in place as they work through the
      review; there is no separate Resolved section.
+   - This structure is enforced: the \`# Review: <hash>\` header, the
+     \`<!-- base: ... -->\` comment, and at least one file pointer per chunk
+     are all required — a missing one blocks your turn (\`gtd step-agent\`
+     refuses until it's fixed).
 
 4. Leave \`.gtd/REVIEW.md\` **uncommitted** and finish your turn — the human reviews
    it next.
@@ -1415,6 +1455,10 @@ Spawn a **planning-model subagent** using model \`MODEL-clean\` to author a
      \`.gtd/REVIEW.md\` (or any code edits) are treated as a change-request.
    - The user checks off or edits items in place as they work through the
      review; there is no separate Resolved section.
+   - This structure is enforced: the \`# Review: <hash>\` header, the
+     \`<!-- base: ... -->\` comment, and at least one file pointer per chunk
+     are all required — a missing one blocks your turn (\`gtd step-agent\`
+     refuses until it's fixed).
 
 4. Leave \`.gtd/REVIEW.md\` **uncommitted** and finish your turn — the human reviews
    it next.
@@ -1480,6 +1524,10 @@ Spawn a **planning-model subagent** using model \`MODEL-clean\` to author a
      \`.gtd/REVIEW.md\` (or any code edits) are treated as a change-request.
    - The user checks off or edits items in place as they work through the
      review; there is no separate Resolved section.
+   - This structure is enforced: the \`# Review: <hash>\` header, the
+     \`<!-- base: ... -->\` comment, and at least one file pointer per chunk
+     are all required — a missing one blocks your turn (\`gtd step-agent\`
+     refuses until it's fixed).
 
 4. Leave \`.gtd/REVIEW.md\` **uncommitted** and finish your turn — the human reviews
    it next.

--- a/src/program.ts
+++ b/src/program.ts
@@ -3,7 +3,14 @@ import { FileSystem } from "@effect/platform"
 import { Effect } from "effect"
 import { ConfigInit, ConfigService } from "./Config.js"
 import { Cwd } from "./Cwd.js"
-import { gatherEvents, perform, reviewAgainst } from "./Events.js"
+import {
+  gatherEvents,
+  perform,
+  readOpenQuestionsDoc,
+  readReviewDoc,
+  reviewAgainst,
+  type ReviewDocResult,
+} from "./Events.js"
 import * as Format from "./Format.js"
 import { GitService, type GitOperations } from "./Git.js"
 import { predictTurn, resolve, type EdgeAction, type GtdEvent, type Result } from "./Machine.js"
@@ -24,6 +31,8 @@ Commands:
   next             Print the prompt for whichever actor is awaited (no mutation)
   status           Predict the next commit and state from the working tree (no mutation)
   review <target>  Anchor an ad-hoc human review against a git ref or branch
+  questions        List open questions from the active grilling/architecting doc
+  changesets       List changesets/files from the active review doc
   format <file>    Format a markdown file in place
 
 Options:
@@ -314,6 +323,17 @@ const runStep = (
 const commandArgs = (argv: readonly string[]): string[] =>
   argv.slice(3).filter((a) => a.length > 0 && !a.startsWith("--"))
 
+/** Rejects extra positional arguments for a subcommand that takes none (`status`, `questions`, `changesets`). */
+const rejectExtraArgs = (command: string, argv: readonly string[]): Effect.Effect<void, Error> => {
+  const args = commandArgs(argv)
+  if (args.length > 0) {
+    return Effect.fail(
+      new Error(`gtd ${command}: too many arguments — expected none, got: ${args.join(", ")}`),
+    )
+  }
+  return Effect.void
+}
+
 /** `gtd format <file>`: reformat a markdown file in place. Rejects `--json` (not a v2 state command). */
 const runFormatCommand = (
   argv: readonly string[],
@@ -421,12 +441,7 @@ const runStatusCommand = (
   write: (chunk: string) => void,
 ): Effect.Effect<void, Error, ProgramRequirements> =>
   Effect.gen(function* () {
-    const args = commandArgs(argv)
-    if (args.length > 0) {
-      return yield* Effect.fail(
-        new Error(`gtd status: too many arguments — expected none, got: ${args.join(", ")}`),
-      )
-    }
+    yield* rejectExtraArgs("status", argv)
     const events = yield* gatherEvents("none")
     const prediction = yield* Effect.try({
       try: () => predictTurn(events),
@@ -490,7 +505,92 @@ const runReviewCommand = (
     }
   })
 
-const KNOWN_SUBCOMMANDS = ["step", "step-agent", "next", "status", "review"] as const
+/**
+ * `gtd questions`: pure reader over whichever of `.gtd/TODO.md` /
+ * `.gtd/ARCHITECTURE.md` is present — the open-questions list, for a future
+ * UI. No dirty-tree check, no mutation: reports whatever is on disk right
+ * now, well-formed or not (`errors` surfaces the same structural problems
+ * that would refuse `gtd step-agent`'s next agent turn).
+ */
+const runQuestionsCommand = (
+  argv: readonly string[],
+  json: boolean,
+  write: (chunk: string) => void,
+): Effect.Effect<void, Error, ProgramRequirements> =>
+  Effect.gen(function* () {
+    yield* rejectExtraArgs("questions", argv)
+    const result = yield* readOpenQuestionsDoc()
+    if (json) {
+      write(JSON.stringify(result) + "\n")
+      return
+    }
+    if (result.file === null) {
+      write("no open questions (not currently grilling or architecting)\n")
+      return
+    }
+    const lines = [`${result.file}:`]
+    if (result.questions.length === 0 && result.errors.length === 0) {
+      lines.push("  (no open questions)")
+    }
+    for (const q of result.questions) {
+      lines.push(`  - ${q.question}`, `    ${q.status}: ${q.text}`)
+    }
+    for (const err of result.errors) {
+      lines.push(`  error: ${err}`)
+    }
+    write(lines.join("\n") + "\n")
+  })
+
+/** Renders one changeset's title plus its file-pointer lines, plain-text. */
+const formatChangesetPlain = (c: ReviewDocResult["changesets"][number]) => [
+  `  - ${c.title}`,
+  ...c.files.map(
+    (f) =>
+      `      ${f.checked ? "[x]" : "[ ]"} ${f.path}${f.line !== undefined ? `#${f.line}` : ""}`,
+  ),
+]
+
+/** Renders a `readReviewDoc` result as the plain-text `gtd changesets` body (never called when `result.file` is `null`). */
+const formatChangesetsResultPlain = (result: ReviewDocResult): string =>
+  [
+    `${result.file}${result.shortHash ? ` (${result.shortHash})` : ""}:`,
+    ...result.changesets.flatMap(formatChangesetPlain),
+    ...result.errors.map((err) => `  error: ${err}`),
+  ].join("\n") + "\n"
+
+/**
+ * `gtd changesets`: pure reader over `.gtd/REVIEW.md`, if present — the
+ * changeset/file list, for a future UI. No dirty-tree check, no mutation:
+ * reports whatever is on disk right now, well-formed or not (`errors`
+ * surfaces the same structural problems that would refuse `gtd step-agent`'s
+ * next agent turn).
+ */
+const runChangesetsCommand = (
+  argv: readonly string[],
+  json: boolean,
+  write: (chunk: string) => void,
+): Effect.Effect<void, Error, ProgramRequirements> =>
+  Effect.gen(function* () {
+    yield* rejectExtraArgs("changesets", argv)
+    const result = yield* readReviewDoc()
+    if (json) {
+      write(JSON.stringify(result) + "\n")
+    } else if (result.file === null) {
+      write("no review in progress\n")
+    } else {
+      write(formatChangesetsResultPlain(result))
+    }
+  })
+
+const KNOWN_SUBCOMMANDS = [
+  "step",
+  "step-agent",
+  "next",
+  "status",
+  "review",
+  "questions",
+  "changesets",
+] as const
 type KnownSubcommand = (typeof KNOWN_SUBCOMMANDS)[number]
 
 /**
@@ -577,6 +677,10 @@ const dispatchKnownSubcommand = (
       return runStatusCommand(argv, json, write)
     case "review":
       return runReviewCommand(argv, git, json, write)
+    case "questions":
+      return runQuestionsCommand(argv, json, write)
+    case "changesets":
+      return runChangesetsCommand(argv, json, write)
   }
 }
 

--- a/src/prompts/architecting-agent.md
+++ b/src/prompts/architecting-agent.md
@@ -29,9 +29,13 @@ architecture. The subagent works entirely by editing `.gtd/ARCHITECTURE.md`:
    until the architecture is as complete as it can get without human input.
    Do not leave this to a future round — there isn't one before the human is
    asked.
-4. For every remaining open question, write it near the top of the file with
-   a **suggested default** — your best-guess answer, stated plainly, that the
-   human can accept as-is. A question with no suggested default is incomplete.
+4. For every remaining open question, add it under a `## Open Questions`
+   section near the top of the file, one `### <question>` sub-heading per
+   question, whose first body line is `Suggested default: <answer>` — your
+   best-guess answer, stated plainly, that the human can accept as-is. This
+   structure is enforced: a `###` question with no `Suggested default:` line
+   blocks your turn — `gtd step-agent` refuses until it's fixed. Omit the
+   `## Open Questions` section entirely once there are none.
 5. Leave `.gtd/ARCHITECTURE.md` **uncommitted** — the human's turn (`gtd step`)
    reads it next.
 <% if (it.context.turnDiff && it.context.turnDiff.trim()) { %>

--- a/src/prompts/architecting-answers.md
+++ b/src/prompts/architecting-answers.md
@@ -1,14 +1,16 @@
 <%~ include("@header") %>
 
 `.gtd/ARCHITECTURE.md` holds the technical plan under development, with open
-questions written near the top — each one carrying a suggested default.
+questions under a `## Open Questions` section — each `### <question>`
+carrying a suggested default.
 
 This is a human gate; there is nothing for the agent to do.
 
 Tell the user:
 
-- To answer a question, edit `.gtd/ARCHITECTURE.md` in place (replace the
-  question's text with your answer, or annotate it), then run `gtd step`.
+- To answer a question, edit its `### <question>` entry under `## Open
+  Questions` in place — replace the `Suggested default: ...` line with
+  `Answer: ...` (or annotate it further), then run `gtd step`.
 - To accept **all** suggested defaults as-is, run `gtd step` with **no
   edits** — this converges the architecture and moves on to decomposition.
 

--- a/src/prompts/grilling-agent.md
+++ b/src/prompts/grilling-agent.md
@@ -24,9 +24,13 @@ The subagent works entirely by editing `.gtd/TODO.md`:
 3. **Iterate internally** (spawn further subagents, reconsider, cross-check)
    until the plan is as complete as it can get without human input. Do not
    leave this to a future round — there isn't one before the human is asked.
-4. For every remaining open question, write it near the top of the file with
-   a **suggested default** — your best-guess answer, stated plainly, that the
-   human can accept as-is. A question with no suggested default is incomplete.
+4. For every remaining open question, add it under a `## Open Questions`
+   section near the top of the file, one `### <question>` sub-heading per
+   question, whose first body line is `Suggested default: <answer>` — your
+   best-guess answer, stated plainly, that the human can accept as-is. This
+   structure is enforced: a `###` question with no `Suggested default:` line
+   blocks your turn — `gtd step-agent` refuses until it's fixed. Omit the
+   `## Open Questions` section entirely once there are none.
 5. Leave `.gtd/TODO.md` **uncommitted** — the human's turn (`gtd step`) reads it
    next.
 <% if (it.context.turnDiff && it.context.turnDiff.trim()) { %>

--- a/src/prompts/grilling-answers.md
+++ b/src/prompts/grilling-answers.md
@@ -1,14 +1,16 @@
 <%~ include("@header") %>
 
-`.gtd/TODO.md` holds the plan under development, with open questions written near
-the top — each one carrying a suggested default.
+`.gtd/TODO.md` holds the plan under development, with open questions under a
+`## Open Questions` section — each `### <question>` carrying a suggested
+default.
 
 This is a human gate; there is nothing for the agent to do.
 
 Tell the user:
 
-- To answer a question, edit `.gtd/TODO.md` in place (replace the question's text
-  with your answer, or annotate it), then run `gtd step`.
+- To answer a question, edit its `### <question>` entry under `## Open
+  Questions` in place — replace the `Suggested default: ...` line with
+  `Answer: ...` (or annotate it further), then run `gtd step`.
 - To accept **all** suggested defaults as-is, run `gtd step` with **no
   edits** — this converges the plan and moves on to technical architecting.
 

--- a/src/prompts/review.md
+++ b/src/prompts/review.md
@@ -41,6 +41,10 @@ Spawn a **planning-model subagent** using model `<%= it.model %>` to author a
      `.gtd/REVIEW.md` (or any code edits) are treated as a change-request.
    - The user checks off or edits items in place as they work through the
      review; there is no separate Resolved section.
+   - This structure is enforced: the `# Review: <hash>` header, the
+     `<!-- base: ... -->` comment, and at least one file pointer per chunk
+     are all required — a missing one blocks your turn (`gtd step-agent`
+     refuses until it's fixed).
 
 4. Leave `.gtd/REVIEW.md` **uncommitted** and finish your turn — the human reviews
    it next.

--- a/tests/integration/features/changesets-subcommand.feature
+++ b/tests/integration/features/changesets-subcommand.feature
@@ -1,0 +1,96 @@
+@inmem
+Feature: gtd changesets subcommand
+
+  `gtd changesets` is a pure, read-only reporter over `.gtd/REVIEW.md`, if
+  present. It parses the header/base-comment/chunk structure (see
+  `document-structure.feature`) and reports the changeset/file list, plus any
+  structural errors — the same diagnosis that would make `gtd step-agent`
+  refuse the agent's next review-turn capture. It never mutates and always
+  exits 0, on a clean or a dirty tree, with or without a well-formed file.
+
+  Scenario: No REVIEW.md reports an empty list
+    Given a test project
+    When I run gtd with args "changesets"
+    Then it succeeds
+    And stdout contains "no review in progress"
+
+  Scenario: --json reports null/empty when no file exists
+    Given a test project
+    When I run gtd with args "changesets --json"
+    Then it succeeds
+    And stdout contains "\"file\":null"
+    And stdout contains "\"changesets\":[]"
+    And stdout contains "\"errors\":[]"
+
+  Scenario: A well-formed REVIEW.md reports its changesets and files
+    Given a test project
+    And a file ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: abc1234000000000000000000000000000000 -->
+
+      ## Add calculator
+
+      New add function for the calculator.
+
+      - [ ] ./src/calc.ts#1
+      - [x] ./src/calc.ts#5
+      """
+    When I run gtd with args "changesets"
+    Then it succeeds
+    And stdout contains ".gtd/REVIEW.md"
+    And stdout contains "abc1234"
+    And stdout contains "Add calculator"
+    And stdout contains "[ ] ./src/calc.ts#1"
+    And stdout contains "[x] ./src/calc.ts#5"
+
+  Scenario: --json reports the structured changeset list
+    Given a test project
+    And a file ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: abc1234000000000000000000000000000000 -->
+
+      ## Add calculator
+
+      - [ ] ./src/calc.ts#1 — new add function
+      """
+    When I run gtd with args "changesets --json"
+    Then it succeeds
+    And stdout contains "\"file\":\".gtd/REVIEW.md\""
+    And stdout contains "\"shortHash\":\"abc1234\""
+    And stdout contains "\"fullHash\":\"abc1234000000000000000000000000000000\""
+    And stdout contains "\"title\":\"Add calculator\""
+    And stdout contains "\"path\":\"./src/calc.ts\""
+    And stdout contains "\"line\":1"
+    And stdout contains "\"checked\":false"
+    And stdout contains "\"note\":\"new add function\""
+    And stdout contains "\"errors\":[]"
+
+  Scenario: A malformed REVIEW.md is reported as errors, not a failure
+    Given a test project
+    And a file ".gtd/REVIEW.md" with:
+      """
+      # Review
+
+      ## Add calculator
+
+      Just prose, no pointers.
+      """
+    When I run gtd with args "changesets"
+    Then it succeeds
+    And stdout contains "error:"
+    When I run gtd with args "changesets --json"
+    Then it succeeds
+    And stdout contains "\"errors\":["
+    And stdout contains "Missing or malformed"
+    And stdout contains "Missing '<!-- base:"
+    And stdout contains "has no file pointers"
+
+  Scenario: gtd changesets rejects extra positional arguments
+    Given a test project
+    When I run gtd with args "changesets extra"
+    Then it fails
+    And stderr contains "gtd changesets: too many arguments"

--- a/tests/integration/features/command-surface.feature
+++ b/tests/integration/features/command-surface.feature
@@ -1,10 +1,10 @@
 @inmem
 Feature: Command surface — bare gtd, unknown subcommands, --help, --version
 
-  gtd v2 exposes `step`, `step-agent`, `next`, `status`, `format`, and `review`
-  as its subcommands. Bare `gtd` (no subcommand) is a usage error. `--help` and
-  `--version` short-circuit before any repo-state work and exit 0 everywhere,
-  including outside a workflow state.
+  gtd v2 exposes `step`, `step-agent`, `next`, `status`, `format`, `review`,
+  `questions`, and `changesets` as its subcommands. Bare `gtd` (no subcommand)
+  is a usage error. `--help` and `--version` short-circuit before any
+  repo-state work and exit 0 everywhere, including outside a workflow state.
 
   Scenario: Bare gtd fails with usage help and authors nothing
     Given a test project

--- a/tests/integration/features/document-structure.feature
+++ b/tests/integration/features/document-structure.feature
@@ -1,0 +1,209 @@
+@inmem
+Feature: Structural validation of the agent's grilling/architecting/review draft
+
+  `.gtd/TODO.md` / `.gtd/ARCHITECTURE.md` (an optional `## Open Questions`
+  section, `###` sub-headings each carrying a `Suggested default:`/`Answer:`
+  line) and `.gtd/REVIEW.md` (a `# Review: <hash>` header, a
+  `<!-- base: ... -->` comment, and `##` chunks each with at least one file
+  pointer) follow an enforced structure. A malformed file blocks the AGENT's
+  own turn capture — `gtd step-agent` refuses with zero commits and a
+  diagnostic on stderr — but never blocks a HUMAN's own turn at the same gate,
+  since file content otherwise never steers the machine.
+
+  Scenario: A malformed open question refuses the agent's grilling turn
+    Given a test project
+    And a file "notes.md" with:
+      """
+      Build a calculator that can add and subtract.
+      """
+    And I run gtd step
+    And a file ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      Build a calculator.
+
+      ## Open Questions
+
+      ### Which operations?
+
+      Not sure yet.
+      """
+    And I record the commit count
+    When I run gtd step-agent
+    Then it fails
+    And the commit count is unchanged
+    And stderr contains ".gtd/TODO.md does not match the required structure"
+    And stderr contains "Which operations?"
+
+  Scenario: Fixing the malformed question lets the agent's grilling turn land
+    Given a test project
+    And a file "notes.md" with:
+      """
+      Build a calculator that can add and subtract.
+      """
+    And I run gtd step
+    And a file ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      Build a calculator.
+
+      ## Open Questions
+
+      ### Which operations?
+
+      Suggested default: add and subtract.
+      """
+    When I run gtd step-agent
+    Then it succeeds
+    And the last commit subject is "gtd(agent): grilling"
+
+  Scenario: A human's non-conforming edit at the grilling answer gate is never refused
+    Given a test project
+    And a file "notes.md" with:
+      """
+      Build a calculator that can add and subtract.
+      """
+    And I run gtd step
+    And a file ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      Build a calculator.
+
+      ## Open Questions
+
+      ### Which operations?
+
+      Suggested default: add and subtract.
+      """
+    And I run gtd step-agent
+    And ".gtd/TODO.md" is modified to:
+      """
+      # Plan
+
+      Build a calculator. Just do addition, subtraction, and multiplication —
+      no need for a formal question/answer section.
+      """
+    When I run gtd step
+    Then it succeeds
+    And the last commit subject is "gtd(human): grilling"
+
+  Scenario: A malformed open question refuses the agent's architecting turn
+    Given a test project
+    And a file ".gtd/ARCHITECTURE.md" with:
+      """
+      # Architecture
+
+      Refactor the calculator module to use a strategy pattern.
+      """
+    And I run gtd step
+    And ".gtd/ARCHITECTURE.md" is modified to:
+      """
+      # Architecture
+
+      Refactor the calculator module to use a strategy pattern.
+
+      ## Open Questions
+
+      ### Which design pattern?
+
+      Strategy pattern seems reasonable but not confirmed.
+      """
+    And I record the commit count
+    When I run gtd step-agent
+    Then it fails
+    And the commit count is unchanged
+    And stderr contains ".gtd/ARCHITECTURE.md does not match the required structure"
+    And stderr contains "Which design pattern?"
+
+  Scenario: A malformed REVIEW.md refuses the agent's review turn
+    Given a test project
+    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      Build a calculator.
+      """
+    And a commit "gtd: planning" that deletes ".gtd/TODO.md"
+    And a commit "gtd: building" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd: package done"
+    And a file ".gtd/REVIEW.md" with:
+      """
+      # Review
+
+      ## Add calculator
+
+      - [ ] ./src/calc.ts#1
+      """
+    And I record the commit count
+    When I run gtd step-agent
+    Then it fails
+    And the commit count is unchanged
+    And stderr contains ".gtd/REVIEW.md does not match the required structure"
+    And stderr contains "base"
+
+  Scenario: A well-formed REVIEW.md lets the agent's review turn land
+    Given a test project
+    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      Build a calculator.
+      """
+    And a commit "gtd: planning" that deletes ".gtd/TODO.md"
+    And a commit "gtd: building" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd: package done"
+    And a file ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: abc1234000000000000000000000000000000 -->
+
+      ## Add calculator
+
+      - [ ] ./src/calc.ts#1
+      """
+    When I run gtd step-agent
+    Then it succeeds
+    And the last commit subject is "gtd(human): grilling"
+
+  Scenario: A human's substantive REVIEW.md edit is never refused, even if it breaks the structure
+    Given a test project
+    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      Build a calculator.
+      """
+    And a commit "gtd: planning" that deletes ".gtd/TODO.md"
+    And a commit "gtd: building" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd: package done"
+    And a file ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: abc1234000000000000000000000000000000 -->
+
+      ## Add calculator
+
+      - [ ] ./src/calc.ts#1
+      """
+    And I run gtd step-agent
+    And ".gtd/REVIEW.md" is modified to:
+      """
+      Please also add a subtract function.
+      """
+    When I run gtd step
+    Then it succeeds
+    And the last commit subject is "gtd: review feedback"

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -39,7 +39,9 @@ Feature: gtd-loop — the packaged reference loop driver
         *"help a human to review the changes"*)
           mkdir -p .gtd
           cat > .gtd/REVIEW.md <<'REVIEW'
-      # Review
+      # Review: abc1234
+
+      <!-- base: abc1234000000000000000000000000000000 -->
 
       ## Add calculator
 
@@ -99,7 +101,9 @@ Feature: gtd-loop — the packaged reference loop driver
         *"help a human to review the changes"*)
           mkdir -p .gtd
           cat > .gtd/REVIEW.md <<'REVIEW'
-      # Review
+      # Review: abc1234
+
+      <!-- base: abc1234000000000000000000000000000000 -->
 
       ## Add calculator
 

--- a/tests/integration/features/journeys.feature
+++ b/tests/integration/features/journeys.feature
@@ -108,7 +108,9 @@ Feature: Full lifecycle journeys — the step-first two-beat loop end to end
     # The review agent writes REVIEW.md.
     When a file ".gtd/REVIEW.md" with:
       """
-      # Review
+      # Review: abc1234
+
+      <!-- base: abc1234000000000000000000000000000000 -->
 
       ## Add calculator
 
@@ -221,7 +223,9 @@ Feature: Full lifecycle journeys — the step-first two-beat loop end to end
     And the last commit subject is "gtd: package done"
     When a file ".gtd/REVIEW.md" with:
       """
-      # Review
+      # Review: abc1234
+
+      <!-- base: abc1234000000000000000000000000000000 -->
 
       ## Add calculator
 

--- a/tests/integration/features/questions-subcommand.feature
+++ b/tests/integration/features/questions-subcommand.feature
@@ -1,0 +1,108 @@
+@inmem
+Feature: gtd questions subcommand
+
+  `gtd questions` is a pure, read-only reporter over whichever of
+  `.gtd/TODO.md` / `.gtd/ARCHITECTURE.md` is present. It parses the
+  `## Open Questions` structure (see `document-structure.feature`) and reports
+  the question list, plus any structural errors — the same diagnosis that
+  would make `gtd step-agent` refuse the agent's next turn capture. It never
+  mutates and always exits 0, on a clean or a dirty tree, with or without a
+  well-formed file.
+
+  Scenario: No grilling/architecting file reports an empty list
+    Given a test project
+    When I run gtd with args "questions"
+    Then it succeeds
+    And stdout contains "no open questions"
+
+  Scenario: --json reports null/empty when no file exists
+    Given a test project
+    When I run gtd with args "questions --json"
+    Then it succeeds
+    And stdout contains "\"file\":null"
+    And stdout contains "\"questions\":[]"
+    And stdout contains "\"errors\":[]"
+
+  Scenario: A well-formed TODO.md reports its open questions
+    Given a test project
+    And a file ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      Build a calculator.
+
+      ## Open Questions
+
+      ### Which operations?
+
+      Suggested default: add and subtract.
+      """
+    When I run gtd with args "questions"
+    Then it succeeds
+    And stdout contains ".gtd/TODO.md"
+    And stdout contains "Which operations?"
+    And stdout contains "suggested: add and subtract."
+
+  Scenario: --json reports the structured question list for TODO.md
+    Given a test project
+    And a file ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      ## Open Questions
+
+      ### Which operations?
+
+      Answer: add, subtract, and multiply.
+      """
+    When I run gtd with args "questions --json"
+    Then it succeeds
+    And stdout contains "\"file\":\".gtd/TODO.md\""
+    And stdout contains "\"question\":\"Which operations?\""
+    And stdout contains "\"status\":\"answered\""
+    And stdout contains "\"text\":\"add, subtract, and multiply.\""
+    And stdout contains "\"errors\":[]"
+
+  Scenario: A well-formed ARCHITECTURE.md reports its open questions
+    Given a test project
+    And a file ".gtd/ARCHITECTURE.md" with:
+      """
+      # Architecture
+
+      ## Open Questions
+
+      ### Which design pattern?
+
+      Suggested default: strategy pattern.
+      """
+    When I run gtd with args "questions --json"
+    Then it succeeds
+    And stdout contains "\"file\":\".gtd/ARCHITECTURE.md\""
+    And stdout contains "\"question\":\"Which design pattern?\""
+
+  Scenario: A malformed open question is reported as an error, not a failure
+    Given a test project
+    And a file ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      ## Open Questions
+
+      ### Which operations?
+
+      Not sure yet.
+      """
+    When I run gtd with args "questions"
+    Then it succeeds
+    And stdout contains "error:"
+    And stdout contains "Which operations?"
+    When I run gtd with args "questions --json"
+    Then it succeeds
+    And stdout contains "\"questions\":[]"
+    And stdout contains "\"errors\":[\"Open question"
+
+  Scenario: gtd questions rejects extra positional arguments
+    Given a test project
+    When I run gtd with args "questions extra"
+    Then it fails
+    And stderr contains "gtd questions: too many arguments"


### PR DESCRIPTION
Add an optional `## Open Questions` / `###` sub-heading structure to
.gtd/TODO.md and .gtd/ARCHITECTURE.md, and formalize .gtd/REVIEW.md's
header/base-comment/chunk contract, so both stay plain markdown but are
now machine-parseable. A malformed agent-authored draft refuses the
agent's own gtd step-agent turn capture (never a human's edits at the
same gate). Add gtd questions / gtd changesets read-only CLI commands
(plain + --json) exposing the parsed data for a future UI.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MtMM4f7cFVg74Dw2wZnSHv