### PR TITLE
feat: surface which change routes where at human gates

### DIFF
--- a/STATES.md
+++ b/STATES.md
@@ -25,7 +25,7 @@ A workflow is a set of named **states**. Each state declares:
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `actor`                                       | A plain string: who acts here. No closed vocabulary, no "kinds" — every actor just makes changes in the working tree. `gtd step <actor>` authenticates against it. **Commit states carry no `actor`** — gtd itself performs them.                                                                                                                                                                                                                                                                                                                                                    |
 | `script` \| `prompt` \| `message` \| `commit` | Exactly one — the state's content kind (see §2). All four are Eta templates, inline or a `./`-relative file reference auto-inlined at config load (see [Configuration](docs/configuration.md)).                                                                                                                                                                                                                                                                                                                                                                                      |
-| `on`                                          | An ordered map of change patterns → next state (see §3). Evaluated at step time against the pending diff; **first match wins**. Absent on a commit state (a commit state has no outgoing edges — the process ends there).                                                                                                                                                                                                                                                                                                                                                            |
+| `on`                                          | An ordered map of change patterns → next state (see §3). Evaluated at step time against the pending diff; **first match wins**. A row's value is either the target state name or a `{ to, describe }` object carrying an optional human-readable `describe` sentence (see §3). Absent on a commit state (a commit state has no outgoing edges — the process ends there).                                                                                                                                                                                                             |
 | `initial: true`                               | Exactly one state across the whole workflow: where an unrecognized HEAD resolves (see §5). Must not be a commit state.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `retry`                                       | Optional `{ max, otherwise }` — redirects a transition into this state to `otherwise` once this state has already been entered `max` times within the current process (see §7).                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `model`                                       | Optional, opaque string — a harness hint (e.g. `smart`, `fast`, or a concrete model id) emitted alongside the state's content for the driving loop to map onto its agent harness. **Rendered as an Eta template through the same `it.vars`-carrying context as content** (a plain string with no Eta tags passes through unchanged) — see [Configuration](docs/configuration.md#model--the-opaque-harness-hint-template-rendered). gtd never interprets the rendered value; unset means "use the harness's default". **Forbidden on a commit state** (never at rest, emits nothing). |
@@ -35,7 +35,12 @@ A workflow is a set of named **states**. Each state declares:
 **Emission:** `gtd next --json`/`gtd status --json` gain optional `file`
 (rendered) and `mode` (verbatim) keys, omitted — never `null` — when unset,
 exactly like `model`; plain `gtd status` prints `File:`/`Mode:` lines (after
-`Model:`) when set.
+`Model:`) when set. Both also emit an `edges` array — the resting state's `on`
+edges as `{ pattern, target, describe? }` (the same list a `message:` template
+sees as `it.edges`, see §3) — omitted only when the state has no `on` (a commit
+state); a per-edge `describe` key is likewise omitted when that edge declares
+none. Plain-text output carries none of these structured keys (JSON-only,
+exactly like `model`/`file`/`mode`).
 
 A state is either a **rest** (has an `actor` — `gtd` halts there and awaits that
 actor's next step) or a **commit state** (has `commit:` instead of an
@@ -85,6 +90,21 @@ changes.
 **Declaration order, first match wins.** `on` rows are evaluated top to bottom
 (a YAML mapping preserves key order); the first row whose pattern fires against
 the pending diff decides the target.
+
+**Row value: a target, or a `{ to, describe }` object.** A row's value is
+normally just the target state name. It may instead be an object
+`{ to: <target>, describe: <sentence> }`, where `describe` is a human-readable
+sentence explaining what making that kind of change does next — e.g.
+`describe: "Change nothing to accept the current state and proceed."`. The
+`describe` is **inert to the engine** — it is not part of matching, not
+Eta-rendered (exactly like the pattern key itself), and never affects a
+decision. It exists only to be surfaced: a state's own edges are handed to that
+state's content template as `it.edges` (an array of
+`{ pattern, target, describe? }`), so a human gate's `message:` can render a
+"what each change does next" list straight from the routing it documents — one
+source of truth, no prose that can drift from the `on` map.
+`gtd next --json`/`gtd status --json` emit the same `edges` array (see §1). The
+bundled default uses this at every human gate (see §10).
 
 > **Documented discrepancy:** an early design note called `"* *"` "the catch-all
 > for any dirty tree". Per the single-segment rule above that is only true when
@@ -374,6 +394,15 @@ diffs never reach back across it.
 both declare `model: smart`, an opaque hint `gtd next`/`gtd status` `--json`
 emit verbatim for the driving loop to map onto its harness. Every other state
 leaves `model` unset, so the harness's own default applies.
