### PR TITLE
feat: review checkout window as a declarative state property

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,15 +21,21 @@ see [STATES.md](STATES.md) for the model. The sections below describe what
 replaced the old machinery; if you're looking for `TurnGate`, `captureRules`,
 `Gtd-Counters`, or `WorkflowConfig` guards, they no longer exist.
 
+The review checkout window is the one item on that deleted list that has since
+RETURNED — not as hardwired machinery but as a declarative state property
+(`reviewWindow: true`, plus an optional `reviewBase: true`), opened/closed
+entirely at the edge in `src/ReviewWindow.ts` and oblivious to the pure engine
+(see STATES.md §11).
+
 ### Changing the Workflow
 
 There is no engine-side wiring left to trace through when a workflow's shape
 changes — a workflow (bundled default or custom) is DATA, not code. To change
 what the bundled default does, edit `src/workflows/default.yaml` (states,
-`actor`, exactly one content kind, `on` edges, `retry`, `model`) —
-`src/workflows/ default.ts` compiles it through the same `compileWorkflowConfig`
-a user's `.gtdrc` `workflow:` key goes through, so it never needs its own logic.
-After editing the YAML, update:
+`actor`, exactly one content kind, `on` edges, `retry`, `model`, `file`/`mode`,
+`reviewWindow`/`reviewBase`) — `src/workflows/ default.ts` compiles it through
+the same `compileWorkflowConfig` a user's `.gtdrc` `workflow:` key goes through,
+so it never needs its own logic. After editing the YAML, update:
 
 - **STATES.md §10** — the bundled-default table and walkthrough
 - **e2e feature files** that assert on the default workflow's shape
@@ -76,6 +82,12 @@ touches `src/PatternMachine.ts` (types + `validateDefinition`),
   `buildTemplateContext`, `renderRest`, `executeDecision` (performs a `"commit"`
   or `"squash"` `StepDecision` — the only place a turn is actually written or a
   squash actually performed).
