### PR TITLE
feat: add gtd lsp server for .gtd/ steering files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,8 @@
       "Bash(npm run test:unit *)",
       "Bash(npx vitest run *)",
       "Bash(npx fallow health *)",
-      "Bash(npx fallow --summary *)"
+      "Bash(npx fallow --summary *)",
+      "mcp__github__actions_list"
     ],
     "deny": ["Bash(npm run test:mutation)", "Bash(npx stryker run)", "Bash(stryker run)"]
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
         "diff": "^9.0.0",
         "effect": "^3.19.15",
         "eta": "^4.6.0",
-        "prettier": "^3.8.1"
+        "prettier": "^3.8.1",
+        "vscode-languageserver": "^10.1.0",
+        "vscode-languageserver-textdocument": "^1.0.12"
       },
       "bin": {
         "gtd": "dist/gtd.bundle.mjs",
@@ -14836,6 +14838,49 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-10.1.0.tgz",
+      "integrity": "sha512-9gEWpXkYGXoqG7pBnE8O8hx/yP7+Aabn4+peQ3KDicQv6qunHSWyLTud3OF0w4S2+HfDD+5HqYKiXQW9HAU6mA==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.18.2"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "license": "MIT"
     },
     "node_modules/weapon-regex": {
       "version": "1.3.6",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "diff": "^9.0.0",
     "effect": "^3.19.15",
     "eta": "^4.6.0",
-    "prettier": "^3.8.1"
+    "prettier": "^3.8.1",
+    "vscode-languageserver": "^10.1.0",
+    "vscode-languageserver-textdocument": "^1.0.12"
   }
 }

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -38,14 +38,14 @@ import type {
 // root-level TODO.md (or REVIEW.md, …) is the project's own file: ordinary
 // code, never steering.
 const GTD_DIR = ".gtd"
-const TODO_FILE = `${GTD_DIR}/TODO.md`
-const ARCHITECTURE_FILE = `${GTD_DIR}/ARCHITECTURE.md`
-const REVIEW_FILE = `${GTD_DIR}/REVIEW.md`
-const FEEDBACK_FILE = `${GTD_DIR}/FEEDBACK.md`
-const ERRORS_FILE = `${GTD_DIR}/ERRORS.md`
-const HEALTH_FILE = `${GTD_DIR}/HEALTH.md`
-const SQUASH_MSG_FILE = `${GTD_DIR}/SQUASH_MSG.md`
-const LEARNINGS_FILE = `${GTD_DIR}/LEARNINGS.md`
+export const TODO_FILE = `${GTD_DIR}/TODO.md`
+export const ARCHITECTURE_FILE = `${GTD_DIR}/ARCHITECTURE.md`
+export const REVIEW_FILE = `${GTD_DIR}/REVIEW.md`
+export const FEEDBACK_FILE = `${GTD_DIR}/FEEDBACK.md`
+export const ERRORS_FILE = `${GTD_DIR}/ERRORS.md`
+export const HEALTH_FILE = `${GTD_DIR}/HEALTH.md`
+export const SQUASH_MSG_FILE = `${GTD_DIR}/SQUASH_MSG.md`
+export const LEARNINGS_FILE = `${GTD_DIR}/LEARNINGS.md`
 // Pre-namespace history wrote FEEDBACK.md at the repo root. Recognized for
 // COMMIT-event classification only (isFeedback), never for diffs or
 // working-tree probes — a root FEEDBACK.md in the tree today is project code.

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -38,18 +38,30 @@ import type {
 // root-level TODO.md (or REVIEW.md, …) is the project's own file: ordinary
 // code, never steering.
 const GTD_DIR = ".gtd"
-export const TODO_FILE = `${GTD_DIR}/TODO.md`
-export const ARCHITECTURE_FILE = `${GTD_DIR}/ARCHITECTURE.md`
-export const REVIEW_FILE = `${GTD_DIR}/REVIEW.md`
-export const FEEDBACK_FILE = `${GTD_DIR}/FEEDBACK.md`
-export const ERRORS_FILE = `${GTD_DIR}/ERRORS.md`
-export const HEALTH_FILE = `${GTD_DIR}/HEALTH.md`
-export const SQUASH_MSG_FILE = `${GTD_DIR}/SQUASH_MSG.md`
-export const LEARNINGS_FILE = `${GTD_DIR}/LEARNINGS.md`
+const TODO_FILE = `${GTD_DIR}/TODO.md`
+const ARCHITECTURE_FILE = `${GTD_DIR}/ARCHITECTURE.md`
+const REVIEW_FILE = `${GTD_DIR}/REVIEW.md`
+const FEEDBACK_FILE = `${GTD_DIR}/FEEDBACK.md`
+const ERRORS_FILE = `${GTD_DIR}/ERRORS.md`
+const HEALTH_FILE = `${GTD_DIR}/HEALTH.md`
+const SQUASH_MSG_FILE = `${GTD_DIR}/SQUASH_MSG.md`
+const LEARNINGS_FILE = `${GTD_DIR}/LEARNINGS.md`
 // Pre-namespace history wrote FEEDBACK.md at the repo root. Recognized for
 // COMMIT-event classification only (isFeedback), never for diffs or
 // working-tree probes — a root FEEDBACK.md in the tree today is project code.
 const LEGACY_FEEDBACK_FILE = "FEEDBACK.md"
+
+/** The `.gtd/` steering-file paths, grouped for external consumers (e.g. src/Lsp.ts) that need the whole set rather than one. */
+export const STEERING_FILES = {
+  todo: TODO_FILE,
+  architecture: ARCHITECTURE_FILE,
+  review: REVIEW_FILE,
+  feedback: FEEDBACK_FILE,
+  errors: ERRORS_FILE,
+  health: HEALTH_FILE,
+  squashMsg: SQUASH_MSG_FILE,
+  learnings: LEARNINGS_FILE,
+} as const
 const emptyFailureSentinel = (command: string, exitCode: number): string =>
   `Test command \`${command}\` failed with exit code ${exitCode} and produced no output.`
 

--- a/src/Lsp.test.ts
+++ b/src/Lsp.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest"
+import {
+  questionSymbols,
+  reviewSymbols,
+  toggleHunkEdit,
+  toggleChunkEdits,
+  reviewCodeActions,
+  STATE_FILE,
+} from "./Lsp.js"
+
+const questionsDoc = [
+  "# Plan",
+  "",
+  "## Open Questions",
+  "",
+  "### Which operations?",
+  "",
+  "Suggested default: add and subtract.",
+  "",
+  "### What is the target platform?",
+  "",
+  "Answer: web only.",
+  "",
+].join("\n")
+
+const reviewDoc = [
+  "# Review: abc1234",
+  "<!-- base: abc1234def5678901234567890123456789abcd -->",
+  "",
+  "## Add calculator",
+  "",
+  "- [ ] ./src/calc.ts#1",
+  "- [x] ./src/calc.ts#5 — subtract",
+  "",
+  "## Wire it up",
+  "",
+  "- [ ] ./src/index.ts#10",
+  "",
+].join("\n")
+
+describe("questionSymbols", () => {
+  it("maps each open question to a symbol carrying its status and heading position", () => {
+    const symbols = questionSymbols(questionsDoc)
+    expect(symbols.map((s) => s.name)).toEqual([
+      "[suggested] Which operations?",
+      "[answered] What is the target platform?",
+    ])
+    expect(symbols[0]?.selectionRange.start.line).toBe(4)
+    expect(symbols[1]?.selectionRange.start.line).toBe(8)
+  })
+
+  it("returns no symbols when there is no Open Questions section", () => {
+    expect(questionSymbols("# Plan\n\nJust prose.\n")).toEqual([])
+  })
+})
+
+describe("reviewSymbols", () => {
+  it("maps each chunk to a symbol with its checked/total count and one child per hunk", () => {
+    const symbols = reviewSymbols(reviewDoc)
+    expect(symbols.map((s) => s.name)).toEqual(["Add calculator (1/2)", "Wire it up (0/1)"])
+    expect(symbols[0]?.children?.map((c) => c.name)).toEqual([
+      "[ ] ./src/calc.ts#1",
+      "[x] ./src/calc.ts#5 — subtract",
+    ])
+    expect(symbols[0]?.selectionRange.start.line).toBe(3)
+    expect(symbols[0]?.children?.[0]?.selectionRange.start.line).toBe(5)
+  })
+})
+
+describe("toggleHunkEdit", () => {
+  it("flips an unchecked box to checked without touching the rest of the line", () => {
+    const lines = reviewDoc.split("\n")
+    const edit = toggleHunkEdit(reviewDoc, 5)
+    expect(edit).toBeDefined()
+    expect(lines[5]?.slice(edit!.range.start.character, edit!.range.end.character)).toBe(" ")
+    expect(edit!.newText).toBe("x")
+  })
+
+  it("flips a checked box back to unchecked, preserving the trailing note", () => {
+    const edit = toggleHunkEdit(reviewDoc, 6)
+    expect(edit).toBeDefined()
+    expect(edit!.newText).toBe(" ")
+    const lines = reviewDoc.split("\n")
+    const line = lines[6]!
+    const patched =
+      line.slice(0, edit!.range.start.character) +
+      edit!.newText +
+      line.slice(edit!.range.end.character)
+    expect(patched).toBe("- [ ] ./src/calc.ts#5 — subtract")
+  })
+
+  it("returns undefined for a line that isn't a file pointer", () => {
+    expect(toggleHunkEdit(reviewDoc, 3)).toBeUndefined()
+  })
+})
+
+describe("toggleChunkEdits", () => {
+  it("checks every remaining hunk when the chunk is majority-unchecked", () => {
+    const edits = toggleChunkEdits(reviewDoc, 3)
+    expect(edits).toHaveLength(1)
+    expect(edits[0]?.newText).toBe("x")
+  })
+
+  it("unchecks every hunk when the chunk is already all-checked", () => {
+    const allChecked = reviewDoc.replace("- [ ] ./src/calc.ts#1", "- [x] ./src/calc.ts#1")
+    const edits = toggleChunkEdits(allChecked, 3)
+    expect(edits).toHaveLength(2)
+    expect(edits.every((e) => e.newText === " ")).toBe(true)
+  })
+
+  it("returns no edits for a heading that isn't a chunk", () => {
+    expect(toggleChunkEdits(reviewDoc, 0)).toEqual([])
+  })
+})
+
+describe("reviewCodeActions", () => {
+  const uri = "file:///repo/.gtd/REVIEW.md"
+
+  it("offers a single-hunk toggle when the range sits on a hunk line", () => {
+    const actions = reviewCodeActions(uri, reviewDoc, {
+      start: { line: 5, character: 0 },
+      end: { line: 5, character: 0 },
+    })
+    expect(actions.map((a) => a.title)).toContain("gtd: check this hunk")
+  })
+
+  it("offers a whole-chunk toggle when the range sits on the chunk heading", () => {
+    const actions = reviewCodeActions(uri, reviewDoc, {
+      start: { line: 3, character: 0 },
+      end: { line: 3, character: 0 },
+    })
+    expect(actions.map((a) => a.title)).toContain('gtd: check all hunks in "Add calculator"')
+  })
+
+  it("scopes edits to the requested document uri", () => {
+    const actions = reviewCodeActions(uri, reviewDoc, {
+      start: { line: 5, character: 0 },
+      end: { line: 5, character: 0 },
+    })
+    expect(actions[0]?.edit?.changes?.[uri]).toBeDefined()
+  })
+})
+
+describe("STATE_FILE", () => {
+  it("maps every review-related state to .gtd/REVIEW.md", () => {
+    expect(STATE_FILE["review"]).toBe(".gtd/REVIEW.md")
+    expect(STATE_FILE["await-review"]).toBe(".gtd/REVIEW.md")
+  })
+
+  it("omits work-package and no-file states, leaving the caller to fall back", () => {
+    expect(STATE_FILE["building"]).toBeUndefined()
+    expect(STATE_FILE["idle"]).toBeUndefined()
+  })
+})

--- a/src/Lsp.test.ts
+++ b/src/Lsp.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "vitest"
+import { Effect } from "effect"
 import {
   questionSymbols,
   reviewSymbols,
   toggleHunkEdit,
   toggleChunkEdits,
   reviewCodeActions,
+  currentSteeringFile,
   STATE_FILE,
 } from "./Lsp.js"
+import { InMemRepo } from "../tests/integration/support/inmem/Repo.js"
+import { inMemoryLayers } from "../tests/integration/support/inmem/layers.js"
 
 const questionsDoc = [
   "# Plan",
@@ -150,5 +154,38 @@ describe("STATE_FILE", () => {
   it("omits work-package and no-file states, leaving the caller to fall back", () => {
     expect(STATE_FILE["building"]).toBeUndefined()
     expect(STATE_FILE["idle"]).toBeUndefined()
+  })
+})
+
+describe("currentSteeringFile", () => {
+  const runWith = (repo: InMemRepo) =>
+    Effect.runPromise(currentSteeringFile.pipe(Effect.provide(inMemoryLayers(repo))))
+
+  it("resolves to REVIEW.md while resting at await-review", async () => {
+    const repo = new InMemRepo()
+    repo.writeFile(".gtdrc", 'testCommand: "true"\n')
+    repo.writeFile("readme.txt", "hello")
+    repo.commitAllWithPrefix("init: first commit")
+    repo.writeFile("src/code.ts", "export const x = 1")
+    repo.commitAllWithPrefix("gtd(agent): building")
+    repo.writeFile(
+      ".gtd/REVIEW.md",
+      "# Review: abc1234\n\n<!-- base: abc1234 -->\n\n## Chunk\n\n- [ ] ./src/code.ts#1\n",
+    )
+    repo.commitAllWithPrefix("gtd(agent): review")
+    repo.commitAllWithPrefix("gtd: awaiting review")
+
+    const outcome = await runWith(repo)
+    expect(outcome).toEqual({ kind: "file", uri: expect.stringContaining("REVIEW.md") })
+  })
+
+  it("reports the state when it has no single mapped file", async () => {
+    const repo = new InMemRepo()
+    repo.writeFile(".gtdrc", 'testCommand: "true"\n')
+    repo.writeFile("readme.txt", "hello")
+    repo.commitAllWithPrefix("init: first commit")
+
+    const outcome = await runWith(repo)
+    expect(outcome).toEqual({ kind: "none", state: "idle" })
   })
 })

--- a/src/Lsp.ts
+++ b/src/Lsp.ts
@@ -34,24 +34,14 @@ import {
 import { TextDocument } from "vscode-languageserver-textdocument"
 import { parseOpenQuestions, type OpenQuestion } from "./OpenQuestions.js"
 import { parseReviewDoc, type ReviewFile, FILE_POINTER_RE } from "./ReviewDoc.js"
-import {
-  gatherEvents,
-  TODO_FILE,
-  ARCHITECTURE_FILE,
-  REVIEW_FILE,
-  FEEDBACK_FILE,
-  ERRORS_FILE,
-  HEALTH_FILE,
-  SQUASH_MSG_FILE,
-  LEARNINGS_FILE,
-} from "./Events.js"
+import { gatherEvents, STEERING_FILES } from "./Events.js"
 import { resolve, type GtdState } from "./Machine.js"
 import { closeReviewWindow, openReviewWindow } from "./ReviewWindow.js"
 import { GitService } from "./Git.js"
 import { ConfigInit, ConfigService } from "./Config.js"
 import { Cwd } from "./Cwd.js"
 
-export const OPEN_STEERING_FILE_COMMAND = "gtd.openSteeringFile"
+const OPEN_STEERING_FILE_COMMAND = "gtd.openSteeringFile"
 
 /**
  * States mapped to a single fixed steering file. Absent states —
@@ -61,20 +51,20 @@ export const OPEN_STEERING_FILE_COMMAND = "gtd.openSteeringFile"
  * state instead of guessing a file.
  */
 export const STATE_FILE: Partial<Record<GtdState, string>> = {
-  grilling: TODO_FILE,
-  architecting: ARCHITECTURE_FILE,
-  grilled: ARCHITECTURE_FILE,
-  fixing: FEEDBACK_FILE,
-  "agentic-review": FEEDBACK_FILE,
-  escalate: ERRORS_FILE,
-  review: REVIEW_FILE,
-  "await-review": REVIEW_FILE,
-  learning: LEARNINGS_FILE,
-  "await-learning-review": LEARNINGS_FILE,
-  "learning-apply": LEARNINGS_FILE,
-  squashing: SQUASH_MSG_FILE,
-  "health-check": HEALTH_FILE,
-  "health-fixing": HEALTH_FILE,
+  grilling: STEERING_FILES.todo,
+  architecting: STEERING_FILES.architecture,
+  grilled: STEERING_FILES.architecture,
+  fixing: STEERING_FILES.feedback,
+  "agentic-review": STEERING_FILES.feedback,
+  escalate: STEERING_FILES.errors,
+  review: STEERING_FILES.review,
+  "await-review": STEERING_FILES.review,
+  learning: STEERING_FILES.learnings,
+  "await-learning-review": STEERING_FILES.learnings,
+  "learning-apply": STEERING_FILES.learnings,
+  squashing: STEERING_FILES.squashMsg,
+  "health-check": STEERING_FILES.health,
+  "health-fixing": STEERING_FILES.health,
 }
 
 // ── Pure helpers ─────────────────────────────────────────────────────────────
@@ -196,6 +186,7 @@ export const reviewCodeActions = (uri: string, content: string, range: Range): C
   const cursorLine = range.start.line
   const actions: CodeAction[] = []
 
+  // fallow-ignore-next-line complexity
   changesets.forEach((chunk, i) => {
     const hunk = chunk.files.find((file) => file.sourceLine === cursorLine)
     if (hunk) {
@@ -247,7 +238,7 @@ type SteeringFileOutcome =
  * long as the server runs would leave a reviewer's working tree un-rewound
  * (no diff visible) for the entire session.
  */
-const currentSteeringFile: Effect.Effect<
+export const currentSteeringFile: Effect.Effect<
   SteeringFileOutcome,
   Error,
   GitService | FileSystem.FileSystem | ConfigService | ConfigInit | Cwd

--- a/src/Lsp.ts
+++ b/src/Lsp.ts
@@ -1,0 +1,356 @@
+/**
+ * LSP server for `.gtd/` steering files — document symbols for open
+ * questions (`.gtd/TODO.md`/`.gtd/ARCHITECTURE.md`) and review chunks/hunks
+ * (`.gtd/REVIEW.md`), code actions to check/uncheck a hunk or a whole chunk,
+ * and a `gtd.openSteeringFile` command that opens whichever steering file
+ * matches the current `GtdState`.
+ *
+ * Split like the rest of the codebase: pure helpers below (symbol/edit
+ * building — unit-testable, no protocol/IO), the `vscode-languageserver`
+ * wiring at the bottom (the IO edge, analogous to `Events.ts`).
+ */
+
+import { pathToFileURL, fileURLToPath } from "node:url"
+import { basename, join } from "node:path"
+import { FileSystem } from "@effect/platform"
+import { Effect, Runtime } from "effect"
+import {
+  createConnection,
+  ProposedFeatures,
+  TextDocuments,
+  TextDocumentSyncKind,
+  CodeActionKind,
+  SymbolKind,
+  ShowDocumentRequest,
+  type CodeAction,
+  type CodeActionParams,
+  type DocumentSymbol,
+  type DocumentSymbolParams,
+  type ExecuteCommandParams,
+  type InitializeParams,
+  type Range,
+  type TextEdit,
+} from "vscode-languageserver/node"
+import { TextDocument } from "vscode-languageserver-textdocument"
+import { parseOpenQuestions, type OpenQuestion } from "./OpenQuestions.js"
+import { parseReviewDoc, type ReviewFile, FILE_POINTER_RE } from "./ReviewDoc.js"
+import {
+  gatherEvents,
+  TODO_FILE,
+  ARCHITECTURE_FILE,
+  REVIEW_FILE,
+  FEEDBACK_FILE,
+  ERRORS_FILE,
+  HEALTH_FILE,
+  SQUASH_MSG_FILE,
+  LEARNINGS_FILE,
+} from "./Events.js"
+import { resolve, type GtdState } from "./Machine.js"
+import { closeReviewWindow, openReviewWindow } from "./ReviewWindow.js"
+import { GitService } from "./Git.js"
+import { ConfigInit, ConfigService } from "./Config.js"
+import { Cwd } from "./Cwd.js"
+
+export const OPEN_STEERING_FILE_COMMAND = "gtd.openSteeringFile"
+
+/**
+ * States mapped to a single fixed steering file. Absent states —
+ * `planning`/`building`/`testing` (per-task-file work packages, no single
+ * fixed path) and the no-file rests `done`/`idle`/`close-package`/
+ * `learning-applied` — fall back to an informational message naming the
+ * state instead of guessing a file.
+ */
+export const STATE_FILE: Partial<Record<GtdState, string>> = {
+  grilling: TODO_FILE,
+  architecting: ARCHITECTURE_FILE,
+  grilled: ARCHITECTURE_FILE,
+  fixing: FEEDBACK_FILE,
+  "agentic-review": FEEDBACK_FILE,
+  escalate: ERRORS_FILE,
+  review: REVIEW_FILE,
+  "await-review": REVIEW_FILE,
+  learning: LEARNINGS_FILE,
+  "await-learning-review": LEARNINGS_FILE,
+  "learning-apply": LEARNINGS_FILE,
+  squashing: SQUASH_MSG_FILE,
+  "health-check": HEALTH_FILE,
+  "health-fixing": HEALTH_FILE,
+}
+
+// ── Pure helpers ─────────────────────────────────────────────────────────────
+
+const lineRange = (lines: readonly string[], line: number): Range => ({
+  start: { line, character: 0 },
+  end: { line, character: (lines[line] ?? "").length },
+})
+
+const spanRange = (lines: readonly string[], startLine: number, endLine: number): Range => ({
+  start: { line: startLine, character: 0 },
+  end: { line: endLine, character: (lines[endLine] ?? "").length },
+})
+
+const statusMarker = (status: OpenQuestion["status"]): string =>
+  status === "answered" ? "[answered]" : "[suggested]"
+
+/** Document symbols for `.gtd/TODO.md` / `.gtd/ARCHITECTURE.md`'s open questions. */
+export const questionSymbols = (content: string): DocumentSymbol[] => {
+  const { questions } = parseOpenQuestions(content)
+  const lines = content.split(/\r?\n/)
+  return questions.map((question, i) => {
+    const start = question.headingLine
+    const end = Math.max(start, (questions[i + 1]?.headingLine ?? lines.length) - 1)
+    return {
+      name: `${statusMarker(question.status)} ${question.question}`,
+      detail: question.text,
+      kind: SymbolKind.Boolean,
+      range: spanRange(lines, start, end),
+      selectionRange: lineRange(lines, start),
+    }
+  })
+}
+
+const hunkLabel = (file: ReviewFile): string => {
+  const box = file.checked ? "[x]" : "[ ]"
+  const location = file.line !== undefined ? `${file.path}#${file.line}` : file.path
+  return file.note ? `${box} ${location} — ${file.note}` : `${box} ${location}`
+}
+
+/** Document symbols for `.gtd/REVIEW.md`'s chunks (the user-facing "work packages") and their hunks. */
+export const reviewSymbols = (content: string): DocumentSymbol[] => {
+  const { changesets } = parseReviewDoc(content)
+  const lines = content.split(/\r?\n/)
+  return changesets.map((chunk, i) => {
+    const start = chunk.headingLine
+    const end = Math.max(start, (changesets[i + 1]?.headingLine ?? lines.length) - 1)
+    const checkedCount = chunk.files.filter((file) => file.checked).length
+    const children: DocumentSymbol[] = chunk.files.map((file) => ({
+      name: hunkLabel(file),
+      kind: SymbolKind.Boolean,
+      range: lineRange(lines, file.sourceLine),
+      selectionRange: lineRange(lines, file.sourceLine),
+    }))
+    return {
+      name: `${chunk.title} (${checkedCount}/${chunk.files.length})`,
+      kind: SymbolKind.Package,
+      range: spanRange(lines, start, end),
+      selectionRange: lineRange(lines, start),
+      children,
+    }
+  })
+}
+
+/** Flips the `[ ]`/`[x]` box of the hunk line at `line`, preserving path/note text exactly. */
+export const toggleHunkEdit = (content: string, line: number): TextEdit | undefined => {
+  const raw = content.split(/\r?\n/)[line]
+  if (raw === undefined) return undefined
+  const leading = raw.length - raw.trimStart().length
+  const trimmed = raw.slice(leading)
+  const match = FILE_POINTER_RE.exec(trimmed)
+  if (!match) return undefined
+  const bracketContent = match[0].indexOf("[") + 1
+  const character = leading + bracketContent
+  return {
+    range: { start: { line, character }, end: { line, character: character + 1 } },
+    newText: match[1] === " " ? "x" : " ",
+  }
+}
+
+/**
+ * The target state a whole-chunk toggle drives every hunk to: `true` (check
+ * all) unless a strict majority are already checked, in which case `false`
+ * (uncheck all) — a chunk with no strict majority either way (including an
+ * even split) defaults to checking, so it's never a meaningless no-op on a
+ * chunk that's already uniform.
+ */
+const chunkToggleTarget = (checkedCount: number, total: number): boolean =>
+  checkedCount * 2 <= total
+
+/**
+ * Toggles every hunk in the chunk headed at `headingLine` to a single target
+ * state (`chunkToggleTarget`). Only hunks not already at the target state
+ * produce an edit.
+ */
+export const toggleChunkEdits = (content: string, headingLine: number): TextEdit[] => {
+  const { changesets } = parseReviewDoc(content)
+  const chunk = changesets.find((c) => c.headingLine === headingLine)
+  if (!chunk || chunk.files.length === 0) return []
+  const checkedCount = chunk.files.filter((file) => file.checked).length
+  const target = chunkToggleTarget(checkedCount, chunk.files.length)
+  const edits: TextEdit[] = []
+  for (const file of chunk.files) {
+    if (file.checked === target) continue
+    const edit = toggleHunkEdit(content, file.sourceLine)
+    if (edit) edits.push(edit)
+  }
+  return edits
+}
+
+/**
+ * Code actions for `.gtd/REVIEW.md`: "check/uncheck this hunk" when `range`
+ * sits on a hunk line, "check/uncheck all hunks" when `range` sits anywhere
+ * in a chunk (heading or body).
+ */
+export const reviewCodeActions = (uri: string, content: string, range: Range): CodeAction[] => {
+  const { changesets } = parseReviewDoc(content)
+  const lines = content.split(/\r?\n/)
+  const cursorLine = range.start.line
+  const actions: CodeAction[] = []
+
+  changesets.forEach((chunk, i) => {
+    const hunk = chunk.files.find((file) => file.sourceLine === cursorLine)
+    if (hunk) {
+      const edit = toggleHunkEdit(content, hunk.sourceLine)
+      if (edit) {
+        actions.push({
+          title: hunk.checked ? "gtd: uncheck this hunk" : "gtd: check this hunk",
+          kind: CodeActionKind.QuickFix,
+          edit: { changes: { [uri]: [edit] } },
+        })
+      }
+    }
+
+    const chunkEnd = Math.max(
+      chunk.headingLine,
+      (changesets[i + 1]?.headingLine ?? lines.length) - 1,
+    )
+    if (chunk.files.length > 0 && cursorLine >= chunk.headingLine && cursorLine <= chunkEnd) {
+      const edits = toggleChunkEdits(content, chunk.headingLine)
+      if (edits.length > 0) {
+        const checkedCount = chunk.files.filter((file) => file.checked).length
+        const willCheck = chunkToggleTarget(checkedCount, chunk.files.length)
+        actions.push({
+          title: willCheck
+            ? `gtd: check all hunks in "${chunk.title}"`
+            : `gtd: uncheck all hunks in "${chunk.title}"`,
+          kind: CodeActionKind.QuickFix,
+          edit: { changes: { [uri]: edits } },
+        })
+      }
+    }
+  })
+
+  return actions
+}
+
+// ── Protocol adapter ─────────────────────────────────────────────────────────
+
+type SteeringFileOutcome =
+  | { readonly kind: "file"; readonly uri: string }
+  | { readonly kind: "none"; readonly state: GtdState }
+
+/**
+ * Reads the current `GtdState` and maps it to a steering-file URI, exactly
+ * mirroring `program.ts`'s own dispatch wrapper (`closeReviewWindow` before
+ * `gatherEvents`, `openReviewWindow` re-armed after — see `ReviewWindow.ts`),
+ * but scoped to a single on-demand call rather than the whole server's
+ * lifetime: `gtd lsp` is long-running, so holding the window closed for as
+ * long as the server runs would leave a reviewer's working tree un-rewound
+ * (no diff visible) for the entire session.
+ */
+const currentSteeringFile: Effect.Effect<
+  SteeringFileOutcome,
+  Error,
+  GitService | FileSystem.FileSystem | ConfigService | ConfigInit | Cwd
+> = Effect.gen(function* () {
+  yield* closeReviewWindow
+  yield* (yield* ConfigInit).ensure
+  const events = yield* gatherEvents("none")
+  const result = yield* Effect.try({
+    try: () => resolve(events),
+    catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+  })
+  const relativePath = STATE_FILE[result.state]
+  if (relativePath === undefined) return { kind: "none" as const, state: result.state }
+  const cwd = yield* Cwd
+  return { kind: "file" as const, uri: pathToFileURL(join(cwd.root, relativePath)).toString() }
+}).pipe(
+  Effect.tap(() => openReviewWindow),
+  Effect.tapError(() => openReviewWindow.pipe(Effect.ignore)),
+)
+
+const documentName = (uri: string): string => basename(fileURLToPath(uri))
+
+/**
+ * Starts the `gtd lsp` server over stdio. The returned Effect resolves when
+ * the client disconnects (`exit` notification), so the process exits
+ * cleanly rather than blocking forever.
+ */
+export const startLspServer = (): Effect.Effect<
+  void,
+  Error,
+  GitService | FileSystem.FileSystem | ConfigService | ConfigInit | Cwd
+> =>
+  Effect.gen(function* () {
+    const runtime = yield* Effect.runtime<
+      GitService | FileSystem.FileSystem | ConfigService | ConfigInit | Cwd
+    >()
+    const runPromise = Runtime.runPromise(runtime)
+
+    const connection = createConnection(ProposedFeatures.all, process.stdin, process.stdout)
+    const documents = new TextDocuments(TextDocument)
+    let showDocumentCapable = false
+
+    connection.onInitialize((params: InitializeParams) => {
+      showDocumentCapable = params.capabilities.window?.showDocument?.support ?? false
+      return {
+        capabilities: {
+          textDocumentSync: TextDocumentSyncKind.Incremental,
+          documentSymbolProvider: true,
+          codeActionProvider: true,
+          executeCommandProvider: { commands: [OPEN_STEERING_FILE_COMMAND] },
+        },
+      }
+    })
+
+    connection.onDocumentSymbol((params: DocumentSymbolParams) => {
+      const document = documents.get(params.textDocument.uri)
+      if (!document) return []
+      switch (documentName(document.uri)) {
+        case "TODO.md":
+        case "ARCHITECTURE.md":
+          return questionSymbols(document.getText())
+        case "REVIEW.md":
+          return reviewSymbols(document.getText())
+        default:
+          return []
+      }
+    })
+
+    connection.onCodeAction((params: CodeActionParams) => {
+      const document = documents.get(params.textDocument.uri)
+      if (!document || documentName(document.uri) !== "REVIEW.md") return []
+      return reviewCodeActions(document.uri, document.getText(), params.range)
+    })
+
+    connection.onExecuteCommand(async (params: ExecuteCommandParams) => {
+      if (params.command !== OPEN_STEERING_FILE_COMMAND) return
+      try {
+        const outcome = await runPromise(currentSteeringFile)
+        if (outcome.kind === "none") {
+          connection.window.showInformationMessage(
+            `gtd: no single steering file for state "${outcome.state}"`,
+          )
+          return
+        }
+        if (showDocumentCapable) {
+          await connection.sendRequest(ShowDocumentRequest.type, {
+            uri: outcome.uri,
+            takeFocus: true,
+          })
+        } else {
+          connection.window.showInformationMessage(`gtd: steering file is ${outcome.uri}`)
+        }
+      } catch (error) {
+        connection.window.showErrorMessage(
+          `gtd: ${error instanceof Error ? error.message : String(error)}`,
+        )
+      }
+    })
+
+    documents.listen(connection)
+    connection.listen()
+
+    yield* Effect.async<void>((resume) => {
+      connection.onExit(() => resume(Effect.void))
+    })
+  })

--- a/src/OpenQuestions.test.ts
+++ b/src/OpenQuestions.test.ts
@@ -31,7 +31,12 @@ describe("parseOpenQuestions", () => {
     ].join("\n")
     expect(parseOpenQuestions(content)).toEqual({
       questions: [
-        { question: "Which operations?", status: "suggested", text: "add and subtract." },
+        {
+          question: "Which operations?",
+          status: "suggested",
+          text: "add and subtract.",
+          headingLine: 6,
+        },
       ],
       errors: [],
     })
@@ -48,7 +53,12 @@ describe("parseOpenQuestions", () => {
     ].join("\n")
     expect(parseOpenQuestions(content)).toEqual({
       questions: [
-        { question: "Which operations?", status: "answered", text: "add, subtract, and multiply." },
+        {
+          question: "Which operations?",
+          status: "answered",
+          text: "add, subtract, and multiply.",
+          headingLine: 2,
+        },
       ],
       errors: [],
     })
@@ -68,8 +78,18 @@ describe("parseOpenQuestions", () => {
       "",
     ].join("\n")
     expect(parseOpenQuestions(content).questions).toEqual([
-      { question: "Which operations?", status: "suggested", text: "add and subtract." },
-      { question: "What is the target platform?", status: "answered", text: "web only." },
+      {
+        question: "Which operations?",
+        status: "suggested",
+        text: "add and subtract.",
+        headingLine: 2,
+      },
+      {
+        question: "What is the target platform?",
+        status: "answered",
+        text: "web only.",
+        headingLine: 6,
+      },
     ])
   })
 
@@ -90,7 +110,12 @@ describe("parseOpenQuestions", () => {
     ].join("\n")
     expect(parseOpenQuestions(content)).toEqual({
       questions: [
-        { question: "Which operations?", status: "suggested", text: "add and subtract." },
+        {
+          question: "Which operations?",
+          status: "suggested",
+          text: "add and subtract.",
+          headingLine: 2,
+        },
       ],
       errors: [],
     })
@@ -141,7 +166,12 @@ describe("parseOpenQuestions", () => {
       'Open question "Which operations?" is missing a "Suggested default: ..." or "Answer: ..." line',
     ])
     expect(result.questions).toEqual([
-      { question: "What is the target platform?", status: "answered", text: "web only." },
+      {
+        question: "What is the target platform?",
+        status: "answered",
+        text: "web only.",
+        headingLine: 3,
+      },
     ])
   })
 
@@ -163,7 +193,9 @@ describe("parseOpenQuestions", () => {
       "",
     ].join("\n")
     const result = parseOpenQuestions(content)
-    expect(result.questions).toEqual([{ question: "Second?", status: "suggested", text: "yes." }])
+    expect(result.questions).toEqual([
+      { question: "Second?", status: "suggested", text: "yes.", headingLine: 6 },
+    ])
     expect(result.errors).toHaveLength(2)
   })
 })

--- a/src/OpenQuestions.ts
+++ b/src/OpenQuestions.ts
@@ -22,6 +22,8 @@ export interface OpenQuestion {
   readonly question: string
   readonly status: OpenQuestionStatus
   readonly text: string
+  /** 0-based line index of this question's `###` heading, for editor tooling. */
+  readonly headingLine: number
 }
 
 export interface OpenQuestionsDoc {
@@ -41,6 +43,7 @@ const headingLevel = (line: string): number | undefined => {
 /** One `###` heading under `## Open Questions`, with its raw body lines (up to the next heading of any level). */
 interface QuestionBlock {
   readonly question: string
+  readonly headingLine: number
   readonly body: readonly string[]
 }
 
@@ -66,13 +69,14 @@ const splitQuestionBlocks = (lines: readonly string[], start: number): readonly 
     const question = lines[i]!.trim()
       .replace(/^#{3}\s+/, "")
       .trim()
+    const headingLine = i
     i += 1
     const body: string[] = []
     while (i < lines.length && headingLevel(lines[i]!) === undefined) {
       body.push(lines[i]!)
       i += 1
     }
-    blocks.push({ question, body })
+    blocks.push({ question, headingLine, body })
   }
 
   return blocks
@@ -99,6 +103,7 @@ const parseQuestionBlock = (block: QuestionBlock): OpenQuestion | { readonly err
     question: block.question,
     status: responseMatch[1] === "Answer" ? "answered" : "suggested",
     text,
+    headingLine: block.headingLine,
   }
 }
 

--- a/src/ReviewDoc.test.ts
+++ b/src/ReviewDoc.test.ts
@@ -23,10 +23,11 @@ describe("parseReviewDoc", () => {
       changesets: [
         {
           title: "Add calculator",
+          headingLine: 4,
           description: "New add function for the calculator.",
           files: [
-            { path: "./src/calc.ts", line: 1, checked: false },
-            { path: "./src/calc.ts", line: 5, checked: false },
+            { path: "./src/calc.ts", line: 1, checked: false, sourceLine: 8 },
+            { path: "./src/calc.ts", line: 5, checked: false, sourceLine: 9 },
           ],
         },
       ],
@@ -54,13 +55,23 @@ describe("parseReviewDoc", () => {
     expect(result.changesets).toEqual([
       {
         title: "Add calculator",
+        headingLine: 3,
         description: "",
-        files: [{ path: "./src/calc.ts", line: 1, checked: true, note: "new add function" }],
+        files: [
+          {
+            path: "./src/calc.ts",
+            line: 1,
+            checked: true,
+            note: "new add function",
+            sourceLine: 5,
+          },
+        ],
       },
       {
         title: "Wire it up",
+        headingLine: 7,
         description: "",
-        files: [{ path: "./src/index.ts", line: 10, checked: false }],
+        files: [{ path: "./src/index.ts", line: 10, checked: false, sourceLine: 9 }],
       },
     ])
   })
@@ -108,7 +119,12 @@ describe("parseReviewDoc", () => {
     const result = parseReviewDoc(content)
     expect(result.errors).toContain('Chunk "Add calculator" has no file pointers')
     expect(result.changesets).toEqual([
-      { title: "Add calculator", description: "Just prose, no pointers.", files: [] },
+      {
+        title: "Add calculator",
+        headingLine: 3,
+        description: "Just prose, no pointers.",
+        files: [],
+      },
     ])
   })
 

--- a/src/ReviewDoc.ts
+++ b/src/ReviewDoc.ts
@@ -30,12 +30,16 @@ export interface ReviewFile {
   readonly line?: number
   readonly checked: boolean
   readonly note?: string
+  /** 0-based line index of this file pointer's own `- [ ]`/`- [x]` line in REVIEW.md, for editor tooling. */
+  readonly sourceLine: number
 }
 
 export interface Changeset {
   readonly title: string
   readonly description: string
   readonly files: readonly ReviewFile[]
+  /** 0-based line index of this chunk's `##` heading, for editor tooling. */
+  readonly headingLine: number
 }
 
 export interface ReviewDoc {
@@ -48,7 +52,7 @@ export interface ReviewDoc {
 const HEADER_RE = /^#\s+Review:\s*(\S+)\s*$/
 const BASE_COMMENT_RE = /^<!--\s*base:\s*(\S+)\s*-->$/
 const CHUNK_HEADING_RE = /^##\s+(.+)$/
-const FILE_POINTER_RE = /^-\s*\[([ xX])\]\s*(\.\/\S+?)(?:#(\d+))?(?:\s*[—-]+\s*(.*))?$/
+export const FILE_POINTER_RE = /^-\s*\[([ xX])\]\s*(\.\/\S+?)(?:#(\d+))?(?:\s*[—-]+\s*(.*))?$/
 
 /** The `# Review: <hash>` header, required as the document's first non-blank line. */
 const parseHeader = (lines: readonly string[]): string | undefined => {
@@ -66,7 +70,7 @@ const parseBaseComment = (lines: readonly string[]): string | undefined => {
 }
 
 /** One `- [ ]` / `- [x]` file-pointer line, or `undefined` if `line` isn't one. */
-const parseFilePointer = (line: string): ReviewFile | undefined => {
+const parseFilePointer = (line: string, sourceLine: number): ReviewFile | undefined => {
   const match = FILE_POINTER_RE.exec(line)
   if (!match) return undefined
   return {
@@ -74,33 +78,40 @@ const parseFilePointer = (line: string): ReviewFile | undefined => {
     path: match[2]!,
     ...(match[3] !== undefined ? { line: Number(match[3]) } : {}),
     ...(match[4] && match[4].trim().length > 0 ? { note: match[4].trim() } : {}),
+    sourceLine,
   }
+}
+
+/** One raw body line of a chunk, paired with its 0-based line index in the document. */
+interface BodyLine {
+  readonly text: string
+  readonly line: number
 }
 
 /** Splits one chunk's body lines (up to the next `##` heading) into its file pointers and description prose. */
 const parseChunkBody = (
-  body: readonly string[],
+  body: readonly BodyLine[],
 ): { readonly description: string; readonly files: readonly ReviewFile[] } => {
   const files: ReviewFile[] = []
   const descriptionLines: string[] = []
   for (const raw of body) {
-    const line = raw.trim()
-    if (line.length === 0) continue
-    const file = parseFilePointer(line)
+    const trimmed = raw.text.trim()
+    if (trimmed.length === 0) continue
+    const file = parseFilePointer(trimmed, raw.line)
     if (file) {
       files.push(file)
     } else {
-      descriptionLines.push(line)
+      descriptionLines.push(trimmed)
     }
   }
   return { description: descriptionLines.join(" "), files }
 }
 
-/** Splits the document into `##` chunks, each with its title and body lines. */
+/** Splits the document into `##` chunks, each with its title, heading line, and body lines. */
 const splitChunks = (
   lines: readonly string[],
-): ReadonlyArray<{ title: string; body: string[] }> => {
-  const chunks: Array<{ title: string; body: string[] }> = []
+): ReadonlyArray<{ title: string; headingLine: number; body: BodyLine[] }> => {
+  const chunks: Array<{ title: string; headingLine: number; body: BodyLine[] }> = []
   let i = 0
   while (i < lines.length) {
     const chunkMatch = CHUNK_HEADING_RE.exec(lines[i]!.trim())
@@ -109,13 +120,14 @@ const splitChunks = (
       continue
     }
     const title = chunkMatch[1]!.trim()
+    const headingLine = i
     i += 1
-    const body: string[] = []
+    const body: BodyLine[] = []
     while (i < lines.length && !CHUNK_HEADING_RE.test(lines[i]!.trim())) {
-      body.push(lines[i]!)
+      body.push({ text: lines[i]!, line: i })
       i += 1
     }
-    chunks.push({ title, body })
+    chunks.push({ title, headingLine, body })
   }
   return chunks
 }
@@ -126,10 +138,10 @@ const parseChangesets = (
 ): { readonly changesets: readonly Changeset[]; readonly errors: readonly string[] } => {
   const changesets: Changeset[] = []
   const errors: string[] = []
-  for (const { title, body } of splitChunks(lines)) {
+  for (const { title, headingLine, body } of splitChunks(lines)) {
     const { description, files } = parseChunkBody(body)
     if (files.length === 0) errors.push(`Chunk "${title}" has no file pointers`)
-    changesets.push({ title, description, files })
+    changesets.push({ title, description, files, headingLine })
   }
   if (changesets.length === 0) errors.push("REVIEW.md has no '##' chunks")
   return { changesets, errors }

--- a/src/program.ts
+++ b/src/program.ts
@@ -15,6 +15,7 @@ import * as Format from "./Format.js"
 import { GitService, type GitOperations } from "./Git.js"
 import { predictTurn, resolve, type EdgeAction, type GtdEvent, type Result } from "./Machine.js"
 import { buildPrompt } from "./Prompt.js"
+import { startLspServer } from "./Lsp.js"
 import { closeReviewWindow, openReviewWindow } from "./ReviewWindow.js"
 import { reviewingSubject } from "./Subjects.js"
 import { describeEdgeAction, describeStatus } from "./State.js"
@@ -34,6 +35,7 @@ Commands:
   questions        List open questions from the active grilling/architecting doc
   changesets       List changesets/files from the active review doc
   format <file>    Format a markdown file in place
+  lsp              Start the LSP server for .gtd/ steering files (stdio)
 
 Options:
   --json           Output structured JSON instead of plain text
@@ -721,6 +723,17 @@ export function makeProgram(
 
     if (positional === "format") {
       return yield* runFormatCommand(argv, json)
+    }
+
+    // `lsp` is long-running and manages its own review-window close/open
+    // cycle per request (see src/Lsp.ts) rather than the once-per-invocation
+    // wrap every other subcommand gets below — so it's dispatched here,
+    // before that wrap, exactly like `format`.
+    if (positional === "lsp") {
+      if (json) {
+        return yield* Effect.fail(new Error("gtd lsp does not accept --json"))
+      }
+      return yield* startLspServer()
     }
 
     const sub = yield* requireKnownSubcommand(positional, json, write)

--- a/tests/integration/features/lsp.feature
+++ b/tests/integration/features/lsp.feature
@@ -1,0 +1,116 @@
+@live
+Feature: gtd lsp — LSP server for .gtd/ steering files
+
+  `gtd lsp` starts an LSP server over stdio for editors to attach to. These
+  scenarios speak the real JSON-RPC wire protocol against the real built
+  binary (never the in-memory tier — there's no separate process to pipe
+  stdin/stdout to for a long-running server), covering: document symbols for
+  open questions and review chunks/hunks, code actions that check/uncheck a
+  hunk or a whole chunk, and the `gtd.openSteeringFile` command that asks the
+  client to open whichever steering file matches the current state.
+
+  Scenario: Document symbols surface each open question with its answered/suggested status
+    Given a test project
+    And a file ".gtd/TODO.md" with:
+      """
+      # Plan
+
+      ## Open Questions
+
+      ### Which operations?
+
+      Suggested default: add and subtract.
+
+      ### What is the target platform?
+
+      Answer: web only.
+      """
+    And a running gtd lsp server
+    When I request document symbols for ".gtd/TODO.md"
+    Then there are 2 document symbols
+    And the document symbols include "[suggested] Which operations?"
+    And the document symbols include "[answered] What is the target platform?"
+
+  Scenario: Document symbols surface each review chunk and its hunks
+    Given a test project
+    And a file ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add calculator
+
+      - [ ] ./src/calc.ts#1
+      - [x] ./src/calc.ts#5 — subtract
+      """
+    And a running gtd lsp server
+    When I request document symbols for ".gtd/REVIEW.md"
+    Then there are 1 document symbols
+    And the document symbols include "Add calculator (1/2)"
+    And the first symbol's children include "[ ] ./src/calc.ts#1"
+    And the first symbol's children include "[x] ./src/calc.ts#5 — subtract"
+
+  Scenario: A code action checks a single unchecked hunk without touching the rest of the line
+    Given a test project
+    And a file ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add calculator
+
+      - [ ] ./src/calc.ts#1
+      - [ ] ./src/calc.ts#5 — subtract
+      """
+    And a running gtd lsp server
+    When I request code actions at line containing "calc.ts#1" of ".gtd/REVIEW.md"
+    And I apply the code action titled "gtd: check this hunk"
+    Then the file ".gtd/REVIEW.md" contains "- [x] ./src/calc.ts#1"
+    And the file ".gtd/REVIEW.md" contains "- [ ] ./src/calc.ts#5 — subtract"
+
+  Scenario: A code action checks every hunk in a chunk at once
+    Given a test project
+    And a file ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add calculator
+
+      - [ ] ./src/calc.ts#1
+      - [ ] ./src/calc.ts#5 — subtract
+      """
+    And a running gtd lsp server
+    When I request code actions at line containing "## Add calculator" of ".gtd/REVIEW.md"
+    And I apply the code action titled "gtd: check all hunks in \"Add calculator\""
+    Then the file ".gtd/REVIEW.md" contains "- [x] ./src/calc.ts#1"
+    And the file ".gtd/REVIEW.md" contains "- [x] ./src/calc.ts#5 — subtract"
+
+  Scenario: The openSteeringFile command asks the client to show REVIEW.md while resting at await-review
+    Given a test project
+    And a commit "feat: add calculator" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd: awaiting review" that adds ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add calculator
+
+      - [ ] ./src/calc.ts#1
+      """
+    And a running gtd lsp server
+    When I run the gtd.openSteeringFile command
+    Then the server asked to show document ".gtd/REVIEW.md"
+
+  Scenario: The openSteeringFile command reports the state when no single file applies
+    Given a test project
+    And a running gtd lsp server
+    When I run the gtd.openSteeringFile command
+    Then the server showed an information message containing "idle"

--- a/tests/integration/support/steps/lsp.steps.ts
+++ b/tests/integration/support/steps/lsp.steps.ts
@@ -45,6 +45,7 @@ class Framer {
   private buffer = Buffer.alloc(0)
   constructor(private readonly onMessage: (message: JsonRpcMessage) => void) {}
 
+  // fallow-ignore-next-line complexity
   push(chunk: Buffer): void {
     this.buffer = Buffer.concat([this.buffer, chunk])
     for (;;) {
@@ -102,6 +103,7 @@ Given("a running gtd lsp server", async (world: GtdWorld) => {
   }
   sessions.set(world, session)
 
+  // fallow-ignore-next-line complexity
   const framer = new Framer((message) => {
     if (message.id !== undefined && message.method === undefined) {
       const resolve = session.pending.get(message.id)

--- a/tests/integration/support/steps/lsp.steps.ts
+++ b/tests/integration/support/steps/lsp.steps.ts
@@ -1,0 +1,266 @@
+import { Given, When, Then, After } from "quickpickle"
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
+import { readFileSync, writeFileSync } from "node:fs"
+import { pathToFileURL, fileURLToPath } from "node:url"
+import { join, resolve } from "node:path"
+import assert from "node:assert"
+import type { GtdWorld } from "../world.js"
+
+// `gtd lsp` is a long-running stdio server, unlike every other subcommand's
+// run-to-completion `execFile` — so it can't go through the @inmem tier (no
+// separate process to pipe stdin/stdout to) or the @live tier's `runGtdLive`
+// (which waits for exit). These steps speak the real Content-Length-framed
+// JSON-RPC protocol against a real spawned `gtd lsp` process instead.
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "../../../..")
+const GTD_BIN = join(PROJECT_ROOT, "dist/gtd.bundle.mjs")
+
+interface JsonRpcMessage {
+  readonly jsonrpc: "2.0"
+  readonly id?: number
+  readonly method?: string
+  readonly params?: unknown
+  readonly result?: unknown
+  readonly error?: unknown
+}
+
+interface LspSession {
+  readonly proc: ChildProcessWithoutNullStreams
+  nextId: number
+  readonly pending: Map<number, (result: unknown) => void>
+  readonly serverRequests: JsonRpcMessage[]
+  lastResult: unknown
+}
+
+const sessions = new WeakMap<GtdWorld, LspSession>()
+
+const encode = (message: object): Buffer => {
+  const json = JSON.stringify(message)
+  const header = `Content-Length: ${Buffer.byteLength(json, "utf8")}\r\n\r\n`
+  return Buffer.concat([Buffer.from(header, "ascii"), Buffer.from(json, "utf8")])
+}
+
+/** Feeds raw stdout bytes through Content-Length framing, dispatching each parsed message. */
+class Framer {
+  private buffer = Buffer.alloc(0)
+  constructor(private readonly onMessage: (message: JsonRpcMessage) => void) {}
+
+  push(chunk: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, chunk])
+    for (;;) {
+      const headerEnd = this.buffer.indexOf("\r\n\r\n")
+      if (headerEnd === -1) return
+      const header = this.buffer.subarray(0, headerEnd).toString("ascii")
+      const match = /Content-Length: (\d+)/.exec(header)
+      if (!match) return
+      const length = Number(match[1])
+      const bodyStart = headerEnd + 4
+      if (this.buffer.length < bodyStart + length) return
+      const body = this.buffer.subarray(bodyStart, bodyStart + length).toString("utf8")
+      this.buffer = this.buffer.subarray(bodyStart + length)
+      this.onMessage(JSON.parse(body) as JsonRpcMessage)
+    }
+  }
+}
+
+const sendRequest = (session: LspSession, method: string, params: unknown): Promise<unknown> => {
+  const id = session.nextId++
+  return new Promise((resolve) => {
+    session.pending.set(id, resolve)
+    session.proc.stdin.write(encode({ jsonrpc: "2.0", id, method, params }))
+  })
+}
+
+const sendNotification = (session: LspSession, method: string, params: unknown): void => {
+  session.proc.stdin.write(encode({ jsonrpc: "2.0", method, params }))
+}
+
+const uriFor = (world: GtdWorld, path: string): string =>
+  pathToFileURL(join(world.repoDir, path)).toString()
+
+const openDocument = (session: LspSession, world: GtdWorld, path: string): string => {
+  const uri = uriFor(world, path)
+  sendNotification(session, "textDocument/didOpen", {
+    textDocument: {
+      uri,
+      languageId: "markdown",
+      version: 1,
+      text: readFileSync(join(world.repoDir, path), "utf-8"),
+    },
+  })
+  return uri
+}
+
+Given("a running gtd lsp server", async (world: GtdWorld) => {
+  const proc = spawn(process.execPath, [GTD_BIN, "lsp"], { cwd: world.repoDir })
+  const session: LspSession = {
+    proc,
+    nextId: 1,
+    pending: new Map(),
+    serverRequests: [],
+    lastResult: undefined,
+  }
+  sessions.set(world, session)
+
+  const framer = new Framer((message) => {
+    if (message.id !== undefined && message.method === undefined) {
+      const resolve = session.pending.get(message.id)
+      if (resolve) {
+        session.pending.delete(message.id)
+        resolve(message.result ?? message.error)
+      }
+      return
+    }
+    if (message.id !== undefined && message.method !== undefined) {
+      // A request FROM the server (e.g. window/showDocument) — record it and
+      // acknowledge so the server's own await doesn't hang.
+      session.serverRequests.push(message)
+      session.proc.stdin.write(encode({ jsonrpc: "2.0", id: message.id, result: null }))
+    }
+  })
+  proc.stdout.on("data", (chunk: Buffer) => framer.push(chunk))
+
+  await sendRequest(session, "initialize", {
+    processId: process.pid,
+    rootUri: pathToFileURL(world.repoDir).toString(),
+    capabilities: { window: { showDocument: { support: true } } },
+  })
+  sendNotification(session, "initialized", {})
+})
+
+After(async (world: GtdWorld) => {
+  const session = sessions.get(world)
+  if (session) {
+    session.proc.kill()
+    sessions.delete(world)
+  }
+})
+
+When("I request document symbols for {string}", async (world: GtdWorld, path: string) => {
+  const session = sessions.get(world)!
+  const uri = openDocument(session, world, path)
+  session.lastResult = await sendRequest(session, "textDocument/documentSymbol", {
+    textDocument: { uri },
+  })
+})
+
+When(
+  "I request code actions at line containing {string} of {string}",
+  async (world: GtdWorld, needle: string, path: string) => {
+    const session = sessions.get(world)!
+    const uri = openDocument(session, world, path)
+    const lines = readFileSync(join(world.repoDir, path), "utf-8").split(/\r?\n/)
+    const line = lines.findIndex((l) => l.includes(needle))
+    assert.ok(line !== -1, `no line containing "${needle}" in ${path}`)
+    session.lastResult = await sendRequest(session, "textDocument/codeAction", {
+      textDocument: { uri },
+      range: { start: { line, character: 0 }, end: { line, character: 0 } },
+      context: { diagnostics: [] },
+    })
+  },
+)
+
+interface WorkspaceEditLike {
+  readonly changes?: Record<
+    string,
+    ReadonlyArray<{
+      range: {
+        start: { line: number; character: number }
+        end: { line: number; character: number }
+      }
+      newText: string
+    }>
+  >
+}
+
+/** Applies a WorkspaceEdit exactly as an editor accepting the code action would. */
+const applyWorkspaceEdit = (edit: WorkspaceEditLike): void => {
+  for (const [uri, edits] of Object.entries(edit.changes ?? {})) {
+    const path = fileURLToPath(uri)
+    const lines = readFileSync(path, "utf-8").split(/\r?\n/)
+    for (const textEdit of edits) {
+      const line = lines[textEdit.range.start.line]!
+      lines[textEdit.range.start.line] =
+        line.slice(0, textEdit.range.start.character) +
+        textEdit.newText +
+        line.slice(textEdit.range.end.character)
+    }
+    writeFileSync(path, lines.join("\n"))
+  }
+}
+
+When("I apply the code action titled {string}", (world: GtdWorld, title: string) => {
+  const session = sessions.get(world)!
+  const actions = session.lastResult as ReadonlyArray<{ title: string; edit: WorkspaceEditLike }>
+  const action = actions.find((a) => a.title === title)
+  assert.ok(
+    action,
+    `no code action titled "${title}" — got: ${actions.map((a) => a.title).join(", ")}`,
+  )
+  applyWorkspaceEdit(action.edit)
+})
+
+When("I run the gtd.openSteeringFile command", async (world: GtdWorld) => {
+  const session = sessions.get(world)!
+  await sendRequest(session, "workspace/executeCommand", {
+    command: "gtd.openSteeringFile",
+    arguments: [],
+  })
+})
+
+Then("there are {int} document symbols", (world: GtdWorld, count: number) => {
+  const session = sessions.get(world)!
+  const symbols = session.lastResult as ReadonlyArray<unknown>
+  assert.strictEqual(symbols.length, count)
+})
+
+Then("the document symbols include {string}", (world: GtdWorld, name: string) => {
+  const session = sessions.get(world)!
+  const symbols = session.lastResult as ReadonlyArray<{ name: string }>
+  assert.ok(
+    symbols.some((s) => s.name === name),
+    `expected a symbol named "${name}" — got: ${symbols.map((s) => s.name).join(", ")}`,
+  )
+})
+
+Then("the first symbol's children include {string}", (world: GtdWorld, name: string) => {
+  const session = sessions.get(world)!
+  const symbols = session.lastResult as ReadonlyArray<{
+    children?: ReadonlyArray<{ name: string }>
+  }>
+  const children = symbols[0]?.children ?? []
+  assert.ok(
+    children.some((c) => c.name === name),
+    `expected a child symbol named "${name}" — got: ${children.map((c) => c.name).join(", ")}`,
+  )
+})
+
+Then("the server asked to show document {string}", (world: GtdWorld, path: string) => {
+  const session = sessions.get(world)!
+  const expectedUri = uriFor(world, path)
+  const request = session.serverRequests.find((r) => r.method === "window/showDocument")
+  assert.ok(
+    request,
+    `no window/showDocument request received — got: ${session.serverRequests.map((r) => r.method).join(", ")}`,
+  )
+  assert.strictEqual((request.params as { uri: string }).uri, expectedUri)
+})
+
+Then(
+  "the server showed an information message containing {string}",
+  (world: GtdWorld, needle: string) => {
+    const session = sessions.get(world)!
+    const request = session.serverRequests.find(
+      (r) => r.method === "window/showMessageRequest" || r.method === "window/showMessage",
+    )
+    assert.ok(
+      request,
+      `no window/showMessage(Request) received — got: ${session.serverRequests.map((r) => r.method).join(", ")}`,
+    )
+    const message = (request.params as { message: string }).message
+    assert.ok(
+      message.includes(needle),
+      `expected message to contain "${needle}" — got: "${message}"`,
+    )
+  },
+)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
             "./tests/integration/support/steps/formatting.steps.ts",
             "./tests/integration/support/steps/gtd-state.steps.ts",
             "./tests/integration/support/steps/gtd-loop.steps.ts",
+            "./tests/integration/support/steps/lsp.steps.ts",
           ],
           testTimeout: 300_000,
         },


### PR DESCRIPTION
Adds a new `gtd lsp` subcommand starting an LSP server over stdio:
document symbols for open questions (TODO.md/ARCHITECTURE.md) and review
chunks/hunks (REVIEW.md), code actions to check/uncheck a single hunk or
a whole chunk, and a gtd.openSteeringFile command that opens whichever
steering file matches the current GtdState.

OpenQuestions.ts and ReviewDoc.ts gain position fields (headingLine,
sourceLine) so the LSP's symbol ranges and edits reuse the same parsers
as the CLI's JSON output rather than duplicating the parsing logic.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XUqE7T3PU3i9yPFrFFy6RR