+
+Every human gate (`idle`, `grilling-answer`, `escalate`, `await-review`)
+declares a `describe` on each of its `on` edges (see §3) and closes its
+`message:` with a "what each change does next" list rendered from `it.edges` —
+so the message tells the human, at that gate, which change routes to which next
+state (e.g. `await-review`: delete `.gtd/REVIEW.md` to approve → `idle`; tick a
+box → `review-deciding`; edit only code → `grilling`). The list is generated
+from the same `on` edges the engine routes on, so it can never drift from the
+routing it describes.
 
 The default's `vars:` also declares `todoFile`/`reviewFile`/`feedbackFile` (the
 three filenames above, in one place), which every `file:` and every

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,8 +86,9 @@ process in the same step that entered it — see
 [STATES.md §5](../STATES.md#5-resolution)).
 
 Plain mode prints the rendered content verbatim (with exactly one trailing
-newline) — never the `model`/`file`/`mode` hints, which are JSON-only. `--json`
-emits `{state, actor, kind, content, model?, file?, mode?}`:
+newline) — never the `model`/`file`/`mode`/`edges` structured keys, which are
+JSON-only. `--json` emits
+`{state, actor, kind, content, model?, file?, mode?, edges?}`:
 
 ```json
 {
@@ -113,6 +114,14 @@ emits `{state, actor, kind, content, model?, file?, mode?}`:
   [Configuration](configuration.md#filemode--the-steering-file-association)).
   Both present only when the state declares them; **omitted entirely** (never
   `null`) otherwise.
+- `edges` — the resting state's `on` edges as `[{ pattern, target, describe? }]`
+  (declaration order) — the same list the content template sees as `it.edges`
+  (see
+  [Configuration](configuration.md#on-values--a-target-or-a--to-describe--route-description)).
+  A driver relaying a human gate's message has the routing (and each edge's
+  human-readable `describe`) alongside the rendered text. **Omitted entirely**
+  when the state has no `on` (a commit state); a per-edge `describe` is likewise
+  omitted when that edge declares none.
 
 ## `gtd run`
 
@@ -159,10 +168,12 @@ after `Awaits:` when the resolved state declares a `model:` hint, and
 declared — each independently, only when set.
 
 `--json` emits
-`{state, actor, changes: [{status, path, pattern}], model?, file?, mode?}` —
-`pattern` is `null` when no declared row matches that change; `model`/`file`/
+`{state, actor, changes: [{status, path, pattern}], model?, file?, mode?, edges?}`
+— `pattern` is `null` when no declared row matches that change; `model`/`file`/
 `mode` are present only when the resolved state declares them (omitted entirely,
-never `null`, otherwise):
+never `null`, otherwise); `edges` is the resting state's `on` edges as
+`[{ pattern, target, describe? }]` (same as `gtd next --json`), omitted when the
+state has no `on`:
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,8 @@ workflow:
       message: <string>
       commit: <string>
       on: # a mapping, DECLARATION ORDER PRESERVED
-        "<pattern>": <targetState>
+        "<pattern>": <targetState> # short form
+        "<pattern>": { to: <targetState>, describe: <sentence> } # with a human-readable route description
       initial: true # exactly one state across the whole workflow
       retry:
         max: <number>
@@ -89,6 +90,51 @@ workflow:
 A `vars:` key sibling to `states:` inside `workflow:` declares the workflow's
 own defaults for `it.vars` — see ["Variables"](#variables) below for the full
 three-layer picture.
+
+### `on:` values — a target, or a `{ to, describe }` route description
+
+An `on` row's value is normally the target state name. It may instead be an
+object `{ to: <target>, describe: <sentence> }`, attaching a human-readable
+`describe` — a plain sentence explaining what making that kind of change does
+next. `describe` is **inert to the engine**: it plays no part in matching, is
+never Eta-rendered (exactly like the pattern key itself — see the "Known
+limitation" note below), and never affects a decision. It exists only to be
+surfaced. A state's own edges are handed to its content template as `it.edges`
+(an array of `{ pattern, target, describe? }`, in declaration order), so a human
+gate's `message:` can render a "what each change does next" list from the same
+routing the engine uses — one source of truth:
+
+```yaml
+workflow:
+  states:
+    await-review:
+      actor: human
+      message: |
+        Review the diff, then run `gtd step human`.
+
+        What each change does next:
+        <% it.edges.forEach(function (e) { if (e.describe) { %>
+        <%~ "- " + e.describe + "\n" %>
+        <% } }) %>
+      on:
+        "D .gtd/REVIEW.md":
+          to: idle
+          describe:
+            "Delete `.gtd/REVIEW.md` to approve the whole cycle and rest at
+            idle."
+        "* **":
+          to: grilling
+          describe:
+            "Change any source file to leave feedback and start another round."
+```
+
+The `<%~ "- " + e.describe + "\n" %>` idiom keeps each bullet's own newline: Eta
+strips the template's line breaks around `<% %>` control tags (its `autoTrim`
+default), not text inside an interpolation. Edges without a `describe` are
+skipped by the `if (e.describe)` guard. `gtd next --json` and
+`gtd status --json` also emit the `edges` array; both omit it when the state has
+no `on` (a commit state), and omit a per-edge `describe` when that edge declares
+none.
 
 ### `model:` — the opaque harness hint, template-rendered
 

--- a/schema.json
+++ b/schema.json
@@ -47,9 +47,29 @@
               },
               "on": {
                 "type": "object",
-                "description": "Ordered map of change pattern -> target state. Patterns: \"C\" (clean tree) or \"<A|M|D|*> <glob>\" over the pending diff; first declared match wins. Every target must name a defined state, and every non-initial state must be reachable through these edges (or a retry.otherwise).",
+                "description": "Ordered map of change pattern -> target state. Patterns: \"C\" (clean tree) or \"<A|M|D|*> <glob>\" over the pending diff; first declared match wins. Every target must name a defined state, and every non-initial state must be reachable through these edges (or a retry.otherwise). A value is either the target state name (string) or a { to, describe } object whose describe is a human-readable sentence templates can surface as it.edges (e.g. in a human gate's message).",
                 "additionalProperties": {
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "description": "The target state name."
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": ["to"],
+                      "properties": {
+                        "to": {
+                          "type": "string",
+                          "description": "The target state name."
+                        },
+                        "describe": {
+                          "type": "string",
+                          "description": "Human-readable sentence describing where this change routes; surfaced verbatim (never Eta-rendered) to templates as it.edges[].describe."
+                        }
+                      }
+                    }
+                  ]
                 }
               },
               "initial": {

--- a/src/ConfigSchema.ts
+++ b/src/ConfigSchema.ts
@@ -74,8 +74,25 @@ const stateJsonSchema = {
     on: {
       type: "object",
       description:
-        'Ordered map of change pattern -> target state. Patterns: "C" (clean tree) or "<A|M|D|*> <glob>" over the pending diff; first declared match wins. Every target must name a defined state, and every non-initial state must be reachable through these edges (or a retry.otherwise).',
-      additionalProperties: { type: "string" },
+        'Ordered map of change pattern -> target state. Patterns: "C" (clean tree) or "<A|M|D|*> <glob>" over the pending diff; first declared match wins. Every target must name a defined state, and every non-initial state must be reachable through these edges (or a retry.otherwise). A value is either the target state name (string) or a { to, describe } object whose describe is a human-readable sentence templates can surface as it.edges (e.g. in a human gate\'s message).',
+      additionalProperties: {
+        oneOf: [
+          { type: "string", description: "The target state name." },
+          {
+            type: "object",
+            additionalProperties: false,
+            required: ["to"],
+            properties: {
+              to: { type: "string", description: "The target state name." },
+              describe: {
+                type: "string",
+                description:
+                  "Human-readable sentence describing where this change routes; surfaced verbatim (never Eta-rendered) to templates as it.edges[].describe.",
+              },
+            },
+          },
+        ],
+      },
     },
     initial: {
       type: "boolean",

--- a/src/Edge.test.ts
+++ b/src/Edge.test.ts
@@ -8,6 +8,7 @@ import {
   renderFile,
   renderModel,
   resolveVars,
+  toTemplateEdges,
 } from "./Edge.js"
 import type { TemplateContext } from "./PatternTemplates.js"
 import type { StateDef, WorkflowDefinition } from "./PatternMachine.js"
@@ -194,6 +195,7 @@ const context = (overrides: Partial<TemplateContext> = {}): TemplateContext => (
     throw new Error("no file registered")
   },
   vars: {},
+  edges: [],
   ...overrides,
 })
 
@@ -311,6 +313,29 @@ describe("resolveVars — the three-layer `it.vars` merge (workflow < rc < env)"
     expect(
       resolveVars({}, {}, { PATH: "/usr/bin", GTD_VAR_kept: "yes", GTD_VAR_unset: undefined }),
     ).toEqual({ kept: "yes" })
+  })
+})
+
+describe("toTemplateEdges — OnEdge tuples to the `{ pattern, target, describe? }` templates see", () => {
+  it("maps a two-element edge with no describe key, and a three-element edge with one", () => {
+    expect(
+      toTemplateEdges([
+        ["C", "building", "Change nothing to accept and build."],
+        ["* **", "grilling"],
+      ]),
+    ).toEqual([
+      { pattern: "C", target: "building", describe: "Change nothing to accept and build." },
+      { pattern: "* **", target: "grilling" },
+    ])
+  })
+
+  it("returns an empty list for a state with no `on` (a commit state)", () => {
+    expect(toTemplateEdges(undefined)).toEqual([])
+  })
+
+  it("omits the describe key entirely (never `undefined`) when an edge carries none", () => {
+    const [edge] = toTemplateEdges([["* **", "next"]])
+    expect("describe" in edge!).toBe(false)
   })
 })
 

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -8,13 +8,14 @@ import {
   resolveState,
   type ChangeStatus,
   type ContentKind,
+  type OnEdge,
   type PendingChange,
   type StateDef,
   type StateName,
   type StepDecision,
   type WorkflowDefinition,
 } from "./PatternMachine.js"
-import { renderStateTemplate, type TemplateContext } from "./PatternTemplates.js"
+import { renderStateTemplate, type TemplateContext, type TemplateEdge } from "./PatternTemplates.js"
 
 /**
  * The v3 Effect edge (see `docs/design/pattern-machine-plan.md`, "Phase 3:
@@ -170,7 +171,13 @@ export const resolveVars = (
 
 // ── Template context ─────────────────────────────────────────────────────────
 
-/** Build the `PatternTemplates.TemplateContext` for rendering `state`'s content at the resolved rest. `vars` is the already-merged three-layer map (see `resolveVars`). */
+/** Map a state's raw `on` edges to the `{ pattern, target, describe? }` shape templates see as `it.edges`. `undefined` (a commit state, no `on`) yields an empty list. */
+export const toTemplateEdges = (edges: readonly OnEdge[] | undefined): readonly TemplateEdge[] =>
+  (edges ?? []).map(([pattern, target, describe]) =>
+    describe !== undefined ? { pattern, target, describe } : { pattern, target },
+  )
+
+/** Build the `PatternTemplates.TemplateContext` for rendering `state`'s content at the resolved rest. `vars` is the already-merged three-layer map (see `resolveVars`); `edges` is the resting state's own `on` edges (see `toTemplateEdges`). */
 export const buildTemplateContext = (
   git: GitOperations,
   read: (path: string) => string,
@@ -178,6 +185,7 @@ export const buildTemplateContext = (
   actor: string,
   run: ProcessRun,
   vars: Record<string, string>,
+  edges: readonly OnEdge[] | undefined,
 ): Effect.Effect<TemplateContext, Error> =>
   Effect.gen(function* () {
     const hasCommits = yield* git.hasCommits()
@@ -206,6 +214,7 @@ export const buildTemplateContext = (
       lastDiff,
       read,
       vars,
+      edges: toTemplateEdges(edges),
     }
   })
 
@@ -222,6 +231,8 @@ export interface RenderedRest {
   readonly file?: string
   /** The resolved rest's `mode:` hint, verbatim (a closed literal — never Eta-rendered) — omitted when the state declares none. */
   readonly mode?: StateDef["mode"]
+  /** The resolved rest's `on` edges as `{ pattern, target, describe? }` — the same list templates see as `it.edges` (see `toTemplateEdges`). Always present (an empty array at a commit state); `gtd next --json` emits it so a driver has the routing (and its human-readable `describe`s) alongside the rendered content. */
+  readonly edges: readonly TemplateEdge[]
 }
 
 /**
@@ -288,6 +299,7 @@ export const renderRest = (
       ...(model !== undefined ? { model } : {}),
       ...(file !== undefined ? { file } : {}),
       ...(rest.stateDef.mode !== undefined ? { mode: rest.stateDef.mode } : {}),
+      edges: toTemplateEdges(rest.stateDef.on),
     }
   })
 

--- a/src/Lsp.ts
+++ b/src/Lsp.ts
@@ -311,6 +311,7 @@ export const buildFileModeMap = (
           )
         },
         vars,
+        edges: [],
       })
     } catch (e) {
       warnings.push(
@@ -451,6 +452,7 @@ const resolveSteeringFile = (
       rest.actor,
       run,
       vars,
+      rest.stateDef.on,
     )
     const file = yield* renderFile(rest.stateDef, context)
     return { state: rest.state, file }

--- a/src/PatternConfig.test.ts
+++ b/src/PatternConfig.test.ts
@@ -190,6 +190,35 @@ states:
       ["C", "c"],
     ])
   })
+
+  it("compiles the { to, describe } object form, carrying describe as the edge's third element, while the string form stays a two-element edge", () => {
+    const { definition } = compileWorkflowConfig(
+      {
+        states: {
+          gate: {
+            actor: "human",
+            message: "choose",
+            initial: true,
+            on: {
+              C: { to: "accept", describe: "Change nothing to accept and proceed." },
+              "* **": "revise",
+            },
+          },
+          accept: { commit: "chore: accept" },
+          revise: {
+            actor: "agent",
+            prompt: "revise",
+            on: { "* **": "gate" },
+          },
+        },
+      },
+      "/config-dir",
+    )
+    expect(definition.states["gate"]!.on).toEqual([
+      ["C", "accept", "Change nothing to accept and proceed."],
+      ["* **", "revise"],
+    ])
+  })
 })
 
 // ── File references ──────────────────────────────────────────────────────────
@@ -387,7 +416,7 @@ describe("compileWorkflowConfig — config-shape validation", () => {
     ).toThrowError(/state "a": "on" must be a mapping of pattern -> target state/)
   })
 
-  it("rejects a non-string `on` target", () => {
+  it("rejects an `on` value that is neither a target string nor a { to, describe } object", () => {
     expect(() =>
       compileWorkflowConfig(
         {
@@ -397,7 +426,60 @@ describe("compileWorkflowConfig — config-shape validation", () => {
         },
         "/dir",
       ),
-    ).toThrowError(/state "a": "on" target for pattern "\* \*" must be a string/)
+    ).toThrowError(
+      /state "a": "on" entry for pattern "\* \*" must be a target state name \(string\) or a \{ to, describe \} object/,
+    )
+  })
+
+  it('rejects an object `on` entry whose "to" is not a string', () => {
+    expect(() =>
+      compileWorkflowConfig(
+        {
+          states: {
+            a: { actor: "human", message: "hi", initial: true, on: { "* *": { to: 1 } } },
+          },
+        },
+        "/dir",
+      ),
+    ).toThrowError(/state "a": "on.\* \*.to" must be a target state name \(string\)/)
+  })
+
+  it('rejects an object `on` entry whose "describe" is not a string', () => {
+    expect(() =>
+      compileWorkflowConfig(
+        {
+          states: {
+            a: {
+              actor: "human",
+              message: "hi",
+              initial: true,
+              on: { "* *": { to: "b", describe: 5 } },
+            },
+            b: { commit: "chore: b" },
+          },
+        },
+        "/dir",
+      ),
+    ).toThrowError(/state "a": "on.\* \*.describe" must be a string/)
+  })
+
+  it("rejects an unknown key inside an object `on` entry", () => {
+    expect(() =>
+      compileWorkflowConfig(
+        {
+          states: {
+            a: {
+              actor: "human",
+              message: "hi",
+              initial: true,
+              on: { "* *": { to: "b", explain: "nope" } },
+            },
+            b: { commit: "chore: b" },
+          },
+        },
+        "/dir",
+      ),
+    ).toThrowError(/state "a": "on" entry for pattern "\* \*" has unknown key\(s\) explain/)
   })
 
   it("compiles a `model` string through onto the state", () => {

--- a/src/PatternConfig.ts
+++ b/src/PatternConfig.ts
@@ -29,7 +29,8 @@ import {
  *     actor: <string>    # forbidden on a commit state, required otherwise
  *     script: <string>   # exactly one of script/prompt/message/commit
  *     on:                # a mapping, DECLARATION ORDER PRESERVED
- *       "<pattern>": <targetState>
+ *       "<pattern>": <targetState>                    # short form
+ *       "<pattern>": { to: <targetState>, describe: <sentence> }  # with a human-readable route description
  *     initial: true       # exactly one state across the whole workflow
  *     retry:
  *       max: <number>
@@ -189,7 +190,51 @@ const resolveContent = (
 
 // ── Per-state field compilers ────────────────────────────────────────────────
 
-/** The `on` mapping: pattern -> target, preserving declaration order as `OnEdge` tuples. */
+const KNOWN_EDGE_KEYS: ReadonlySet<string> = new Set(["to", "describe"])
+
+/**
+ * Compile one `on` row's value into an `OnEdge` (or `undefined`, pushing a
+ * finding, when the value is malformed). The value is EITHER a target-state
+ * name (a string) OR a `{ to: <target>, describe: <sentence> }` object — the
+ * object form attaches an optional human-readable `describe` a `message:`
+ * template can surface at a rest (see `PatternMachine.OnEdge`).
+ */
+const compileOnEdge = (
+  pattern: string,
+  value: unknown,
+  name: string,
+  errors: string[],
+): OnEdge | undefined => {
+  if (typeof value === "string") return [pattern, value]
+  if (!isPlainObject(value)) {
+    errors.push(
+      `state "${name}": "on" entry for pattern "${pattern}" must be a target state name (string) or a { to, describe } object`,
+    )
+    return undefined
+  }
+  const unknownKeys = Object.keys(value).filter((k) => !KNOWN_EDGE_KEYS.has(k))
+  if (unknownKeys.length > 0) {
+    errors.push(
+      `state "${name}": "on" entry for pattern "${pattern}" has unknown key(s) ${unknownKeys.join(", ")}`,
+    )
+  }
+  const { to, describe } = value
+  if (typeof to !== "string") {
+    errors.push(`state "${name}": "on.${pattern}.to" must be a target state name (string)`)
+    return undefined
+  }
+  if (describe !== undefined && typeof describe !== "string") {
+    errors.push(`state "${name}": "on.${pattern}.describe" must be a string`)
+    return undefined
+  }
+  return describe !== undefined ? [pattern, to, describe] : [pattern, to]
+}
+
+/**
+ * The `on` mapping: pattern -> edge, preserving declaration order as `OnEdge`
+ * tuples. Each row's value is compiled by `compileOnEdge` (a target string or
+ * a `{ to, describe }` object).
+ */
 const compileOn = (raw: unknown, name: string, errors: string[]): readonly OnEdge[] | undefined => {
   if (raw === undefined) return undefined
   if (!isPlainObject(raw)) {
@@ -197,12 +242,9 @@ const compileOn = (raw: unknown, name: string, errors: string[]): readonly OnEdg
     return undefined
   }
   const edges: OnEdge[] = []
-  for (const [pattern, target] of Object.entries(raw)) {
-    if (typeof target !== "string") {
-      errors.push(`state "${name}": "on" target for pattern "${pattern}" must be a string`)
-      continue
-    }
-    edges.push([pattern, target])
+  for (const [pattern, value] of Object.entries(raw)) {
+    const edge = compileOnEdge(pattern, value, name, errors)
+    if (edge !== undefined) edges.push(edge)
   }
   return edges
 }

--- a/src/PatternMachine.ts
+++ b/src/PatternMachine.ts
@@ -40,14 +40,22 @@ export interface RetryDef {
 }
 
 /**
- * One `on` row: a raw pattern string paired with its target state. Kept as
- * an ordered PAIR (not an object key) so declaration order survives
- * regardless of how a definition is built — object key order is an
- * incidental JS guarantee that a config compiler (YAML, merged definitions)
- * could easily break by rebuilding an object; a tuple array cannot silently
- * reorder or dedupe two rows that happen to share a pattern string.
+ * One `on` row: a raw pattern string paired with its target state, plus an
+ * OPTIONAL human-readable `describe` — a plain sentence a `message:` template
+ * can surface at a rest to tell a human which change routes where (see
+ * `PatternTemplates.TemplateContext.edges`). Kept as an ordered TUPLE (not an
+ * object key) so declaration order survives regardless of how a definition is
+ * built — object key order is an incidental JS guarantee that a config
+ * compiler (YAML, merged definitions) could easily break by rebuilding an
+ * object; a tuple array cannot silently reorder or dedupe two rows that happen
+ * to share a pattern string.
+ *
+ * `describe` is INERT to the engine — `step`/`resolveState`/`matchesPattern`
+ * never read it (it is not Eta-rendered either, exactly like the pattern key
+ * itself; see STATES.md §3). It exists only to be emitted verbatim so the
+ * driving loop / a `message:` template can present it to a human.
  */
-export type OnEdge = readonly [pattern: string, target: StateName]
+export type OnEdge = readonly [pattern: string, target: StateName, describe?: string]
 
 /**
  * One state's declaration. Exactly one of `script`/`prompt`/`message`/

--- a/src/PatternTemplates.test.ts
+++ b/src/PatternTemplates.test.ts
@@ -15,6 +15,7 @@ const baseContext = (overrides: Partial<TemplateContext> = {}): TemplateContext 
     return `contents of ${path}`
   },
   vars: { greeting: "hi" },
+  edges: [],
   ...overrides,
 })
 
@@ -54,6 +55,40 @@ describe("renderStateTemplate — the full variable set", () => {
       baseContext({ vars: {} }),
     )
     expect(out).toBe("greeting=none")
+  })
+
+  it("renders a human-gate route list from `it.edges`, skipping edges without a describe", () => {
+    const out = renderStateTemplate(
+      [
+        "What each change does next:",
+        "<% it.edges.forEach(function (e) { if (e.describe) { %>",
+        '<%~ "- " + e.describe + "\\n" %>',
+        "<% } }) %>",
+      ].join("\n"),
+      baseContext({
+        edges: [
+          { pattern: "C", target: "building", describe: "Change nothing to accept and build." },
+          { pattern: "* **", target: "grilling", describe: "Edit the plan to grill again." },
+          { pattern: "M .gtd/X.md", target: "elsewhere" },
+        ],
+      }),
+    )
+    expect(out).toBe(
+      "What each change does next:\n- Change nothing to accept and build.\n- Edit the plan to grill again.\n",
+    )
+  })
+
+  it("the route list collapses to just its heading when no edge carries a describe", () => {
+    const out = renderStateTemplate(
+      [
+        "Heading:",
+        "<% it.edges.forEach(function (e) { if (e.describe) { %>",
+        '<%~ "- " + e.describe + "\\n" %>',
+        "<% } }) %>",
+      ].join("\n"),
+      baseContext({ edges: [{ pattern: "* **", target: "x" }] }),
+    )
+    expect(out).toBe("Heading:\n")
   })
 })
 

--- a/src/PatternTemplates.ts
+++ b/src/PatternTemplates.ts
@@ -19,6 +19,20 @@ import { Eta } from "eta"
  */
 
 /**
+ * One resolved `on` edge, as a `message:`/`prompt:` template sees it in
+ * `it.edges`: the raw pattern, its target state, and the optional
+ * human-readable `describe` sentence the workflow author attached (see
+ * `PatternMachine.OnEdge`). All three are LITERAL strings — none is
+ * Eta-rendered (the pattern key never was; `describe` follows the same rule),
+ * so a template renders `describe` verbatim, typically with `<%~ %>`.
+ */
+export interface TemplateEdge {
+  readonly pattern: string
+  readonly target: string
+  readonly describe?: string
+}
+
+/**
  * The full variable set a `script`/`prompt`/`message`/`commit` template may
  * reference as `it.<name>` (Eta's default view-model name). All fields are
  * caller-supplied — see the module docstring.
@@ -53,6 +67,16 @@ export interface TemplateContext {
    * unless a workflow/config/env layer populates it.
    */
   readonly vars: Record<string, string>
+  /**
+   * The resting state's own `on` edges, in declaration order — each a
+   * `{ pattern, target, describe? }` (see `TemplateEdge`). Lets a `message:`
+   * template surface, at a human gate, which change routes to which next
+   * state (e.g. iterating the edges that carry a `describe`). Empty for a
+   * commit state (no `on`); populated but typically unused for `script`/
+   * `prompt` states. Injected by the caller (`src/Edge.ts`) — like every
+   * other field, this module never derives it.
+   */
+  readonly edges: readonly TemplateEdge[]
 }
 
 // One shared Eta instance, `renderString`-only (no named template registry —

--- a/src/program.ts
+++ b/src/program.ts
@@ -16,6 +16,7 @@ import {
   renderRest,
   resolveRest,
   resolveVars,
+  toTemplateEdges,
   type ExecutableDecision,
   type ProcessRun,
   type ResolvedRest,
@@ -163,6 +164,7 @@ const resolveRestContext = (
       rest.actor,
       run,
       vars,
+      rest.stateDef.on,
     )
     return { rest, run, context }
   })
@@ -208,13 +210,15 @@ const stepAsActor = (
 
     const executable: ExecutableDecision = decision
     const vars = resolveVars(config.workflowVars, config.rcVars, envVars.all)
+    const renderedState = decision.kind === "squash" ? decision.state : rest.state
     const context = yield* buildTemplateContext(
       git,
       worktree.read,
-      decision.kind === "squash" ? decision.state : rest.state,
+      renderedState,
       invoker,
       run,
       vars,
+      rest.def.states[renderedState]?.on,
     )
     const outcome = yield* executeDecision(git, run, executable, context)
     return { state: rest.state, subject: outcome.kind === "noop" ? null : outcome.subject }
@@ -276,6 +280,7 @@ const runNextCommand = (
           ...(rendered.model !== undefined ? { model: rendered.model } : {}),
           ...(rendered.file !== undefined ? { file: rendered.file } : {}),
           ...(rendered.mode !== undefined ? { mode: rendered.mode } : {}),
+          ...(rendered.edges.length > 0 ? { edges: rendered.edges } : {}),
         }) + "\n",
       )
     } else {
@@ -350,6 +355,7 @@ const writeStatusJson = (
   model: string | undefined,
   file: string | undefined,
 ): void => {
+  const edges = toTemplateEdges(rest.stateDef.on)
   write(
     JSON.stringify({
       state: rest.state,
@@ -358,6 +364,7 @@ const writeStatusJson = (
       ...(model !== undefined ? { model } : {}),
       ...(file !== undefined ? { file } : {}),
       ...(rest.stateDef.mode !== undefined ? { mode: rest.stateDef.mode } : {}),
+      ...(edges.length > 0 ? { edges } : {}),
     }) + "\n",
   )
 }

--- a/src/workflows/default.yaml
+++ b/src/workflows/default.yaml
@@ -125,13 +125,31 @@ states:
   idle:
     actor: human
     initial: true
+    # Every human-gate `message:` below closes with the SAME rendered block —
+    # a "What each change does next" list built from `it.edges`, the resting
+    # state's own `on` edges (see PatternTemplates.TemplateContext.edges). Each
+    # edge's human-readable route lives in its `describe:` (the single source
+    # of truth), so the list can never drift from the routing it documents.
+    # The block skips edges without a `describe`, and each `<%~ ... "\n" %>`
+    # keeps the bullet's own newline (Eta's autoTrim strips the template's own
+    # line breaks around `<% %>` tags, not text inside an interpolation).
     message: |
       No active gtd cycle.
 
-      To start one: write `.gtd/TODO.md` with a short sketch of what you want
-      built — a few sentences is enough — then run `gtd step human`.
+      To start one, write `.gtd/TODO.md` with a short sketch of what you want
+      built — a few sentences is enough.
+
+      What each change does next (then run `gtd step human`):
+      <% it.edges.forEach(function (e) { if (e.describe) { %>
+      <%~ "- " + e.describe + "\n" %>
+      <% } }) %>
     on:
-      "* **": grilling
+      "* **":
+        to: grilling
+        describe: >-
+          Save your sketch to `.gtd/TODO.md` (any working-tree change) to start
+          the cycle — the agent reads it, explores the codebase, and develops it
+          into a concrete implementation plan (**grilling**).
 
   grilling:
     actor: agent
@@ -262,17 +280,24 @@ states:
     message: |
       `<%= it.vars.todoFile %>` holds the plan under development, with any
       open questions under `## Open Questions` — each carrying a suggested