+- **`src/ReviewWindow.ts`** — the review checkout window edge (see STATES.md
+  §11): `openReviewWindow`/`closeReviewWindow` (the `git reset --mixed`
+  open/close bracketing every state subcommand, keyed on the resolved rest's
+  `reviewWindow: true` and on `refs/gtd/review-head` existence) and
+  `reviewBaseHash` (the `reviewBase`-state diff-base derivation). Pure engine is
+  oblivious; `program.ts` calls it, it calls `GitService`/`Edge.ts`.
 - **`src/program.ts`** — CLI dispatch (`step`/`next`/`run`/`status`/`format`).
   Calls `Edge.ts` for everything IO-shaped; calls `PatternMachine.ts`'s pure
   `step`/`matchesPattern`/`parsePattern` directly where no IO is needed (e.g.

--- a/STATES.md
+++ b/STATES.md
@@ -31,6 +31,8 @@ A workflow is a set of named **states**. Each state declares:
 | `model`                                       | Optional, opaque string — a harness hint (e.g. `smart`, `fast`, or a concrete model id) emitted alongside the state's content for the driving loop to map onto its agent harness. **Rendered as an Eta template through the same `it.vars`-carrying context as content** (a plain string with no Eta tags passes through unchanged) — see [Configuration](docs/configuration.md#model--the-opaque-harness-hint-template-rendered). gtd never interprets the rendered value; unset means "use the harness's default". **Forbidden on a commit state** (never at rest, emits nothing). |
 | `file`                                        | Optional — THE steering file this state is about: the file a human/editor should look at while the machine rests here. An **Eta template**, rendered exactly like `model` (must render non-empty). **Forbidden on a commit state.** Multiple states may share one `file:`. gtd itself never reads a path out of this string — only `gtd lsp` (`src/Lsp.ts`) interprets it, to map rendered paths to `mode` — see [Configuration](docs/configuration.md#filemode--the-steering-file-association).                                                                                     |
 | `mode`                                        | Optional, requires `file:`. The associated file's FORMAT, from a closed vocabulary (`qa` \| `review`) the LSP dispatches document symbols/code actions/diagnostics on. An unknown value is a load error. Like `model`, this is opaque emitted data — the ENGINE never branches on it. **Forbidden on a commit state.**                                                                                                                                                                                                                                                               |
+| `reviewWindow: true`                          | Optional boolean. While the machine RESTS at this state, gtd opens a **review checkout window** — HEAD and the index are rewound to the review base with the working tree untouched, so the whole `base..HEAD` diff surfaces as ordinary uncommitted changes in the editor's git integration; it closes automatically once the machine rests anywhere else (see §11). The pure engine never observes it. **Forbidden on a commit state.**                                                                                                                                            |
+| `reviewBase: true`                            | Optional boolean. Marks the state whose most-recent in-process commit anchors the review window's diff base (`base..HEAD`); absent any such state, the base is the process start (§11). Like `reviewWindow`, history-derived edge data the engine never reads. **Forbidden on a commit state.**                                                                                                                                                                                                                                                                                      |
 
 **Emission:** `gtd next --json`/`gtd status --json` gain optional `file`
 (rendered) and `mode` (verbatim) keys, omitted — never `null` — when unset,
@@ -233,7 +235,8 @@ workflow with:
 - an `on` row whose pattern doesn't parse, or whose target names an undefined
   state,
 - a `retry.otherwise` naming an undefined state, or a `retry.max` that isn't a
-  non-negative integer.
+  non-negative integer,
+- `reviewWindow`/`reviewBase` declared on a commit state (never at rest).
 
 A bad config fails loudly — one thrown error naming every finding — before
 anything touches the repository. See
@@ -269,6 +272,11 @@ checkbox review format — that map the functionality the deleted v2 LSP server
 (`todoFile: .gtd/TODO.md`, `reviewFile: .gtd/REVIEW.md`,
 `feedbackFile: .gtd/FEEDBACK.md` — see below); `fixing`/`escalate` declare
 `file:` alone (`.gtd/FEEDBACK.md` is plain text, no LSP format).
+
+`await-review` additionally declares **`reviewWindow: true`**: while the cycle
+rests there for human review, gtd opens a review checkout window over the whole
+cycle diff (no `reviewBase` state is declared, so the base is the cycle's
+process boundary). See §11.
 
 There is no squash — the cycle ends at human approval, an empty
 `gtd(human): idle` turn commit that rests the machine back at its own initial
@@ -384,3 +392,51 @@ desyncing the machine. `gtd lsp` (§3 of
 reads this same `file:`/`mode:` pair to dispatch document symbols/code
 actions/diagnostics, config-driven rather than hardcoded to `TODO.md`/
 `REVIEW.md`.
+
+## 11. The review checkout window
+
+A state may declare **`reviewWindow: true`** (§1). While the machine RESTS at
+such a state, gtd surfaces the reviewable diff directly in the editor's git
+integration — no custom UI, just ordinary working-tree changes an SCM panel,
+gutters, per-file diff, and discard-hunk already understand.
+
+**Mechanism.** The whole cycle's work is already committed by the time review
+begins, so an editor would otherwise show a clean tree. gtd temporarily rewinds
+HEAD and the index to the review base (`git reset --mixed <base>`) with the
+working tree untouched, so the entire `base..HEAD` diff re-appears as
+uncommitted changes. The real head is preserved under `refs/gtd/review-head`
+(the base under `refs/gtd/review-base`) so nothing is lost.
+
+**The base.** By default it is the process start (the same boundary
+`computeProcessRun` uses — see §7), so the window shows the whole current cycle.
+A workflow can narrow it by marking an earlier state **`reviewBase: true`**: the
+most-recent in-process commit that entered such a state becomes the base, so
+only work committed after that milestone surfaces (planning-doc churn before it
+stays committed and out of view).
+
+**Open / close lifecycle.** The pure engine (§5–§8) never observes an open
+window — it is opened and closed entirely at the edge (`src/ReviewWindow.ts`),
+bracketing every state subcommand (`step`/`next`/`run`/`status`):
+
+- **Close first, always.** Before anything reads or mutates state, gtd restores
+  the real head if a window is open (keyed solely on `refs/gtd/review-head`
+  existing). This is why the machine resolves the true rest, not the rewound
+  base — and why a reviewer's own edits, made while the window was open, land as
+  the resting state's ordinary pending changes and are captured by its `on`
+  patterns like any other diff (in the bundled default, a code edit at
+  `await-review` routes to `grilling` as feedback; deleting `.gtd/REVIEW.md`
+  approves).
+- **Re-arm last.** After the subcommand finishes — on success, on refusal, and
+  after read-only commands too — gtd re-opens the window if the resolved rest
+  declares `reviewWindow: true`. Every command participates, so the editor's
+  diff view stays consistent no matter which one the driving loop last ran.
+
+Both steps are idempotent under re-entry, so a crash at any point is recovered
+by the next invocation's close. The close fails loudly (leaving the refs in
+place) only if HEAD has moved off the reviewed branch — a `--mixed` reset there
+would rewrite the wrong branch's tip; the error message spells out the manual
+recovery.
+
+`.gtd/` workflow plumbing (the review doc, plan/feedback files) is pinned back
+to the real head's index while the window is open, so the editor's unstaged view
+shows only the actual code changes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,6 +172,49 @@ change to that path MEANS keeps matching the old literal path. The vars are a
 DRY mechanism inside templates and the state↔file association, not a rename
 switch. (Making pattern keys var-aware at compile time is possible future work.)
 
+### `reviewWindow:`/`reviewBase:` — the review checkout window
+
+A state may declare `reviewWindow: true`. While the machine RESTS there, gtd
+opens a **review checkout window**: it rewinds HEAD and the index to the review
+base (`git reset --mixed`) with the working tree untouched, so the whole
+`base..HEAD` diff surfaces as ordinary uncommitted changes in the editor's git
+integration (SCM panel, gutters, per-file diff, discard-hunk). The window closes
+automatically on the next invocation, once the machine rests anywhere else — and
+a reviewer's own edits, made while it was open, become the resting state's
+ordinary pending changes, captured by its `on` patterns like any other diff.
+Forbidden on a commit state (never at rest).
+
+The diff base defaults to the current process's start. To narrow it, mark an
+earlier state `reviewBase: true`: the most-recent in-process commit that entered
+such a state becomes the base, so only work committed after that milestone
+surfaces.
+
+```yaml
+workflow:
+  states:
+    # …
+    building:
+      actor: agent
+      reviewBase: true # the diff shown at review starts here…
+      prompt: implement the plan
+      on:
+        "* **": review
+    review:
+      actor: human
+      reviewWindow: true # …and is surfaced while resting here
+      message: review the diff in your editor, then `gtd step human`
+      on:
+        "C": done
+        "* **": building
+```
+
+The bundled default enables `reviewWindow: true` on `await-review` (no
+`reviewBase` state, so the base is the whole cycle). The pure engine never
+observes an open window — it is opened/closed entirely at the edge; the real
+head is preserved under `refs/gtd/review-head` (the base under
+`refs/gtd/review-base`) for the window's lifetime. See
+[STATES.md §11](../STATES.md) for the full lifecycle.
+
 ### Template variables
 
 Every `script`/`prompt`/`message`/`commit`/`model` template is rendered as an

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -49,8 +49,14 @@ upgrading.
   tiering — a workflow author is free to build any of that shape back with
   states of their own, but gtd no longer bakes it in.
 - **The review checkout window.** v2 rewound HEAD/index to the review base while
-  a human review rested, so editors would show the diff directly. Deleted in v3
-  (may return later as an explicit state property — not in scope now).
+  a human review rested, so editors would show the diff directly. Dropped in the
+  v3.0 rewrite, then RE-INTRODUCED as the explicit state property it was always
+  meant to become: a state declaring `reviewWindow: true` opens the window while
+  the machine rests there (base = the process start, or a state marked
+  `reviewBase: true`). The bundled default enables it on `await-review`. Unlike
+  v2's hardwired gate, it is pure workflow DATA and the engine stays oblivious —
+  see [STATES.md §11](../STATES.md) and the `file:`/`mode:` neighbours in
+  [configuration.md](configuration.md).
 - **`forceApprove`, content-inspection verdicts.** FEEDBACK.md emptiness,
   checkbox-only REVIEW.md diffs, and doc-structure validation are gone as ENGINE
   mechanisms — verdicts are now expressed purely by which file a turn writes or

--- a/src/Edge.test.ts
+++ b/src/Edge.test.ts
@@ -31,6 +31,8 @@ const stubGit = (overrides: Partial<GitOperations>): GitOperations => ({
   hasCommits: notImplemented("hasCommits"),
   diffRef: notImplemented("diffRef"),
   resolveRef: notImplemented("resolveRef"),
+  readRefOption: notImplemented("readRefOption"),
+  isAncestor: notImplemented("isAncestor"),
   topLevel: notImplemented("topLevel"),
   commitHistory: notImplemented("commitHistory"),
   commitDiff: notImplemented("commitDiff"),
@@ -39,6 +41,11 @@ const stubGit = (overrides: Partial<GitOperations>): GitOperations => ({
   softResetTo: notImplemented("softResetTo"),
   commitAsIs: notImplemented("commitAsIs"),
   discardPending: notImplemented("discardPending"),
+  updateRef: notImplemented("updateRef"),
+  deleteRef: notImplemented("deleteRef"),
+  mixedResetTo: notImplemented("mixedResetTo"),
+  restoreStagedFrom: notImplemented("restoreStagedFrom"),
+  addIntentToAdd: notImplemented("addIntentToAdd"),
   ...overrides,
 })
 

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -1,7 +1,7 @@
 import { Command, CommandExecutor } from "@effect/platform"
 import { readFileSync, existsSync } from "node:fs"
 import { join } from "node:path"
-import { Context, Effect, Layer, Stream } from "effect"
+import { Context, Effect, Layer, Option, Stream } from "effect"
 import { renderDiff } from "./Diff.js"
 import { Cwd } from "./Cwd.js"
 
@@ -22,6 +22,10 @@ export interface GitReaderOperations {
    */
   readonly diffRef: (ref: string, exclude?: ReadonlyArray<string>) => Effect.Effect<string, Error>
   readonly resolveRef: (ref: string) => Effect.Effect<string, Error>
+  /** `git rev-parse --verify --quiet <ref>` — the ref's hash if it resolves, `Option.none` if it doesn't exist (never fails). Used to detect an open review checkout window (`refs/gtd/review-head`). */
+  readonly readRefOption: (ref: string) => Effect.Effect<Option.Option<string>, Error>
+  /** `git merge-base --is-ancestor <a> <b>` — true iff `a` is an ancestor of `b`. Never fails: a non-zero exit (or error) reports `false`. Guards the review window's close against a HEAD that has moved off the reviewed branch. */
+  readonly isAncestor: (a: string, b: string) => Effect.Effect<boolean, Error>
   /** `git rev-parse --show-toplevel` — the working-tree root; fails outside a repository. */
   readonly topLevel: () => Effect.Effect<string, Error>
   /**
@@ -102,6 +106,29 @@ export interface GitWriterOperations {
    * lands the squash commit.
    */
   readonly discardPending: () => Effect.Effect<void, Error>
+  /** `git update-ref <ref> <hash>` — point a repo-local ref (e.g. `refs/gtd/review-head`) at a commit. */
+  readonly updateRef: (ref: string, hash: string) => Effect.Effect<void, Error>
+  /** `git update-ref -d <ref>` — idempotent: deleting a missing ref is a no-op. */
+  readonly deleteRef: (ref: string) => Effect.Effect<void, Error>
+  /** `git reset --mixed <ref>` — HEAD and index move to `ref`, the working tree is untouched (so committed work re-surfaces as pending changes). The open/close primitive of the review checkout window. */
+  readonly mixedResetTo: (ref: string) => Effect.Effect<void, Error>
+  /**
+   * `git restore --staged --source=<source> -- <paths…>` — set the index
+   * entries under each path to their state at `source` (including removals),
+   * leaving HEAD and the working tree untouched. Tolerant when no path matches.
+   * Pins `.gtd/` plumbing back to the real head while the review window is open
+   * so it stays out of the surfaced diff.
+   */
+  readonly restoreStagedFrom: (
+    source: string,
+    paths: ReadonlyArray<string>,
+  ) => Effect.Effect<void, Error>
+  /**
+   * `git add --intent-to-add .` — register untracked files in the index with
+   * an empty placeholder so they render as additions (with content hunks) in
+   * `git diff` and editor SCM views, without staging their content.
+   */
+  readonly addIntentToAdd: () => Effect.Effect<void, Error>
 }
 
 export interface GitOperations extends GitReaderOperations, GitWriterOperations {}
@@ -409,6 +436,19 @@ const makeGitImpl = (executor: CommandExecutor.CommandExecutor, root: string): G
         ),
       ),
 
+    readRefOption: (ref: string) =>
+      exec("git", "rev-parse", "--verify", "--quiet", ref).pipe(
+        Effect.map((s) => Option.some(s.trim())),
+        Effect.catchAll(() => Effect.succeed(Option.none<string>())),
+      ),
+
+    isAncestor: (a: string, b: string) =>
+      run(root, "git", "merge-base", "--is-ancestor", a, b).pipe(
+        Effect.provide(Layer.succeed(CommandExecutor.CommandExecutor, executor)),
+        Effect.map(() => true),
+        Effect.catchAll(() => Effect.succeed(false)),
+      ),
+
     topLevel: () => exec("git", "rev-parse", "--show-toplevel").pipe(Effect.map((s) => s.trim())),
 
     commitHistory: (base?: string) => {
@@ -486,6 +526,24 @@ const makeGitImpl = (executor: CommandExecutor.CommandExecutor, root: string): G
         yield* exec("git", "add", "-A")
         yield* exec("git", "reset", "--hard", "HEAD")
       }).pipe(Effect.asVoid),
+
+    updateRef: (ref: string, hash: string) =>
+      exec("git", "update-ref", ref, hash).pipe(Effect.asVoid),
+
+    deleteRef: (ref: string) => exec("git", "update-ref", "-d", ref).pipe(Effect.asVoid),
+
+    mixedResetTo: (ref: string) => exec("git", "reset", "--mixed", ref).pipe(Effect.asVoid),
+
+    restoreStagedFrom: (source: string, paths: ReadonlyArray<string>) =>
+      paths.length === 0
+        ? Effect.void
+        : exec("git", "restore", "--staged", `--source=${source}`, "--", ...paths).pipe(
+            // Tolerant: a path that never existed at `source` (or in the index)
+            // makes `git restore` complain — the pin is best-effort plumbing.
+            Effect.catchAll(() => Effect.void),
+          ),
+
+    addIntentToAdd: () => exec("git", "add", "--intent-to-add", ".").pipe(Effect.asVoid),
   }
 }
 

