### PR TITLE
feat: gtd mermaid — render the active workflow's shape as Mermaid stateDiagram-v2

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,6 +13,8 @@ Commands:
                    actor (the built-in script driver)
   status           Print the resolved rest's state/actor and which declared
                    pattern (if any) each pending change matches (no mutation)
+  mermaid          Print the active workflow's shape as Mermaid
+                   stateDiagram-v2 source (no mutation)
   format <file>    Format a markdown file in place
   lsp              Start the LSP server for .gtd/ steering files (stdio)
 
@@ -175,6 +177,46 @@ never `null`, otherwise):
 
 `gtd status` takes no arguments — extra positional args are rejected.
 
+## `gtd mermaid`
+
+Pure emitter of the active workflow's **shape** — not the resolved rest — as
+Mermaid [`stateDiagram-v2`](https://mermaid.js.org/syntax/stateDiagram.html)
+source (see `src/Mermaid.ts`): one node per declared state, the `[*] -->`
+initial-state marker, one edge per declared `on` row labeled with its raw
+pattern string (same declaration order the engine itself evaluates), a `--> [*]`
+edge for every commit state (final, no outgoing edges — see
+[STATES.md §8](../STATES.md#8-the-squash-lifecycle)), and one `note right of`
+per rest naming its actor, content kind, and retry cap (e.g.
+`agent · prompt · retry 3→escalate`). No git, no HEAD resolution, no template
+rendering — purely a function of the compiled `WorkflowDefinition`, so its
+output is identical regardless of the current process/branch state.
+
+```
+$ gtd mermaid
+stateDiagram-v2
+    state "idle" as idle
+    state "grilling" as grilling
+    ...
+    [*] --> idle
+    idle --> grilling : * **
+    ...
+    note right of idle : human · message
+    ...
+```
+
+Pipe it straight into a `.md`/`.mmd` file, a GitHub issue/PR description, or any
+Mermaid-aware renderer (GitHub, GitLab, VS Code, Obsidian, the
+[Mermaid Live Editor](https://mermaid.live)) to get a diagram of a custom
+`.gtdrc` `workflow:` with no hand-maintained docs required.
+
+State names are aliased to Mermaid-safe identifiers (non-word characters fold to
+`_`; a digit-led name gets an `s_` prefix) via a `state "<name>" as <alias>`
+declaration up front, so a hyphenated name like `todo-validating` still displays
+with its exact declared spelling. Rejects `--json` (exit 1,
+`gtd mermaid does not accept --json`) — there is no structured shape to emit
+beyond the Mermaid source itself — and takes no arguments (extra positional args
+are rejected).
+
 ## `gtd format <file>`
 
 Formats a markdown file in place with a bundled prettier (`parser: "markdown"`,
@@ -249,7 +291,7 @@ the plain-text one.
   green run, and the check's `"C"` pattern never fires. Gitignore every path
   your scripts write before wiring gtd into a repo.
 - **Repository root invocation.** Every state subcommand (`step`/`next`/`run`/
-  `status`) must run from the git repository root — the workflow, pending
-  changes, and process history are resolved against the process cwd.
+  `status`/`mermaid`) must run from the git repository root — the workflow,
+  pending changes, and process history are resolved against the process cwd.
   `--help`/`--version`, `format`, and `lsp` skip this guard entirely (and any
   git/`.gtdrc` dependency along with it).

--- a/src/Mermaid.test.ts
+++ b/src/Mermaid.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest"
+import { renderMermaid } from "./Mermaid.js"
+import { defaultWorkflowDefinition } from "./workflows/default.js"
+import type { WorkflowDefinition } from "./PatternMachine.js"
+
+const simpleWorkflow: WorkflowDefinition = {
+  states: {
+    idle: {
+      actor: "human",
+      message: "waiting",
+      initial: true,
+      on: [["* **", "working"]],
+    },
+    working: {
+      actor: "agent",
+      prompt: "do the thing",
+      on: [["A DONE.md", "done"]],
+    },
+    done: {
+      commit: "chore: done",
+    },
+  },
+}
+
+describe("renderMermaid", () => {
+  it("opens with the stateDiagram-v2 header", () => {
+    expect(renderMermaid(simpleWorkflow)).toMatch(/^stateDiagram-v2\n/)
+  })
+
+  it("declares every state with its exact name, aliased", () => {
+    const out = renderMermaid(simpleWorkflow)
+    expect(out).toContain('state "idle" as idle')
+    expect(out).toContain('state "working" as working')
+    expect(out).toContain('state "done" as done')
+  })
+
+  it("marks the initial state", () => {
+    expect(renderMermaid(simpleWorkflow)).toContain("[*] --> idle")
+  })
+
+  it("emits one edge per on row, labeled with the raw pattern", () => {
+    const out = renderMermaid(simpleWorkflow)
+    expect(out).toContain("idle --> working : * **")
+    expect(out).toContain("working --> done : A DONE.md")
+  })
+
+  it("routes a commit state to the final marker instead of an on row", () => {
+    expect(renderMermaid(simpleWorkflow)).toContain("done --> [*]")
+  })
+
+  it("notes each rest's actor and content kind, but never a commit state", () => {
+    const out = renderMermaid(simpleWorkflow)
+    expect(out).toContain("note right of idle : human · message")
+    expect(out).toContain("note right of working : agent · prompt")
+    expect(out).not.toContain("note right of done")
+  })
+
+  it("notes a retry cap alongside actor/content kind", () => {
+    const withRetry: WorkflowDefinition = {
+      states: {
+        ...simpleWorkflow.states,
+        working: {
+          ...simpleWorkflow.states["working"]!,
+          retry: { max: 3, otherwise: "idle" },
+        },
+      },
+    }
+    expect(renderMermaid(withRetry)).toContain(
+      "note right of working : agent · prompt · retry 3→idle",
+    )
+  })
+
+  it("aliases a hyphenated state name while preserving its label", () => {
+    const hyphenated: WorkflowDefinition = {
+      states: {
+        "todo-validating": {
+          actor: "check",
+          script: "true",
+          initial: true,
+          on: [["C", "todo-validating"]],
+        },
+      },
+    }
+    const out = renderMermaid(hyphenated)
+    expect(out).toContain('state "todo-validating" as todo_validating')
+    expect(out).toContain("[*] --> todo_validating")
+    expect(out).toContain("todo_validating --> todo_validating : C")
+  })
+
+  it("prefixes an alias when the folded name would start with a digit", () => {
+    const digitLed: WorkflowDefinition = {
+      states: {
+        "3rd-pass": {
+          actor: "human",
+          message: "go",
+          initial: true,
+          on: [["C", "3rd-pass"]],
+        },
+      },
+    }
+    expect(renderMermaid(digitLed)).toContain('state "3rd-pass" as s_3rd_pass')
+  })
+
+  it("escapes a double quote inside a label so the quoted declaration stays valid", () => {
+    const quoted: WorkflowDefinition = {
+      states: {
+        idle: {
+          actor: "human",
+          message: "go",
+          initial: true,
+          on: [['A "weird".md', "idle"]],
+        },
+      },
+    }
+    expect(renderMermaid(quoted)).toContain("idle --> idle : A 'weird'.md")
+  })
+
+  it("renders the bundled default workflow without throwing, covering every state", () => {
+    const out = renderMermaid(defaultWorkflowDefinition)
+    for (const name of Object.keys(defaultWorkflowDefinition.states)) {
+      expect(out).toContain(`"${name}"`)
+    }
+    expect(out).toContain("[*] -->")
+  })
+})

--- a/src/Mermaid.ts
+++ b/src/Mermaid.ts
@@ -1,0 +1,91 @@
+/**
+ * `gtd mermaid`: a pure emitter of the active workflow's SHAPE as Mermaid
+ * `stateDiagram-v2` source — one node per state, the `[*] -->` initial-state
+ * marker, one edge per declared `on` row (labeled with its raw pattern
+ * string), `--> [*]` for every commit state (final, no outgoing edges), and
+ * one `note right of` per rest naming its actor/content-kind/retry cap. No
+ * git, no Effect, no template rendering: same purity discipline as
+ * `PatternMachine.ts` — a plain function of an already-`validateDefinition`d
+ * `WorkflowDefinition` (see `Config.ts`'s `toOperations`/`compileWorkflowConfig`
+ * — every `WorkflowDefinition` this module ever sees has already been
+ * validated, so an `on` target or `retry.otherwise` is trusted to name a
+ * defined state rather than re-checked here).
+ */
+
+import {
+  contentKindOf,
+  initialStateOf,
+  isCommitState,
+  type StateDef,
+  type WorkflowDefinition,
+} from "./PatternMachine.js"
+
+/**
+ * Mermaid identifiers must avoid quotes/newlines inside a quoted label —
+ * collapse both so the label stays on one line and the diagram stays
+ * parseable even if a state name or `on` pattern happens to carry either.
+ */
+const escapeLabel = (text: string): string => text.replace(/"/g, "'").replace(/\r?\n/g, " ")
+
+/**
+ * A Mermaid-safe node id for one state name: every non-word character folds
+ * to `_` (state names may carry hyphens — `todo-validating`,
+ * `review-deciding` — which Mermaid's bare identifier grammar doesn't
+ * guarantee), and a leading digit gets an `s_` prefix (Mermaid ids can't
+ * start with one). The exact original name still reaches the diagram via
+ * this alias's `state "<name>" as <alias>` declaration.
+ */
+const aliasFor = (name: string): string => {
+  const folded = name.replace(/[^A-Za-z0-9_]/g, "_")
+  return /^[0-9]/.test(folded) ? `s_${folded}` : folded
+}
+
+/** One rest's actor/content-kind/retry-cap summary, for a `note right of` line. */
+const stateNote = (state: StateDef): string => {
+  const parts = [state.actor, contentKindOf(state)].filter((p): p is string => p !== undefined)
+  const retry =
+    state.retry !== undefined ? [`retry ${state.retry.max}→${state.retry.otherwise}`] : []
+  return [...parts, ...retry].join(" · ")
+}
+
+/**
+ * Render `def`'s shape as Mermaid `stateDiagram-v2` source. One
+ * `state "<name>" as <alias>` declaration per state up front (so every
+ * transition/note below can reference the safe alias while the rendered
+ * diagram still shows the exact declared name), then the initial-state
+ * marker, then one edge per `on` row (declaration order — same "first match
+ * wins" order the engine itself evaluates), then `<alias> --> [*]` for every
+ * commit state, then one actor/content-kind/retry note per rest.
+ */
+export const renderMermaid = (def: WorkflowDefinition): string => {
+  const names = Object.keys(def.states)
+  const alias = new Map(names.map((name) => [name, aliasFor(name)] as const))
+
+  const lines: string[] = ["stateDiagram-v2"]
+
+  for (const name of names) {
+    lines.push(`    state "${escapeLabel(name)}" as ${alias.get(name)}`)
+  }
+
+  lines.push(`    [*] --> ${alias.get(initialStateOf(def))}`)
+
+  for (const name of names) {
+    const state = def.states[name]!
+    const from = alias.get(name)!
+    if (isCommitState(state)) {
+      lines.push(`    ${from} --> [*]`)
+      continue
+    }
+    for (const [pattern, target] of state.on ?? []) {
+      lines.push(`    ${from} --> ${alias.get(target)} : ${escapeLabel(pattern)}`)
+    }
+  }
+
+  for (const name of names) {
+    const state = def.states[name]!
+    if (isCommitState(state)) continue
+    lines.push(`    note right of ${alias.get(name)} : ${escapeLabel(stateNote(state))}`)
+  }
+
+  return lines.join("\n") + "\n"
+}

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -101,6 +101,7 @@ describe("--help short-circuit", () => {
     expect(output).toContain("next")
     expect(output).toContain("status")
     expect(output).toContain("run")
+    expect(output).toContain("mermaid")
     expect(output).toContain("format")
     expect(output).toMatch(/\n$/)
   })

--- a/src/program.ts
+++ b/src/program.ts
@@ -22,6 +22,7 @@ import {
 } from "./Edge.js"
 import { formatFile } from "./Format.js"
 import { startLspServer } from "./Lsp.js"
+import { renderMermaid } from "./Mermaid.js"
 import {
   matchesPattern,
   parsePattern,
@@ -46,6 +47,8 @@ Commands:
                    actor (the built-in script driver)
   status           Print the resolved rest's state/actor and which declared
                    pattern (if any) each pending change matches (no mutation)
+  mermaid          Print the active workflow's shape as Mermaid
+                   stateDiagram-v2 source (no mutation)
   format <file>    Format a markdown file in place
   lsp              Start the LSP server for .gtd/ steering files (stdio)
 
@@ -403,7 +406,31 @@ const runStatusCommand = (
     }
   })
 
-const KNOWN_SUBCOMMANDS = ["step", "next", "run", "status"] as const
+/**
+ * `gtd mermaid`: pure emitter of the active workflow's SHAPE (not the
+ * resolved rest) as Mermaid `stateDiagram-v2` source — see `src/Mermaid.ts`.
+ * Needs only `ConfigService` (no HEAD resolution, no rendering), but is
+ * dispatched alongside `next`/`status` since it still depends on the active
+ * `.gtdrc` — unlike `format`/`lsp`, which need neither git nor config — so it
+ * goes through the same repository-root guard and auto-init. Rejects
+ * `--json`: there is no structured shape to emit beyond the Mermaid source
+ * itself.
+ */
+const runMermaidCommand = (
+  argv: readonly string[],
+  json: boolean,
+  write: (chunk: string) => void,
+): Effect.Effect<void, Error, ProgramRequirements> =>
+  Effect.gen(function* () {
+    if (json) {
+      return yield* Effect.fail(new Error("gtd mermaid does not accept --json"))
+    }
+    yield* rejectExtraArgs("mermaid", argv)
+    const config = yield* ConfigService
+    write(renderMermaid(config.workflow))
+  })
+
+const KNOWN_SUBCOMMANDS = ["step", "next", "run", "status", "mermaid"] as const
 type KnownSubcommand = (typeof KNOWN_SUBCOMMANDS)[number]
 
 /**
@@ -488,6 +515,8 @@ const dispatchKnownSubcommand = (
       return runRunCommand(argv, json, write)
     case "status":
       return runStatusCommand(argv, json, write)
+    case "mermaid":
+      return runMermaidCommand(argv, json, write)
   }
 }
 

--- a/tests/integration/features/command-surface.feature
+++ b/tests/integration/features/command-surface.feature
@@ -1,9 +1,9 @@
 @inmem
 Feature: Command surface — bare gtd, unknown subcommands, --help, --version
 
-  gtd v3 exposes `step <actor>`, `next`, `run`, `status`, `format`, and `lsp`
-  as its subcommands. Bare `gtd` (no subcommand) is a usage error. `--help`
-  and `--version` short-circuit before any repo-state work and exit 0
+  gtd v3 exposes `step <actor>`, `next`, `run`, `status`, `mermaid`, `format`,
+  and `lsp` as its subcommands. Bare `gtd` (no subcommand) is a usage error.
+  `--help` and `--version` short-circuit before any repo-state work and exit 0
   everywhere, including outside a workflow state.
 
   Scenario: Bare gtd fails with usage help and authors nothing

--- a/tests/integration/features/mermaid.feature
+++ b/tests/integration/features/mermaid.feature
@@ -1,0 +1,88 @@
+@inmem
+Feature: gtd mermaid — the active workflow's shape as Mermaid stateDiagram-v2 source
+
+  `gtd mermaid` (see src/Mermaid.ts) renders the active workflow's SHAPE —
+  states, `on` edges, initial-state marker, commit-state finality, and each
+  rest's actor/content-kind/retry summary — as Mermaid `stateDiagram-v2`
+  source. It never resolves HEAD and never mutates the repository: its output
+  depends only on the compiled `WorkflowDefinition`, not on the current
+  process/branch state.
+
+  Scenario: the bundled default workflow renders every state, the initial marker, and a commit-state finality edge
+    Given a test project
+    When I run gtd with args "mermaid"
+    Then it succeeds
+    And stdout contains "stateDiagram-v2"
+    And stdout contains "state \"idle\" as idle"
+    And stdout contains "state \"grilling\" as grilling"
+    And stdout contains "state \"todo-validating\" as todo_validating"
+    And stdout contains "[*] --> idle"
+    And stdout contains "idle --> grilling : * **"
+    And stdout contains "note right of fixing : agent · prompt · retry 3→escalate"
+
+  Scenario: a custom workflow's shape — including a hyphenated state name and a retry cap — renders correctly
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          start:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: "npm test"
+            on:
+              "A FEEDBACK.md": fixing
+              "C": done
+          fixing:
+            actor: agent
+            retry:
+              max: 2
+              otherwise: escalate
+            prompt: "fix it"
+            on:
+              "* **": checking
+          escalate:
+            actor: human
+            message: "stuck"
+            on:
+              "* **": checking
+          done:
+            commit: "chore: done"
+      """
+    When I run gtd with args "mermaid"
+    Then it succeeds
+    And stdout contains "[*] --> start"
+    And stdout contains "start --> checking : * **"
+    And stdout contains "checking --> fixing : A FEEDBACK.md"
+    And stdout contains "checking --> done : C"
+    And stdout contains "done --> [*]"
+    And stdout contains "note right of fixing : agent · prompt · retry 2→escalate"
+    And stdout does not contain "note right of done"
+
+  Scenario: gtd mermaid rejects --json — there is no structured shape beyond the Mermaid source itself
+    Given a test project
+    When I run gtd with args "mermaid --json"
+    Then it fails
+    And stderr contains "gtd mermaid does not accept --json"
+
+  Scenario: gtd mermaid rejects extra arguments
+    Given a test project
+    When I run gtd with args "mermaid bogus"
+    Then it fails
+
+  Scenario: gtd mermaid authors nothing, regardless of the repo's current state
+    Given a test project
+    And a file ".gtd/TODO.md" with:
+      """
+      Build a thing.
+      """
+    And I record the commit count
+    When I run gtd with args "mermaid"
+    Then it succeeds
+    And the commit count is unchanged
+    And ".gtd/TODO.md" exists


### PR DESCRIPTION
Pure emitter (src/Mermaid.ts) over a compiled WorkflowDefinition: no git, no
HEAD resolution, no template rendering — states, on edges (labeled with their
raw pattern), the initial-state marker, commit-state finality, and each
rest's actor/content-kind/retry summary as a note. Works for the bundled
default and any custom .gtdrc workflow alike, so a custom shape gets a
diagram with no hand-maintained docs.

Wired as a new `gtd mermaid` subcommand alongside next/status (repo-root
guard + auto-init, since it still depends on the active config); rejects
--json and extra arguments.