-      default.
+      default. Answer a question by editing its entry in place: replace its
+      `Suggested default: ...` line with `Answer: ...`, or add further detail.
 
-      To answer a question, edit its entry in place (replace
-      `Suggested default: ...` with `Answer: ...`, or add further detail),
-      then run `gtd step human`.
-
-      To accept all suggested defaults as-is and move on to implementation,
-      run `gtd step human` with no edits.
+      What each change does next (then run `gtd step human`):
+      <% it.edges.forEach(function (e) { if (e.describe) { %>
+      <%~ "- " + e.describe + "\n" %>
+      <% } }) %>
     on:
-      "C": building
-      "* **": grilling
+      "C":
+        to: building
+        describe: >-
+          Change nothing to accept every suggested default as-is and move on to
+          implementation (**building**).
+      "* **":
+        to: grilling
+        describe: >-
+          Edit the plan — answer a question, add detail, or raise a new one — to
+          send it back for another round of grilling (**grilling**).
 
   building:
     actor: agent
@@ -363,11 +388,16 @@ states:
       The agent could not get the check to pass after repeated attempts.
       `<%= it.vars.feedbackFile %>` holds the last failing output.
 
-      Investigate and fix it yourself (editing code and/or
-      `<%= it.vars.feedbackFile %>`), then run `gtd step human` to try the
-      check again.
+      What each change does next (then run `gtd step human`):
+      <% it.edges.forEach(function (e) { if (e.describe) { %>
+      <%~ "- " + e.describe + "\n" %>
+      <% } }) %>
     on:
-      "* **": checking
+      "* **":
+        to: checking
+        describe: >-
+          Fix the failure yourself — edit the code and/or `.gtd/FEEDBACK.md` —
+          to re-run the check (**checking**).
 
   reviewing:
     actor: agent
@@ -509,26 +539,31 @@ states:
     mode: review
     message: |
       `<%= it.vars.reviewFile %>` holds the review record for the completed
-      cycle — tick a pointer's `- [ ]` box to `- [x]` to approve that item;
-      add notes, untick, or edit code for feedback.
+      cycle — one `- [ ]` checkbox per reviewable item, grouped into chunks.
 
-      To approve: tick every box, then run `gtd step human`.
-
-      To approve the whole cycle without ticking every box individually:
-      delete `<%= it.vars.reviewFile %>` and run `gtd step human`.
-
-      To request changes: edit `<%= it.vars.reviewFile %>`
-      (ticking/unticking boxes, adding notes) and/or the code, then run
-      `gtd step human` — any edit to `<%= it.vars.reviewFile %>` sends the
-      cycle to a deterministic check that either closes the cycle out (every
-      box ticked) or extracts the still-unticked items into a fresh
-      `<%= it.vars.todoFile %>` and routes back through grilling with that
-      feedback. Code-only edits (leaving `<%= it.vars.reviewFile %>`
-      untouched) go straight back to grilling.
+      What each change does next (then run `gtd step human`):
+      <% it.edges.forEach(function (e) { if (e.describe) { %>
+      <%~ "- " + e.describe + "\n" %>
+      <% } }) %>
     on:
-      "D .gtd/REVIEW.md": idle
-      "M .gtd/REVIEW.md": review-deciding
-      "* **": grilling
+      "D .gtd/REVIEW.md":
+        to: idle
+        describe: >-
+          Delete `.gtd/REVIEW.md` outright to approve the whole cycle at once
+          and rest back at the start (**idle**).
+      "M .gtd/REVIEW.md":
+        to: review-deciding
+        describe: >-
+          Edit `.gtd/REVIEW.md` — tick a `- [ ]` box to `- [x]` to approve that
+          item, or add notes — to hand it to a deterministic check
+          (**review-deciding**) that closes the cycle out when every box is
+          ticked, or extracts the still-unticked items into a fresh
+          `.gtd/TODO.md` and loops back through **grilling** with that feedback.
+      "* **":
+        to: grilling
+        describe: >-
+          Change only code, leaving `.gtd/REVIEW.md` untouched, to send that as
+          feedback straight back to **grilling**.
 
   review-deciding:
     actor: check

--- a/tests/integration/features/default-workflow.feature
+++ b/tests/integration/features/default-workflow.feature
@@ -367,6 +367,23 @@ Feature: The bundled default workflow — full cycle journeys
     And the last commit subject is "gtd(human): idle"
     And ".gtd/REVIEW.md" does not exist
 