--- a/src/PatternConfig.test.ts
+++ b/src/PatternConfig.test.ts
@@ -343,6 +343,49 @@ describe("compileWorkflowConfig — config-shape validation", () => {
     ).toThrowError(/state "a": "initial" must be a boolean/)
   })
 
+  it("rejects a non-boolean reviewWindow/reviewBase", () => {
+    expect(() =>
+      compileWorkflowConfig(
+        { states: { a: { actor: "human", message: "hi", initial: true, reviewWindow: "yes" } } },
+        "/dir",
+      ),
+    ).toThrowError(/state "a": "reviewWindow" must be a boolean/)
+    expect(() =>
+      compileWorkflowConfig(
+        { states: { a: { actor: "human", message: "hi", initial: true, reviewBase: 1 } } },
+        "/dir",
+      ),
+    ).toThrowError(/state "a": "reviewBase" must be a boolean/)
+  })
+
+  it("compiles reviewWindow/reviewBase booleans onto the StateDef (false omitted)", () => {
+    const { definition } = compileWorkflowConfig(
+      {
+        states: {
+          a: {
+            actor: "human",
+            message: "hi",
+            initial: true,
+            reviewBase: true,
+            on: { "* *": "b" },
+          },
+          b: {
+            actor: "human",
+            message: "review",
+            reviewWindow: true,
+            reviewBase: false,
+            on: { C: "a" },
+          },
+        },
+      },
+      "/dir",
+    )
+    expect(definition.states.a!.reviewBase).toBe(true)
+    expect(definition.states.b!.reviewWindow).toBe(true)
+    // `false` compiles away — never lands on the StateDef.
+    expect("reviewBase" in definition.states.b!).toBe(false)
+  })
+
   it("rejects zero content keys and more than one content key", () => {
     expect(() =>
       compileWorkflowConfig({ states: { a: { actor: "human", initial: true } } }, "/dir"),

--- a/src/PatternConfig.ts
+++ b/src/PatternConfig.ts
@@ -138,6 +138,8 @@ const KNOWN_STATE_KEYS: ReadonlySet<string> = new Set([
   "model",
   "file",
   "mode",
+  "reviewWindow",
+  "reviewBase",
 ])
 
 const KNOWN_TOP_KEYS: ReadonlySet<string> = new Set(["vars", "states"])
@@ -313,13 +315,27 @@ const compileInitial = (
   raw: Record<string, unknown>,
   name: string,
   errors: string[],
+): true | undefined => compileBooleanFlag(raw, "initial", name, errors)
+
+/**
+ * A boolean state flag (`initial`/`reviewWindow`/`reviewBase`): `true` only
+ * when the raw value is the literal `true`; a non-boolean is a config error;
+ * `false` (or absent) compiles away to `undefined` so it never lands in the
+ * `StateDef` — `false` and "unset" mean the same thing for every such flag.
+ */
+const compileBooleanFlag = (
+  raw: Record<string, unknown>,
+  key: string,
+  name: string,
+  errors: string[],
 ): true | undefined => {
-  if (raw.initial === undefined) return undefined
-  if (raw.initial !== true && raw.initial !== false) {
-    errors.push(`state "${name}": "initial" must be a boolean`)
+  const value = raw[key]
+  if (value === undefined) return undefined
+  if (value !== true && value !== false) {
+    errors.push(`state "${name}": "${key}" must be a boolean`)
     return undefined
   }
-  return raw.initial === true ? true : undefined
+  return value === true ? true : undefined
 }
 
 /** One state's compiled parts, assembled into a `StateDef` (only present fields carried over — `exactOptionalPropertyTypes`). */
@@ -332,6 +348,8 @@ interface StateParts {
   readonly model: string | undefined
   readonly file: string | undefined
   readonly mode: StateMode | undefined
+  readonly reviewWindow: true | undefined
+  readonly reviewBase: true | undefined
 }
 
 const assembleContentFields = (
@@ -372,6 +390,8 @@ const assembleStateDef = (parts: StateParts): StateDef => ({
     model: parts.model,
     file: parts.file,
     mode: parts.mode,
+    reviewWindow: parts.reviewWindow,
+    reviewBase: parts.reviewBase,
   }),
   ...assembleContentFields(parts.content),
 })
@@ -402,6 +422,8 @@ const compileState = (
     model: compileModel(raw, name, errors),
     file: compileFile(raw, name, errors),
     mode: compileMode(raw, name, errors),
+    reviewWindow: compileBooleanFlag(raw, "reviewWindow", name, errors),
+    reviewBase: compileBooleanFlag(raw, "reviewBase", name, errors),
   })
 }
 

--- a/src/PatternMachine.test.ts
+++ b/src/PatternMachine.test.ts
@@ -4,6 +4,8 @@ import {
   contentKindOf,
   initialStateOf,
   isCommitState,
+  isReviewBaseState,
+  isReviewWindowState,
   matchesPattern,
   parsePattern,
   parseStateSubject,
@@ -105,6 +107,38 @@ describe("isCommitState", () => {
     expect(isCommitState({ commit: "x" })).toBe(true)
     expect(isCommitState({ prompt: "x" })).toBe(false)
     expect(isCommitState({})).toBe(false)
+  })
+})
+
+describe("isReviewWindowState / isReviewBaseState", () => {
+  const def: WorkflowDefinition = {
+    states: {
+      idle: {
+        actor: "human",
+        message: "x",
+        initial: true,
+        reviewBase: true,
+        on: [["* *", "gate"]],
+      },
+      gate: { actor: "human", message: "review", reviewWindow: true, on: [["C", "idle"]] },
+      plain: { actor: "agent", prompt: "x", on: [["* *", "idle"]] },
+    },
+  }
+
+  it("reports the reviewWindow flag by state name", () => {
+    expect(isReviewWindowState(def, "gate")).toBe(true)
+    expect(isReviewWindowState(def, "plain")).toBe(false)
+    expect(isReviewWindowState(def, "idle")).toBe(false)
+  })
+
+  it("reports the reviewBase flag by state name", () => {
+    expect(isReviewBaseState(def, "idle")).toBe(true)
+    expect(isReviewBaseState(def, "gate")).toBe(false)
+  })
+
+  it("is false for an unknown state name", () => {
+    expect(isReviewWindowState(def, "ghost")).toBe(false)
+    expect(isReviewBaseState(def, "ghost")).toBe(false)
   })
 })
 
