### PR TITLE
feat: add file-presence process entry points (PLAN.md decompose, HEALTH.md fixing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ architecture, decomposes it into work packages, builds them one at a time, runs
 your tests after every package, has the agent review its own diff, walks you
 through a final review, and squashes the whole cycle into one clean commit.
 
+You don't have to start at the beginning: the steering file you hand the entry
+turn picks the phase — plain notes start product grilling,
+`.gtd/ARCHITECTURE.md` starts technical grilling, a final `.gtd/PLAN.md` goes
+straight to decomposition, and a hand-written `.gtd/HEALTH.md` goes straight
+into the error-fixing loop. See
+[Entry points](docs/workflow.md#entry-points-which-file-starts-the-cycle-where).
+
 `gtd-loop`, installed alongside `gtd`, is a ready-to-run driver for the whole
 protocol — point it at a repo and it runs the loop until it's your turn. See
 [Driving the loop](docs/loop.md).

--- a/STATES.md
+++ b/STATES.md
@@ -33,8 +33,8 @@ A transition is a pure function of four inputs, nothing else:
 3. **the class of HEAD's commit subject** — turn commit, routing commit, or
    boundary commit (§2)
 4. **which steering files are present** (`.gtd/TODO.md`, `.gtd/ARCHITECTURE.md`,
-   `.gtd/NN-…/` work packages, `.gtd/REVIEW.md`, `.gtd/FEEDBACK.md`,
-   `.gtd/ERRORS.md`, `.gtd/HEALTH.md`, `.gtd/SQUASH_MSG.md`,
+   `.gtd/PLAN.md`, `.gtd/NN-…/` work packages, `.gtd/REVIEW.md`,
+   `.gtd/FEEDBACK.md`, `.gtd/ERRORS.md`, `.gtd/HEALTH.md`, `.gtd/SQUASH_MSG.md`,
    `.gtd/LEARNINGS.md`)
 
 All steering files live under `.gtd/` — the directory is the workflow's
@@ -161,9 +161,11 @@ grilling | architecting | grilled | building | fixing | agentic-review | review
 `(actor, gate)` pair is reachable: turns are strictly separated (§3), so a gate
 is only ever authored by its awaited actor — there is no `gtd(human): building`
 at all, and `gtd(human)` appears only at the human gates (`grilling`'s and
-`architecting`'s entry and answer turns, `review`, `escalate`, and — mirroring
-`review` — `learning`, whose human turn (at the `await-learning-review` rest)
-shares the agent draft turn's gate name rather than getting its own).
+`architecting`'s entry and answer turns, `grilled`'s and `health-fixing`'s entry
+turns (the `.gtd/PLAN.md` and hand-written `.gtd/HEALTH.md` entry points — see
+§5.5 rung 1), `review`, `escalate`, and — mirroring `review` — `learning`, whose
+human turn (at the `await-learning-review` rest) shares the agent draft turn's
+gate name rather than getting its own).
 
 ### 2.2 Routing phases (`RoutingPhase`) and their awaited actor
 
@@ -201,24 +203,26 @@ ordinary review-scope rules (§4, Review).
 **Turn-commit classification** (the other half of `classifyHead`, keyed on
 `(actor, gate)`):
 
-| Turn commit                  | Class                                                     | Lands at                                                                                                                                                                                           |
-| ---------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `gtd(agent): grilling`       | empty diff → rest; non-empty → rest                       | `grilling`, agent (empty, re-emit) or `grilling`, human (non-empty, answer gate)                                                                                                                   |
-| `gtd(human): grilling`       | empty diff → mid-chain; non-empty → rest                  | empty → `commitRouting "gtd: architecting", seedArchitectureFromTodo: true` → `architecting`/agent; non-empty → rest `grilling`, agent                                                             |
-| `gtd(agent): architecting`   | empty diff → rest; non-empty → rest                       | `architecting`, agent (empty, re-emit) or `architecting`, human (non-empty, answer gate)                                                                                                           |
-| `gtd(human): architecting`   | empty diff → mid-chain; non-empty → rest                  | empty → `commitRouting "gtd: grilled"` → `grilled`/agent; non-empty → rest `architecting`, agent                                                                                                   |
-| `gtd(agent): grilled`        | mid-chain                                                 | `commitRouting "gtd: planning"` (removes .gtd/ARCHITECTURE.md)                                                                                                                                     |
-| `gtd(agent): building`       | mid-chain                                                 | `runTest`                                                                                                                                                                                          |
-| `gtd(agent): fixing`         | empty diff → rest; non-empty → mid-chain                  | empty → rest `fixing`, agent (re-emit); non-empty → `runTest`                                                                                                                                      |
-| `gtd(agent): agentic-review` | rest                                                      | `agentic-review`, agent (only reached when .gtd/FEEDBACK.md was never written at all — the .gtd/FEEDBACK.md-present cases are handled by the steering-file precedence check that runs before this) |
-| `gtd(agent): review`         | mid-chain                                                 | `commitRouting "gtd: awaiting review"`                                                                                                                                                             |
-| `gtd(human): review`         | mid-chain                                                 | substantive → `commitRouting "gtd: review feedback"` (removes .gtd/REVIEW.md); non-substantive (clean or checkbox-only) → `commitRouting "gtd: done"` (removes .gtd/REVIEW.md)                     |
-| `gtd(agent): squashing`      | squash base present → mid-chain; else rest                | mid-chain → `squashCommit`; rest → `squashing`, agent                                                                                                                                              |
-| `gtd(agent): health-fixing`  | mid-chain                                                 | `commitRouting "gtd: health-fix"` (removes .gtd/HEALTH.md)                                                                                                                                         |
-| `gtd(human): escalate`       | mid-chain                                                 | `runTest` (re-test after the human's fix)                                                                                                                                                          |
-| `gtd(agent): learning`       | squash base present + non-template → mid-chain; else rest | mid-chain → `commitRouting "gtd: learning drafted"`; rest → `learning`, agent (re-emit until the agent overwrites the template)                                                                    |
-| `gtd(human): learning`       | mid-chain (unconditional — no reject path)                | `commitRouting "gtd: learning approved"`                                                                                                                                                           |
-| `gtd(agent): learning-apply` | mid-chain                                                 | `commitRouting "gtd: learning applied"` (removes .gtd/LEARNINGS.md)                                                                                                                                |
+| Turn commit                  | Class                                                     | Lands at                                                                                                                                                                                                                                                       |
+| ---------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gtd(agent): grilling`       | empty diff → rest; non-empty → rest                       | `grilling`, agent (empty, re-emit) or `grilling`, human (non-empty, answer gate)                                                                                                                                                                               |
+| `gtd(human): grilling`       | empty diff → mid-chain; non-empty → rest                  | empty → `commitRouting "gtd: architecting", seedArchitectureFromTodo: true` → `architecting`/agent; non-empty → rest `grilling`, agent                                                                                                                         |
+| `gtd(agent): architecting`   | empty diff → rest; non-empty → rest                       | `architecting`, agent (empty, re-emit) or `architecting`, human (non-empty, answer gate)                                                                                                                                                                       |
+| `gtd(human): architecting`   | empty diff → mid-chain; non-empty → rest                  | empty → `commitRouting "gtd: grilled"` → `grilled`/agent; non-empty → rest `architecting`, agent                                                                                                                                                               |
+| `gtd(human): grilled`        | `.gtd/PLAN.md` present → mid-chain; else — (ladder)       | mid-chain → `commitRouting "gtd: grilled", seedArchitectureFromPlan: true` (writes .gtd/ARCHITECTURE.md from .gtd/PLAN.md, removes .gtd/PLAN.md); without .gtd/PLAN.md it falls to the ladder (a half-seeded crash recovers via the .gtd/ARCHITECTURE.md rung) |
+| `gtd(agent): grilled`        | mid-chain                                                 | `commitRouting "gtd: planning"` (removes .gtd/ARCHITECTURE.md)                                                                                                                                                                                                 |
+| `gtd(agent): building`       | mid-chain                                                 | `runTest`                                                                                                                                                                                                                                                      |
+| `gtd(agent): fixing`         | empty diff → rest; non-empty → mid-chain                  | empty → rest `fixing`, agent (re-emit); non-empty → `runTest`                                                                                                                                                                                                  |
+| `gtd(agent): agentic-review` | rest                                                      | `agentic-review`, agent (only reached when .gtd/FEEDBACK.md was never written at all — the .gtd/FEEDBACK.md-present cases are handled by the steering-file precedence check that runs before this)                                                             |
+| `gtd(agent): review`         | mid-chain                                                 | `commitRouting "gtd: awaiting review"`                                                                                                                                                                                                                         |
+| `gtd(human): review`         | mid-chain                                                 | substantive → `commitRouting "gtd: review feedback"` (removes .gtd/REVIEW.md); non-substantive (clean or checkbox-only) → `commitRouting "gtd: done"` (removes .gtd/REVIEW.md)                                                                                 |
+| `gtd(agent): squashing`      | squash base present → mid-chain; else rest                | mid-chain → `squashCommit`; rest → `squashing`, agent                                                                                                                                                                                                          |
+| `gtd(agent): health-fixing`  | mid-chain                                                 | `commitRouting "gtd: health-fix"` (removes .gtd/HEALTH.md)                                                                                                                                                                                                     |
+| `gtd(human): health-fixing`  | — (precedence)                                            | the hand-written-HEALTH.md entry turn: no `classifyHead` row — the steering-file precedence rung (§5.2) rests it at `health-fixing`, agent. A clean `gtd step-agent` at this HEAD is inert (the entry description must survive until an agent has read it)     |
+| `gtd(human): escalate`       | mid-chain                                                 | `runTest` (re-test after the human's fix)                                                                                                                                                                                                                      |
+| `gtd(agent): learning`       | squash base present + non-template → mid-chain; else rest | mid-chain → `commitRouting "gtd: learning drafted"`; rest → `learning`, agent (re-emit until the agent overwrites the template)                                                                                                                                |
+| `gtd(human): learning`       | mid-chain (unconditional — no reject path)                | `commitRouting "gtd: learning approved"`                                                                                                                                                                                                                       |
+| `gtd(agent): learning-apply` | mid-chain                                                 | `commitRouting "gtd: learning applied"` (removes .gtd/LEARNINGS.md)                                                                                                                                                                                            |
 
 **The health-fix re-test carve-out.** `gtd: health-fix` classifies as a plain
 rest (`idle`, human) for `gtd next` / `gtd status` — a clean tree there
@@ -461,20 +465,35 @@ agent-develops rest (`@grilling-agent` template).
   suggested defaults.
 
 **Entry:** a dirty boundary tree with `invoker: "human"` (no steering files, no
-committed .gtd/TODO.md, no committed .gtd/ARCHITECTURE.md) captures
-`gtd(human): grilling` — the v2 entry turn (`isDirtyBoundaryEntry` in
+committed .gtd/TODO.md, .gtd/ARCHITECTURE.md, .gtd/PLAN.md, or .gtd/HEALTH.md)
+captures `gtd(human): grilling` — the v2 entry turn (`isDirtyBoundaryEntry` in
 `applyTurnTaking`). `gtd: done` counts as a boundary HEAD for this purpose too,
 even though it parses as `"routing"` — a settled cycle is exactly where the next
 feature's dirty tree lands. `gtd: review feedback` also rests here (agent
 awaited) — the re-grilling entry from review feedback (§4, Review-feedback
 re-grill below).
 
-**Escape hatch:** if the dirty boundary tree already contains
-`.gtd/ARCHITECTURE.md` (an already-technical sketch the human wrote directly),
-the entry turn is captured as `gtd(human): architecting` instead, skipping
-product grilling entirely for this cycle (see `architecting`'s Entry below).
-This is file-_presence_-based routing — the same mechanism every steering-file
-rung in the ladder already uses — not content-based steering.
+**Entry points:** which gate the entry turn is captured under depends on which
+steering file the dirty tree already contains — file-_presence_-based routing,
+the same mechanism every steering-file rung in the ladder already uses, never
+content-based steering. The four files are pairwise illegal combinations (§5.1),
+so the pick is always unambiguous:
+
+- **no steering file / `.gtd/TODO.md`** → `gtd(human): grilling` — product
+  grilling, the default (a hand-written `.gtd/TODO.md` is the draft product plan
+  the agent iterates on).
+- **`.gtd/ARCHITECTURE.md`** → `gtd(human): architecting` — an already-technical
+  sketch skips product grilling entirely for this cycle (see `architecting`'s
+  Entry below).
+- **`.gtd/PLAN.md`** → `gtd(human): grilled` — a FINAL architecture skips both
+  grilling phases: the turn mid-chains to
+  `commitRouting "gtd: grilled", seedArchitectureFromPlan: true` (writes
+  `.gtd/ARCHITECTURE.md` from the `.gtd/PLAN.md` content and deletes
+  `.gtd/PLAN.md`, in one commit) and rests at the decompose prompt (see
+  `grilled`'s Entry below).
+- **`.gtd/HEALTH.md`** (hand-written) → `gtd(human): health-fixing` — an error
+  description enters the health-fixing detour directly (see `health-fixing`'s
+  Entry below).
 
 **Exit:** an empty human turn at the answer gate (`gtd(human): grilling` with an
 empty diff) mid-chains to
@@ -509,9 +528,9 @@ Mechanically an exact mirror of `grilling`, one file and one phase later.
 
 **Entry:** the routing commit `gtd: architecting` is a rest landing here (agent)
 — reached either from grilling's converged exit (`.gtd/ARCHITECTURE.md` seeded
-from `.gtd/TODO.md`) or directly from the escape-hatch dirty-boundary entry
-(`.gtd/ARCHITECTURE.md` authored by the human from scratch, no `.gtd/TODO.md`
-ever existing).
+from `.gtd/TODO.md`) or directly from the `.gtd/ARCHITECTURE.md` entry point
+(§4, `grilling`'s Entry points: the file authored by the human from scratch, no
+`.gtd/TODO.md` ever existing).
 
 **Exit:** an empty human turn at the answer gate (`gtd(human): architecting`
 with an empty diff) mid-chains to `commitRouting "gtd: grilled"` → **grilled**.
@@ -531,7 +550,19 @@ packages are vertical slices, task files are self-contained. The subagent must
 not commit — this runs inside a larger orchestration that depends on uncommitted
 state.
 
-**Entry:** the routing commit `gtd: grilled` is a rest landing here (agent).
+**Entry:** the routing commit `gtd: grilled` is a rest landing here (agent) —
+reached from architecting's converged exit, or directly from the `.gtd/PLAN.md`
+entry point: a dirty boundary tree containing `.gtd/PLAN.md` (a final,
+decompose-as-is architecture) captures `gtd(human): grilled`, which mid-chains
+to `commitRouting "gtd: grilled", seedArchitectureFromPlan: true` — writing
+`.gtd/ARCHITECTURE.md` from the `.gtd/PLAN.md` content (with a seed banner) and
+deleting `.gtd/PLAN.md` in that one commit, so the decompose prompt and
+everything downstream are untouched by which entry the cycle used. The seed hop
+is guarded on `.gtd/PLAN.md` actually being present (mirroring the packages
+guard on `gtd(agent): grilled`): a hand-crafted `gtd(human): grilled` HEAD
+without it falls through the ladder, and a crash half-way through the seed
+(ARCHITECTURE.md written, PLAN.md deleted, commit failed) recovers via the
+`architectureExists` rung as a normal architecting round.
 
 **Exit:** `gtd(agent): grilled` mid-chains to `commitRouting "gtd: planning"`
 (also removing `.gtd/ARCHITECTURE.md`) → **planning**.
@@ -931,11 +962,17 @@ on.
 into one conventional-commits message. Two entry points share this state:
 
 - **Feature-cycle squash**: `gtd: done` → squash base = parent of the first
-  grilling turn commit of the cycle (or the `gtd: reviewing <hash>` anchor,
-  whichever is nearest HEAD within the cycle).
-- **Health-fix squash**: a health-fix cycle went green with ≥1 `gtd: health-fix`
-  commit present and squash enabled — squash base = parent of the first
-  `gtd: health-check` of that run.
+  grilling, architecting, or grilled entry turn commit of the cycle — whichever
+  entry point (§4, `grilling`'s Entry points) the cycle used — (or the
+  `gtd: reviewing <hash>` anchor, whichever is nearest HEAD within the cycle).
+- **Health-fix squash**: a health-fix cycle went green with squash enabled —
+  squash base = parent of the run's earliest start marker: the first
+  `gtd: health-check` of the run, or the `gtd(human): health-fixing` entry turn
+  for a hand-written-HEALTH.md run (which may go green with zero
+  `gtd: health-check` commits ever landing). The anchor resets on
+  `gtd: tests green` (a processed run never re-triggers the chain at later idle
+  rests), except the run's own green marker while HEAD is still inside the
+  post-green learning/squash chain.
 
 **Awaited actor:** agent.
 
@@ -999,7 +1036,16 @@ gate below the fix-attempt cap. (No `.gtd/`, no `.gtd/REVIEW.md`, no
 `.gtd/HEALTH.md`'s content as the "Feedback to address," fix the code, leave
 uncommitted.
 
-**Entry:** `gtd: health-check` rest with `.gtd/ERRORS.md` absent.
+**Entry:** `gtd: health-check` rest with `.gtd/ERRORS.md` absent — or the
+hand-written-HEALTH.md entry point: a dirty boundary tree containing
+`.gtd/HEALTH.md` (a human-authored error description) captures
+`gtd(human): health-fixing`, after which the steering-file precedence rung
+(§5.2) rests here exactly as for the machine-written detour. The description is
+a means to make `testCommand` green: a red re-test overwrites it with the actual
+failure output, and a green one closes the run. One guard protects the entry:
+while HEAD is still the human's entry turn, a clean `gtd step-agent` (the loop
+protocol's opening beat) is **inert** rather than a meaningful environmental-fix
+turn — otherwise it would consume the description before any agent read it.
 
 **Actions on entry (mid-chain from `gtd(agent): health-fixing`):**
 `commitRouting "gtd: health-fix"`, removing `.gtd/HEALTH.md` — same removal
@@ -1034,22 +1080,37 @@ wins; anything matching nothing is `corruption` — a hard error, never a guess.
 
 ### 5.1 Illegal-combination guard (`assertLegal`, before anything else)
 
-Checked in three passes — .gtd/HEALTH.md-specific rules first (so a
+Checked in four passes — .gtd/HEALTH.md-specific rules first (so a
 .gtd/HEALTH.md + .gtd/FEEDBACK.md, say, gets the two-file diagnosis rather than
 the more generic single-file one), then .gtd/LEARNINGS.md-specific rules, then
-the rest:
+.gtd/PLAN.md-specific rules, then the rest:
 
 ```
 .gtd/HEALTH.md + .gtd
 .gtd/HEALTH.md + .gtd/REVIEW.md
 .gtd/HEALTH.md + .gtd/FEEDBACK.md
 .gtd/HEALTH.md + .gtd/ERRORS.md
+.gtd/HEALTH.md + .gtd/TODO.md         (entry files must be unambiguous;
+.gtd/HEALTH.md + .gtd/ARCHITECTURE.md  scribbling a next-feature draft while a
+.gtd/HEALTH.md + .gtd/PLAN.md          health detour is live is a refused guess,
+                          not a tolerated ride-along — note assertLegal also
+                          runs for `gtd status`/`gtd next`, so those error too)
 .gtd/LEARNINGS.md + .gtd
 .gtd/LEARNINGS.md + .gtd/REVIEW.md
 .gtd/LEARNINGS.md + .gtd/FEEDBACK.md
 .gtd/LEARNINGS.md + .gtd/ERRORS.md
 .gtd/LEARNINGS.md + .gtd/HEALTH.md
 .gtd/LEARNINGS.md + .gtd/SQUASH_MSG.md
+.gtd/PLAN.md + .gtd/TODO.md
+.gtd/PLAN.md + .gtd/ARCHITECTURE.md
+.gtd/PLAN.md + .gtd
+.gtd/PLAN.md + .gtd/REVIEW.md
+.gtd/PLAN.md + .gtd/FEEDBACK.md
+.gtd/PLAN.md + .gtd/ERRORS.md
+.gtd/PLAN.md + .gtd/SQUASH_MSG.md     (the last two are defensive, like the
+.gtd/PLAN.md + .gtd/LEARNINGS.md       LEARNINGS.md rules: they keep a stray
+                          PLAN.md from riding into a squash/learning capture
+                          and stranding committed at a boundary HEAD)
 .gtd/REVIEW.md + .gtd
 .gtd/REVIEW.md + committed .gtd/TODO.md
 uncommitted .gtd/REVIEW.md + .gtd/TODO.md
@@ -1109,39 +1170,51 @@ In order:
 4. `.gtd/ARCHITECTURE.md` present (any other HEAD) → **architecting** continues
    (mirrors rung 3 — the two files never coexist, per the illegal-combination
    guard, so ordering between rungs 3 and 4 is inert).
-5. `.gtd/` exists with a pending package **and** the nearest workflow commit
+5. `.gtd/PLAN.md` present (any other HEAD) → rest **grilled**, **human**. Unlike
+   rungs 3/4 (agent-developed files mid-process), PLAN.md is only ever
+   human-authored entry input: the ordinary case is the pre-entry dirty boundary
+   (rung 1 of §5.5 short-circuits this baseline), and the recovery case is a
+   committed PLAN.md at a boundary HEAD, where the human's `gtd step` resumes
+   the entry (captures `gtd(human): grilled`, which seeds and routes) instead of
+   corrupting.
+6. `.gtd/` exists with a pending package **and** the nearest workflow commit
    (skipping boundary commits stacked on top) is still `gtd(agent): building` →
    **building** (operational-recovery carve-out: a boundary commit, e.g. a
    config fix, landed on top of the checkpoint after a mid-chain failure, but
    the checkpoint is still the active one). Narrow by design — an unrecognized
    boundary HEAD with no such checkpoint in its history still hard-errors.
-6. No steering files at all, no recognized workflow HEAD → idle/health
+7. No steering files at all, no recognized workflow HEAD → idle/health
    (`resolveIdleOrHealth`): reviewable diff → **review**; else → **idle**,
    human.
-7. Anything else → `corrupt()` — hard error.
+8. Anything else → `corrupt()` — hard error.
 
 ### 5.5 Turn-taking layer (`applyTurnTaking`, always applied last)
 
 Independent of the ladder above, layered on every resolved baseline:
 
 1. **Dirty-boundary entry** (`invoker === "human"`, dirty tree, no committed
-   .gtd/TODO.md, no committed .gtd/ARCHITECTURE.md, no other steering files,
-   boundary/`gtd: done` HEAD) → captures `gtd(human): grilling`, short-
-   circuiting everything else — UNLESS the dirty tree already contains
-   `.gtd/ARCHITECTURE.md` (the escape hatch), in which case it captures
-   `gtd(human): architecting` instead, skipping product grilling for this cycle.
+   .gtd/TODO.md, .gtd/ARCHITECTURE.md, .gtd/PLAN.md, or .gtd/HEALTH.md, no
+   packages/REVIEW.md/FEEDBACK.md/ERRORS.md, boundary/`gtd: done` HEAD) →
+   captures the entry turn, short-circuiting everything else. Which gate depends
+   on which steering file the dirty tree contains (§4, `grilling`'s Entry
+   points; pairwise illegal per §5.1, so the pick order is inert):
+   `.gtd/HEALTH.md` → `gtd(human): health-fixing`; `.gtd/PLAN.md` →
+   `gtd(human): grilled`; `.gtd/ARCHITECTURE.md` → `gtd(human): architecting`;
+   otherwise → `gtd(human): grilling`.
 2. **Mid-chain baseline** → `invoker === "none"` reports `pending: true`; any
    other invoker performs the edge action.
 3. **Rest baseline, `invoker === "none"`** → report state/actor, no mutation.
 4. **`gtd: health-fix` (rest = idle) or `gtd: health-check` at the exhausted
    cap** → force a `runHealthCheck` re-test regardless of invoker (the
    carve-outs from §2).
-5. **Out-of-turn**: `invoker === "agent"`, awaited === human → `refusal`.
-6. **Out-of-turn**: `invoker === "human"`, awaited === agent → dirty tree
-   captures `gtd(human): <gate>`; clean tree no-ops.
-7. **Idle carve-out**: `baseline.state === "idle"`, `invoker === "human"` →
+5. **Out-of-turn**: the invoker is not the awaited actor → `refusal`, in BOTH
+   directions, on clean and dirty trees alike (§3) — the wrong mutator always
+   errors instead of no-op-ing or adopting the dirty tree as a turn of its own;
+   pending edits stay in the tree and ride along as input to the awaited actor's
+   next captured turn.
+6. **Idle carve-out**: `baseline.state === "idle"`, `invoker === "human"` →
    force `runHealthCheck`, never an empty commit or plain no-op.
-8. **In-turn, fixpoint check**: HEAD already carries this exact
+7. **In-turn, fixpoint check**: HEAD already carries this exact
    `gtd(<invoker>): <gate>` turn AND the tree is clean → report rest, no
    mutation (idempotent re-run). Otherwise → capture a fresh turn commit under
    `gateForState(baseline.state)` (every state defaults to its own name as the
@@ -1263,7 +1336,7 @@ gtd: grilled                    # human's next clean step converges
 Mechanically identical to the grilling round above, one file and one phase
 later.
 
-### Escape hatch: already-technical input
+### Entry point: already-technical input
 
 ```
 <boundary/init>
@@ -1273,6 +1346,39 @@ gtd(human): architecting      # dirty-boundary entry, but the human authored
 gtd(agent): architecting      # agent develops the architecture from that raw input
 gtd(human): architecting      # human accepts (empty turn)
 gtd: grilled                    # routing: converged — .gtd/TODO.md never existed
+```
+
+### Entry point: a final plan, straight to decomposition
+
+```
+<boundary/init>
+gtd(human): grilled           # dirty-boundary entry — the human authored
+                                 # .gtd/PLAN.md, a FINAL architecture
+gtd: grilled                    # routing: .gtd/ARCHITECTURE.md seeded from
+                                 # .gtd/PLAN.md (removed) — same invocation
+gtd(agent): grilled           # decompose turn (packages written)
+gtd: planning                   # routing: .gtd/ARCHITECTURE.md removed
+...                             # building/testing/review proceed as usual —
+                                 # no grilling or architecting round ever ran
+```
+
+### Entry point: a hand-written error report, straight to error fixing
+
+```
+<boundary/init>
+gtd(human): health-fixing     # dirty-boundary entry — the human authored
+                                 # .gtd/HEALTH.md describing the errors
+<gtd next → health-fixing prompt with the hand-written description>
+<a clean opening gtd step-agent here is INERT — the description survives>
+gtd(agent): health-fixing     # fixer's turn (the actual fix)
+gtd: health-fix                 # routing: .gtd/HEALTH.md removed; re-tests in
+                                 # the same chain
+# green, squash on  → gtd: tests green → gtd: squash template → ... → one
+#                     squash commit collapsing from the entry turn (the run
+#                     may have ZERO gtd: health-check commits)
+# green, squash off → stop, plain idle rest
+# red               → gtd: health-check (machine-written HEALTH.md now carries
+#                     the test output) — the normal detour loop from here
 ```
 
 ### Escalation and recovery

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -27,9 +27,11 @@ the machine performs itself between turns) looks like `gtd: tests green`.
 `src/Subjects.ts` is the closed grammar both the machine and the edge read.
 
 All workflow state lives under **`.gtd/`**: the product plan (`.gtd/TODO.md`),
-the technical architecture it converges into (`.gtd/ARCHITECTURE.md`), work
-packages (`.gtd/01-…/`), review records (`.gtd/REVIEW.md`, `.gtd/FEEDBACK.md`),
-and loop bookkeeping (`.gtd/ERRORS.md`, `.gtd/HEALTH.md`, `.gtd/LEARNINGS.md`,
+the technical architecture it converges into (`.gtd/ARCHITECTURE.md`), a
+hand-written final architecture (`.gtd/PLAN.md`, an entry file — see
+[Entry points](#entry-points-which-file-starts-the-cycle-where)), work packages
+(`.gtd/01-…/`), review records (`.gtd/REVIEW.md`, `.gtd/FEEDBACK.md`), and loop
+bookkeeping (`.gtd/ERRORS.md`, `.gtd/HEALTH.md`, `.gtd/LEARNINGS.md`,
 `.gtd/SQUASH_MSG.md`). One rule follows for every agent in the loop: **never
 touch `.gtd/`** except the single file a prompt explicitly grants. A `TODO.md`
 or `REVIEW.md` at the repository root is the project's own file — gtd never
@@ -65,7 +67,7 @@ The closed set of gates:
 | ---------------- | ------------------------------------------------------------------ |
 | `grilling`       | human (answers) / agent (product-plan iteration)                   |
 | `architecting`   | human (answers) / agent (architecture iteration)                   |
-| `grilled`        | agent (converged, ready to decompose)                              |
+| `grilled`        | agent (converged, ready to decompose) / human (PLAN.md entry turn) |
 | `building`       | agent (package work, or human feedback while agent is out of turn) |
 | `fixing`         | agent (test-fix or review-fix round)                               |
 | `agentic-review` | agent (writes .gtd/FEEDBACK.md verdict)                            |
@@ -73,7 +75,7 @@ The closed set of gates:
 | `squashing`      | agent (overwrites .gtd/SQUASH_MSG.md)                              |
 | `learning`       | agent (overwrites .gtd/LEARNINGS.md) / human (accepts or edits)    |
 | `learning-apply` | agent (integrates .gtd/LEARNINGS.md into CLAUDE.md/AGENTS.md/docs) |
-| `health-fixing`  | agent (idle health-check repair)                                   |
+| `health-fixing`  | agent (idle health-check repair) / human (HEALTH.md entry turn)    |
 | `escalate`       | human (deletes .gtd/ERRORS.md to resume)                           |
 
 ### Routing commits — `gtd: <phase>`
@@ -120,11 +122,29 @@ structure, data model, tech-stack choices — and the human answers or accepts
 defaults at the `architecting` gate. Accepting converges to `gtd: grilled` and
 `gtd next` emits the decompose prompt (which now reads `.gtd/ARCHITECTURE.md`).
 
-**Escape hatch for already-technical input:** if the human's initial dirty tree
-already contains `.gtd/ARCHITECTURE.md` (their own technical sketch), `gtd step`
-captures the entry turn as `gtd(human): architecting` directly, skipping product
-grilling for that cycle entirely — no CLI flag needed, it's driven purely by
-which steering file is present.
+## Entry points: which file starts the cycle where
+
+The entry turn's gate is driven purely by which steering file the human's
+initial dirty tree contains (file _presence_, never content — no CLI flag
+needed). Four entry points:
+
+| File in the dirty tree      | Entry point                                                                                                                                                                                                                                                                                                                   |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| none (plain notes/sketches) | **Product grilling** — `gtd(human): grilling`; the agent develops `.gtd/TODO.md` from your notes                                                                                                                                                                                                                              |
+| `.gtd/TODO.md`              | **Product grilling** — same gate; your draft IS the product plan the agent iterates on                                                                                                                                                                                                                                        |
+| `.gtd/ARCHITECTURE.md`      | **Technical grilling** — `gtd(human): architecting`; product grilling is skipped, the agent iterates your technical sketch (great for refactorings or test improvements with no product-facing changes)                                                                                                                       |
+| `.gtd/PLAN.md`              | **Decomposition** — `gtd(human): grilled`; the plan is FINAL: a mid-chain hop seeds `.gtd/ARCHITECTURE.md` from it (deleting `.gtd/PLAN.md`) and rests at the decompose prompt — no grilling round ever runs                                                                                                                  |
+| `.gtd/HEALTH.md`            | **Error fixing** — `gtd(human): health-fixing`; your hand-written error description rests at the health-fixing prompt, and the normal health detour takes over (fix → re-test with `testCommand` → cap/escalate → squash/learning tail). The description is a means to make `testCommand` green — a red re-test overwrites it |
+
+The entry files are pairwise **illegal combinations** (see
+[STATES.md](../STATES.md) §5.1), so the pick is always unambiguous — a tree
+containing both `.gtd/PLAN.md` and `.gtd/TODO.md` hard-errors instead of
+guessing.
+
+One guard worth knowing for the HEALTH.md entry: the loop protocol opens every
+iteration with a clean-tree `gtd step-agent`, and at this one rest that opening
+beat is **inert** while HEAD is still the human's entry turn — so the
+hand-written description is never consumed before an agent has read it.
 
 ## Structured grilling/architecting and review files
 
@@ -218,9 +238,12 @@ routes to `gtd: awaiting review` when `.gtd/REVIEW.md` exists, and a squashing
 (or learning) turn only proceeds once its template has been overwritten. The one
 deliberate exception is `health-fixing`, whose empty turn is meaningful (the
 failure may have been environmental — the machine removes `.gtd/HEALTH.md` and
-re-tests). Human gates are unaffected: an empty **human** turn stays a signal
-(accept-defaults at grilling/architecting, clean approval at review,
-accept-the-draft-as-is at the learning review gate).
+re-tests) — except while HEAD is still the human's hand-written HEALTH.md entry
+turn (`gtd(human): health-fixing`), where the empty opening beat is inert so the
+description survives until an agent has actually read it. Human gates are
+unaffected: an empty **human** turn stays a signal (accept-defaults at
+grilling/architecting, clean approval at review, accept-the-draft-as-is at the
+learning review gate).
 
 ## Human review gate
 
@@ -299,14 +322,15 @@ finishes its turn. `gtd step-agent` then performs the squash itself:
 `git reset --soft <base>` + `git commit`, collapsing every intermediate `gtd: *`
 commit of the cycle into one — including any review-feedback detours, and the
 learning phase's own commits if learning ran: the squash base is the cycle's
-ORIGINAL start (the first grilling or, via the escape hatch, architecting turn
-since the previous `gtd: done` boundary, or the `gtd: reviewing <hash>` anchor
-for an ad-hoc review cycle), not the most recent re-grilling round — the
-collapse folds the whole cycle into one, using the overwritten message's content
-verbatim (turn position, not message content, triggers the squash). Doc edits
-made during `learning-apply` survive in the squashed tree, not as their own
-commit. With `squash: false`, `gtd: done` (or `gtd: learning applied`) is the
-resting boundary and no template is ever written.
+ORIGINAL start (the first grilling, architecting, or grilled entry turn since
+the previous `gtd: done` boundary — whichever entry point the cycle used — or
+the `gtd: reviewing <hash>` anchor for an ad-hoc review cycle), not the most
+recent re-grilling round — the collapse folds the whole cycle into one, using
+the overwritten message's content verbatim (turn position, not message content,
+triggers the squash). Doc edits made during `learning-apply` survive in the
+squashed tree, not as their own commit. With `squash: false`, `gtd: done` (or
+`gtd: learning applied`) is the resting boundary and no template is ever
+written.
 
 ## Health check
 
@@ -318,6 +342,10 @@ turn (`gtd(agent): health-fixing`) removes `.gtd/HEALTH.md` and re-tests in the
 same chain — a green re-test continues to learning (if enabled), then squash (if
 enabled), or idle; red repeats the health-fix loop; red at the cap writes
 `.gtd/ERRORS.md` and escalates.
+
+The same detour is also a direct entry point: hand-write `.gtd/HEALTH.md`
+describing the errors and run `gtd step` (see
+[Entry points](#entry-points-which-file-starts-the-cycle-where)).
 
 ## Escalate / budget reset
 

--- a/src/Events.test.ts
+++ b/src/Events.test.ts
@@ -349,6 +349,18 @@ describe("gatherEvents — COMMIT flags from the v2 grammar", { timeout: 30_000 
     expect(commits[1]).toMatchObject({ isHealthCheck: false })
     expect(commits[2]).toMatchObject({ isHealthCheck: false })
   })
+
+  it("sets isTestsGreen for gtd: tests green only", async () => {
+    commitFile("gtd: tests green", "x.ts", "//x\n")
+    commitFile("gtd: health-fix", "y.ts", "//y\n")
+    commitFile("feat: regular", "z.ts", "//z\n")
+
+    const commits = commitsOf(await runGather())
+    expect(commits).toHaveLength(3)
+    expect(commits[0]).toMatchObject({ isTestsGreen: true })
+    expect(commits[1]).toMatchObject({ isTestsGreen: false })
+    expect(commits[2]).toMatchObject({ isTestsGreen: false })
+  })
 })
 
 // ── gatherEvents: RESOLVE payload ────────────────────────────────────────────
@@ -569,6 +581,32 @@ describe("gatherEvents — RESOLVE payload", { timeout: 30_000 }, () => {
 
   it("HEALTH.md is excluded from codeDirty (steering file)", async () => {
     writeRepoFile(join(repoDir, ".gtd/HEALTH.md"), "# Health\nfail\n")
+    const p = resolveOf(await runGather())
+    expect(p.codeDirty).toBe(false)
+  })
+
+  it("PLAN.md absent → planExists false, planCommitted false", async () => {
+    const p = resolveOf(await runGather())
+    expect(p.planExists).toBe(false)
+    expect(p.planCommitted).toBe(false)
+  })
+
+  it("present uncommitted PLAN.md → planExists true, planCommitted false", async () => {
+    writeRepoFile(join(repoDir, ".gtd/PLAN.md"), "# Plan\nfinal architecture\n")
+    const p = resolveOf(await runGather())
+    expect(p.planExists).toBe(true)
+    expect(p.planCommitted).toBe(false)
+  })
+
+  it("present committed PLAN.md → planExists true, planCommitted true", async () => {
+    commitFile("gtd(human): grilled", ".gtd/PLAN.md", "# Plan\nfinal architecture\n")
+    const p = resolveOf(await runGather())
+    expect(p.planExists).toBe(true)
+    expect(p.planCommitted).toBe(true)
+  })
+
+  it("PLAN.md is excluded from codeDirty (steering file)", async () => {
+    writeRepoFile(join(repoDir, ".gtd/PLAN.md"), "# Plan\nfinal architecture\n")
     const p = resolveOf(await runGather())
     expect(p.codeDirty).toBe(false)
   })
@@ -1032,6 +1070,20 @@ describe(
       expect(p.squashDiff).not.toContain("first.ts")
     })
 
+    it("PLAN.md-entry cycle → squashBase = parent of the gtd(human): grilled entry turn", async () => {
+      initRepo(true)
+      const entryParent = git("rev-parse", "HEAD")
+      commitFile(turnSubject("human", "grilled"), ".gtd/PLAN.md", "# Plan\n")
+      git("rm", "-q", ".gtd/PLAN.md")
+      git("commit", "-q", "-m", "gtd: grilled")
+      commitFile("feat: work", "work.ts", "export const work = 1\n")
+      git("commit", "--allow-empty", "-q", "-m", "gtd: done")
+
+      const p = resolveOf(await runGather("none", { squash: true }))
+      expect(p.squashBase).toBe(entryParent)
+      expect(p.squashDiff).toContain("work.ts")
+    })
+
     it("squashMsgPresent flag only — no squashMsgContent field on the payload", async () => {
       initRepo(true)
       commitFile(turnSubject("human", "grilling"), ".gtd/TODO.md", "# Plan\n")
@@ -1074,6 +1126,73 @@ describe(
     })
   },
 )
+
+// ── gatherEvents: health-fix base anchoring ──────────────────────────────────
+
+describe("gatherEvents — healthFixBase anchoring", { timeout: 30_000 }, () => {
+  afterEach(cleanup)
+
+  it("anchors on the first gtd: health-check of the run (idle-path detour)", async () => {
+    initRepo(false)
+    const base = git("rev-parse", "HEAD")
+    commitFile("gtd: health-check", ".gtd/HEALTH.md", "red\n")
+    commitFile("gtd(agent): health-fixing", "fix.ts", "export const f = 1\n")
+    git("rm", "-q", ".gtd/HEALTH.md")
+    git("commit", "-q", "-m", "gtd: health-fix")
+    const p = resolveOf(await runGather("none", { squash: true }))
+    expect(p.healthFixBase).toBe(base)
+  })
+
+  it("anchors on the human's hand-written HEALTH.md entry turn (zero health-check commits)", async () => {
+    initRepo(false)
+    const base = git("rev-parse", "HEAD")
+    commitFile(turnSubject("human", "health-fixing"), ".gtd/HEALTH.md", "fix the build\n")
+    commitFile("gtd(agent): health-fixing", "fix.ts", "export const f = 1\n")
+    git("rm", "-q", ".gtd/HEALTH.md")
+    git("commit", "-q", "-m", "gtd: health-fix")
+    const p = resolveOf(await runGather("none", { squash: true }))
+    expect(p.healthFixBase).toBe(base)
+  })
+
+  it("picks the EARLIEST anchor when the entry turn is followed by health-check rounds", async () => {
+    initRepo(false)
+    const base = git("rev-parse", "HEAD")
+    commitFile(turnSubject("human", "health-fixing"), ".gtd/HEALTH.md", "fix the build\n")
+    commitFile("gtd(agent): health-fixing", "fix.ts", "export const f = 1\n")
+    git("rm", "-q", ".gtd/HEALTH.md")
+    git("commit", "-q", "-m", "gtd: health-fix")
+    commitFile("gtd: health-check", ".gtd/HEALTH.md", "still red\n")
+    const p = resolveOf(await runGather("none", { squash: true }))
+    expect(p.healthFixBase).toBe(base)
+  })
+
+  it("a processed run (gtd: tests green in history, HEAD past the chain) clears the anchor", async () => {
+    initRepo(false)
+    commitFile("gtd: health-check", ".gtd/HEALTH.md", "red\n")
+    commitFile("gtd(agent): health-fixing", "fix.ts", "export const f = 1\n")
+    git("rm", "-q", ".gtd/HEALTH.md")
+    git("commit", "-q", "-m", "gtd: health-fix")
+    git("commit", "--allow-empty", "-q", "-m", "gtd: tests green")
+    commitFile("gtd: learning applied", "AGENTS.md", "# lessons\n")
+    const p = resolveOf(await runGather("none", { squash: false, learning: true }))
+    expect(p.healthFixBase).toBeUndefined()
+  })
+
+  it("keeps the anchor while HEAD is the run's own gtd: tests green (the chain still needs it)", async () => {
+    initRepo(false)
+    const base = git("rev-parse", "HEAD")
+    commitFile("gtd: health-check", ".gtd/HEALTH.md", "red\n")
+    commitFile("gtd(agent): health-fixing", "fix.ts", "export const f = 1\n")
+    git("rm", "-q", ".gtd/HEALTH.md")
+    git("commit", "-q", "-m", "gtd: health-fix")
+    git("commit", "--allow-empty", "-q", "-m", "gtd: tests green")
+    const p = resolveOf(await runGather("none", { squash: true }))
+    expect(p.healthFixBase).toBe(base)
+    // The health path carries the run's diff as the squash range.
+    expect(p.squashBase).toBe(base)
+    expect(p.squashDiff).toContain("fix.ts")
+  })
+})
 
 // ── gatherEvents: COMMIT-stream base folds ───────────────────────────────────
 
@@ -1191,6 +1310,31 @@ describe("perform — EdgeAction execution", { timeout: 30_000 }, () => {
     const nameStatus = git("show", "--name-status", "--format=", "HEAD")
     expect(nameStatus).toContain("D\t.gtd/TODO.md")
     expect(nameStatus).toContain(".gtd/ARCHITECTURE.md")
+  })
+
+  it("commitRouting seedArchitectureFromPlan: seeds ARCHITECTURE.md from PLAN.md's content and removes PLAN.md", async () => {
+    commitFile("gtd(human): grilled", ".gtd/PLAN.md", "# Plan\n\nsplit the parser module\n")
+    await runPerform({
+      kind: "commitRouting",
+      subject: "gtd: grilled",
+      seedArchitectureFromPlan: true,
+    })
+    expect(existsSync(join(repoDir, ".gtd/PLAN.md"))).toBe(false)
+    const architecture = readFileSync(join(repoDir, ".gtd/ARCHITECTURE.md"), "utf8")
+    expect(architecture).toContain("split the parser module")
+    expect(architecture).toContain("seeded from the final plan")
+    expect(git("log", "-1", "--format=%s")).toBe("gtd: grilled")
+    const nameStatus = git("show", "--name-status", "--format=", "HEAD")
+    expect(nameStatus).toContain("D\t.gtd/PLAN.md")
+    expect(nameStatus).toContain(".gtd/ARCHITECTURE.md")
+  })
+
+  it("captureTurn: formats a pending PLAN.md before committing", async () => {
+    writeRepoFile(join(repoDir, ".gtd/PLAN.md"), "#    Plan\nunformatted   \n")
+    await runPerform({ kind: "captureTurn", actor: "human", gate: "grilled" })
+    const formatted = readFileSync(join(repoDir, ".gtd/PLAN.md"), "utf8")
+    expect(formatted).not.toBe("#    Plan\nunformatted   \n")
+    expect(git("status", "--porcelain").trim()).toBe("")
   })
 
   it("commitRouting removeReview: deletes REVIEW.md and lands its removal in the commit", async () => {

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -40,6 +40,7 @@ import type {
 const GTD_DIR = ".gtd"
 const TODO_FILE = `${GTD_DIR}/TODO.md`
 const ARCHITECTURE_FILE = `${GTD_DIR}/ARCHITECTURE.md`
+const PLAN_FILE = `${GTD_DIR}/PLAN.md`
 const REVIEW_FILE = `${GTD_DIR}/REVIEW.md`
 const FEEDBACK_FILE = `${GTD_DIR}/FEEDBACK.md`
 const ERRORS_FILE = `${GTD_DIR}/ERRORS.md`
@@ -55,6 +56,7 @@ const LEGACY_FEEDBACK_FILE = "FEEDBACK.md"
 export const STEERING_FILES = {
   todo: TODO_FILE,
   architecture: ARCHITECTURE_FILE,
+  plan: PLAN_FILE,
   review: REVIEW_FILE,
   feedback: FEEDBACK_FILE,
   errors: ERRORS_FILE,
@@ -410,6 +412,7 @@ export const gatherEvents = (
         isWorkflowCommit: isTurn || isRouting,
         removedErrors: commit.removedErrors,
         isHealthCheck: isRouting && parsed.phase === "health-check",
+        isTestsGreen: isRouting && parsed.phase === "tests-green",
       }
     })
 
@@ -499,6 +502,7 @@ export const gatherEvents = (
     // Steering-file presence (committed and/or pending).
     const todoExists = yield* fs.exists(resolve(TODO_FILE))
     const architectureExists = yield* fs.exists(resolve(ARCHITECTURE_FILE))
+    const planExists = yield* fs.exists(resolve(PLAN_FILE))
     const reviewPresent = yield* fs.exists(resolve(REVIEW_FILE))
     const feedbackPresent = yield* fs.exists(resolve(FEEDBACK_FILE))
     const errorsPresent = yield* fs.exists(resolve(ERRORS_FILE))
@@ -526,6 +530,8 @@ export const gatherEvents = (
     const todoCommitted = todoExists && !isUncommitted(TODO_FILE)
     // ARCHITECTURE.md tracked at HEAD.
     const architectureCommitted = architectureExists && !isUncommitted(ARCHITECTURE_FILE)
+    // PLAN.md tracked at HEAD.
+    const planCommitted = planExists && !isUncommitted(PLAN_FILE)
 
     // Structural validation of whichever grilling-phase file is present (the
     // two never coexist) and of REVIEW.md, consulted ONLY by the machine when
@@ -643,13 +649,20 @@ export const gatherEvents = (
         }
       }
 
-      // Find first grilling-or-architecting turn commit in the current cycle
-      // (task start) — the escape hatch lets a cycle start directly at
-      // `architecting` (no grilling turn at all), so both gates count.
+      // Find the first entry-capable turn commit in the current cycle (task
+      // start) — the entry points let a cycle start directly at
+      // `architecting` (technical grilling, no grilling turn at all) or at
+      // `grilled` (a final `.gtd/PLAN.md`, straight to decomposition), so all
+      // three gates count. Safe for normal cycles: their `gtd(agent): grilled`
+      // decompose turn is always preceded by a grilling/architecting turn in
+      // the same cycle, and first-match wins.
       const isGrillingTurn = (message: string): boolean => {
         const parsed = parseSubject(subjectOf(message))
         return (
-          parsed.kind === "turn" && (parsed.gate === "grilling" || parsed.gate === "architecting")
+          parsed.kind === "turn" &&
+          (parsed.gate === "grilling" ||
+            parsed.gate === "architecting" ||
+            parsed.gate === "grilled")
         )
       }
       const firstGrilling = currentCycle.find((c) => isGrillingTurn(c.message))
@@ -735,10 +748,17 @@ export const gatherEvents = (
         // pre-feedback half of the cycle (its grilling/building/review
         // commits) permanently in history — the squash must collapse the
         // entire cycle back to where it actually began.
+        // All three entry-capable gates count as a cycle start (mirrors the
+        // review-base `isGrillingTurn` above): `grilled` covers the PLAN.md
+        // entry turn — harmless for normal cycles, whose decompose turn is
+        // always preceded by a grilling/architecting turn (first match wins).
         const isGrillingTurnSubject = (subject: string): boolean => {
           const parsed = parseSubject(subject)
           return (
-            parsed.kind === "turn" && (parsed.gate === "grilling" || parsed.gate === "architecting")
+            parsed.kind === "turn" &&
+            (parsed.gate === "grilling" ||
+              parsed.gate === "architecting" ||
+              parsed.gate === "grilled")
           )
         }
         const isReviewingAnchor = (subject: string): boolean => {
@@ -805,42 +825,55 @@ export const gatherEvents = (
     // --- Health squash base (squash/learning after green health-fix run) --------
     // Only computed when squash and/or learning is enabled. Mirrors
     // foldCounters: scans all of history forward, resetting on
-    // isPackageStart/removedErrors events, tracking the FIRST
-    // `gtd: health-check` of the current health run. healthFixBase is the
-    // parent of that first health-check commit.
+    // isPackageStart/removedErrors/isTestsGreen events, and anchoring on the
+    // EARLIEST of the current run's two possible start markers — the first
+    // `gtd: health-check` routing commit (the idle-path detour) or the first
+    // `gtd(human): health-fixing` turn commit (a hand-written HEALTH.md
+    // entry, which may reach green with zero health-check commits ever
+    // landing). healthFixBase is the parent of that anchor commit.
+    //
+    // `gtd: tests green` ends a health run for anchoring purposes (without
+    // this reset, a run whose green re-test chained into learning but never
+    // squash-collapsed would leave its anchor in history forever, and every
+    // later idle `gtd step` would re-trigger the learning/squash chain) —
+    // EXCEPT the newest one while HEAD is still inside the post-green
+    // learning/squash processing chain, which is that run's own green marker:
+    // the chain's remaining hops (learning draft, squash) still need the
+    // base. `learning-applied` counts as in-chain only while squash is
+    // enabled — with squash off it is the chain's final rest, after which the
+    // run is fully processed.
     let healthFixBase: string | undefined
     if (config.squash || config.learning) {
-      let firstHealthCheckHash: string | undefined
-      let healthCheckCount = 0
-      for (const commit of commitEvents) {
-        if (commit.isPackageStart || commit.removedErrors) {
-          // Reset: new package or budget reset
-          firstHealthCheckHash = undefined
-          healthCheckCount = 0
-        }
-        if (commit.isHealthCheck) {
-          healthCheckCount++
-        }
+      const inHealthProcessingChain =
+        (headParsedForSquash.kind === "routing" &&
+          (headParsedForSquash.phase === "tests-green" ||
+            headParsedForSquash.phase === "learning-template" ||
+            headParsedForSquash.phase === "learning-drafted" ||
+            headParsedForSquash.phase === "learning-approved" ||
+            headParsedForSquash.phase === "squash-template" ||
+            (headParsedForSquash.phase === "learning-applied" && config.squash))) ||
+        (headParsedForSquash.kind === "turn" &&
+          SQUASH_OR_LEARNING_TURN_GATES.has(headParsedForSquash.gate))
+      let lastTestsGreenIdx = -1
+      for (let i = 0; i < commitEvents.length; i++) {
+        if (commitEvents[i]!.isTestsGreen) lastTestsGreenIdx = i
       }
-      // Re-derive the hash: commitEvents don't carry hashes, so re-scan
-      // `history` in lockstep for the first health-check hash after the same
-      // reset boundaries.
-      if (healthCheckCount > 0) {
-        let resetAt = -1
-        for (let i = 0; i < history.length; i++) {
-          const c = commitEvents[i]!
-          if (c.isPackageStart || c.removedErrors) resetAt = i
+      const ignoredTestsGreenIdx = inHealthProcessingChain ? lastTestsGreenIdx : -1
+      const isHealthEntryTurn = (c: CommitEvent): boolean =>
+        c.turnActor === "human" && c.turnGate === "health-fixing"
+      let anchorIdx = -1
+      for (let i = 0; i < commitEvents.length; i++) {
+        const c = commitEvents[i]!
+        if (c.isPackageStart || c.removedErrors || (c.isTestsGreen && i !== ignoredTestsGreenIdx)) {
+          anchorIdx = -1
+          continue
         }
-        for (let i = resetAt + 1; i < history.length; i++) {
-          if (commitEvents[i]!.isHealthCheck) {
-            firstHealthCheckHash = history[i]!.hash
-            break
-          }
-        }
+        if (anchorIdx === -1 && (c.isHealthCheck || isHealthEntryTurn(c))) anchorIdx = i
       }
-      if (healthCheckCount > 0 && firstHealthCheckHash !== undefined) {
+      if (anchorIdx !== -1) {
+        const anchorHash = history[anchorIdx]!.hash
         const healthBase = yield* git
-          .resolveRef(`${firstHealthCheckHash}~1`)
+          .resolveRef(`${anchorHash}~1`)
           .pipe(Effect.catchAll(() => Effect.succeed(EMPTY_TREE)))
         healthFixBase = healthBase
         // On the health path, squashBase/squashDiff carry the health-fix cycle
@@ -865,6 +898,8 @@ export const gatherEvents = (
       todoCommitted,
       architectureExists,
       architectureCommitted,
+      planExists,
+      planCommitted,
       packagesPresent: packages.length > 0,
       reviewPresent,
       feedbackPresent,
@@ -1018,6 +1053,15 @@ const ARCHITECTURE_SEED_BANNER =
   "<!-- gtd: seeded from the converged product plan (.gtd/TODO.md); decide the technical/architectural questions below. -->\n\n"
 
 /**
+ * Banner prepended to `.gtd/ARCHITECTURE.md` when it is seeded from a
+ * hand-written `.gtd/PLAN.md` (the direct-to-decompose entry) — same
+ * orientation role as `ARCHITECTURE_SEED_BANNER`, one phase later: the plan
+ * is final, the next turn decomposes it.
+ */
+const ARCHITECTURE_PLAN_SEED_BANNER =
+  "<!-- gtd: seeded from the final plan (.gtd/PLAN.md); decompose into ordered work packages. -->\n\n"
+
+/**
  * A short skeleton written by `writeLearningTemplate`, instructing the
  * learning agent to replace it with the real distilled learnings.
  */
@@ -1063,16 +1107,15 @@ export const perform = (
       .pipe(Effect.catchAll(() => Effect.void))
 
     switch (action.kind) {
-      // Capture a human/agent turn: format the pending TODO.md/ARCHITECTURE.md
-      // (best-effort), then commit-all under `gtd(<actor>): <gate>` (--allow-empty).
+      // Capture a human/agent turn: format the pending TODO.md/
+      // ARCHITECTURE.md/PLAN.md (best-effort), then commit-all under
+      // `gtd(<actor>): <gate>` (--allow-empty).
       case "captureTurn": {
-        const todoExists = yield* fs.exists(resolve(TODO_FILE))
-        if (todoExists) {
-          yield* formatFile(resolve(TODO_FILE)).pipe(Effect.catchAll(() => Effect.void))
-        }
-        const architectureExists = yield* fs.exists(resolve(ARCHITECTURE_FILE))
-        if (architectureExists) {
-          yield* formatFile(resolve(ARCHITECTURE_FILE)).pipe(Effect.catchAll(() => Effect.void))
+        for (const file of [TODO_FILE, ARCHITECTURE_FILE, PLAN_FILE]) {
+          const exists = yield* fs.exists(resolve(file))
+          if (exists) {
+            yield* formatFile(resolve(file)).pipe(Effect.catchAll(() => Effect.void))
+          }
         }
         yield* git.commitAllWithPrefix(turnSubject(action.actor, action.gate))
         return { stop: false }
@@ -1083,6 +1126,9 @@ export const perform = (
       // `seedArchitectureFromTodo` instead reads TODO.md, writes it (with a
       // scaffold banner) as ARCHITECTURE.md, and deletes TODO.md — the
       // grilling→architecting hand-off, in this same commit.
+      // `seedArchitectureFromPlan` mirrors it for the PLAN.md entry: the
+      // final plan becomes ARCHITECTURE.md (the decompose prompt's input) in
+      // the same commit that routes to the decompose rest.
       case "commitRouting": {
         if (action.seedArchitectureFromTodo === true) {
           const todoContent = yield* fs
@@ -1094,6 +1140,17 @@ export const perform = (
             ARCHITECTURE_SEED_BANNER + todoContent,
           )
           yield* fs.remove(resolve(TODO_FILE)).pipe(Effect.catchAll(() => Effect.void))
+        }
+        if (action.seedArchitectureFromPlan === true) {
+          const planContent = yield* fs
+            .readFileString(resolve(PLAN_FILE))
+            .pipe(Effect.catchAll(() => Effect.succeed("")))
+          yield* ensureGtdDir
+          yield* fs.writeFileString(
+            resolve(ARCHITECTURE_FILE),
+            ARCHITECTURE_PLAN_SEED_BANNER + planContent,
+          )
+          yield* fs.remove(resolve(PLAN_FILE)).pipe(Effect.catchAll(() => Effect.void))
         }
         if (action.removeArchitecture === true) {
           yield* fs.remove(resolve(ARCHITECTURE_FILE)).pipe(Effect.catchAll(() => Effect.void))

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -396,23 +396,27 @@ export const gatherEvents = (
       const parsed = parseSubject(subject)
       const isTurn = parsed.kind === "turn"
       const isRouting = parsed.kind === "routing"
+      // One discriminant read each; "" never matches a real phase/gate, so
+      // every flag below collapses to a single comparison instead of an
+      // `isRouting && …` / `isTurn && …` conjunct.
+      const routingPhase = parsed.kind === "routing" ? parsed.phase : ""
+      const turnGate = parsed.kind === "turn" ? parsed.gate : ""
       return {
         type: "COMMIT",
-        ...(isTurn ? { turnActor: parsed.actor, turnGate: parsed.gate } : {}),
-        isErrors: isRouting && parsed.phase === "errors",
+        ...(parsed.kind === "turn" ? { turnActor: parsed.actor, turnGate: parsed.gate } : {}),
+        isErrors: routingPhase === "errors",
         // A `gtd(agent): agentic-review` turn whose diff touched
         // `.gtd/FEEDBACK.md` — a findings round. Over-counts the approval
         // round too (an empty FEEDBACK.md write still touches the path), but
         // `gtd: package done` resets the reviewFixCount fold immediately
         // after, so the extra count is harmless (documented in the task
         // contract).
-        isFeedback: isTurn && parsed.gate === "agentic-review" && touchedFeedback(commit.touched),
-        isPackageStart:
-          isRouting && (parsed.phase === "planning" || parsed.phase === "package-done"),
+        isFeedback: turnGate === "agentic-review" && touchedFeedback(commit.touched),
+        isPackageStart: routingPhase === "planning" || routingPhase === "package-done",
         isWorkflowCommit: isTurn || isRouting,
         removedErrors: commit.removedErrors,
-        isHealthCheck: isRouting && parsed.phase === "health-check",
-        isTestsGreen: isRouting && parsed.phase === "tests-green",
+        isHealthCheck: routingPhase === "health-check",
+        isTestsGreen: routingPhase === "tests-green",
       }
     })
 

--- a/src/Lsp.ts
+++ b/src/Lsp.ts
@@ -296,6 +296,9 @@ export const startLspServer = (): Effect.Effect<
     connection.onDocumentSymbol((params: DocumentSymbolParams) => {
       const document = documents.get(params.textDocument.uri)
       if (!document) return []
+      // PLAN.md is deliberately absent: it has no enforced structure (a
+      // human-authored final architecture, consumed whole by the entry seed),
+      // so there are no symbols to surface.
       switch (documentName(document.uri)) {
         case "TODO.md":
         case "ARCHITECTURE.md":

--- a/src/Machine.property.test.ts
+++ b/src/Machine.property.test.ts
@@ -94,6 +94,8 @@ const arbPayload: fc.Arbitrary<ResolvePayload> = fc
     todoCommittedRaw: fc.boolean(),
     architectureExists: fc.boolean(),
     architectureCommittedRaw: fc.boolean(),
+    planExists: fc.boolean(),
+    planCommittedRaw: fc.boolean(),
     packagesPresent: fc.boolean(),
     reviewPresent: fc.boolean(),
     reviewTrackedRaw: fc.boolean(),
@@ -131,6 +133,8 @@ const arbPayload: fc.Arbitrary<ResolvePayload> = fc
       todoCommitted: raw.todoExists && raw.todoCommittedRaw,
       architectureExists: raw.architectureExists,
       architectureCommitted: raw.architectureExists && raw.architectureCommittedRaw,
+      planExists: raw.planExists,
+      planCommitted: raw.planExists && raw.planCommittedRaw,
       packagesPresent: raw.packagesPresent,
       reviewPresent: raw.reviewPresent,
       feedbackPresent: raw.feedbackPresent,
@@ -174,6 +178,7 @@ const arbCommit: fc.Arbitrary<GtdEvent> = fc
     isPackageStart: fc.boolean(),
     removedErrors: fc.boolean(),
     isHealthCheck: fc.boolean(),
+    isTestsGreen: fc.boolean(),
   })
   .map((f) => ({ type: "COMMIT" as const, isWorkflowCommit: true, ...f }))
 
@@ -200,7 +205,18 @@ const isIllegal = (p: ResolvePayload): boolean =>
   (p.healthPresent && p.packagesPresent) ||
   (p.healthPresent && p.reviewPresent) ||
   (p.healthPresent && p.feedbackPresent) ||
-  (p.healthPresent && p.errorsPresent)
+  (p.healthPresent && p.errorsPresent) ||
+  (p.healthPresent && p.todoExists) ||
+  (p.healthPresent && p.architectureExists) ||
+  (p.healthPresent && p.planExists) ||
+  (p.planExists && p.todoExists) ||
+  (p.planExists && p.architectureExists) ||
+  (p.planExists && p.packagesPresent) ||
+  (p.planExists && p.reviewPresent) ||
+  (p.planExists && p.feedbackPresent) ||
+  (p.planExists && p.errorsPresent) ||
+  (p.planExists && p.squashMsgPresent) ||
+  (p.planExists && p.learningMsgPresent)
 
 /**
  * Scopes property (a) to payloads where HEAD is an agent turn commit with an

--- a/src/Machine.test.ts
+++ b/src/Machine.test.ts
@@ -22,6 +22,7 @@ const commit = (
     isWorkflowCommit?: boolean
     removedErrors?: boolean
     isHealthCheck?: boolean
+    isTestsGreen?: boolean
   } = {},
 ): GtdEvent => ({
   type: "COMMIT",
@@ -33,6 +34,7 @@ const commit = (
   isWorkflowCommit: flags.isWorkflowCommit ?? true,
   removedErrors: flags.removedErrors ?? false,
   isHealthCheck: flags.isHealthCheck ?? false,
+  isTestsGreen: flags.isTestsGreen ?? false,
 })
 
 const basePayload = (overrides: Partial<ResolvePayload> = {}): ResolvePayload => ({
@@ -132,6 +134,15 @@ describe("foldCounters — healthFixCount", () => {
     const events = [commit({ isHealthCheck: true }), commit({ isPackageStart: true })]
     expect(foldCounters(events).healthFixCount).toBe(0)
   })
+
+  it("resets on isTestsGreen (a green re-test ends the health run)", () => {
+    const events = [
+      commit({ isHealthCheck: true }),
+      commit({ isHealthCheck: true }),
+      commit({ isTestsGreen: true }),
+    ]
+    expect(foldCounters(events).healthFixCount).toBe(0)
+  })
 })
 
 // ── awaitedActor ──────────────────────────────────────────────────────────
@@ -213,6 +224,43 @@ describe("assertLegal / GtdStateError", () => {
       GtdStateError,
     )
   })
+
+  it("throws illegal-combination for PLAN.md + TODO.md and PLAN.md + ARCHITECTURE.md", () => {
+    expect(() => resolve([R({ planExists: true, todoExists: true })])).toThrow(
+      "illegal combination: .gtd/PLAN.md + .gtd/TODO.md",
+    )
+    expect(() => resolve([R({ planExists: true, architectureExists: true })])).toThrow(
+      "illegal combination: .gtd/PLAN.md + .gtd/ARCHITECTURE.md",
+    )
+  })
+
+  it("throws illegal-combination for PLAN.md + packages / REVIEW.md / FEEDBACK.md / ERRORS.md", () => {
+    expect(() => resolve([R({ planExists: true, packagesPresent: true })])).toThrow(GtdStateError)
+    expect(() => resolve([R({ planExists: true, reviewPresent: true })])).toThrow(GtdStateError)
+    expect(() =>
+      resolve([R({ planExists: true, feedbackPresent: true, packagesPresent: true })]),
+    ).toThrow("illegal combination: .gtd/PLAN.md + packages")
+    expect(() => resolve([R({ planExists: true, errorsPresent: true })])).toThrow(GtdStateError)
+  })
+
+  it("throws illegal-combination for PLAN.md + SQUASH_MSG.md / LEARNINGS.md (defensive)", () => {
+    expect(() => resolve([R({ planExists: true, squashMsgPresent: true })])).toThrow(GtdStateError)
+    expect(() => resolve([R({ planExists: true, learningMsgPresent: true })])).toThrow(
+      GtdStateError,
+    )
+  })
+
+  it("throws illegal-combination for HEALTH.md + TODO.md / ARCHITECTURE.md / PLAN.md", () => {
+    expect(() => resolve([R({ healthPresent: true, todoExists: true })])).toThrow(
+      "illegal combination: .gtd/HEALTH.md + .gtd/TODO.md",
+    )
+    expect(() => resolve([R({ healthPresent: true, architectureExists: true })])).toThrow(
+      GtdStateError,
+    )
+    expect(() => resolve([R({ healthPresent: true, planExists: true })])).toThrow(
+      "illegal combination: .gtd/HEALTH.md + .gtd/PLAN.md",
+    )
+  })
 })
 
 // ── Boundary entry: dirty tree + human invoker → grilling capture ─────────
@@ -247,6 +295,148 @@ describe("dirty boundary entry", () => {
   it("next (invoker none) reports the state without mutating", () => {
     const result = resolve([R({ invoker: "none", workingTreeClean: false })])
     expect(result.edgeAction).toBeUndefined()
+  })
+
+  it("PLAN.md entry: a dirty tree that already contains PLAN.md captures gtd(human): grilled", () => {
+    const result = resolve([R({ invoker: "human", workingTreeClean: false, planExists: true })])
+    expect(result.state).toBe("grilled")
+    expect(result.actor).toBe("human")
+    expect(result.edgeAction).toEqual({ kind: "captureTurn", actor: "human", gate: "grilled" })
+  })
+
+  it("HEALTH.md entry: a dirty tree with a hand-written HEALTH.md captures gtd(human): health-fixing", () => {
+    const result = resolve([
+      R({
+        invoker: "human",
+        workingTreeClean: false,
+        healthPresent: true,
+        healthContent: "the build script crashes on Node 22",
+      }),
+    ])
+    expect(result.state).toBe("health-fixing")
+    expect(result.actor).toBe("human")
+    expect(result.edgeAction).toEqual({
+      kind: "captureTurn",
+      actor: "human",
+      gate: "health-fixing",
+    })
+  })
+
+  it("a committed PLAN.md at a boundary HEAD resumes the entry on a clean human step", () => {
+    const result = resolve([
+      R({
+        invoker: "human",
+        workingTreeClean: true,
+        planExists: true,
+        planCommitted: true,
+      }),
+    ])
+    expect(result.state).toBe("grilled")
+    expect(result.edgeAction).toEqual({ kind: "captureTurn", actor: "human", gate: "grilled" })
+  })
+
+  it("a committed PLAN.md at a boundary HEAD refuses an agent step (awaits human)", () => {
+    const result = resolve([
+      R({ invoker: "agent", workingTreeClean: true, planExists: true, planCommitted: true }),
+    ])
+    expect(result.refusal).toContain("awaits a human turn")
+    expect(result.edgeAction).toBeUndefined()
+  })
+})
+
+// ── PLAN.md entry: the seed hop ────────────────────────────────────────────
+
+describe("gtd(human): grilled seeds ARCHITECTURE.md from PLAN.md", () => {
+  it("with PLAN.md present → mid-chains to gtd: grilled with seedArchitectureFromPlan", () => {
+    const result = resolve([
+      R({
+        invoker: "human",
+        lastCommitSubject: "gtd(human): grilled",
+        planExists: true,
+        planCommitted: true,
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.state).toBe("grilled")
+    expect(result.edgeAction).toEqual({
+      kind: "commitRouting",
+      subject: "gtd: grilled",
+      seedArchitectureFromPlan: true,
+    })
+  })
+
+  it("invoker none reports the seed hop as pending", () => {
+    const result = resolve([
+      R({
+        invoker: "none",
+        lastCommitSubject: "gtd(human): grilled",
+        planExists: true,
+        planCommitted: true,
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.pending).toBe(true)
+    expect(result.edgeAction).toBeUndefined()
+  })
+
+  it("without PLAN.md (hand-crafted or half-seeded history) → never seeds; falls through the ladder", () => {
+    // No steering files at all → idle, fabricating nothing.
+    const bare = resolve([
+      R({ invoker: "none", lastCommitSubject: "gtd(human): grilled", workingTreeClean: true }),
+    ])
+    expect(bare.state).toBe("idle")
+    expect(bare.edgeAction).toBeUndefined()
+    // Half-seeded crash (ARCHITECTURE.md written, PLAN.md deleted, commit
+    // failed) → recovers through a normal architecting round, preserving the
+    // seeded content.
+    const halfSeeded = resolve([
+      R({
+        invoker: "none",
+        lastCommitSubject: "gtd(human): grilled",
+        architectureExists: true,
+        workingTreeClean: false,
+      }),
+    ])
+    expect(halfSeeded.state).toBe("architecting")
+  })
+})
+
+// ── HEALTH.md entry: empty-agent-turn guard ────────────────────────────────
+
+describe("empty agent turn at the HEALTH.md entry rest", () => {
+  it("is inert while HEAD is the human entry turn (the hand-written HEALTH.md survives)", () => {
+    const result = resolve([
+      R({
+        invoker: "agent",
+        lastCommitSubject: "gtd(human): health-fixing",
+        healthPresent: true,
+        healthCommitted: true,
+        healthContent: "the build script crashes on Node 22",
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.state).toBe("health-fixing")
+    expect(result.edgeAction).toBeUndefined()
+    expect(result.refusal).toBeUndefined()
+  })
+
+  it("stays meaningful on the machine-written detour (HEAD = gtd: health-check)", () => {
+    const result = resolve([
+      R({
+        invoker: "agent",
+        lastCommitSubject: "gtd: health-check",
+        healthPresent: true,
+        healthCommitted: true,
+        healthContent: "test output",
+        workingTreeClean: true,
+      }),
+    ])
+    expect(result.state).toBe("health-fixing")
+    expect(result.edgeAction).toEqual({
+      kind: "captureTurn",
+      actor: "agent",
+      gate: "health-fixing",
+    })
   })
 })
 
@@ -747,6 +937,46 @@ describe("predictTurn", () => {
     expect(prediction.state).toBe("architecting")
   })
 
+  it("PLAN.md entry: predicts the human grilled capture when PLAN.md is in the dirty tree", () => {
+    const prediction = predictTurn([R({ workingTreeClean: false, planExists: true })])
+    expect(prediction.actor).toBe("human")
+    expect(prediction.subject).toBe("gtd(human): grilled")
+    expect(prediction.state).toBe("grilled")
+  })
+
+  it("HEALTH.md entry: predicts the human health-fixing capture when a hand-written HEALTH.md is in the dirty tree", () => {
+    const prediction = predictTurn([R({ workingTreeClean: false, healthPresent: true })])
+    expect(prediction.actor).toBe("human")
+    expect(prediction.subject).toBe("gtd(human): health-fixing")
+    expect(prediction.state).toBe("health-fixing")
+  })
+
+  it("predicts null at the HEALTH.md entry rest (clean tree, HEAD is the human entry turn)", () => {
+    const prediction = predictTurn([
+      R({
+        lastCommitSubject: "gtd(human): health-fixing",
+        healthPresent: true,
+        healthCommitted: true,
+        workingTreeClean: true,
+      }),
+    ])
+    expect(prediction.state).toBe("health-fixing")
+    expect(prediction.subject).toBeNull()
+  })
+
+  it("predicts the seed routing commit at the PLAN.md entry turn HEAD", () => {
+    const prediction = predictTurn([
+      R({
+        lastCommitSubject: "gtd(human): grilled",
+        planExists: true,
+        planCommitted: true,
+        workingTreeClean: true,
+      }),
+    ])
+    expect(prediction.subject).toBe("gtd: grilled")
+    expect(prediction.state).toBe("grilled")
+  })
+
   it("predicts null at a settled rest (idle, health check is not a commit-predicting action)", () => {
     const prediction = predictTurn([
       R({ workingTreeClean: true, lastCommitSubject: "gtd: health-fix" }),
@@ -818,6 +1048,57 @@ describe("health lifecycle", () => {
     ])
     expect(result.state).toBe("escalate")
     expect(result.actor).toBe("human")
+  })
+
+  it("gtd: health-fix re-test chains after green on healthFixBase alone (green-first-try entry run has zero health-check commits)", () => {
+    const result = resolve([
+      R({
+        invoker: "agent",
+        lastCommitSubject: "gtd: health-fix",
+        workingTreeClean: true,
+        squashEnabled: true,
+        healthFixBase: "abc123",
+      }),
+    ])
+    expect(result.edgeAction).toEqual({
+      kind: "runHealthCheck",
+      errorCount: 0,
+      capReached: false,
+      chainAfterGreen: true,
+    })
+  })
+
+  it("gtd: health-fix re-test does not chain when no healthFixBase is anchored", () => {
+    const result = resolve([
+      R({
+        invoker: "agent",
+        lastCommitSubject: "gtd: health-fix",
+        workingTreeClean: true,
+        squashEnabled: true,
+      }),
+    ])
+    expect(result.edgeAction).toEqual({
+      kind: "runHealthCheck",
+      errorCount: 0,
+      capReached: false,
+      chainAfterGreen: false,
+    })
+  })
+
+  it("idle human step does not chain after green once the run's anchor is gone (no healthFixBase)", () => {
+    const events = [
+      commit({ isHealthCheck: true }),
+      commit({ isTestsGreen: true }),
+      R({ invoker: "human", workingTreeClean: true, squashEnabled: true }),
+    ]
+    const result = resolve(events)
+    expect(result.state).toBe("idle")
+    expect(result.edgeAction).toEqual({
+      kind: "runHealthCheck",
+      errorCount: 0,
+      capReached: false,
+      chainAfterGreen: false,
+    })
   })
 })
 

--- a/src/Machine.test.ts
+++ b/src/Machine.test.ts
@@ -25,16 +25,17 @@ const commit = (
     isTestsGreen?: boolean
   } = {},
 ): GtdEvent => ({
+  // Defaults first, caller overrides spread on top — call sites pass literal
+  // objects holding only the keys they mean to set, never explicit undefined.
   type: "COMMIT",
-  ...(flags.turnActor !== undefined ? { turnActor: flags.turnActor } : {}),
-  ...(flags.turnGate !== undefined ? { turnGate: flags.turnGate } : {}),
-  isErrors: flags.isErrors ?? false,
-  isFeedback: flags.isFeedback ?? false,
-  isPackageStart: flags.isPackageStart ?? false,
-  isWorkflowCommit: flags.isWorkflowCommit ?? true,
-  removedErrors: flags.removedErrors ?? false,
-  isHealthCheck: flags.isHealthCheck ?? false,
-  isTestsGreen: flags.isTestsGreen ?? false,
+  isErrors: false,
+  isFeedback: false,
+  isPackageStart: false,
+  isWorkflowCommit: true,
+  removedErrors: false,
+  isHealthCheck: false,
+  isTestsGreen: false,
+  ...flags,
 })
 
 const basePayload = (overrides: Partial<ResolvePayload> = {}): ResolvePayload => ({

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -71,6 +71,8 @@ export interface CommitEvent {
   readonly removedErrors: boolean
   /** Routing `gtd: health-check`. */
   readonly isHealthCheck: boolean
+  /** Routing `gtd: tests green` — ends a health-fix run for counter purposes. */
+  readonly isTestsGreen: boolean
 }
 
 /** The terminal working-tree snapshot the ladder branches on. */
@@ -126,6 +128,10 @@ export interface ResolvePayload {
   readonly architectureExists: boolean
   /** The present `ARCHITECTURE.md` is tracked at HEAD. */
   readonly architectureCommitted: boolean
+  /** `PLAN.md` exists (committed or pending) — a final, decompose-as-is architecture. */
+  readonly planExists: boolean
+  /** The present `PLAN.md` is tracked at HEAD. */
+  readonly planCommitted: boolean
   /** Numbered work packages exist under `.gtd/` (committed or pending). NOT "the directory exists" — steering files share `.gtd/`, so bare dir presence means nothing. */
   readonly packagesPresent: boolean
   /** `REVIEW.md` is present (committed and/or pending). */
@@ -247,6 +253,11 @@ export interface ResolvePayload {
  *                          short scaffold banner) as `ARCHITECTURE.md`, and
  *                          deletes `TODO.md` — the grilling→architecting
  *                          hand-off, all in this one commit.
+ *                          `seedArchitectureFromPlan` mirrors it for the
+ *                          PLAN.md entry: reads the present `PLAN.md`, writes
+ *                          its content (with a banner) as `ARCHITECTURE.md`,
+ *                          and deletes `PLAN.md` — the direct-to-decompose
+ *                          hand-off.
  *   - `runTest`          — run the configured test command; on red write
  *                          FEEDBACK (below cap) or ERRORS (`capReached`),
  *                          commit `gtd: errors`; on green commit
@@ -272,6 +283,7 @@ export type EdgeAction =
       readonly kind: "commitRouting"
       readonly subject: string
       readonly seedArchitectureFromTodo?: boolean
+      readonly seedArchitectureFromPlan?: boolean
       readonly removeArchitecture?: boolean
       readonly removeReview?: boolean
       readonly removeFeedback?: boolean
@@ -358,8 +370,11 @@ export class GtdStateError extends Error {
  *   `removedErrors`} and increments on `isErrors`.
  * - `reviewFixCount` resets to 0 on `isPackageStart` and increments on
  *   `isFeedback`.
- * - `healthFixCount` resets to 0 on `isPackageStart` and `removedErrors`, and
- *   increments on `isHealthCheck`.
+ * - `healthFixCount` resets to 0 on `isPackageStart`, `removedErrors`, and
+ *   `isTestsGreen` (a green re-test ends the health run — without this reset,
+ *   a run that ends without a history-collapsing squash would leave the count
+ *   lingering and re-trigger the learning/squash chain at later idle rests),
+ *   and increments on `isHealthCheck`.
  */
 /**
  * One counter's reset/increment rule, read off a `CommitEvent`: `resetsOn`
@@ -383,7 +398,7 @@ const counterRules: Record<keyof Counters, CounterRule> = {
     incrementsOn: (e) => e.isFeedback,
   },
   healthFixCount: {
-    resetsOn: (e) => e.isPackageStart || e.removedErrors,
+    resetsOn: (e) => e.isPackageStart || e.removedErrors || e.isTestsGreen,
     incrementsOn: (e) => e.isHealthCheck,
   },
 }
@@ -440,6 +455,8 @@ export const DEFAULT_PAYLOAD: ResolvePayload = {
   todoCommitted: false,
   architectureExists: false,
   architectureCommitted: false,
+  planExists: false,
+  planCommitted: false,
   packagesPresent: false,
   reviewPresent: false,
   feedbackPresent: false,
@@ -518,6 +535,53 @@ const healthFileConflictRules: readonly IllegalCombinationRule[] = [
   {
     isViolated: (p) => p.healthPresent && p.errorsPresent,
     message: ".gtd/HEALTH.md + .gtd/ERRORS.md",
+  },
+  // HEALTH.md now doubles as an entry file (a hand-written error description
+  // enters the fix loop directly), so it must be unambiguous against the
+  // other entry files. This also outlaws scribbling a next-feature TODO.md/
+  // ARCHITECTURE.md draft while a health detour is live — previously a
+  // tolerated ride-along that silently misattributed the draft into the
+  // health-fixer's turn; now a refused guess.
+  {
+    isViolated: (p) => p.healthPresent && p.todoExists,
+    message: ".gtd/HEALTH.md + .gtd/TODO.md",
+  },
+  {
+    isViolated: (p) => p.healthPresent && p.architectureExists,
+    message: ".gtd/HEALTH.md + .gtd/ARCHITECTURE.md",
+  },
+  {
+    isViolated: (p) => p.healthPresent && p.planExists,
+    message: ".gtd/HEALTH.md + .gtd/PLAN.md",
+  },
+]
+
+// PLAN.md is a pure entry file: it exists only between the human writing it
+// and the entry turn's seed hop consuming it, so it may never coexist with
+// any other steering state. The SQUASH_MSG.md/LEARNINGS.md rules are
+// defensive (like `learningFileConflictRules`): without them a stray PLAN.md
+// would ride into a squash/learning capture, strand committed at a boundary
+// HEAD, and silently block every future dirty-boundary entry.
+const planFileConflictRules: readonly IllegalCombinationRule[] = [
+  { isViolated: (p) => p.planExists && p.todoExists, message: ".gtd/PLAN.md + .gtd/TODO.md" },
+  {
+    isViolated: (p) => p.planExists && p.architectureExists,
+    message: ".gtd/PLAN.md + .gtd/ARCHITECTURE.md",
+  },
+  { isViolated: (p) => p.planExists && p.packagesPresent, message: ".gtd/PLAN.md + packages" },
+  { isViolated: (p) => p.planExists && p.reviewPresent, message: ".gtd/PLAN.md + .gtd/REVIEW.md" },
+  {
+    isViolated: (p) => p.planExists && p.feedbackPresent,
+    message: ".gtd/PLAN.md + .gtd/FEEDBACK.md",
+  },
+  { isViolated: (p) => p.planExists && p.errorsPresent, message: ".gtd/PLAN.md + .gtd/ERRORS.md" },
+  {
+    isViolated: (p) => p.planExists && p.squashMsgPresent,
+    message: ".gtd/PLAN.md + .gtd/SQUASH_MSG.md",
+  },
+  {
+    isViolated: (p) => p.planExists && p.learningMsgPresent,
+    message: ".gtd/PLAN.md + .gtd/LEARNINGS.md",
   },
 ]
 
@@ -626,6 +690,7 @@ const assertLegal = (p: ResolvePayload): void => {
   for (const rule of [
     ...healthFileConflictRules,
     ...learningFileConflictRules,
+    ...planFileConflictRules,
     ...reviewAndFeedbackRules,
   ]) {
     if (rule.isViolated(p)) {
@@ -681,6 +746,7 @@ const nextAfterReviewOrLearning = (
 interface ClassifyFlags {
   readonly headTurnIsEmpty: boolean
   readonly hasPackages: boolean
+  readonly planExists: boolean
   readonly agenticReviewForceApproved: boolean
   readonly squashEnabled: boolean
   readonly hasSquashBase: boolean
@@ -794,6 +860,31 @@ const classifyHead = (subject: string, flags: ClassifyFlags): HeadClass | null =
             action: { kind: "commitRouting", subject: "gtd: grilled" },
           }
         : { kind: "rest", state: "architecting", actor: "agent" }
+    }
+
+    if (actor === "human" && gate === "grilled") {
+      // The PLAN.md entry turn: the human handed the machine a final
+      // architecture (`.gtd/PLAN.md`) — seed `.gtd/ARCHITECTURE.md` from it
+      // and route straight to the decompose rest. Guarded on the plan file
+      // actually being present (mirrors the `hasPackages` guard on the agent's
+      // decompose turn below): a hand-crafted history without PLAN.md, or a
+      // crash half-way through the seed (ARCHITECTURE.md written, PLAN.md
+      // deleted, commit failed), must not overwrite an already-seeded
+      // ARCHITECTURE.md with a banner-only body — fall through to the ladder
+      // instead, whose `architectureExists` rung recovers the half-seeded
+      // crash through a normal architecting round.
+      return flags.planExists
+        ? {
+            kind: "mid-chain",
+            state: "grilled",
+            actor: "agent",
+            action: {
+              kind: "commitRouting",
+              subject: "gtd: grilled",
+              seedArchitectureFromPlan: true,
+            },
+          }
+        : null
     }
 
     if (actor === "agent" && gate === "grilled") {
@@ -1034,7 +1125,11 @@ const gateForState = (state: GtdState): TurnGate =>
  * (CLAUDE.md/AGENTS.md/docs), so it's unconditionally inert on a clean tree,
  * same as `building`/`fixing`. `health-fixing` is deliberately absent: its
  * empty turn is meaningful (environmental fix; the machine removes
- * HEALTH.md and re-tests).
+ * HEALTH.md and re-tests) — EXCEPT while HEAD is the human's hand-written
+ * HEALTH.md entry turn (`gtd(human): health-fixing`), where the loop
+ * protocol's opening clean-tree `gtd step-agent` would otherwise consume the
+ * human's error description before any agent read it (see
+ * `isInertEmptyAgentRest`).
  */
 const INERT_EMPTY_AGENT_GATES: ReadonlySet<GtdState> = new Set([
   "grilling",
@@ -1048,6 +1143,16 @@ const INERT_EMPTY_AGENT_GATES: ReadonlySet<GtdState> = new Set([
 ])
 
 /**
+ * HEAD is the human's HEALTH.md entry turn (`gtd(human): health-fixing`) —
+ * the hand-written error description was just captured and no agent has
+ * acted on it yet.
+ */
+const isHumanHealthEntryHead = (head: string): boolean => {
+  const parsed = parseSubject(head)
+  return parsed.kind === "turn" && parsed.actor === "human" && parsed.gate === "health-fixing"
+}
+
+/**
  * True when a `step-agent` invocation at this rest has nothing to capture —
  * see `INERT_EMPTY_AGENT_GATES`. Shared by `applyTurnTaking` (author nothing)
  * and `predictTurn` (predict null) so the two can never disagree.
@@ -1056,7 +1161,8 @@ const isInertEmptyAgentRest = (state: GtdState, p: ResolvePayload): boolean =>
   p.workingTreeClean &&
   (INERT_EMPTY_AGENT_GATES.has(state) ||
     (state === "squashing" && p.squashMsgIsTemplate) ||
-    (state === "learning" && p.learningMsgIsTemplate))
+    (state === "learning" && p.learningMsgIsTemplate) ||
+    (state === "health-fixing" && isHumanHealthEntryHead(p.lastCommitSubject)))
 
 /**
  * The baseline decision: classify HEAD, falling through to the payload-driven
@@ -1167,6 +1273,7 @@ const resolveBaseline = (
   const flags: ClassifyFlags = {
     headTurnIsEmpty: p.headTurnIsEmpty,
     hasPackages: p.packagesPresent,
+    planExists: p.planExists,
     agenticReviewForceApproved: forceApprove,
     squashEnabled: p.squashEnabled,
     hasSquashBase: p.squashBase !== undefined,
@@ -1258,6 +1365,18 @@ const resolveBaseline = (
     return { kind: "rest", state: "architecting", actor: "agent" }
   }
 
+  // PLAN.md present, boundary/other HEAD. Unlike TODO.md/ARCHITECTURE.md
+  // (agent-developed mid-process), PLAN.md is only ever human-authored entry
+  // input, so the awaited actor is the HUMAN: the ordinary case is the
+  // pre-entry dirty boundary (the entry turn in `applyTurnTaking`
+  // short-circuits this baseline), and the recovery case is a committed
+  // PLAN.md at a boundary HEAD, where the human's `gtd step` resumes the
+  // entry (captures `gtd(human): grilled`, which seeds and routes) instead of
+  // corrupting. An agent invocation here is refused as out-of-turn.
+  if (p.planExists) {
+    return { kind: "rest", state: "grilled", actor: "human" }
+  }
+
   // `.gtd/` exists with a pending package, and the nearest workflow commit
   // (skipping any boundary commits on top of it) is still the
   // `gtd(agent): building` checkpoint — an operational recovery commit (e.g. a
@@ -1294,7 +1413,8 @@ const resolveBaseline = (
     !p.errorsPresent &&
     !p.healthPresent &&
     !p.todoExists &&
-    !p.architectureExists
+    !p.architectureExists &&
+    !p.planExists
   ) {
     return resolveIdleOrHealth(p)
   }
@@ -1338,26 +1458,40 @@ const applyTurnTaking = (
   // feature's dirty tree lands), even though it parses as a `"routing"`
   // subject in the general taxonomy.
   //
-  // Escape hatch: which gate the entry turn is captured under depends on
-  // whether the human's dirty tree already contains `.gtd/ARCHITECTURE.md`
-  // — an already-technical sketch skips product grilling entirely and enters
-  // directly at `architecting` (file *presence*, never content, decides
-  // this — the same mechanism every other steering-file rung in this
-  // ladder already uses).
+  // Entry points: which gate the entry turn is captured under depends on
+  // which steering file the human's dirty tree already contains (file
+  // *presence*, never content, decides this — the same mechanism every other
+  // steering-file rung in this ladder already uses):
+  //   - `.gtd/HEALTH.md`       → `health-fixing` (a hand-written error
+  //                              description enters the fix loop directly)
+  //   - `.gtd/PLAN.md`         → `grilled` (a final architecture goes
+  //                              straight to decomposition)
+  //   - `.gtd/ARCHITECTURE.md` → `architecting` (an already-technical sketch
+  //                              skips product grilling)
+  //   - anything else          → `grilling` (product grilling, the default)
+  // The four are pairwise illegal combinations (`assertLegal`), so the pick
+  // order below is inert.
   const isDirtyBoundaryEntry =
     invoker === "human" &&
     !p.workingTreeClean &&
     !p.todoCommitted &&
     !p.architectureCommitted &&
+    !p.planCommitted &&
     !p.packagesPresent &&
     !p.reviewPresent &&
     !p.feedbackPresent &&
     !p.errorsPresent &&
-    !p.healthPresent &&
+    !p.healthCommitted &&
     (parseSubject(head).kind === "boundary" || head === "gtd: done")
 
   if (isDirtyBoundaryEntry) {
-    const entryGate: TurnGate = p.architectureExists ? "architecting" : "grilling"
+    const entryGate: TurnGate = p.healthPresent
+      ? "health-fixing"
+      : p.planExists
+        ? "grilled"
+        : p.architectureExists
+          ? "architecting"
+          : "grilling"
     return {
       state: entryGate as GtdState,
       actor: "human",
@@ -1409,10 +1543,13 @@ const applyTurnTaking = (
     (head === "gtd: health-fix" && baseline.state === "idle") ||
     (healthCheckCapReached && baseline.state === "health-fixing")
   ) {
+    // `healthFixBase !== undefined` alone: the edge only anchors a base for a
+    // live, unprocessed health run (the anchor scan resets on `gtd: tests
+    // green`), and a hand-written-HEALTH.md entry run whose first fix goes
+    // green has a base but ZERO `gtd: health-check` commits — so a count
+    // conjunct would wrongly skip its squash/learning chain.
     const chainAfterGreenAtHealthFix =
-      (p.squashEnabled || p.learningEnabled) &&
-      counters.healthFixCount > 0 &&
-      p.healthFixBase !== undefined
+      (p.squashEnabled || p.learningEnabled) && p.healthFixBase !== undefined
     return {
       state: "idle",
       actor: "agent",
@@ -1453,10 +1590,9 @@ const applyTurnTaking = (
   // Idle carve-out: a human step at idle always re-runs the health check —
   // never an empty turn commit, and never a plain fixpoint no-op.
   if (baseline.state === "idle" && invoker === "human") {
-    const chainAfterGreen =
-      (p.squashEnabled || p.learningEnabled) &&
-      counters.healthFixCount > 0 &&
-      p.healthFixBase !== undefined
+    // Same reasoning as `chainAfterGreenAtHealthFix` above: base presence is
+    // the whole signal.
+    const chainAfterGreen = (p.squashEnabled || p.learningEnabled) && p.healthFixBase !== undefined
     return {
       state: "idle",
       actor: "human",
@@ -1635,14 +1771,21 @@ export const predictTurn = (events: readonly GtdEvent[]): TurnPrediction => {
     !payload.workingTreeClean &&
     !payload.todoCommitted &&
     !payload.architectureCommitted &&
+    !payload.planCommitted &&
     !payload.packagesPresent &&
     !payload.reviewPresent &&
     !payload.feedbackPresent &&
     !payload.errorsPresent &&
-    !payload.healthPresent &&
+    !payload.healthCommitted &&
     (parseSubject(head).kind === "boundary" || head === "gtd: done")
   if (isDirtyBoundaryEntry) {
-    const entryGate: TurnGate = payload.architectureExists ? "architecting" : "grilling"
+    const entryGate: TurnGate = payload.healthPresent
+      ? "health-fixing"
+      : payload.planExists
+        ? "grilled"
+        : payload.architectureExists
+          ? "architecting"
+          : "grilling"
     return {
       actor: "human",
       subject: `gtd(human): ${entryGate}`,

--- a/src/ReviewWindow.test.ts
+++ b/src/ReviewWindow.test.ts
@@ -31,6 +31,28 @@ describe("reviewWindowBase", () => {
     expect(base).toBe("h2")
   })
 
+  it("picks the architecting entry turn for an escape-hatch cycle (no grilling turn at all)", () => {
+    const base = reviewWindowBase([
+      entry("h1", "chore: boundary"),
+      entry("h2", "gtd(human): architecting"),
+      entry("h3", "gtd(agent): grilled"),
+      entry("h4", "gtd(agent): building"),
+      entry("h5", "gtd: awaiting review"), // HEAD — excluded
+    ])
+    expect(base).toBe("h2")
+  })
+
+  it("picks the grilled entry turn for a PLAN.md cycle (no grilling/architecting turn at all)", () => {
+    const base = reviewWindowBase([
+      entry("h1", "chore: boundary"),
+      entry("h2", "gtd(human): grilled"),
+      entry("h3", "gtd(agent): grilled"),
+      entry("h4", "gtd(agent): building"),
+      entry("h5", "gtd: awaiting review"), // HEAD — excluded
+    ])
+    expect(base).toBe("h2")
+  })
+
   it("prefers the previous awaiting-review over the first grilling turn", () => {
     const base = reviewWindowBase([
       entry("h1", "gtd(human): grilling"),

--- a/src/ReviewWindow.ts
+++ b/src/ReviewWindow.ts
@@ -71,7 +71,15 @@ export const reviewWindowBase = (
     if (parsed.kind === "routing" && parsed.phase === "awaiting-review") {
       lastAwaitingReview = c.hash
     }
-    if (parsed.kind === "turn" && parsed.gate === "grilling" && firstGrilling === undefined) {
+    // All three entry-capable gates count as the cycle start (mirrors
+    // `isGrillingTurn` in src/Events.ts): `architecting` covers the
+    // ARCHITECTURE.md escape-hatch entry and `grilled` the PLAN.md entry —
+    // without them the window silently never opens for those cycles.
+    if (
+      parsed.kind === "turn" &&
+      (parsed.gate === "grilling" || parsed.gate === "architecting" || parsed.gate === "grilled") &&
+      firstGrilling === undefined
+    ) {
       firstGrilling = c.hash
     }
   }

--- a/src/State.test.ts
+++ b/src/State.test.ts
@@ -91,6 +91,16 @@ describe("describeEdgeAction (exhaustive over EdgeAction)", () => {
     ).toBe('commit routing as "gtd: architecting" (seeding .gtd/ARCHITECTURE.md from .gtd/TODO.md)')
   })
 
+  it("commitRouting notes the seedArchitectureFromPlan hand-off", () => {
+    expect(
+      describeEdgeAction({
+        kind: "commitRouting",
+        subject: "gtd: grilled",
+        seedArchitectureFromPlan: true,
+      }),
+    ).toBe('commit routing as "gtd: grilled" (seeding .gtd/ARCHITECTURE.md from .gtd/PLAN.md)')
+  })
+
   it("commitRouting lists removeLearning", () => {
     expect(
       describeEdgeAction({

--- a/src/State.ts
+++ b/src/State.ts
@@ -28,6 +28,9 @@ const edgeActionHandlers: EdgeActionHandlers = {
     if (a.seedArchitectureFromTodo) {
       msg += " (seeding .gtd/ARCHITECTURE.md from .gtd/TODO.md)"
     }
+    if (a.seedArchitectureFromPlan) {
+      msg += " (seeding .gtd/ARCHITECTURE.md from .gtd/PLAN.md)"
+    }
     const removed: string[] = []
     if (a.removeArchitecture) removed.push(".gtd/ARCHITECTURE.md")
     if (a.removeReview) removed.push(".gtd/REVIEW.md")

--- a/src/prompts/health-fixing.md
+++ b/src/prompts/health-fixing.md
@@ -1,11 +1,11 @@
 <%~ include("@header") %>
 
-The idle health check failed — the repository's test suite is red outside any
-work cycle. Spawn a **fix subagent** using model `<%= it.model %>` to repair
-it:
+The repository's health gate is red outside any work cycle — either the idle
+health check failed, or a human hand-wrote `.gtd/HEALTH.md` describing errors
+to fix. Spawn a **fix subagent** using model `<%= it.model %>` to repair it:
 
-1. **Work through the failure output below** — make the failing test command
-   pass again.
+1. **Work through the report below** — fix the described errors and make the
+   test command pass.
 2. **Make the fix in place** — keep the change focused; do not refactor
    unrelated code.
 3. **If the failure does not reproduce** (or nothing needs changing), change

--- a/tests/integration/features/entry-points.feature
+++ b/tests/integration/features/entry-points.feature
@@ -1,0 +1,255 @@
+@inmem
+Feature: Entry points — which steering file the dirty tree contains picks the phase a cycle starts at
+
+  A human's `gtd step` on a dirty tree at a boundary HEAD is the v2 entry
+  turn. WHICH gate it is captured under is driven purely by steering-file
+  presence (never content), so a cycle can start at any phase:
+
+  | file in the dirty tree | entry                                            |
+  | none (plain notes)     | product grilling (`gtd(human): grilling`)        |
+  | .gtd/TODO.md           | product grilling (the draft product plan)        |
+  | .gtd/ARCHITECTURE.md   | technical grilling (`gtd(human): architecting`)  |
+  | .gtd/PLAN.md           | decomposition (`gtd(human): grilled`)            |
+  | .gtd/HEALTH.md         | error fixing (`gtd(human): health-fixing`)       |
+
+  A `.gtd/PLAN.md` is a FINAL architecture: the entry turn commits it, then a
+  mid-chain hop seeds `.gtd/ARCHITECTURE.md` from it (deleting PLAN.md) and
+  routes straight to the decompose rest — no grilling round ever runs. A
+  hand-written `.gtd/HEALTH.md` is an error description: the entry turn
+  commits it and rests at health-fixing for the agent; the normal health
+  detour (fix → re-test → cap/escalate → squash/learning tail) takes over.
+  The entry files are pairwise illegal combinations, so the pick is always
+  unambiguous.
+
+  Scenario: A dirty tree seeded with PLAN.md enters directly at decomposition
+    Given a test project
+    And a file ".gtd/PLAN.md" with:
+      """
+      # Plan
+
+      Split the calculator into parser and evaluator modules.
+      """
+    When I run gtd step
+    Then it succeeds
+    And the last commit subject is "gtd: grilled"
+    And the git log contains "gtd(human): grilled"
+    And the git log does not contain "gtd(human): grilling"
+    And the git log does not contain "gtd(human): architecting"
+    And the file ".gtd/PLAN.md" does not exist
+    And the file ".gtd/ARCHITECTURE.md" exists
+    And the file ".gtd/ARCHITECTURE.md" contains "Split the calculator into parser and evaluator modules."
+    And the file ".gtd/ARCHITECTURE.md" contains "seeded from the final plan"
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "Decompose it into an ordered set of"
+
+  Scenario: The PLAN.md entry proceeds through decompose into planning with no further special-casing
+    Given a test project
+    And a file ".gtd/PLAN.md" with:
+      """
+      # Plan
+
+      Split the calculator into parser and evaluator modules.
+      """
+    And I run gtd step
+    And a file ".gtd/01-parser/01-extract-parser.md" with:
+      """
+      # Extract the parser
+
+      - [ ] parser.ts exists
+      """
+    When I run gtd step-agent
+    Then it succeeds
+    And the git log contains "gtd(agent): grilled"
+    And the last commit subject is "gtd: planning"
+    And the file ".gtd/ARCHITECTURE.md" does not exist
+    And the file ".gtd/01-parser/01-extract-parser.md" exists
+
+  Scenario: A PLAN.md-entry cycle still reaches the human review gate (the review base anchors on the entry turn)
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      testCommand: "true"
+      agenticReview: false
+      squash: false
+      learning: false
+      """
+    And a file ".gtd/PLAN.md" with:
+      """
+      # Plan
+
+      Split the calculator into parser and evaluator modules.
+      """
+    And I run gtd step
+    And a file ".gtd/01-parser/01-extract-parser.md" with:
+      """
+      # Extract the parser
+
+      - [ ] parser.ts exists
+      """
+    And I run gtd step-agent
+    And a file "parser.ts" with:
+      """
+      export const parse = (s: string) => s
+      """
+    When I run gtd step-agent
+    Then it succeeds
+    And the git log contains "gtd: tests green"
+    And the last commit subject is "gtd: package done"
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"state\":\"review\""
+    And stdout contains "\"actor\":\"agent\""
+
+  Scenario: A dirty tree with a hand-written HEALTH.md enters directly at error fixing
+    Given a test project
+    And a file ".gtd/HEALTH.md" with:
+      """
+      The build breaks on Node 22 with ERR_REQUIRE_ESM in scripts/build.mjs.
+      """
+    When I run gtd step
+    Then it succeeds
+    And the last commit subject is "gtd(human): health-fixing"
+    And the file ".gtd/HEALTH.md" exists
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"actor\":\"agent\""
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "ERR_REQUIRE_ESM"
+
+  Scenario: The loop protocol's opening clean step-agent is inert at the HEALTH.md entry — the hand-written description survives unread
+    Given a test project
+    And a file ".gtd/HEALTH.md" with:
+      """
+      The build breaks on Node 22 with ERR_REQUIRE_ESM in scripts/build.mjs.
+      """
+    And I run gtd step
+    And I record the commit count
+    When I run gtd step-agent
+    Then it succeeds
+    And the commit count is unchanged
+    And the file ".gtd/HEALTH.md" exists
+    And the file ".gtd/HEALTH.md" contains "ERR_REQUIRE_ESM"
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "ERR_REQUIRE_ESM"
+
+  Scenario: A HEALTH.md-entry fix that goes green first try still chains into the squash template
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      testCommand: "true"
+      squash: true
+      learning: false
+      """
+    And a file ".gtd/HEALTH.md" with:
+      """
+      scripts/build.mjs crashes on startup.
+      """
+    And I run gtd step
+    And a file "scripts/build.mjs" with:
+      """
+      export const fixed = true
+      """
+    When I run gtd step-agent
+    Then it succeeds
+    And the git log contains "gtd(human): health-fixing"
+    And the git log contains "gtd(agent): health-fixing"
+    And the git log contains "gtd: health-fix"
+    And the git log contains "gtd: tests green"
+    And the git log contains "gtd: squash template"
+    And the file ".gtd/HEALTH.md" does not exist
+    And the file ".gtd/SQUASH_MSG.md" exists
+
+  Scenario: A HEALTH.md-entry fix that stays red re-enters the normal health-check loop
+    Given a test project
+    And a commit "chore: test gate" that adds "gate.sh" with:
+      """
+      echo SENTINEL_STILL_RED
+      exit 1
+      """
+    And a gtd config file at ".gtdrc" with:
+      """
+      testCommand: bash gate.sh
+      """
+    And a file ".gtd/HEALTH.md" with:
+      """
+      Something is broken in gate.sh.
+      """
+    And I run gtd step
+    And a file "attempt.ts" with:
+      """
+      export const attempt = 1
+      """
+    When I run gtd step-agent
+    Then it succeeds
+    And the git log contains "gtd(agent): health-fixing"
+    And the git log contains "gtd: health-fix"
+    And the last commit subject is "gtd: health-check"
+    And the file ".gtd/HEALTH.md" exists
+    And the file ".gtd/HEALTH.md" contains "SENTINEL_STILL_RED"
+
+  Scenario: gtd status predicts the PLAN.md and HEALTH.md entry turns
+    Given a test project
+    And a file ".gtd/PLAN.md" with:
+      """
+      # Plan
+
+      Split the calculator into parser and evaluator modules.
+      """
+    When I run gtd status with "--json"
+    Then it succeeds
+    And stdout contains "\"predictedCommit\":\"gtd(human): grilled\""
+
+  Scenario: gtd status predicts the HEALTH.md entry turn
+    Given a test project
+    And a file ".gtd/HEALTH.md" with:
+      """
+      The build is broken.
+      """
+    When I run gtd status with "--json"
+    Then it succeeds
+    And stdout contains "\"predictedCommit\":\"gtd(human): health-fixing\""
+
+  Scenario: PLAN.md next to TODO.md is an illegal combination — the entry refuses to guess
+    Given a test project
+    And a file ".gtd/PLAN.md" with:
+      """
+      # Plan
+      """
+    And a file ".gtd/TODO.md" with:
+      """
+      # Todo
+      """
+    When I run gtd step
+    Then it fails
+    And stderr contains "illegal combination: .gtd/PLAN.md + .gtd/TODO.md"
+
+  Scenario: PLAN.md next to ARCHITECTURE.md is an illegal combination
+    Given a test project
+    And a file ".gtd/PLAN.md" with:
+      """
+      # Plan
+      """
+    And a file ".gtd/ARCHITECTURE.md" with:
+      """
+      # Architecture
+      """
+    When I run gtd step
+    Then it fails
+    And stderr contains "illegal combination: .gtd/PLAN.md + .gtd/ARCHITECTURE.md"
+
+  Scenario: A hand-written HEALTH.md next to TODO.md is an illegal combination
+    Given a test project
+    And a file ".gtd/HEALTH.md" with:
+      """
+      The build is broken.
+      """
+    And a file ".gtd/TODO.md" with:
+      """
+      # Todo
+      """
+    When I run gtd step
+    Then it fails
+    And stderr contains "illegal combination: .gtd/HEALTH.md + .gtd/TODO.md"


### PR DESCRIPTION
The dirty-boundary entry turn's gate is now picked by which steering file
the human's tree contains, giving four entry points: plain notes/TODO.md
start product grilling (unchanged), ARCHITECTURE.md starts technical
grilling (the former escape hatch, unchanged), a new .gtd/PLAN.md holds a
FINAL architecture and enters straight at decomposition, and a hand-written
.gtd/HEALTH.md enters straight at error fixing.

- PLAN.md entry captures gtd(human): grilled; a new classifyHead branch
  (guarded on the file's presence) mid-chains to
  `commitRouting "gtd: grilled", seedArchitectureFromPlan: true`, seeding
  ARCHITECTURE.md from PLAN.md so decompose and everything downstream stay
  untouched. A PLAN.md ladder rung (rest grilled/human) covers the
  pre-entry and stranded-committed states.
- HEALTH.md entry captures gtd(human): health-fixing; the existing
  steering-file precedence rung takes over. The loop protocol's opening
  clean `gtd step-agent` is inert while HEAD is the entry turn, so the
  hand-written description survives until an agent reads it.
- Cycle anchors learn the new entries: squash/review bases accept the
  `grilled` gate (reviewWindowBase also gains the previously missing
  `architecting` gate), and healthFixBase anchors on the earliest of the
  first gtd: health-check or the human entry turn — so a green-first-try
  entry fix still chains into learning/squash.
- New CommitEvent flag isTestsGreen resets healthFixCount and the
  healthFixBase scan (except the run's own green marker while HEAD is
  inside the post-green chain), fixing the pre-existing residue bug where
  a processed health run re-triggered the learning/squash chain at later
  idle rests; chainAfterGreen now keys on base presence alone.
- New illegal combinations keep the entry files pairwise unambiguous:
  PLAN.md against every other steering file, and HEALTH.md against
  TODO.md/ARCHITECTURE.md/PLAN.md (a next-feature draft scribbled during a
  live health detour is now a refused guess, not a silent ride-along).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qc7VqpmTMCq1KpFq8PpYvK