+  Scenario: at await-review, gtd next surfaces which change routes where — the human gate's route list, rendered from its `on` edge descriptions
+    Given a test project
+    And a commit "gtd(check): await-review" that adds ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Chunk
+
+      - [ ] ./src/thing.ts#1
+      """
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "What each change does next (then run `gtd step human`):"
+    And stdout contains "- Delete `.gtd/REVIEW.md` outright to approve the whole cycle"
+    And stdout contains "- Change only code, leaving `.gtd/REVIEW.md` untouched"
+
   Scenario: a code-only edit at await-review (REVIEW.md untouched) is feedback straight to grilling
     Given a test project
     And a commit "gtd(check): await-review" that adds ".gtd/REVIEW.md" with:

--- a/tests/integration/features/driver-json-status.feature
+++ b/tests/integration/features/driver-json-status.feature
@@ -1,9 +1,11 @@
 @inmem
 Feature: Driver protocol — gtd next --json content kinds, gtd status pattern matches
 
-  Pins the `gtd next --json` contract (`{state, actor, kind, content}`, see
-  docs/design/pattern-machine-plan.md §3) for the `script` and `prompt` kinds
-  — smoke.feature already pins the `message` kind at `idle` — and `gtd
+  Pins the `gtd next --json` contract (`{state, actor, kind, content, edges}`,
+  see docs/design/pattern-machine-plan.md §3) for the `script` and `prompt`
+  kinds — smoke.feature already pins the `message` kind at `idle` — the
+  `edges` list (the resting state's `on` edges as `{pattern, target,
+  describe?}`, also what a `message:` template sees as `it.edges`), and `gtd
   status`'s pattern-match reporting (plain text and `--json`), which shows
   which declared `on` pattern (if any) each pending change matches.
 
@@ -289,3 +291,73 @@ Feature: Driver protocol — gtd next --json content kinds, gtd status pattern m
     Then it succeeds
     And stdout does not contain "\"file\""
     And stdout does not contain "\"mode\""
+
+  Scenario: a human gate's message renders its `on` edge descriptions as a route list, and gtd next --json carries the same edges
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          gate:
+            actor: human
+            initial: true
+            message: |
+              Decide what to do next.
+
+              What each change does next (then run `gtd step human`):
+              <% it.edges.forEach(function (e) { if (e.describe) { %>
+              <%~ "- " + e.describe + "\n" %>
+              <% } }) %>
+            on:
+              "C":
+                to: accept
+                describe: "Change nothing to accept the current state and proceed."
+              "* **":
+                to: revise
+                describe: "Change any source file to leave feedback and start another round."
+          accept:
+            commit: "chore: accept"
+          revise:
+            actor: agent
+            prompt: "revise"
+            on:
+              "* **": gate
+      """
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "What each change does next (then run `gtd step human`):"
+    And stdout contains "- Change nothing to accept the current state and proceed."
+    And stdout contains "- Change any source file to leave feedback and start another round."
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"pattern\":\"C\""
+    And stdout contains "\"target\":\"accept\""
+    And stdout contains "\"describe\":\"Change nothing to accept the current state and proceed.\""
+    And stdout contains "\"target\":\"revise\""
+
+  Scenario: a string-form `on` edge emits an edge with no describe, and gtd next --json omits "edges" for a commit-only-target state with none
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "..."
+            on:
+              "* **": idle
+      """
+    And a commit "gtd(human): working" that adds "NOTE.md" with:
+      """
+      a note
+      """
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"edges\":[{\"pattern\":\"* **\",\"target\":\"idle\"}]"
+    And stdout does not contain "\"describe\""


### PR DESCRIPTION
Add an optional human-readable `describe` to each `on` edge and expose the
resting state's edges to templates as `it.edges`, so a `message:` can render a
"what each change does next" list from the same routing the engine matches on —
one source of truth, no prose that can drift from the `on` map.

Grammar: an `on` row's value is now either the target state name (unchanged) or
a `{ to, describe }` object. `describe` is inert to the engine — never matched,
never Eta-rendered — carried as an optional third element of the `OnEdge` tuple.

Every bundled-default human gate (idle, grilling-answer, escalate, await-review)
now declares a `describe` per edge and closes its message with the generated
route list, naming the next state each change leads to.

`gtd next --json` and `gtd status --json` also emit an `edges` array
({pattern, target, describe?}); omitted for a commit state, and a per-edge
`describe` omitted when the edge declares none.

Updated STATES.md (§1/§3/§10), docs/configuration.md, docs/cli.md, the JSON
schema, and e2e coverage in default-workflow.feature / driver-json-status.feature.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AZTMjH5Ejk1WrycC2GvsCe