@@ -862,6 +896,42 @@ describe("validateDefinition", () => {
       },
     })
     expect(errors).toContain('state "b": a commit state cannot declare "mode"')
+  })
+
+  it("accepts a non-commit state declaring `reviewWindow`/`reviewBase`", () => {
+    const errors = validateDefinition({
+      states: {
+        a: {
+          actor: "h",
+          message: "x",
+          initial: true,
+          reviewBase: true,
+          on: [["* *", "b"]],
+        },
+        b: { actor: "h", message: "review", reviewWindow: true, on: [["C", "a"]] },
+      },
+    })
+    expect(errors).toEqual([])
+  })
+
+  it("rejects a commit state that declares `reviewWindow`", () => {
+    const errors = validateDefinition({
+      states: {
+        a: { actor: "h", message: "x", initial: true, on: [["* *", "b"]] },
+        b: { commit: "chore: b", reviewWindow: true },
+      },
+    })
+    expect(errors).toContain('state "b": a commit state cannot declare "reviewWindow"')
+  })
+
+  it("rejects a commit state that declares `reviewBase`", () => {
+    const errors = validateDefinition({
+      states: {
+        a: { actor: "h", message: "x", initial: true, on: [["* *", "b"]] },
+        b: { commit: "chore: b", reviewBase: true },
+      },
+    })
+    expect(errors).toContain('state "b": a commit state cannot declare "reviewBase"')
   })
 
   it("aggregates a bad `file`/`mode` alongside other unrelated findings", () => {

--- a/src/PatternMachine.ts
+++ b/src/PatternMachine.ts
@@ -94,6 +94,29 @@ export interface StateDef {
    * `validateDefinition`).
    */
   readonly mode?: StateMode
+  /**
+   * Optional. When `true`, gtd opens a "review checkout window" while a
+   * process RESTS at this state: HEAD and the index are temporarily rewound to
+   * the review base (see `reviewBase`) with the working tree untouched, so the
+   * whole `base..HEAD` diff surfaces as ordinary uncommitted changes in any
+   * editor's standard git integration. The window is closed (HEAD/index
+   * restored) the moment the process rests anywhere else. This module's PURE
+   * functions never read it — `resolveState`/`step` are oblivious; the window
+   * is opened/closed entirely at the edge (`src/ReviewWindow.ts`), keyed on
+   * this flag of the resolved rest. Forbidden on a commit state (never at
+   * rest — see `validateDefinition`).
+   */
+  readonly reviewWindow?: boolean
+  /**
+   * Optional. Marks a state whose most-recent in-process turn commit is the
+   * BASE of the review window's diff (`base..HEAD`) — everything committed
+   * after entering this state surfaces as pending while the window is open.
+   * When no in-process commit entered a `reviewBase` state, the window falls
+   * back to the process start (see `src/ReviewWindow.ts`). Like `reviewWindow`
+   * the ENGINE never reads it — it is history-derived edge data. Forbidden on
+   * a commit state (see `validateDefinition`).
+   */
+  readonly reviewBase?: boolean
 }
 
 /** The closed vocabulary `mode:` may declare — see `StateDef.mode`. */
@@ -115,6 +138,14 @@ export const contentKindOf = (state: StateDef): ContentKind | undefined => {
 
 /** True when a state is a commit (final, squash) state. */
 export const isCommitState = (state: StateDef): boolean => state.commit !== undefined
+
+/** True when a rest at `state` should open the review checkout window (see `StateDef.reviewWindow`). Safe for an unknown state name (returns `false`). */
+export const isReviewWindowState = (def: WorkflowDefinition, state: StateName): boolean =>
+  def.states[state]?.reviewWindow === true
+
+/** True when `state` anchors the review window's diff base (see `StateDef.reviewBase`). Safe for an unknown state name (returns `false`). */
+export const isReviewBaseState = (def: WorkflowDefinition, state: StateName): boolean =>
+  def.states[state]?.reviewBase === true
 
 // ── Commit-subject grammar ───────────────────────────────────────────────────
 
@@ -602,6 +633,24 @@ const validateMode = (name: string, state: StateDef): string[] => {
   return errors
 }
 
+/**
+ * `reviewWindow`/`reviewBase`, when present, are booleans (the compiler
+ * enforces the type) — forbidden on a commit state, same rule family as
+ * `model`/`file`/`mode`: a commit state is never at rest, so no window ever
+ * opens or anchors there.
+ */
+const validateReviewWindow = (name: string, state: StateDef): string[] => {
+  if (!isCommitState(state)) return []
+  const errors: string[] = []
+  if (state.reviewWindow !== undefined) {
+    errors.push(`state "${name}": a commit state cannot declare "reviewWindow"`)
+  }
+  if (state.reviewBase !== undefined) {
+    errors.push(`state "${name}": a commit state cannot declare "reviewBase"`)
+  }
+  return errors
+}
+
 /** Every `on` row parses, and its target names a defined state. */
 const validateOnEdges = (name: string, state: StateDef, names: readonly string[]): string[] => {
   const errors: string[] = []
@@ -646,6 +695,7 @@ const validateState = (
     ...validateModel(name, state),
     ...validateFile(name, state),
     ...validateMode(name, state),
+    ...validateReviewWindow(name, state),
   ]
 }
 
@@ -663,7 +713,8 @@ const validateState = (
  * never declared on a commit state; `file`, when present, is a non-empty
  * string and is never declared on a commit state; `mode`, when present, is
  * one of the closed vocabulary (`qa`/`review`), requires a sibling `file`,
- * and is never declared on a commit state.
+ * and is never declared on a commit state; `reviewWindow`/`reviewBase`, when
+ * present, are never declared on a commit state.
  */
 export const validateDefinition = (def: WorkflowDefinition): readonly string[] => {
   const names = Object.keys(def.states)

--- a/src/ReviewWindow.test.ts
+++ b/src/ReviewWindow.test.ts
@@ -1,0 +1,151 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { join, dirname } from "node:path"
+import { tmpdir } from "node:os"
+import { execSync } from "node:child_process"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { Effect, Layer } from "effect"
+import { NodeContext } from "@effect/platform-node"
+import { GitService } from "./Git.js"
+import { ConfigService } from "./Config.js"
+import { Cwd } from "./Cwd.js"
+import { computeProcessRun } from "./Edge.js"
+import {
+  closeReviewWindow,
+  openReviewWindow,
+  reviewBaseHash,
+  REVIEW_BASE_REF,
+  REVIEW_HEAD_REF,
+} from "./ReviewWindow.js"
+import type { WorkflowDefinition } from "./PatternMachine.js"
+
+/**
+ * Live-git coverage for the review checkout window: the mixed-reset open/close
+ * round trip and the `reviewBase` base-narrowing, exercised against a REAL git
+ * repository (the @inmem `review-window.feature` covers the same lifecycle
+ * through the program edge; this file proves the actual git plumbing).
+ */
+
+// A workflow: idle → building → gate (a reviewWindow rest), with an optional
+// `checkpoint` reviewBase state between two building turns.
+const def: WorkflowDefinition = {
+  states: {
+    idle: { actor: "human", message: "i", initial: true, on: [["* **", "building"]] },
+    building: { actor: "agent", prompt: "b", on: [["* **", "gate"]] },
+    checkpoint: { actor: "human", message: "c", reviewBase: true, on: [["* **", "gate"]] },
+    gate: { actor: "human", message: "g", reviewWindow: true, on: [["* **", "idle"]] },
+  },
+}
+
+let repoDir: string
+
+const gitExec = (...args: string[]): string =>
+  execSync(`git ${args.join(" ")}`, { cwd: repoDir, encoding: "utf8", stdio: "pipe" }).trim()
+
+const commit = (message: string, files: Record<string, string> = {}): void => {
+  for (const [path, content] of Object.entries(files)) {
+    mkdirSync(join(repoDir, dirname(path)), { recursive: true })
+    writeFileSync(join(repoDir, path), content)
+  }
+  gitExec("add", "-A")
+  // `-m` via execSync needs the message quoted; keep messages free of quotes.
+  gitExec("commit", "--allow-empty", "-m", `"${message}"`)
+}
+
+const headSubject = (): string => gitExec("log", "-1", "--format=%s")
+const status = (): string => gitExec("status", "--porcelain", "-uall")
+const refExists = (ref: string): boolean => {
+  try {
+    gitExec("rev-parse", "--verify", "--quiet", ref)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const run = <A>(eff: Effect.Effect<A, Error, GitService | ConfigService>): Promise<A> =>
+  Effect.runPromise(
+    eff.pipe(
+      Effect.provide(GitService.Live),
+      Effect.provide(Layer.succeed(ConfigService, { workflow: def, workflowVars: {}, rcVars: {} })),
+      Effect.provide(Cwd.layer(repoDir)),
+      Effect.provide(NodeContext.layer),
+    ),
+  )
+
+beforeEach(() => {
+  repoDir = mkdtempSync(join(tmpdir(), "gtd-review-window-"))
+  gitExec("init")
+  gitExec("config", "user.email", '"t@t.com"')
+  gitExec("config", "user.name", '"T"')
+  commit("chore: initial commit", { "readme.txt": "hello" })
+})
+
+afterEach(() => {
+  rmSync(repoDir, { recursive: true, force: true })
+})
+
+describe("openReviewWindow / closeReviewWindow — base = process start", () => {
+  it("rewinds HEAD to the cycle boundary, surfaces the diff, and restores on close", async () => {
+    commit("gtd(agent): building", { "src/calc.ts": "export const add = 1\n" })
+    commit("gtd(human): gate", { "src/other.ts": "export const x = 1\n" })
+    const realHead = gitExec("rev-parse", "HEAD")
+
+    const opened = await run(openReviewWindow)
+    expect(opened.opened).toBe(true)
+    // HEAD rewound to the process boundary (the non-gtd initial commit).
+    expect(headSubject()).toBe("chore: initial commit")
+    expect(refExists(REVIEW_HEAD_REF)).toBe(true)
+    expect(refExists(REVIEW_BASE_REF)).toBe(true)
+    // The whole cycle diff is now uncommitted.
+    expect(status()).toContain("src/calc.ts")
+    expect(status()).toContain("src/other.ts")
+
+    const closed = await run(closeReviewWindow)
+    expect(closed.closed).toBe(true)
+    expect(gitExec("rev-parse", "HEAD")).toBe(realHead)
+    expect(headSubject()).toBe("gtd(human): gate")
+    expect(refExists(REVIEW_HEAD_REF)).toBe(false)
+    expect(refExists(REVIEW_BASE_REF)).toBe(false)
+    // The working tree is clean again — the surfaced diff was re-committed.
+    expect(status()).toBe("")
+  })
+
+  it("is a no-op when resting anywhere but a reviewWindow state", async () => {
+    commit("gtd(agent): building", { "src/calc.ts": "x\n" })
+    const opened = await run(openReviewWindow)
+    expect(opened.opened).toBe(false)
+    expect(refExists(REVIEW_HEAD_REF)).toBe(false)
+  })
+})
+
+describe("reviewBase — narrowing the diff base", () => {
+  it("opens against the most-recent in-process reviewBase commit", async () => {
+    commit("gtd(agent): building", { "src/a.ts": "a\n" })
+    commit("gtd(human): checkpoint")
+    const checkpoint = gitExec("rev-parse", "HEAD")
+    commit("gtd(agent): building", { "src/b.ts": "b\n" })
+    commit("gtd(human): gate")
+
+    const base = await run(
+      Effect.gen(function* () {
+        const git = yield* GitService
+        const run = yield* computeProcessRun(git, def)
+        return yield* reviewBaseHash(git, def, run)
+      }),
+    )
+    expect(base).toBe(checkpoint)
+
+    await run(openReviewWindow)
+    // HEAD rewound to the checkpoint, so only work AFTER it surfaces.
+    expect(headSubject()).toBe("gtd(human): checkpoint")
+    expect(status()).toContain("src/b.ts")
+    expect(status()).not.toContain("src/a.ts")
+  })
+})
+
+describe("closeReviewWindow — safety", () => {
+  it("is a no-op when no window is open", async () => {
+    const closed = await run(closeReviewWindow)
+    expect(closed.closed).toBe(false)
+  })
+})

--- a/src/ReviewWindow.ts
+++ b/src/ReviewWindow.ts
@@ -1,0 +1,172 @@
+import { Effect, Option } from "effect"
+import { GitService } from "./Git.js"
+import { ConfigService } from "./Config.js"
+import {
+  isReviewBaseState,
+  isReviewWindowState,
+  parseStateSubject,
+  resolveState,
+  type WorkflowDefinition,
+} from "./PatternMachine.js"
+import { computeProcessRun, type ProcessRun } from "./Edge.js"
+import type { GitOperations } from "./Git.js"
+
+/**
+ * The review checkout window (v3 re-introduction — see
+ * `docs/design/pattern-machine-plan.md`'s follow-up note and STATES.md §11).
+ * While a process RESTS at a state declaring `reviewWindow: true` (the
+ * bundled default's `await-review`), HEAD and the index are temporarily
+ * rewound to the review base with the working tree untouched, so the entire
+ * `base..HEAD` diff surfaces as ordinary uncommitted changes in any editor's
+ * standard git integration (SCM panel, gutters, per-file diffs, discard-hunk).
+ *
+ * v2 hard-wired this to a single `awaiting-review` gate; v3 drives it purely
+ * from the DECLARATIVE `reviewWindow`/`reviewBase` state properties (see
+ * `PatternMachine.StateDef`) — the pure engine never observes an open window,
+ * exactly as before.
+ *
+ * Lifecycle — driven from the program edge (`src/program.ts`), bracketing
+ * every state subcommand:
+ *
+ * - `closeReviewWindow` runs BEFORE anything reads or mutates state, keyed
+ *   solely on `refs/gtd/review-head` existing: `git reset --mixed
+ *   refs/gtd/review-head` restores HEAD/index exactly, leaving only the
+ *   reviewer's own edits dirty (captured by the resting state's own `on`
+ *   patterns like any other pending change). The pure machine therefore never
+ *   sees the window.
+ * - `openReviewWindow` runs AFTER the subcommand finishes and self-guards on
+ *   the resolved rest declaring `reviewWindow: true`: it saves HEAD to
+ *   `refs/gtd/review-head` (the base to `refs/gtd/review-base`), then `git
+ *   reset --mixed <base>`. It re-arms after read-only commands (`gtd next` /
+ *   `gtd status`) and refused invocations too, so the editor's diff view stays
+ *   consistent no matter which command the loop last ran.
+ *
+ * Every open/close step is idempotent under re-entry, so a crash at any point
+ * is recovered by the next invocation's close (the saved ref also keeps the
+ * real head GC-reachable for the window's whole lifetime).
+ */
+
+export const REVIEW_HEAD_REF = "refs/gtd/review-head"
+export const REVIEW_BASE_REF = "refs/gtd/review-base"
+
+// git's empty-tree object — `computeProcessRun`'s `startParentHash` when a
+// process covers the whole history with no earlier commit. There is no real
+// commit to rewind to, so the window simply does not open in that case.
+const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+const subjectOf = (message: string): string => (message.split("\n")[0] ?? "").trim()
+
+/**
+ * The diff base while the window is open: the hash of the most-recent
+ * in-process turn commit that ENTERED a `reviewBase` state, or `undefined`
+ * when the workflow declares no such state (the caller then falls back to the
+ * process start). Walks the current process run's commits (oldest→newest, via
+ * `commitHistory(startParentHash)`), so it never reaches across the process
+ * boundary into a previous cycle.
+ */
+export const reviewBaseHash = (
+  git: GitOperations,
+  def: WorkflowDefinition,
+  run: ProcessRun,
+): Effect.Effect<string | undefined, Error> =>
+  Effect.gen(function* () {
+    const history = yield* git.commitHistory(run.startParentHash)
+    let base: string | undefined
+    for (const commit of history) {
+      const parsed = parseStateSubject(subjectOf(commit.message))
+      if (parsed !== undefined && isReviewBaseState(def, parsed.state)) base = commit.hash
+    }
+    return base
+  })
+
+/**
+ * Restore the real head if a review checkout window is open; no-op otherwise.
+ * Keyed on `refs/gtd/review-head` existence, NOT on any config or machine
+ * state, so it always runs first and the machine never sees the window.
+ *
+ * Fails loudly — refs left in place — when HEAD is no longer on the reviewed
+ * branch (the base is not an ancestor of HEAD, e.g. after a branch switch): a
+ * mixed reset there would rewrite the wrong branch's tip. Manual commits on
+ * top of the base pass the guard: the reset keeps their content in the working
+ * tree, where the next turn's capture picks it up as review feedback.
+ */
+export const closeReviewWindow: Effect.Effect<{ readonly closed: boolean }, Error, GitService> =
+  Effect.gen(function* () {
+    const git = yield* GitService
+    const savedHead = yield* git.readRefOption(REVIEW_HEAD_REF)
+    if (Option.isNone(savedHead)) return { closed: false }
+
+    const base = yield* git.readRefOption(REVIEW_BASE_REF)
+    if (Option.isSome(base) && base.value !== EMPTY_TREE) {
+      const onReviewedBranch = yield* git.isAncestor(base.value, "HEAD")
+      if (!onReviewedBranch) {
+        return yield* Effect.fail(
+          new Error(
+            "a gtd review checkout window is open but HEAD has moved off the reviewed branch — " +
+              "return to it, or restore manually with " +
+              "`git reset --mixed refs/gtd/review-head && git update-ref -d refs/gtd/review-head && git update-ref -d refs/gtd/review-base`",
+          ),
+        )
+      }
+    }
+
+    yield* git.mixedResetTo(REVIEW_HEAD_REF)
+    yield* git.deleteRef(REVIEW_HEAD_REF)
+    yield* git.deleteRef(REVIEW_BASE_REF)
+    return { closed: true }
+  })
+
+/**
+ * Open (or re-arm) the review checkout window. Self-guarded: a no-op unless
+ * the resolved rest's state declares `reviewWindow: true` and a distinct base
+ * commit exists, so the caller invokes it unconditionally after every state
+ * subcommand.
+ *
+ * The base is the most-recent in-process `reviewBase` commit
+ * (`reviewBaseHash`) or, absent any such state, the process start
+ * (`startParentHash`). When that resolves to the empty tree (a process with no
+ * prior commit) or to HEAD itself (an empty process), there is nothing to
+ * surface and the window stays closed.
+ *
+ * Ordering is crash-safe: base ref → head ref → mixed reset → `.gtd/` index
+ * pin → intent-to-add. A crash before the head-ref write leaves only a stale
+ * base ref (overwritten on the next open); a crash after it leaves HEAD ==
+ * review-head, which the next invocation's close restores as a no-op.
+ */
+export const openReviewWindow: Effect.Effect<
+  { readonly opened: boolean },
+  Error,
+  GitService | ConfigService
+> = Effect.gen(function* () {
+  const git = yield* GitService
+  const config = yield* ConfigService
+  const def = config.workflow
+
+  const hasCommits = yield* git.hasCommits()
+  if (!hasCommits) return { opened: false }
+
+  const headSubject = yield* git.lastCommitSubject()
+  const state = resolveState(def, headSubject)
+  if (!isReviewWindowState(def, state)) return { opened: false }
+
+  const run = yield* computeProcessRun(git, def)
+  const explicitBase = yield* reviewBaseHash(git, def, run)
+  const base = explicitBase ?? run.startParentHash
+  const headHash = yield* git.resolveRef("HEAD")
+  // No real base commit to rewind to (whole-history process), or an empty
+  // process with nothing committed yet — nothing to surface, so stay closed.
+  if (base === EMPTY_TREE || base === headHash) return { opened: false }
+
+  yield* git.updateRef(REVIEW_BASE_REF, base)
+  yield* git.updateRef(REVIEW_HEAD_REF, headHash)
+  yield* git.mixedResetTo(base)
+  // `.gtd/` (REVIEW.md, plan/feedback files) is workflow plumbing, not part of
+  // the reviewable diff — pin its index entries back to the saved head so the
+  // editor's unstaged view shows only the code changes.
+  yield* git.restoreStagedFrom(REVIEW_HEAD_REF, [".gtd"])
+  // Files added since the base would otherwise show as untracked; register
+  // them so editors render proper content diffs (and "discard" stays a
+  // coherent reject-this-file gesture).
+  yield* git.addIntentToAdd()
+  return { opened: true }
+})

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -24,6 +24,8 @@ const failingGitLayer = Layer.succeed(GitService, {
   lastCommitSubject: () =>
     Effect.fail(new Error("GitService must not be called for --version/--help")),
   resolveRef: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
+  readRefOption: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
+  isAncestor: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   topLevel: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   commitHistory: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   diffHead: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
@@ -35,6 +37,13 @@ const failingGitLayer = Layer.succeed(GitService, {
   softResetTo: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   commitAsIs: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   discardPending: () =>
+    Effect.fail(new Error("GitService must not be called for --version/--help")),
+  updateRef: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
+  deleteRef: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
+  mixedResetTo: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
+  restoreStagedFrom: () =>
+    Effect.fail(new Error("GitService must not be called for --version/--help")),
+  addIntentToAdd: () =>
     Effect.fail(new Error("GitService must not be called for --version/--help")),
 })
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module"
 import { FileSystem } from "@effect/platform"
-import { Effect } from "effect"
+import { Effect, Either } from "effect"
 import { ConfigInit, ConfigService } from "./Config.js"
 import { Cwd } from "./Cwd.js"
 import { EnvVars } from "./EnvVars.js"
@@ -20,6 +20,7 @@ import {
   type ProcessRun,
   type ResolvedRest,
 } from "./Edge.js"
+import { closeReviewWindow, openReviewWindow } from "./ReviewWindow.js"
 import { formatFile } from "./Format.js"
 import { startLspServer } from "./Lsp.js"
 import {
@@ -551,12 +552,26 @@ export function makeProgram(
     const git = yield* GitService
     const fs = yield* FileSystem.FileSystem
     yield* assertRunningFromRepoRoot(git, fs)
+    // Restore the real HEAD before anything reads or mutates workflow state:
+    // while a review checkout window is open (see src/ReviewWindow.ts), HEAD is
+    // rewound to the review base, so the pure machine would otherwise resolve
+    // against the wrong commit. Keyed on the ref alone — a no-op when no window
+    // is open.
+    yield* closeReviewWindow
     // Auto-init runs here and ONLY here: past the version/help short-circuit,
     // the format branch, the known-subcommand guard, and the repo-root guard —
     // a refused or rejected invocation must never mutate the repository.
     yield* (yield* ConfigInit).ensure
 
-    yield* dispatchKnownSubcommand(sub, argv, json, write)
+    // Re-arm the window after the subcommand — on success AND on refusal/error,
+    // and after read-only commands too (every command opts into window
+    // management), so the editor's diff view stays consistent no matter which
+    // command the loop last ran. The subcommand's own error takes priority; a
+    // re-arm failure only surfaces when the subcommand itself succeeded.
+    const outcome = yield* Effect.either(dispatchKnownSubcommand(sub, argv, json, write))
+    const rearm = yield* Effect.either(openReviewWindow)
+    if (Either.isLeft(outcome)) return yield* Effect.fail(outcome.left)
+    if (Either.isLeft(rearm)) return yield* Effect.fail(rearm.left)
   }).pipe(
     json
       ? Effect.catchAll((error) =>

--- a/src/workflows/default.yaml
+++ b/src/workflows/default.yaml
@@ -507,6 +507,14 @@ states:
     actor: human
     file: <%= it.vars.reviewFile %>
     mode: review
+    # While the cycle rests here for human review, gtd opens a "review checkout
+    # window": HEAD and the index are temporarily rewound to this cycle's start
+    # (the process boundary — no `reviewBase` state is declared, so the base
+    # defaults to it) with the working tree untouched, so the whole cycle diff
+    # surfaces as ordinary uncommitted changes in the editor's git integration.
+    # The window closes automatically on the next invocation, once the cycle
+    # rests anywhere else (see src/ReviewWindow.ts, STATES.md §11).
+    reviewWindow: true
     message: |
       `<%= it.vars.reviewFile %>` holds the review record for the completed
       cycle — tick a pointer's `- [ ]` box to `- [x]` to approve that item;

--- a/tests/integration/features/default-workflow.feature
+++ b/tests/integration/features/default-workflow.feature
@@ -151,7 +151,14 @@ Feature: The bundled default workflow — full cycle journeys
     # review-validating (valid, nothing to clean up): a clean step moves to await-review
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): await-review"
+    # await-review declares `reviewWindow: true` (STATES.md §11): landing here
+    # opens the review checkout window, rewinding raw HEAD to the review base.
+    # `gtd status` closes the window before reading, so it still resolves the
+    # true rest — the window then re-arms on its way out.
+    And the git ref "refs/gtd/review-head" exists
+    When I run gtd status
+    Then it succeeds
+    And stdout contains "State: await-review"
 
     # await-review: partial-tick feedback — the reviewer adds a note without
     # ticking the box, routing to the decider (not the catch-all)
@@ -224,7 +231,12 @@ Feature: The bundled default workflow — full cycle journeys
     And the last commit subject is "gtd(agent): review-validating"
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): await-review"
+    # await-review opens the review checkout window (see above) — resolve the
+    # true rest via `gtd status` rather than raw HEAD.
+    And the git ref "refs/gtd/review-head" exists
+    When I run gtd status
+    Then it succeeds
+    And stdout contains "State: await-review"
 
     # await-review: tick every box — the decider sees no unticked pointer
     # left and approves, removing REVIEW.md and resting the cycle at idle
@@ -348,7 +360,12 @@ Feature: The bundled default workflow — full cycle journeys
     Given the file ".gtd/FORMAT.md" is deleted
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): await-review"
+    # await-review opens the review checkout window (reviewWindow: true) — assert
+    # the resolved state via `gtd status`, which closes the window before reading.
+    And the git ref "refs/gtd/review-head" exists
+    When I run gtd status
+    Then it succeeds
+    And stdout contains "State: await-review"
 
   Scenario: deleting REVIEW.md outright at await-review is the power-user approve shortcut, bypassing review-deciding
     Given a test project

--- a/tests/integration/features/review-window.feature
+++ b/tests/integration/features/review-window.feature
@@ -1,0 +1,90 @@
+@inmem
+Feature: Review checkout window — the pending review diff surfaces in the editor
+
+  A state may declare `reviewWindow: true` (see STATES.md §11). While the
+  workflow RESTS at such a state, gtd rewinds HEAD and the index to the review
+  base (the process start, unless a `reviewBase` state narrows it) with the
+  working tree untouched, so the whole reviewable diff shows up as ordinary
+  uncommitted changes in any editor's standard git integration. The real head
+  is preserved under `refs/gtd/review-head` (the base under
+  `refs/gtd/review-base`); every gtd invocation restores it BEFORE reading or
+  mutating state, so the pure machine never sees the window and the reviewer's
+  own edits are captured by the resting state's own `on` patterns like any
+  other pending change.
+
+  The bundled default declares `reviewWindow: true` on `await-review`. Each
+  scenario builds a cycle that rests there: `chore: initial commit` is the
+  process boundary (the diff base), two `building` commits carry the reviewable
+  code, and a final `await-review` commit carries the committed review doc.
+
+  Background:
+    Given a test project
+    And a commit "gtd(agent): building" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd(agent): building" that adds "src/other.ts" with:
+      """
+      export const untouched = () => true
+      """
+    And a commit "gtd(check): await-review" that adds ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: 0000000 -->
+
+      ## calc
+      - [ ] ./src/calc.ts#1 — new add function
+      """
+
+  Scenario: Resting at the gate opens the window — HEAD at the base, the diff dirty
+    When I run gtd next
+    Then it succeeds
+    And the git ref "refs/gtd/review-head" exists
+    And the git ref "refs/gtd/review-base" exists
+    # HEAD rests at the review base: the cycle's process boundary.
+    And the last commit subject is "chore: initial commit"
+    # The whole package diff is visible as uncommitted changes…
+    And the git status contains "src/calc.ts"
+    And the git status contains "src/other.ts"
+    # …while `.gtd/` plumbing stays out of the untracked noise.
+    And the git status does not contain "?? .gtd/"
+
+  Scenario: The machine never sees the window — status resolves the real state
+    Given I run gtd next
+    When I run gtd status
+    Then it succeeds
+    # `gtd status` closed the window, resolved the true rest, then re-armed it:
+    And stdout contains "State: await-review"
+    And the git ref "refs/gtd/review-head" exists
+    And the last commit subject is "chore: initial commit"
+
+  Scenario: Deleting the review doc approves — the window closes and leaves no trace
+    Given I run gtd next
+    And the file ".gtd/REVIEW.md" is deleted
+    When I run gtd step human
+    Then it succeeds
+    And the last commit subject is "gtd(human): idle"
+    And the git ref "refs/gtd/review-head" does not exist
+    And the git ref "refs/gtd/review-base" does not exist
+    And ".gtd/REVIEW.md" does not exist
+
+  Scenario: Reviewer code edits close the window and route back as feedback
+    Given I run gtd next
+    And "src/calc.ts" is modified to:
+      """
+      export const add = (a: number, b: number) => a + b
+      // reviewer: please rename to sum
+      """
+    When I run gtd step human
+    Then it succeeds
+    # A code edit with REVIEW.md untouched is feedback straight to grilling.
+    And the last commit subject is "gtd(human): grilling"
+    And the git ref "refs/gtd/review-head" does not exist
+
+  Scenario: Read-only commands re-arm the window on their way out
+    Given I run gtd next
+    When I run gtd status
+    Then it succeeds
+    And the git ref "refs/gtd/review-head" exists
+    And the last commit subject is "chore: initial commit"

--- a/tests/integration/support/inmem/Repo.ts
+++ b/tests/integration/support/inmem/Repo.ts
@@ -323,6 +323,85 @@ export class InMemRepo {
   deleteFile(path: string): void {
     this.worktree.delete(path)
   }
+
+  // ---------------------------------------------------------------------------
+  // Refs & review-checkout-window plumbing
+  // ---------------------------------------------------------------------------
+
+  /** `git update-ref <ref> <hash>` — point a repo-local ref at a commit (resolves symbolic inputs first). */
+  updateRef(ref: string, hash: string): void {
+    this.refs.set(ref, this.resolveRef(hash) ?? hash)
+  }
+
+  /** `git update-ref -d <ref>` — idempotent removal of a repo-local ref. */
+  deleteRef(ref: string): void {
+    this.refs.delete(ref)
+  }
+
+  /**
+   * `git reset --mixed <ref>` — move HEAD and the index to `ref`'s commit,
+   * leaving the working tree untouched (so committed work re-surfaces as
+   * pending changes). The open/close primitive of the review checkout window.
+   */
+  mixedResetTo(ref: string): void {
+    if (ref === InMemRepo.EMPTY_TREE) {
+      this.head = null
+      this.branches.delete(this.currentBranch)
+      this.index = new Map()
+      return
+    }
+    const hash = this.resolveRef(ref)
+    if (!hash) throw new Error(`Cannot resolve ref: ${ref}`)
+    this.head = hash
+    this.branches.set(this.currentBranch, hash)
+    this.index = new Map(this.getCommit(hash)?.files ?? new Map())
+    // worktree unchanged (mixed reset)
+  }
+
+  /** True iff `a` is an ancestor of (or equal to) `b` on the first-parent chain. */
+  isAncestor(a: string, b: string): boolean {
+    const ha = this.resolveRef(a)
+    const hb = this.resolveRef(b)
+    if (!ha || !hb) return false
+    let cur: string | null = hb
+    while (cur !== null) {
+      if (cur === ha) return true
+      cur = this.getCommit(cur)?.parent ?? null
+    }
+    return false
+  }
+
+  /**
+   * `git restore --staged --source=<source> -- <paths…>` — set the index
+   * entries under each path to their state at `source` (setting or removing),
+   * leaving HEAD and the working tree untouched. Pins `.gtd/` plumbing back to
+   * the real head while the review window is open.
+   */
+  restoreStagedFrom(source: string, paths: ReadonlyArray<string>): void {
+    const hash = this.resolveRef(source)
+    const tree = hash ? (this.getCommit(hash)?.files ?? new Map<string, string>()) : new Map()
+    for (const p of paths) {
+      const prefix = p.endsWith("/") ? p : `${p}/`
+      const affected = new Set<string>()
+      for (const k of this.index.keys()) if (k === p || k.startsWith(prefix)) affected.add(k)
+      for (const k of tree.keys()) if (k === p || k.startsWith(prefix)) affected.add(k)
+      for (const k of affected) {
+        if (tree.has(k)) this.index.set(k, tree.get(k)!)
+        else this.index.delete(k)
+      }
+    }
+  }
+
+  /**
+   * `git add --intent-to-add .` — register every untracked worktree file in
+   * the index with an empty placeholder, so it renders as an addition (with a
+   * content hunk) rather than an untracked `??` entry.
+   */
+  addIntentToAdd(): void {
+    for (const path of this.worktree.keys()) {
+      if (!this.index.has(path)) this.index.set(path, "")
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/support/inmem/layers.ts
+++ b/tests/integration/support/inmem/layers.ts
@@ -107,6 +107,13 @@ const makeGitReaderOps = (repo: InMemRepo): GitReaderOperations => ({
       : Effect.fail(new Error(`Cannot resolve ref: ${ref}`))
   },
 
+  readRefOption: (ref: string) => {
+    const hash = repo.resolveRef(ref)
+    return Effect.succeed(hash !== null ? Option.some(hash) : Option.none<string>())
+  },
+
+  isAncestor: (a: string, b: string) => Effect.succeed(repo.isAncestor(a, b)),
+
   topLevel: () => Effect.succeed("/repo"),
 
   commitHistory: (base?: string) => Effect.succeed(repo.commitHistory(base)),
@@ -157,6 +164,17 @@ const makeGitWriterOps = (repo: InMemRepo): GitWriterOperations => ({
   commitAsIs: (message: string) => tryCatch(() => repo.commitAsIs(message)),
 
   discardPending: () => tryCatch(() => repo.discardPending()),
+
+  updateRef: (ref: string, hash: string) => tryCatch(() => repo.updateRef(ref, hash)),
+
+  deleteRef: (ref: string) => tryCatch(() => repo.deleteRef(ref)),
+
+  mixedResetTo: (ref: string) => tryCatch(() => repo.mixedResetTo(ref)),
+
+  restoreStagedFrom: (source: string, paths: ReadonlyArray<string>) =>
+    tryCatch(() => repo.restoreStagedFrom(source, paths)),
+
+  addIntentToAdd: () => tryCatch(() => repo.addIntentToAdd()),
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/support/steps/review-window.steps.ts
+++ b/tests/integration/support/steps/review-window.steps.ts
@@ -1,0 +1,23 @@
+import { Then } from "quickpickle"
+import assert from "node:assert"
+import type { GtdWorld } from "../world.js"
+
+// ── Review checkout window: refs + surfaced status ────────────────────────────
+
+Then("the git ref {string} exists", (world: GtdWorld, ref: string) => {
+  assert.ok(world.gitRefExists(ref), `Expected the git ref "${ref}" to exist.`)
+})
+
+Then("the git ref {string} does not exist", (world: GtdWorld, ref: string) => {
+  assert.ok(!world.gitRefExists(ref), `Expected the git ref "${ref}" NOT to exist.`)
+})
+
+Then("the git status contains {string}", (world: GtdWorld, text: string) => {
+  const status = world.gitStatus()
+  assert.ok(status.includes(text), `Expected git status to contain "${text}". Got:\n${status}`)
+})
+
+Then("the git status does not contain {string}", (world: GtdWorld, text: string) => {
+  const status = world.gitStatus()
+  assert.ok(!status.includes(text), `Expected git status NOT to contain "${text}". Got:\n${status}`)
+})

--- a/tests/integration/support/world.ts
+++ b/tests/integration/support/world.ts
@@ -202,6 +202,23 @@ export class GtdWorld extends QuickPickleWorld {
     })
   }
 
+  /** Whether a repo-local ref (e.g. `refs/gtd/review-head`) resolves to a commit. */
+  gitRefExists(ref: string): boolean {
+    if (this.repo !== undefined) {
+      return this.repo.resolveRef(ref) !== null
+    }
+    try {
+      execSync(`git rev-parse --verify --quiet ${ref}`, {
+        cwd: this.repoDir,
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+      return true
+    } catch {
+      return false
+    }
+  }
+
   /** Plain working-tree deletion (no git involvement — what an editor's delete does). */
   deleteWorktreeFile(path: string): void {
     if (this.repo !== undefined) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
             "./tests/integration/support/steps/formatting.steps.ts",
             "./tests/integration/support/steps/gtd-loop.steps.ts",
             "./tests/integration/support/steps/lsp.steps.ts",
+            "./tests/integration/support/steps/review-window.steps.ts",
           ],
           testTimeout: 300_000,
         },

--- a/vitest.stryker.config.ts
+++ b/vitest.stryker.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       "./tests/integration/support/steps/formatting.steps.ts",
       "./tests/integration/support/steps/gtd-loop.steps.ts",
       "./tests/integration/support/steps/lsp.steps.ts",
+      "./tests/integration/support/steps/review-window.steps.ts",
     ],
     testTimeout: 300_000,
     hookTimeout: 30_000,


### PR DESCRIPTION
Re-introduce the v2 "review checkout window" (surface the pending review
diff in editors by rewinding HEAD/index to the review base) that the v3
rewrite dropped — this time as workflow DATA, not hardwired machinery.

Engine (pure):
- StateDef gains `reviewWindow?` (open the window while resting here) and
  `reviewBase?` (anchor the diff base); `isReviewWindowState`/
  `isReviewBaseState` helpers; validateDefinition forbids both on commit
  states. Compiled via a shared boolean-flag compiler in PatternConfig.

Edge:
- New src/ReviewWindow.ts: openReviewWindow / closeReviewWindow bracket
  every state subcommand. Close is ref-keyed (refs/gtd/review-head) and
  runs before anything reads state, so the pure engine never observes an
  open window; open re-arms after the command (success, refusal, and
  read-only alike) when the resolved rest declares reviewWindow. Base is
  the most-recent in-process reviewBase commit, else the process start.
- Re-add the git primitives v3 deleted: updateRef, readRefOption,
  deleteRef, mixedResetTo, isAncestor, restoreStagedFrom, addIntentToAdd
  (live impl + in-memory test fake).
- program.ts wires close-before / re-arm-after around dispatch.

Default workflow:
- await-review declares `reviewWindow: true` (base = whole cycle).

Tests: live-git ReviewWindow unit tests (open/close round trip +
reviewBase narrowing), @inmem review-window.feature, pure-engine and
compiler unit tests, and updated default-workflow.feature assertions
(landing at await-review now opens the window).

Docs: STATES.md §11 + property table, configuration.md, upgrading.md,
AGENTS.md module map.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016Z2VrkyyYmsCNJKfcdJFp4