### PR TITLE
feat: track agent token cost across the workflow

### DIFF
--- a/STATES.md
+++ b/STATES.md
@@ -156,6 +156,15 @@ all also resolves to the initial state.
   retry redirection (§7) — unless `<to>` is a commit state, in which case the
   process squashes instead of committing a turn.
 
+**Token cost.** `gtd step <actor> --cost=<n>` records the token cost of the
+invocation that produced the pending changes as a `Gtd-Cost: <n>` trailer on the
+turn commit — a blank line then the trailer, below the untouched
+`gtd(<actor>): <state>` subject, so resolution (§5) is unaffected. The edge
+(`src/Edge.ts`) sums every such trailer across the current process into
+`it.processCost` (see §8 and
+[Configuration: Token cost](docs/configuration.md#token-cost)); the engine never
+interprets the number, it only carries and sums it.
+
 ## 7. Retry
 
 A state's `retry: { max, otherwise }` caps how many times **that state** may be
@@ -191,10 +200,13 @@ transition whose target is a commit state doesn't write a turn commit — instea
 entering it performs, atomically:
 
 1. **Render** the `commit:` Eta template against the PENDING working tree
-   (`it.read(path)` reads files as they currently sit, not from any commit). A
-   failed render (a malformed template, `read()` throwing for a missing path)
-   **refuses the step and touches nothing** — no reset, no commit, no file
-   discarded.
+   (`it.read(path)` reads files as they currently sit, not from any commit;
+   `it.processCost` is the whole-process token total — every turn's `Gtd-Cost:`
+   trailer plus the squashing step's own `--cost` — so the squash message can
+   record the complete cost of the feature even though the per-turn trailers are
+   discarded with the turns below). A failed render (a malformed template,
+   `read()` throwing for a missing path) **refuses the step and touches
+   nothing** — no reset, no commit, no file discarded.
 2. **Soft-reset** to the process's start parent (the commit before the process's
    first turn — `EMPTY_TREE` if the process covers the whole history) and write
    **one** commit with the rendered message, verbatim as its subject/body.

--- a/STATES.md
+++ b/STATES.md
@@ -156,14 +156,15 @@ all also resolves to the initial state.
   retry redirection (§7) — unless `<to>` is a commit state, in which case the
   process squashes instead of committing a turn.
 
-**Token cost.** `gtd step <actor> --cost=<n>` records the token cost of the
-invocation that produced the pending changes as a `Gtd-Cost: <n>` trailer on the
-turn commit — a blank line then the trailer, below the untouched
-`gtd(<actor>): <state>` subject, so resolution (§5) is unaffected. The edge
-(`src/Edge.ts`) sums every such trailer across the current process into
-`it.processCost` (see §8 and
+**Token cost.** `gtd step <actor> --cost=<n> [--model=<name>]` records the token
+cost of the invocation that produced the pending changes — and the model it ran
+on — as a `Gtd-Cost: <n> <model>` trailer on the turn commit: a blank line then
+the trailer, below the untouched `gtd(<actor>): <state>` subject, so resolution
+(§5) is unaffected. The edge (`src/Edge.ts`) collects every such trailer across
+the current process, summing them into `it.processCost` and grouping them by
+model into `it.processCostByModel` (see §8 and
 [Configuration: Token cost](docs/configuration.md#token-cost)); the engine never
-interprets the number, it only carries and sums it.
+interprets the number or the model name, it only carries, sums, and groups them.
 
 ## 7. Retry
 
@@ -201,9 +202,10 @@ entering it performs, atomically:
 
 1. **Render** the `commit:` Eta template against the PENDING working tree
    (`it.read(path)` reads files as they currently sit, not from any commit;
-   `it.processCost` is the whole-process token total — every turn's `Gtd-Cost:`
-   trailer plus the squashing step's own `--cost` — so the squash message can
-   record the complete cost of the feature even though the per-turn trailers are
+   `it.processCost` is the whole-process token total and `it.processCostByModel`
+   its per-model breakdown — every turn's `Gtd-Cost:` trailer plus the squashing
+   step's own `--cost`/`--model` — so the squash message can record the complete
+   cost of the feature, itemized by model, even though the per-turn trailers are
    discarded with the turns below). A failed render (a malformed template,
    `read()` throwing for a missing path) **refuses the step and touches
    nothing** — no reset, no commit, no file discarded.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,8 +7,9 @@ Commands:
   step <actor>     Authenticate as <actor>, match the resolved rest's
                    declared patterns against the pending changes, and commit
                    (or squash) the one resulting transition. Pass
-                   --cost=<n> to record the just-finished invocation's token
-                   cost on the turn commit (summed into it.processCost)
+                   --cost=<n> (optionally --model=<name>) to record the
+                   just-finished invocation's token cost and model on the
+                   turn commit (summed into it.processCost/processCostByModel)
   next             Print the resolved rest's rendered script/prompt/message
                    (no mutation)
   run              Execute the resolved rest's emitted script, then step its
@@ -23,6 +24,7 @@ Commands:
 Options:
   --json           Output structured JSON instead of plain text
   --cost=<n>       (gtd step only) record the invocation's token cost
+  --model=<name>   (gtd step only, with --cost) tag that cost's model
   --version, -v    Print version and exit
   --help, -h       Print this help and exit
 ```
@@ -35,14 +37,15 @@ without touching the repository. Every other command must be run from the
 history relative to cwd, so it refuses with a clear error if invoked from a
 subdirectory.
 
-`--json` and `--cost=<n>` (the latter only for `gtd step`) are the only long
-options. Any other `--` option (including a typo like `--jsn`) is rejected with
-a usage error rather than silently ignored, so a mistyped flag can never degrade
-a JSON caller to plain-text mode. A bare `--cost` with no value, a non-numeric
-or negative value, or `--cost` on any command other than `gtd step` are all
-usage errors.
+`--json`, `--cost=<n>`, and `--model=<name>` (the latter two only for
+`gtd step`) are the only long options. Any other `--` option (including a typo
+like `--jsn`) is rejected with a usage error rather than silently ignored, so a
+mistyped flag can never degrade a JSON caller to plain-text mode. A bare
+`--cost`/`--model` with no value, a non-numeric or negative `--cost`, an empty
+`--model`, `--model` without `--cost`, or either flag on any command other than
+`gtd step` are all usage errors.
 
-## `gtd step <actor> [--cost=<n>]`
+## `gtd step <actor> [--cost=<n>] [--model=<name>]`
 
 Authenticates `<actor>` against the resolved rest and performs the ONE resulting
 transition. Unlike v2, there is no fixpoint chain to drive: the pattern
@@ -52,11 +55,14 @@ authors at most one commit (a normal turn) or performs one squash
 of several. A caller that wants several transitions issues several invocations.
 
 `--cost=<n>` records the token cost of the invocation that produced the pending
-changes (a non-negative number) as a `Gtd-Cost: <n>` trailer on the turn commit
-— persisted in the git log, summed across the process into `it.processCost` (see
-[Configuration: Token cost](configuration.md#token-cost)). On a squash it is
-folded into the process total the `commit:` template renders rather than written
-as a trailer. It is orthogonal to `--json`.
+changes (a non-negative number), and the optional `--model=<name>` tags it with
+the model that ran, as a `Gtd-Cost: <n> <model>` trailer on the turn commit —
+persisted in the git log, summed across the process into `it.processCost` and
+grouped by model into `it.processCostByModel` (see
+[Configuration: Token cost](configuration.md#token-cost)). `--model` requires
+`--cost`. On a squash they are folded into the process total/breakdown the
+`commit:` template renders rather than written as a trailer. Both are orthogonal
+to `--json`.
 
 - **Out-of-turn refusal** — `<actor>` isn't the resolved state's declared actor:
   exit non-zero, zero commits.
@@ -82,12 +88,17 @@ or, at a no-op:
 nothing to do at "idle"
 ```
 
-`--json` emits `{state, subject}` — `subject` is `null` at a no-op — plus a
-`cost` key echoing the recorded `--cost` when one was passed (omitted
-otherwise):
+`--json` emits `{state, subject}` — `subject` is `null` at a no-op — plus
+`cost`/`model` keys echoing what `--cost`/`--model` recorded (each omitted when
+not passed):
 
 ```json
-{ "state": "grilling", "subject": "gtd(human): grilling", "cost": 1450 }
+{
+  "state": "grilling",
+  "subject": "gtd(human): grilling",
+  "cost": 1450,
+  "model": "claude-opus-4-8"
+}
 ```
 
 ## `gtd next [--json]`
@@ -173,15 +184,16 @@ after `Awaits:` when the resolved state declares a `model:` hint, and
 `File: <value>`/`Mode: <value>` lines appear after that (in that order) when
 declared — each independently, only when set. A `Cost: <n>` line appears after
 those when the current process has accumulated any `Gtd-Cost:` (see
-[`gtd step --cost`](#gtd-step-actor---costn)), omitted when the running total is
-`0`.
+[`gtd step --cost`](#gtd-step-actor---costn-model-name)), omitted when the
+running total is `0`; when the breakdown adds information (more than one model,
+or a single tagged model), indented `  <model>: <cost>` lines follow it.
 
 `--json` emits
-`{state, actor, changes: [{status, path, pattern}], model?, file?, mode?, cost?}`
-— `pattern` is `null` when no declared row matches that change; `model`/`file`/
-`mode` are present only when the resolved state declares them, and `cost` only
-when the running process total is above `0` (all omitted entirely, never `null`,
-otherwise):
+`{state, actor, changes: [{status, path, pattern}], model?, file?, mode?, cost?, costByModel?}`
+— `pattern` is `null` when no declared row matches that change;
+`model`/`file`/`mode` are present only when the resolved state declares them,
+and `cost`/`costByModel` (the `[{model, cost}]` breakdown) only when the running
+process total is above `0` (all omitted entirely, never `null`, otherwise):
 
 ```json
 {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,7 +6,9 @@ Usage: gtd [command] [options]
 Commands:
   step <actor>     Authenticate as <actor>, match the resolved rest's
                    declared patterns against the pending changes, and commit
-                   (or squash) the one resulting transition
+                   (or squash) the one resulting transition. Pass
+                   --cost=<n> to record the just-finished invocation's token
+                   cost on the turn commit (summed into it.processCost)
   next             Print the resolved rest's rendered script/prompt/message
                    (no mutation)
   run              Execute the resolved rest's emitted script, then step its
@@ -20,6 +22,7 @@ Commands:
 
 Options:
   --json           Output structured JSON instead of plain text
+  --cost=<n>       (gtd step only) record the invocation's token cost
   --version, -v    Print version and exit
   --help, -h       Print this help and exit
 ```
@@ -32,11 +35,14 @@ without touching the repository. Every other command must be run from the
 history relative to cwd, so it refuses with a clear error if invoked from a
 subdirectory.
 
-`--json` is the only long option. Any other `--` option (including a typo like
-`--jsn`) is rejected with a usage error rather than silently ignored, so a
-mistyped flag can never degrade a JSON caller to plain-text mode.
+`--json` and `--cost=<n>` (the latter only for `gtd step`) are the only long
+options. Any other `--` option (including a typo like `--jsn`) is rejected with
+a usage error rather than silently ignored, so a mistyped flag can never degrade
+a JSON caller to plain-text mode. A bare `--cost` with no value, a non-numeric
+or negative value, or `--cost` on any command other than `gtd step` are all
+usage errors.
 
-## `gtd step <actor>`
+## `gtd step <actor> [--cost=<n>]`
 
 Authenticates `<actor>` against the resolved rest and performs the ONE resulting
 transition. Unlike v2, there is no fixpoint chain to drive: the pattern
@@ -44,6 +50,13 @@ machine's `on` edges are direct one-hop transitions, so a single invocation
 authors at most one commit (a normal turn) or performs one squash
 (§[STATES.md](../STATES.md#8-the-squash-lifecycle)) — never both, never a chain
 of several. A caller that wants several transitions issues several invocations.
+
+`--cost=<n>` records the token cost of the invocation that produced the pending
+changes (a non-negative number) as a `Gtd-Cost: <n>` trailer on the turn commit
+— persisted in the git log, summed across the process into `it.processCost` (see
+[Configuration: Token cost](configuration.md#token-cost)). On a squash it is
+folded into the process total the `commit:` template renders rather than written
+as a trailer. It is orthogonal to `--json`.
 
 - **Out-of-turn refusal** — `<actor>` isn't the resolved state's declared actor:
   exit non-zero, zero commits.
@@ -69,10 +82,12 @@ or, at a no-op:
 nothing to do at "idle"
 ```
 
-`--json` emits `{state, subject}` — `subject` is `null` at a no-op:
+`--json` emits `{state, subject}` — `subject` is `null` at a no-op — plus a
+`cost` key echoing the recorded `--cost` when one was passed (omitted
+otherwise):
 
 ```json
-{ "state": "grilling", "subject": "gtd(human): grilling" }
+{ "state": "grilling", "subject": "gtd(human): grilling", "cost": 1450 }
 ```
 
 ## `gtd next [--json]`
@@ -156,13 +171,17 @@ Pending:
 or, on a clean tree: `Pending: (clean)`. A `Model: <value>` line appears right
 after `Awaits:` when the resolved state declares a `model:` hint, and
 `File: <value>`/`Mode: <value>` lines appear after that (in that order) when
-declared — each independently, only when set.
+declared — each independently, only when set. A `Cost: <n>` line appears after
+those when the current process has accumulated any `Gtd-Cost:` (see
+[`gtd step --cost`](#gtd-step-actor---costn)), omitted when the running total is
+`0`.
 
 `--json` emits
-`{state, actor, changes: [{status, path, pattern}], model?, file?, mode?}` —
-`pattern` is `null` when no declared row matches that change; `model`/`file`/
-`mode` are present only when the resolved state declares them (omitted entirely,
-never `null`, otherwise):
+`{state, actor, changes: [{status, path, pattern}], model?, file?, mode?, cost?}`
+— `pattern` is `null` when no declared row matches that change; `model`/`file`/
+`mode` are present only when the resolved state declares them, and `cost` only
+when the running process total is above `0` (all omitted entirely, never `null`,
+otherwise):
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,43 +177,51 @@ switch. (Making pattern keys var-aware at compile time is possible future work.)
 Every `script`/`prompt`/`message`/`commit`/`model` template is rendered as an
 Eta template (`it.<name>`) with:
 
-| Variable         | Meaning                                                                                                                                                                                                                                                                                                                              |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `startCommit`    | The hash the current process started from (before its first turn).                                                                                                                                                                                                                                                                   |
-| `currentCommit`  | HEAD's hash at render time.                                                                                                                                                                                                                                                                                                          |
-| `previousCommit` | The hash before the last transition (HEAD's parent, in-process).                                                                                                                                                                                                                                                                     |
-| `state`          | The state whose content is being rendered.                                                                                                                                                                                                                                                                                           |
-| `actor`          | The actor this render is for.                                                                                                                                                                                                                                                                                                        |
-| `processDiff`    | `startCommit..HEAD` plus the pending working-tree diff.                                                                                                                                                                                                                                                                              |
-| `lastDiff`       | The diff of the last transition alone.                                                                                                                                                                                                                                                                                               |
-| `processCost`    | The accumulated token cost of the current process — the sum of every `Gtd-Cost:` trailer recorded by `gtd step <actor> --cost=<n>` across its turn commits, plus the in-flight step's own `--cost` (so a `commit:` squash template sees the whole-process total). A number, `0` when none recorded. See ["Token cost"](#token-cost). |
-| `read(path)`     | Reads a working-tree file (pending contents, not HEAD's) by repo-relative path. Throws for a missing/unreadable path — for a `commit:` template, that throw refuses the step (see [STATES.md §8](../STATES.md#8-the-squash-lifecycle)).                                                                                              |
-| `vars`           | The merged three-layer variable map, always a flat `Record<string, string>` — see ["Variables"](#variables) below.                                                                                                                                                                                                                   |
+| Variable             | Meaning                                                                                                                                                                                                                                                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `startCommit`        | The hash the current process started from (before its first turn).                                                                                                                                                                                                                                                                         |
+| `currentCommit`      | HEAD's hash at render time.                                                                                                                                                                                                                                                                                                                |
+| `previousCommit`     | The hash before the last transition (HEAD's parent, in-process).                                                                                                                                                                                                                                                                           |
+| `state`              | The state whose content is being rendered.                                                                                                                                                                                                                                                                                                 |
+| `actor`              | The actor this render is for.                                                                                                                                                                                                                                                                                                              |
+| `processDiff`        | `startCommit..HEAD` plus the pending working-tree diff.                                                                                                                                                                                                                                                                                    |
+| `lastDiff`           | The diff of the last transition alone.                                                                                                                                                                                                                                                                                                     |
+| `processCost`        | The accumulated token cost of the current process — the sum of every `Gtd-Cost:` trailer recorded by `gtd step <actor> --cost=<n>` across its turn commits, plus the in-flight step's own `--cost` (so a `commit:` squash template sees the whole-process total). A number, `0` when none recorded. See ["Token cost"](#token-cost).       |
+| `processCostByModel` | The same accumulated cost broken down per model: an array of `{ model, cost }`, highest-cost first, one entry per distinct `--model` tag (costs recorded with no `--model` group under `"unspecified"`). A squash template iterates it to itemize the feature's cost per model. Empty when none recorded. See ["Token cost"](#token-cost). |
+| `read(path)`         | Reads a working-tree file (pending contents, not HEAD's) by repo-relative path. Throws for a missing/unreadable path — for a `commit:` template, that throw refuses the step (see [STATES.md §8](../STATES.md#8-the-squash-lifecycle)).                                                                                                    |
+| `vars`               | The merged three-layer variable map, always a flat `Record<string, string>` — see ["Variables"](#variables) below.                                                                                                                                                                                                                         |
 
 ### Token cost
 
-A loop driver that knows how many tokens the invocation it just drove cost can
-record it with `gtd step <actor> --cost=<n>` (a non-negative number). gtd
-appends it to that turn's commit as a `Gtd-Cost: <n>` trailer — a blank line
-then the trailer, below the untouched `gtd(<actor>): <state>` subject — so the
-per-turn cost is persisted in the git log:
+A loop driver that knows how many tokens the invocation it just drove cost — and
+on which model — can record both with
+`gtd step <actor> --cost=<n> [--model=<name>]` (`<n>` a non-negative number).
+gtd appends them to that turn's commit as a `Gtd-Cost: <n> <model>` trailer — a
+blank line then the trailer, below the untouched `gtd(<actor>): <state>` subject
+— so the per-turn cost and model are persisted in the git log:
 
 ```
 gtd(agent): reviewing
 
-Gtd-Cost: 1450
+Gtd-Cost: 1450 claude-opus-4-8
 ```
 
-`gtd status` shows the process's running total (a `Cost:` line / a `cost` key,
-omitted when nothing has been recorded), and `gtd step --json` echoes the number
-it recorded (`{ "state": …, "subject": …, "cost": 1450 }`).
+`--model` is optional and requires `--cost` (a model tag with no token count
+records nothing to sum); a cost recorded without a model is grouped under
+`"unspecified"`. `gtd status` shows the process's running total and, when the
+breakdown adds information, a per-model split (a `Cost:` line with indented
+`<model>: <cost>` lines / a `cost` number and a `costByModel` array, omitted
+when nothing has been recorded). `gtd step --json` echoes what it recorded
+(`{ "state": …, "subject": …, "cost": 1450, "model": "claude-opus-4-8" }`).
 
-Every template sees the running total as `it.processCost` (the table above): the
-sum of the current process's turn-commit trailers, plus the in-flight step's own
-`--cost`. Its intended use is a `commit:` squash template, which renders against
-the pending tree as the process collapses — so the whole feature's total
-(including the squashing step itself) lands in the squash message even though
-the intermediate per-turn trailers are discarded with the turns they rode on:
+Every template sees the running total as `it.processCost` and the per-model
+breakdown as `it.processCostByModel` (the table above): the current process's
+turn-commit entries, plus the in-flight step's own `--cost`/`--model`. Their
+intended use is a `commit:` squash template, which renders against the pending
+tree as the process collapses — so the whole feature's total AND its per-model
+itemization (including the squashing step itself) land in the squash message
+even though the intermediate per-turn trailers are discarded with the turns they
+rode on:
 
 ```yaml
 done:
@@ -221,11 +229,14 @@ done:
     feat: ship it
 
     Total token cost: <%= it.processCost %>
+    <% it.processCostByModel.forEach(function(m){ %>
+    - <%= m.model %>: <%= m.cost %>
+    <% }) %>
 ```
 
-`--cost` is accepted only by `gtd step` (a usage error on any other command),
-and gtd never interprets the number's unit — tokens, cents, whatever the driver
-records — it only sums and reports it.
+`--cost`/`--model` are accepted only by `gtd step` (a usage error on any other
+command), and gtd never interprets the number's unit (tokens, cents, whatever
+the driver records) or the model name — it only records, sums, and groups them.
 
 ## Variables
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,17 +177,55 @@ switch. (Making pattern keys var-aware at compile time is possible future work.)
 Every `script`/`prompt`/`message`/`commit`/`model` template is rendered as an
 Eta template (`it.<name>`) with:
 
-| Variable         | Meaning                                                                                                                                                                                                                                 |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `startCommit`    | The hash the current process started from (before its first turn).                                                                                                                                                                      |
-| `currentCommit`  | HEAD's hash at render time.                                                                                                                                                                                                             |
-| `previousCommit` | The hash before the last transition (HEAD's parent, in-process).                                                                                                                                                                        |
-| `state`          | The state whose content is being rendered.                                                                                                                                                                                              |
-| `actor`          | The actor this render is for.                                                                                                                                                                                                           |
-| `processDiff`    | `startCommit..HEAD` plus the pending working-tree diff.                                                                                                                                                                                 |
-| `lastDiff`       | The diff of the last transition alone.                                                                                                                                                                                                  |
-| `read(path)`     | Reads a working-tree file (pending contents, not HEAD's) by repo-relative path. Throws for a missing/unreadable path — for a `commit:` template, that throw refuses the step (see [STATES.md §8](../STATES.md#8-the-squash-lifecycle)). |
-| `vars`           | The merged three-layer variable map, always a flat `Record<string, string>` — see ["Variables"](#variables) below.                                                                                                                      |
+| Variable         | Meaning                                                                                                                                                                                                                                                                                                                              |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `startCommit`    | The hash the current process started from (before its first turn).                                                                                                                                                                                                                                                                   |
+| `currentCommit`  | HEAD's hash at render time.                                                                                                                                                                                                                                                                                                          |
+| `previousCommit` | The hash before the last transition (HEAD's parent, in-process).                                                                                                                                                                                                                                                                     |
+| `state`          | The state whose content is being rendered.                                                                                                                                                                                                                                                                                           |
+| `actor`          | The actor this render is for.                                                                                                                                                                                                                                                                                                        |
+| `processDiff`    | `startCommit..HEAD` plus the pending working-tree diff.                                                                                                                                                                                                                                                                              |
+| `lastDiff`       | The diff of the last transition alone.                                                                                                                                                                                                                                                                                               |
+| `processCost`    | The accumulated token cost of the current process — the sum of every `Gtd-Cost:` trailer recorded by `gtd step <actor> --cost=<n>` across its turn commits, plus the in-flight step's own `--cost` (so a `commit:` squash template sees the whole-process total). A number, `0` when none recorded. See ["Token cost"](#token-cost). |
+| `read(path)`     | Reads a working-tree file (pending contents, not HEAD's) by repo-relative path. Throws for a missing/unreadable path — for a `commit:` template, that throw refuses the step (see [STATES.md §8](../STATES.md#8-the-squash-lifecycle)).                                                                                              |
+| `vars`           | The merged three-layer variable map, always a flat `Record<string, string>` — see ["Variables"](#variables) below.                                                                                                                                                                                                                   |
+
+### Token cost
+
+A loop driver that knows how many tokens the invocation it just drove cost can
+record it with `gtd step <actor> --cost=<n>` (a non-negative number). gtd
+appends it to that turn's commit as a `Gtd-Cost: <n>` trailer — a blank line
+then the trailer, below the untouched `gtd(<actor>): <state>` subject — so the
+per-turn cost is persisted in the git log:
+
+```
+gtd(agent): reviewing
+
+Gtd-Cost: 1450
+```
+
+`gtd status` shows the process's running total (a `Cost:` line / a `cost` key,
+omitted when nothing has been recorded), and `gtd step --json` echoes the number
+it recorded (`{ "state": …, "subject": …, "cost": 1450 }`).
+
+Every template sees the running total as `it.processCost` (the table above): the
+sum of the current process's turn-commit trailers, plus the in-flight step's own
+`--cost`. Its intended use is a `commit:` squash template, which renders against
+the pending tree as the process collapses — so the whole feature's total
+(including the squashing step itself) lands in the squash message even though
+the intermediate per-turn trailers are discarded with the turns they rode on:
+
+```yaml
+done:
+  commit: |
+    feat: ship it
+
+    Total token cost: <%= it.processCost %>
+```
+
+`--cost` is accepted only by `gtd step` (a usage error on any other command),
+and gtd never interprets the number's unit — tokens, cents, whatever the driver
+records — it only sums and reports it.
 
 ## Variables
 

--- a/docs/examples/advanced-workflow.md
+++ b/docs/examples/advanced-workflow.md
@@ -408,17 +408,21 @@ workflow:
       commit: |
         <%~ it.read(".gtd/COMMIT_MSG.md") %>
 
-        Gtd-Cost: <%= it.processCost %>
+        Token cost: <%= it.processCost %>
+        <% it.processCostByModel.forEach(function(m){ %>
+        - <%= m.model %>: <%= m.cost %>
+        <% }) %>
 ````
 
-The `done` commit appends a `Gtd-Cost: <%= it.processCost %>` trailer to the
-squashed message: if the loop driving this workflow passes
-`gtd step <actor> --cost=<n>` after each agent turn, `it.processCost` is the
-summed token cost of the whole cycle (including the `squashing` step itself), so
-the single squash commit records the feature's complete cost even though the
-per-turn trailers are discarded with the turns they collapsed. Drop the trailer
-line if your driver doesn't track cost — `it.processCost` is simply `0` then.
-See [Configuration: Token cost](../configuration.md#token-cost).
+The `done` commit appends a token-cost summary to the squashed message: if the
+loop driving this workflow passes `gtd step <actor> --cost=<n> --model=<name>`
+after each agent turn, `it.processCost` is the summed cost of the whole cycle
+(including the `squashing` step itself) and `it.processCostByModel` itemizes it
+per model — so the single squash commit records the feature's complete cost,
+broken down by which model spent what, even though the per-turn trailers are
+discarded with the turns they collapsed. Drop these lines if your driver doesn't
+track cost — `it.processCost` is `0` and `it.processCostByModel` empty then. See
+[Configuration: Token cost](../configuration.md#token-cost).
 
 A clean `gtd step human` at `grilling-answer`/`architecting-answer` (the `C`
 event) accepts the current phase's draft and moves on; any other pending change

--- a/docs/examples/advanced-workflow.md
+++ b/docs/examples/advanced-workflow.md
@@ -405,8 +405,20 @@ workflow:
         "M .gtd/COMMIT_MSG.md": done
 
     done:
-      commit: '<%~ it.read(".gtd/COMMIT_MSG.md") %>'
+      commit: |
+        <%~ it.read(".gtd/COMMIT_MSG.md") %>
+
+        Gtd-Cost: <%= it.processCost %>
 ````
+
+The `done` commit appends a `Gtd-Cost: <%= it.processCost %>` trailer to the
+squashed message: if the loop driving this workflow passes
+`gtd step <actor> --cost=<n>` after each agent turn, `it.processCost` is the
+summed token cost of the whole cycle (including the `squashing` step itself), so
+the single squash commit records the feature's complete cost even though the
+per-turn trailers are discarded with the turns they collapsed. Drop the trailer
+line if your driver doesn't track cost — `it.processCost` is simply `0` then.
+See [Configuration: Token cost](../configuration.md#token-cost).
 
 A clean `gtd step human` at `grilling-answer`/`architecting-answer` (the `C`
 event) accepts the current phase's draft and moves on; any other pending change

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -5,9 +5,9 @@ gtd (v3, the pattern machine) exposes three commands a loop driver combines:
 - **`gtd step <actor>`** — authenticate as `<actor>`, match the resolved rest's
   declared patterns against the pending changes, and commit (or squash) the one
   resulting transition. Performs AT MOST one transition — there is no fixpoint
-  chain to drive. Pass `--cost=<n>` to record the just-finished invocation's
-  token cost on the turn commit; gtd sums it across the process into
-  `it.processCost` (see
+  chain to drive. Pass `--cost=<n>` (optionally `--model=<name>`) to record the
+  just-finished invocation's token cost and model on the turn commit; gtd sums
+  them across the process into `it.processCost`/`it.processCostByModel` (see
   [Configuration: Token cost](configuration.md#token-cost)).
 - **`gtd next`** — print the resolved rest's rendered script/prompt/message,
   without mutating anything.

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -5,7 +5,10 @@ gtd (v3, the pattern machine) exposes three commands a loop driver combines:
 - **`gtd step <actor>`** — authenticate as `<actor>`, match the resolved rest's
   declared patterns against the pending changes, and commit (or squash) the one
   resulting transition. Performs AT MOST one transition — there is no fixpoint
-  chain to drive.
+  chain to drive. Pass `--cost=<n>` to record the just-finished invocation's
+  token cost on the turn commit; gtd sums it across the process into
+  `it.processCost` (see
+  [Configuration: Token cost](configuration.md#token-cost)).
 - **`gtd next`** — print the resolved rest's rendered script/prompt/message,
   without mutating anything.
 - **`gtd run`** — execute the resolved rest's emitted script (only for a

--- a/skills/loop/SKILL.md
+++ b/skills/loop/SKILL.md
@@ -44,7 +44,11 @@ Repeat this cycle until it halts:
      Execute exactly what it says (the prompt itself says not to run
      `gtd step <actor>` yourself — the harness does). Once you're done acting,
      run `gtd step <actor>` (the `actor` from this same JSON object) to capture
-     your turn, then go back to step 1.
+     your turn, then go back to step 1. If your harness reports the token cost
+     of that agent invocation, pass it as `gtd step <actor> --cost=<n>` — gtd
+     records it on the turn commit and sums it across the process into
+     `it.processCost` (e.g. for a squash commit message). Omit `--cost` when you
+     don't have a number; it is always optional.
 
 ## Halting on a human gate
 

--- a/skills/loop/SKILL.md
+++ b/skills/loop/SKILL.md
@@ -45,10 +45,12 @@ Repeat this cycle until it halts:
      `gtd step <actor>` yourself — the harness does). Once you're done acting,
      run `gtd step <actor>` (the `actor` from this same JSON object) to capture
      your turn, then go back to step 1. If your harness reports the token cost
-     of that agent invocation, pass it as `gtd step <actor> --cost=<n>` — gtd
-     records it on the turn commit and sums it across the process into
-     `it.processCost` (e.g. for a squash commit message). Omit `--cost` when you
-     don't have a number; it is always optional.
+     of that agent invocation, pass it as
+     `gtd step <actor> --cost=<n> [--model=<name>]` — gtd records the cost (and
+     the model it ran on) on the turn commit and aggregates it across the
+     process into `it.processCost`/`it.processCostByModel` (e.g. for a squash
+     commit message that itemizes cost per model). Omit `--cost`/`--model` when
+     you don't have the numbers; both are optional (`--model` needs `--cost`).
 
 ## Halting on a human gate
 

--- a/src/Edge.test.ts
+++ b/src/Edge.test.ts
@@ -8,6 +8,8 @@ import {
   renderFile,
   renderModel,
   resolveVars,
+  sumCostTrailers,
+  withCostTrailer,
 } from "./Edge.js"
 import type { TemplateContext } from "./PatternTemplates.js"
 import type { StateDef, WorkflowDefinition } from "./PatternMachine.js"
@@ -63,6 +65,7 @@ describe("computeProcessRun", () => {
       startHash: "",
       startParentHash: "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
       trace: [],
+      totalCost: 0,
     })
   })
 
@@ -81,6 +84,7 @@ describe("computeProcessRun", () => {
       startHash: "h1",
       startParentHash: "h0",
       trace: ["grilling", "building"],
+      totalCost: 0,
     })
   })
 
@@ -104,7 +108,7 @@ describe("computeProcessRun", () => {
       commitHistory: () => Effect.succeed(history),
     })
     const result = await run(computeProcessRun(git, def))
-    expect(result).toEqual({ startHash: "h0", startParentHash: "h0", trace: [] })
+    expect(result).toEqual({ startHash: "h0", startParentHash: "h0", trace: [], totalCost: 0 })
   })
 
   it("(b) a commit entering the initial state mid-history is ALSO a process boundary, excluded from the newer process's trace — [boundary, …cycle1…, gtd(human): idle, gtd(human): grilling, gtd(agent): building]", async () => {
@@ -124,6 +128,7 @@ describe("computeProcessRun", () => {
       startHash: "h3",
       startParentHash: "h2",
       trace: ["grilling", "building"],
+      totalCost: 0,
     })
   })
 
@@ -138,7 +143,7 @@ describe("computeProcessRun", () => {
       commitHistory: () => Effect.succeed(history),
     })
     const result = await run(computeProcessRun(git, def))
-    expect(result).toEqual({ startHash: "h2", startParentHash: "h2", trace: [] })
+    expect(result).toEqual({ startHash: "h2", startParentHash: "h2", trace: [], totalCost: 0 })
   })
 
   it("(d) retry counting resets across an idle boundary — a state entered 3x before the idle entry counts 0 after", async () => {
@@ -158,6 +163,34 @@ describe("computeProcessRun", () => {
     expect(result.startParentHash).toBe("h4")
     expect(result.trace).toEqual(["grilling"])
     expect(result.trace.filter((state) => state === "fixing")).toHaveLength(0)
+  })
+
+  it("sums the `Gtd-Cost:` trailers of the process's turn commits into totalCost, ignoring the boundary's", async () => {
+    const history = [
+      // Boundary commit's trailer is EXCLUDED from the current process's total.
+      { hash: "h0", message: "chore: init\n\nGtd-Cost: 999", removedErrors: false, touched: [] },
+      {
+        hash: "h1",
+        message: "gtd(human): grilling\n\nGtd-Cost: 120",
+        removedErrors: false,
+        touched: [],
+      },
+      {
+        hash: "h2",
+        message: "gtd(agent): building\n\nGtd-Cost: 300",
+        removedErrors: false,
+        touched: [],
+      },
+      // A turn with no trailer contributes 0.
+      { hash: "h3", message: "gtd(agent): checking", removedErrors: false, touched: [] },
+    ]
+    const git = stubGit({
+      hasCommits: () => Effect.succeed(true),
+      commitHistory: () => Effect.succeed(history),
+    })
+    const result = await run(computeProcessRun(git, def))
+    expect(result.trace).toEqual(["grilling", "building", "checking"])
+    expect(result.totalCost).toBe(420)
   })
 })
 
@@ -190,6 +223,7 @@ const context = (overrides: Partial<TemplateContext> = {}): TemplateContext => (
   actor: "agent",
   processDiff: "",
   lastDiff: "",
+  processCost: 0,
   read: () => {
     throw new Error("no file registered")
   },
@@ -204,7 +238,7 @@ describe("executeDecision", () => {
     const outcome = await run(
       executeDecision(
         git,
-        { startHash: "s", startParentHash: "p", trace: ["grilling"] },
+        { startHash: "s", startParentHash: "p", trace: ["grilling"], totalCost: 0 },
         {
           kind: "commit",
           subject: "gtd(human): grilling-answer",
@@ -219,6 +253,30 @@ describe("executeDecision", () => {
     expect(commitAllWithPrefix).toHaveBeenCalledWith("gtd(human): grilling-answer")
   })
 
+  it("a commit decision with a cost appends a `Gtd-Cost:` trailer (subject line untouched)", async () => {
+    const commitAllWithPrefix = vi.fn(() => Effect.succeed(undefined))
+    const git = stubGit({ commitAllWithPrefix })
+    const outcome = await run(
+      executeDecision(
+        git,
+        { startHash: "s", startParentHash: "p", trace: ["grilling"], totalCost: 0 },
+        {
+          kind: "commit",
+          subject: "gtd(agent): building",
+          actor: "agent",
+          from: "grilling-answer",
+          to: "building",
+        },
+        context(),
+        1234,
+      ),
+    )
+    // The reported subject is still the bare subject line...
+    expect(outcome).toEqual({ kind: "commit", subject: "gtd(agent): building" })
+    // ...while the committed message carries the trailer after a blank line.
+    expect(commitAllWithPrefix).toHaveBeenCalledWith("gtd(agent): building\n\nGtd-Cost: 1234")
+  })
+
   it("a squash decision renders, soft-resets, commits as-is, and discards the rest", async () => {
     const softResetTo = vi.fn(() => Effect.succeed(undefined))
     const commitAsIs = vi.fn(() => Effect.succeed(undefined))
@@ -227,7 +285,7 @@ describe("executeDecision", () => {
     const outcome = await run(
       executeDecision(
         git,
-        { startHash: "s", startParentHash: "parent-hash", trace: ["squashing"] },
+        { startHash: "s", startParentHash: "parent-hash", trace: ["squashing"], totalCost: 0 },
         { kind: "squash", state: "done", template: "feat: <%= it.state %>" },
         context({ state: "done" }),
       ),
@@ -243,7 +301,7 @@ describe("executeDecision", () => {
     const decision = await run(
       executeDecision(
         git,
-        { startHash: "s", startParentHash: "parent-hash", trace: [] },
+        { startHash: "s", startParentHash: "parent-hash", trace: [], totalCost: 0 },
         { kind: "squash", state: "done", template: '<%~ it.read("missing.md") %>' },
         context(),
       ),
@@ -260,12 +318,52 @@ describe("executeDecision", () => {
     const outcome = await run(
       executeDecision(
         git,
-        { startHash: "s", startParentHash: "p", trace: [] },
+        { startHash: "s", startParentHash: "p", trace: [], totalCost: 0 },
         { kind: "noop", state: "idle" },
         context(),
       ),
     )
     expect(outcome).toEqual({ kind: "noop", state: "idle" })
+  })
+})
+
+describe("withCostTrailer", () => {
+  it("returns the subject unchanged when no cost is supplied", () => {
+    expect(withCostTrailer("gtd(agent): building", undefined)).toBe("gtd(agent): building")
+  })
+
+  it("appends a `Gtd-Cost:` trailer after a blank line, leaving the subject as the first line", () => {
+    const message = withCostTrailer("gtd(agent): building", 42)
+    expect(message).toBe("gtd(agent): building\n\nGtd-Cost: 42")
+    expect(message.split("\n")[0]).toBe("gtd(agent): building")
+  })
+
+  it("records a zero cost verbatim (an explicit 0 is not the same as absent)", () => {
+    expect(withCostTrailer("gtd(check): checking", 0)).toBe("gtd(check): checking\n\nGtd-Cost: 0")
+  })
+})
+
+describe("sumCostTrailers", () => {
+  it("sums one trailer per message, treating a message without one as 0", () => {
+    expect(
+      sumCostTrailers([
+        "gtd(human): grilling\n\nGtd-Cost: 120",
+        "gtd(agent): building\n\nGtd-Cost: 300",
+        "gtd(agent): checking", // no trailer → 0
+      ]),
+    ).toBe(420)
+  })
+
+  it("is 0 over an empty list", () => {
+    expect(sumCostTrailers([])).toBe(0)
+  })
+
+  it("accepts decimal costs", () => {
+    expect(sumCostTrailers(["x\n\nGtd-Cost: 1.5", "y\n\nGtd-Cost: 2.25"])).toBe(3.75)
+  })
+
+  it("ignores a `Gtd-Cost:`-looking line that is not a bare number", () => {
+    expect(sumCostTrailers(["x\n\nGtd-Cost: not-a-number", "y\n\nGtd-Cost: 10"])).toBe(10)
   })
 })
 

--- a/src/Edge.test.ts
+++ b/src/Edge.test.ts
@@ -8,7 +8,10 @@ import {
   renderFile,
   renderModel,
   resolveVars,
-  sumCostTrailers,
+  costByModel,
+  parseCostTrailers,
+  totalCostOf,
+  UNATTRIBUTED_MODEL,
   withCostTrailer,
 } from "./Edge.js"
 import type { TemplateContext } from "./PatternTemplates.js"
@@ -65,7 +68,7 @@ describe("computeProcessRun", () => {
       startHash: "",
       startParentHash: "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
       trace: [],
-      totalCost: 0,
+      costEntries: [],
     })
   })
 
@@ -84,7 +87,7 @@ describe("computeProcessRun", () => {
       startHash: "h1",
       startParentHash: "h0",
       trace: ["grilling", "building"],
-      totalCost: 0,
+      costEntries: [],
     })
   })
 
@@ -108,7 +111,7 @@ describe("computeProcessRun", () => {
       commitHistory: () => Effect.succeed(history),
     })
     const result = await run(computeProcessRun(git, def))
-    expect(result).toEqual({ startHash: "h0", startParentHash: "h0", trace: [], totalCost: 0 })
+    expect(result).toEqual({ startHash: "h0", startParentHash: "h0", trace: [], costEntries: [] })
   })
 
   it("(b) a commit entering the initial state mid-history is ALSO a process boundary, excluded from the newer process's trace — [boundary, …cycle1…, gtd(human): idle, gtd(human): grilling, gtd(agent): building]", async () => {
@@ -128,7 +131,7 @@ describe("computeProcessRun", () => {
       startHash: "h3",
       startParentHash: "h2",
       trace: ["grilling", "building"],
-      totalCost: 0,
+      costEntries: [],
     })
   })
 
@@ -143,7 +146,7 @@ describe("computeProcessRun", () => {
       commitHistory: () => Effect.succeed(history),
     })
     const result = await run(computeProcessRun(git, def))
-    expect(result).toEqual({ startHash: "h2", startParentHash: "h2", trace: [], totalCost: 0 })
+    expect(result).toEqual({ startHash: "h2", startParentHash: "h2", trace: [], costEntries: [] })
   })
 
   it("(d) retry counting resets across an idle boundary — a state entered 3x before the idle entry counts 0 after", async () => {
@@ -165,24 +168,34 @@ describe("computeProcessRun", () => {
     expect(result.trace.filter((state) => state === "fixing")).toHaveLength(0)
   })
 
-  it("sums the `Gtd-Cost:` trailers of the process's turn commits into totalCost, ignoring the boundary's", async () => {
+  it("collects the process's turn-commit `Gtd-Cost:` entries (with models), ignoring the boundary's", async () => {
     const history = [
-      // Boundary commit's trailer is EXCLUDED from the current process's total.
-      { hash: "h0", message: "chore: init\n\nGtd-Cost: 999", removedErrors: false, touched: [] },
+      // Boundary commit's trailer is EXCLUDED from the current process's entries.
+      {
+        hash: "h0",
+        message: "chore: init\n\nGtd-Cost: 999 opus",
+        removedErrors: false,
+        touched: [],
+      },
       {
         hash: "h1",
-        message: "gtd(human): grilling\n\nGtd-Cost: 120",
+        message: "gtd(human): grilling\n\nGtd-Cost: 120 opus",
         removedErrors: false,
         touched: [],
       },
       {
         hash: "h2",
-        message: "gtd(agent): building\n\nGtd-Cost: 300",
+        message: "gtd(agent): building\n\nGtd-Cost: 300 haiku",
         removedErrors: false,
         touched: [],
       },
-      // A turn with no trailer contributes 0.
-      { hash: "h3", message: "gtd(agent): checking", removedErrors: false, touched: [] },
+      // A turn with a model-less trailer buckets under UNATTRIBUTED_MODEL.
+      {
+        hash: "h3",
+        message: "gtd(agent): checking\n\nGtd-Cost: 50",
+        removedErrors: false,
+        touched: [],
+      },
     ]
     const git = stubGit({
       hasCommits: () => Effect.succeed(true),
@@ -190,7 +203,11 @@ describe("computeProcessRun", () => {
     })
     const result = await run(computeProcessRun(git, def))
     expect(result.trace).toEqual(["grilling", "building", "checking"])
-    expect(result.totalCost).toBe(420)
+    expect(result.costEntries).toEqual([
+      { cost: 120, model: "opus" },
+      { cost: 300, model: "haiku" },
+      { cost: 50, model: UNATTRIBUTED_MODEL },
+    ])
   })
 })
 
@@ -224,6 +241,7 @@ const context = (overrides: Partial<TemplateContext> = {}): TemplateContext => (
   processDiff: "",
   lastDiff: "",
   processCost: 0,
+  processCostByModel: [],
   read: () => {
     throw new Error("no file registered")
   },
@@ -238,7 +256,7 @@ describe("executeDecision", () => {
     const outcome = await run(
       executeDecision(
         git,
-        { startHash: "s", startParentHash: "p", trace: ["grilling"], totalCost: 0 },
+        { startHash: "s", startParentHash: "p", trace: ["grilling"], costEntries: [] },
         {
           kind: "commit",
           subject: "gtd(human): grilling-answer",
@@ -259,7 +277,7 @@ describe("executeDecision", () => {
     const outcome = await run(
       executeDecision(
         git,
-        { startHash: "s", startParentHash: "p", trace: ["grilling"], totalCost: 0 },
+        { startHash: "s", startParentHash: "p", trace: ["grilling"], costEntries: [] },
         {
           kind: "commit",
           subject: "gtd(agent): building",
@@ -269,12 +287,15 @@ describe("executeDecision", () => {
         },
         context(),
         1234,
+        "claude-opus-4-8",
       ),
     )
     // The reported subject is still the bare subject line...
     expect(outcome).toEqual({ kind: "commit", subject: "gtd(agent): building" })
-    // ...while the committed message carries the trailer after a blank line.
-    expect(commitAllWithPrefix).toHaveBeenCalledWith("gtd(agent): building\n\nGtd-Cost: 1234")
+    // ...while the committed message carries the cost + model trailer after a blank line.
+    expect(commitAllWithPrefix).toHaveBeenCalledWith(
+      "gtd(agent): building\n\nGtd-Cost: 1234 claude-opus-4-8",
+    )
   })
 
   it("a squash decision renders, soft-resets, commits as-is, and discards the rest", async () => {
@@ -285,7 +306,7 @@ describe("executeDecision", () => {
     const outcome = await run(
       executeDecision(
         git,
-        { startHash: "s", startParentHash: "parent-hash", trace: ["squashing"], totalCost: 0 },
+        { startHash: "s", startParentHash: "parent-hash", trace: ["squashing"], costEntries: [] },
         { kind: "squash", state: "done", template: "feat: <%= it.state %>" },
         context({ state: "done" }),
       ),
@@ -301,7 +322,7 @@ describe("executeDecision", () => {
     const decision = await run(
       executeDecision(
         git,
-        { startHash: "s", startParentHash: "parent-hash", trace: [], totalCost: 0 },
+        { startHash: "s", startParentHash: "parent-hash", trace: [], costEntries: [] },
         { kind: "squash", state: "done", template: '<%~ it.read("missing.md") %>' },
         context(),
       ),
@@ -318,7 +339,7 @@ describe("executeDecision", () => {
     const outcome = await run(
       executeDecision(
         git,
-        { startHash: "s", startParentHash: "p", trace: [], totalCost: 0 },
+        { startHash: "s", startParentHash: "p", trace: [], costEntries: [] },
         { kind: "noop", state: "idle" },
         context(),
       ),
@@ -329,41 +350,74 @@ describe("executeDecision", () => {
 
 describe("withCostTrailer", () => {
   it("returns the subject unchanged when no cost is supplied", () => {
-    expect(withCostTrailer("gtd(agent): building", undefined)).toBe("gtd(agent): building")
+    expect(withCostTrailer("gtd(agent): building", undefined, undefined)).toBe(
+      "gtd(agent): building",
+    )
   })
 
   it("appends a `Gtd-Cost:` trailer after a blank line, leaving the subject as the first line", () => {
-    const message = withCostTrailer("gtd(agent): building", 42)
+    const message = withCostTrailer("gtd(agent): building", 42, undefined)
     expect(message).toBe("gtd(agent): building\n\nGtd-Cost: 42")
     expect(message.split("\n")[0]).toBe("gtd(agent): building")
   })
 
+  it("appends the model after the cost when one is supplied", () => {
+    expect(withCostTrailer("gtd(agent): building", 42, "claude-opus-4-8")).toBe(
+      "gtd(agent): building\n\nGtd-Cost: 42 claude-opus-4-8",
+    )
+  })
+
   it("records a zero cost verbatim (an explicit 0 is not the same as absent)", () => {
-    expect(withCostTrailer("gtd(check): checking", 0)).toBe("gtd(check): checking\n\nGtd-Cost: 0")
+    expect(withCostTrailer("gtd(check): checking", 0, undefined)).toBe(
+      "gtd(check): checking\n\nGtd-Cost: 0",
+    )
   })
 })
 
-describe("sumCostTrailers", () => {
-  it("sums one trailer per message, treating a message without one as 0", () => {
+describe("parseCostTrailers", () => {
+  it("parses cost + model, defaulting a model-less entry to UNATTRIBUTED_MODEL", () => {
     expect(
-      sumCostTrailers([
-        "gtd(human): grilling\n\nGtd-Cost: 120",
-        "gtd(agent): building\n\nGtd-Cost: 300",
-        "gtd(agent): checking", // no trailer → 0
+      parseCostTrailers([
+        "gtd(human): grilling\n\nGtd-Cost: 120 opus",
+        "gtd(agent): building\n\nGtd-Cost: 300", // no model
+        "gtd(agent): checking", // no trailer at all
       ]),
-    ).toBe(420)
-  })
-
-  it("is 0 over an empty list", () => {
-    expect(sumCostTrailers([])).toBe(0)
+    ).toEqual([
+      { cost: 120, model: "opus" },
+      { cost: 300, model: UNATTRIBUTED_MODEL },
+    ])
   })
 
   it("accepts decimal costs", () => {
-    expect(sumCostTrailers(["x\n\nGtd-Cost: 1.5", "y\n\nGtd-Cost: 2.25"])).toBe(3.75)
+    expect(parseCostTrailers(["x\n\nGtd-Cost: 1.5 opus"])).toEqual([{ cost: 1.5, model: "opus" }])
   })
 
-  it("ignores a `Gtd-Cost:`-looking line that is not a bare number", () => {
-    expect(sumCostTrailers(["x\n\nGtd-Cost: not-a-number", "y\n\nGtd-Cost: 10"])).toBe(10)
+  it("ignores a `Gtd-Cost:`-looking line whose value is not a bare number", () => {
+    expect(parseCostTrailers(["x\n\nGtd-Cost: not-a-number", "y\n\nGtd-Cost: 10"])).toEqual([
+      { cost: 10, model: UNATTRIBUTED_MODEL },
+    ])
+  })
+})
+
+describe("totalCostOf / costByModel", () => {
+  const entries = [
+    { cost: 120, model: "opus" },
+    { cost: 300, model: "haiku" },
+    { cost: 80, model: "opus" },
+    { cost: 50, model: UNATTRIBUTED_MODEL },
+  ]
+
+  it("totalCostOf sums every entry (0 over an empty list)", () => {
+    expect(totalCostOf(entries)).toBe(550)
+    expect(totalCostOf([])).toBe(0)
+  })
+
+  it("costByModel groups by model, highest-cost first", () => {
+    expect(costByModel(entries)).toEqual([
+      { model: "haiku", cost: 300 },
+      { model: "opus", cost: 200 },
+      { model: UNATTRIBUTED_MODEL, cost: 50 },
+    ])
   })
 })
 

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -36,6 +36,37 @@ const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 const subjectOf = (message: string): string => (message.split("\n")[0] ?? "").trim()
 
+// ── Token-cost trailers ──────────────────────────────────────────────────────
+//
+// `gtd step <actor> --cost=<n>` records the token cost of the invocation that
+// just produced the pending changes as a `Gtd-Cost: <n>` trailer on the turn
+// commit — persisted in the git log, one number per turn. `computeProcessRun`
+// sums every such trailer across the current process's commits so a `commit:`
+// squash template can render the whole-process total via `it.processCost`.
+
+const COST_TRAILER_PREFIX = "Gtd-Cost: "
+// One `Gtd-Cost: <number>` trailer line — a non-negative integer or decimal,
+// matched anywhere in a commit message body (multiline).
+const COST_TRAILER_RE = /^Gtd-Cost:[ \t]*([0-9]+(?:\.[0-9]+)?)[ \t]*$/gm
+
+/**
+ * Append a `Gtd-Cost: <cost>` trailer (after a blank line) to a commit
+ * `subject`, or return the subject unchanged when no cost was supplied. The
+ * subject (first line) is never touched, so `parseStateSubject`/`resolveState`
+ * still read `gtd(<actor>): <state>` back exactly as before.
+ */
+export const withCostTrailer = (subject: string, cost: number | undefined): string =>
+  cost === undefined ? subject : `${subject}\n\n${COST_TRAILER_PREFIX}${cost}`
+
+/** Sum every `Gtd-Cost:` trailer found across the given commit messages (`0` when none). */
+export const sumCostTrailers = (messages: readonly string[]): number => {
+  let total = 0
+  for (const message of messages) {
+    for (const match of message.matchAll(COST_TRAILER_RE)) total += Number(match[1])
+  }
+  return total
+}
+
 /** Collapse an arbitrary git status letter to the pattern grammar's closed `A|M|D` set (mirrors the plan's decision 5 — only those three are meaningful statuses). */
 const normalizeStatus = (raw: string): ChangeStatus => (raw === "A" ? "A" : raw === "D" ? "D" : "M")
 
@@ -94,6 +125,8 @@ export interface ProcessRun {
   readonly startParentHash: string
   /** State names entered so far this process, oldest→newest (empty when no turn has landed yet). */
   readonly trace: readonly StateName[]
+  /** The sum of every `Gtd-Cost:` trailer on the process's turn commits (`0` when none were recorded). */
+  readonly totalCost: number
 }
 
 /**
@@ -121,7 +154,7 @@ export const computeProcessRun = (
 ): Effect.Effect<ProcessRun, Error> =>
   Effect.gen(function* () {
     const hasCommits = yield* git.hasCommits()
-    if (!hasCommits) return { startHash: "", startParentHash: EMPTY_TREE, trace: [] }
+    if (!hasCommits) return { startHash: "", startParentHash: EMPTY_TREE, trace: [], totalCost: 0 }
 
     const initialState = initialStateOf(def)
     const history = yield* git.commitHistory() // oldest -> newest, full first-parent history
@@ -132,11 +165,13 @@ export const computeProcessRun = (
       i--
     }
     const startIdx = i + 1
-    const trace = history.slice(startIdx).map((h) => parseStateSubject(subjectOf(h.message))!.state)
+    const processCommits = history.slice(startIdx)
+    const trace = processCommits.map((h) => parseStateSubject(subjectOf(h.message))!.state)
+    const totalCost = sumCostTrailers(processCommits.map((h) => h.message))
     const startParentHash = i >= 0 ? history[i]!.hash : EMPTY_TREE
     const startHash =
       startIdx < history.length ? history[startIdx]!.hash : history[history.length - 1]!.hash
-    return { startHash, startParentHash, trace }
+    return { startHash, startParentHash, trace, totalCost }
   })
 
 // ── Variables (`it.vars`) ────────────────────────────────────────────────────
@@ -170,7 +205,14 @@ export const resolveVars = (
 
 // ── Template context ─────────────────────────────────────────────────────────
 
-/** Build the `PatternTemplates.TemplateContext` for rendering `state`'s content at the resolved rest. `vars` is the already-merged three-layer map (see `resolveVars`). */
+/**
+ * Build the `PatternTemplates.TemplateContext` for rendering `state`'s content
+ * at the resolved rest. `vars` is the already-merged three-layer map (see
+ * `resolveVars`). `currentCost` is the in-flight step's own `--cost` (added to
+ * the process's committed `run.totalCost` so a `commit:` squash template sees
+ * the whole-process total including the squashing step) — `0` for the pure
+ * emitters (`gtd next`/`gtd status`), where no step is being performed.
+ */
 export const buildTemplateContext = (
   git: GitOperations,
   read: (path: string) => string,
@@ -178,6 +220,7 @@ export const buildTemplateContext = (
   actor: string,
   run: ProcessRun,
   vars: Record<string, string>,
+  currentCost = 0,
 ): Effect.Effect<TemplateContext, Error> =>
   Effect.gen(function* () {
     const hasCommits = yield* git.hasCommits()
@@ -204,6 +247,7 @@ export const buildTemplateContext = (
       actor,
       processDiff,
       lastDiff,
+      processCost: run.totalCost + currentCost,
       read,
       vars,
     }
@@ -304,24 +348,28 @@ export type ExecutableDecision = Extract<StepDecision, { kind: "commit" | "squas
 
 /**
  * Execute a `PatternMachine.step` decision: a `"commit"` decision stages and
- * commits everything pending under the decided subject; a `"squash"`
- * decision renders the commit-state template against the PENDING tree — a
- * render failure REFUSES the step, touching nothing — then soft-resets to
- * the process's start parent, writes ONE commit with the rendered message
- * (via `commitAsIs`, so the still-uncommitted template file is excluded), and
- * discards everything left pending (the template file included). A `"noop"`
- * performs no IO.
+ * commits everything pending under the decided subject, with an optional
+ * `Gtd-Cost: <cost>` trailer (the invocation's `--cost`, persisted in the git
+ * log); a `"squash"` decision renders the commit-state template against the
+ * PENDING tree — a render failure REFUSES the step, touching nothing — then
+ * soft-resets to the process's start parent, writes ONE commit with the
+ * rendered message (via `commitAsIs`, so the still-uncommitted template file
+ * is excluded), and discards everything left pending (the template file
+ * included). A squash records no trailer of its own — the whole-process total
+ * reaches the message through `it.processCost` in the rendered template. A
+ * `"noop"` performs no IO.
  */
 export const executeDecision = (
   git: GitOperations,
   run: ProcessRun,
   decision: ExecutableDecision,
   context: TemplateContext,
+  cost?: number,
 ): Effect.Effect<StepOutcome, Error> =>
   Effect.gen(function* () {
     switch (decision.kind) {
       case "commit": {
-        yield* git.commitAllWithPrefix(decision.subject)
+        yield* git.commitAllWithPrefix(withCostTrailer(decision.subject, cost))
         return { kind: "commit", subject: decision.subject }
       }
       case "squash": {

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -38,33 +38,80 @@ const subjectOf = (message: string): string => (message.split("\n")[0] ?? "").tr
 
 // ── Token-cost trailers ──────────────────────────────────────────────────────
 //
-// `gtd step <actor> --cost=<n>` records the token cost of the invocation that
-// just produced the pending changes as a `Gtd-Cost: <n>` trailer on the turn
-// commit — persisted in the git log, one number per turn. `computeProcessRun`
-// sums every such trailer across the current process's commits so a `commit:`
-// squash template can render the whole-process total via `it.processCost`.
+// `gtd step <actor> --cost=<n> [--model=<name>]` records the token cost of the
+// invocation that just produced the pending changes — and the model it ran on
+// — as a `Gtd-Cost: <n> <model>` trailer on the turn commit, persisted in the
+// git log, one entry per turn. `computeProcessRun` collects every such entry
+// across the current process's commits; the edge sums them into
+// `it.processCost` and groups them by model into `it.processCostByModel`, so a
+// `commit:` squash template can render both the whole-process total and a
+// per-model breakdown (token cost only tells you the price once you know which
+// model spent it).
 
 const COST_TRAILER_PREFIX = "Gtd-Cost: "
-// One `Gtd-Cost: <number>` trailer line — a non-negative integer or decimal,
-// matched anywhere in a commit message body (multiline).
-const COST_TRAILER_RE = /^Gtd-Cost:[ \t]*([0-9]+(?:\.[0-9]+)?)[ \t]*$/gm
+// One `Gtd-Cost: <number>[ <model>]` trailer line — a non-negative integer or
+// decimal, followed by an OPTIONAL model tag (the rest of the line). The number
+// comes first so a model-less entry (`Gtd-Cost: 1450`) still parses. Matched
+// anywhere in a commit message body (multiline).
+const COST_TRAILER_RE = /^Gtd-Cost:[ \t]*([0-9]+(?:\.[0-9]+)?)(?:[ \t]+(.+?))?[ \t]*$/gm
+
+/** The bucket a cost with no `--model` tag is grouped under, kept distinct so a mixed history still totals correctly. */
+export const UNATTRIBUTED_MODEL = "unspecified"
+
+/** One recorded invocation cost: its token count and the model it ran on (`UNATTRIBUTED_MODEL` when none was tagged). */
+export interface CostEntry {
+  readonly cost: number
+  readonly model: string
+}
+
+/** One model's summed token cost — the shape a squash `commit:` template iterates as `it.processCostByModel`. */
+export interface ModelCost {
+  readonly model: string
+  readonly cost: number
+}
 
 /**
- * Append a `Gtd-Cost: <cost>` trailer (after a blank line) to a commit
- * `subject`, or return the subject unchanged when no cost was supplied. The
- * subject (first line) is never touched, so `parseStateSubject`/`resolveState`
- * still read `gtd(<actor>): <state>` back exactly as before.
+ * Append a `Gtd-Cost: <cost>[ <model>]` trailer (after a blank line) to a
+ * commit `subject`, or return the subject unchanged when no cost was supplied.
+ * The subject (first line) is never touched, so `parseStateSubject`/
+ * `resolveState` still read `gtd(<actor>): <state>` back exactly as before.
  */
-export const withCostTrailer = (subject: string, cost: number | undefined): string =>
-  cost === undefined ? subject : `${subject}\n\n${COST_TRAILER_PREFIX}${cost}`
+export const withCostTrailer = (
+  subject: string,
+  cost: number | undefined,
+  model: string | undefined,
+): string =>
+  cost === undefined
+    ? subject
+    : `${subject}\n\n${COST_TRAILER_PREFIX}${cost}${model !== undefined ? ` ${model}` : ""}`
 
-/** Sum every `Gtd-Cost:` trailer found across the given commit messages (`0` when none). */
-export const sumCostTrailers = (messages: readonly string[]): number => {
-  let total = 0
+/** Every `Gtd-Cost:` entry found across the given commit messages (each entry's model defaults to `UNATTRIBUTED_MODEL`). */
+export const parseCostTrailers = (messages: readonly string[]): CostEntry[] => {
+  const entries: CostEntry[] = []
   for (const message of messages) {
-    for (const match of message.matchAll(COST_TRAILER_RE)) total += Number(match[1])
+    for (const match of message.matchAll(COST_TRAILER_RE)) {
+      const model = match[2]?.trim()
+      entries.push({
+        cost: Number(match[1]),
+        model: model !== undefined && model !== "" ? model : UNATTRIBUTED_MODEL,
+      })
+    }
   }
-  return total
+  return entries
+}
+
+/** The total token cost across the given entries (`0` when none). */
+export const totalCostOf = (entries: readonly CostEntry[]): number =>
+  entries.reduce((sum, entry) => sum + entry.cost, 0)
+
+/** Per-model token totals, highest-cost first (ties broken by model name for a stable order). */
+export const costByModel = (entries: readonly CostEntry[]): ModelCost[] => {
+  const byModel = new Map<string, number>()
+  for (const entry of entries)
+    byModel.set(entry.model, (byModel.get(entry.model) ?? 0) + entry.cost)
+  return [...byModel.entries()]
+    .map(([model, cost]) => ({ model, cost }))
+    .sort((a, b) => b.cost - a.cost || a.model.localeCompare(b.model))
 }
 
 /** Collapse an arbitrary git status letter to the pattern grammar's closed `A|M|D` set (mirrors the plan's decision 5 — only those three are meaningful statuses). */
@@ -125,8 +172,8 @@ export interface ProcessRun {
   readonly startParentHash: string
   /** State names entered so far this process, oldest→newest (empty when no turn has landed yet). */
   readonly trace: readonly StateName[]
-  /** The sum of every `Gtd-Cost:` trailer on the process's turn commits (`0` when none were recorded). */
-  readonly totalCost: number
+  /** Every `Gtd-Cost:` entry recorded on the process's turn commits — summed into `it.processCost` and grouped into `it.processCostByModel` (empty when none were recorded). */
+  readonly costEntries: readonly CostEntry[]
 }
 
 /**
@@ -154,7 +201,8 @@ export const computeProcessRun = (
 ): Effect.Effect<ProcessRun, Error> =>
   Effect.gen(function* () {
     const hasCommits = yield* git.hasCommits()
-    if (!hasCommits) return { startHash: "", startParentHash: EMPTY_TREE, trace: [], totalCost: 0 }
+    if (!hasCommits)
+      return { startHash: "", startParentHash: EMPTY_TREE, trace: [], costEntries: [] }
 
     const initialState = initialStateOf(def)
     const history = yield* git.commitHistory() // oldest -> newest, full first-parent history
@@ -167,11 +215,11 @@ export const computeProcessRun = (
     const startIdx = i + 1
     const processCommits = history.slice(startIdx)
     const trace = processCommits.map((h) => parseStateSubject(subjectOf(h.message))!.state)
-    const totalCost = sumCostTrailers(processCommits.map((h) => h.message))
+    const costEntries = parseCostTrailers(processCommits.map((h) => h.message))
     const startParentHash = i >= 0 ? history[i]!.hash : EMPTY_TREE
     const startHash =
       startIdx < history.length ? history[startIdx]!.hash : history[history.length - 1]!.hash
-    return { startHash, startParentHash, trace, totalCost }
+    return { startHash, startParentHash, trace, costEntries }
   })
 
 // ── Variables (`it.vars`) ────────────────────────────────────────────────────
@@ -208,10 +256,11 @@ export const resolveVars = (
 /**
  * Build the `PatternTemplates.TemplateContext` for rendering `state`'s content
  * at the resolved rest. `vars` is the already-merged three-layer map (see
- * `resolveVars`). `currentCost` is the in-flight step's own `--cost` (added to
- * the process's committed `run.totalCost` so a `commit:` squash template sees
- * the whole-process total including the squashing step) — `0` for the pure
- * emitters (`gtd next`/`gtd status`), where no step is being performed.
+ * `resolveVars`). `currentCost`/`currentModel` are the in-flight step's own
+ * `--cost`/`--model` (folded into the process's committed cost entries so a
+ * `commit:` squash template sees the whole-process total AND per-model
+ * breakdown including the squashing step) — `0`/absent for the pure emitters
+ * (`gtd next`/`gtd status`), where no step is being performed.
  */
 export const buildTemplateContext = (
   git: GitOperations,
@@ -221,6 +270,7 @@ export const buildTemplateContext = (
   run: ProcessRun,
   vars: Record<string, string>,
   currentCost = 0,
+  currentModel?: string,
 ): Effect.Effect<TemplateContext, Error> =>
   Effect.gen(function* () {
     const hasCommits = yield* git.hasCommits()
@@ -239,6 +289,13 @@ export const buildTemplateContext = (
       run.trace.length > 0
         ? yield* git.commitDiff(currentCommit).pipe(Effect.catchAll(() => Effect.succeed("")))
         : ""
+    // Fold the in-flight step's own cost into the committed entries so a squash
+    // template (rendered against the pending tree) counts the squashing step too.
+    const stepEntry =
+      currentCost > 0 || currentModel !== undefined
+        ? [{ cost: currentCost, model: currentModel ?? UNATTRIBUTED_MODEL }]
+        : []
+    const allCostEntries = [...run.costEntries, ...stepEntry]
     return {
       startCommit: run.startHash,
       currentCommit,
@@ -247,7 +304,8 @@ export const buildTemplateContext = (
       actor,
       processDiff,
       lastDiff,
-      processCost: run.totalCost + currentCost,
+      processCost: totalCostOf(allCostEntries),
+      processCostByModel: costByModel(allCostEntries),
       read,
       vars,
     }
@@ -349,14 +407,15 @@ export type ExecutableDecision = Extract<StepDecision, { kind: "commit" | "squas
 /**
  * Execute a `PatternMachine.step` decision: a `"commit"` decision stages and
  * commits everything pending under the decided subject, with an optional
- * `Gtd-Cost: <cost>` trailer (the invocation's `--cost`, persisted in the git
- * log); a `"squash"` decision renders the commit-state template against the
- * PENDING tree — a render failure REFUSES the step, touching nothing — then
- * soft-resets to the process's start parent, writes ONE commit with the
- * rendered message (via `commitAsIs`, so the still-uncommitted template file
- * is excluded), and discards everything left pending (the template file
- * included). A squash records no trailer of its own — the whole-process total
- * reaches the message through `it.processCost` in the rendered template. A
+ * `Gtd-Cost: <cost>[ <model>]` trailer (the invocation's `--cost`/`--model`,
+ * persisted in the git log); a `"squash"` decision renders the commit-state
+ * template against the PENDING tree — a render failure REFUSES the step,
+ * touching nothing — then soft-resets to the process's start parent, writes
+ * ONE commit with the rendered message (via `commitAsIs`, so the
+ * still-uncommitted template file is excluded), and discards everything left
+ * pending (the template file included). A squash records no trailer of its own
+ * — the whole-process total and per-model breakdown reach the message through
+ * `it.processCost`/`it.processCostByModel` in the rendered template. A
  * `"noop"` performs no IO.
  */
 export const executeDecision = (
@@ -365,11 +424,12 @@ export const executeDecision = (
   decision: ExecutableDecision,
   context: TemplateContext,
   cost?: number,
+  model?: string,
 ): Effect.Effect<StepOutcome, Error> =>
   Effect.gen(function* () {
     switch (decision.kind) {
       case "commit": {
-        yield* git.commitAllWithPrefix(withCostTrailer(decision.subject, cost))
+        yield* git.commitAllWithPrefix(withCostTrailer(decision.subject, cost, model))
         return { kind: "commit", subject: decision.subject }
       }
       case "squash": {

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -73,12 +73,16 @@ export interface GitReaderOperations {
 
 export interface GitWriterOperations {
   /**
-   * `git add -A` then `git commit --allow-empty -m "<prefix>"`. `--allow-empty`
-   * is load-bearing: the machine emits `commitPending` with a fixed prefix even
+   * `git add -A` then `git commit --allow-empty -m "<message>"`. `--allow-empty`
+   * is load-bearing: the machine emits `commitPending` with a fixed subject even
    * on a clean tree (e.g. `gtd: grilled`), and the uncommitted-FEEDBACK Fixing
    * path can net an empty commit — neither must throw "nothing to commit".
+   * `message` is normally the bare `gtd(<actor>): <state>` subject, but may
+   * carry a trailing body (a blank line then a `Gtd-Cost: <n>` trailer when
+   * `gtd step --cost=<n>` recorded one) — `-m` preserves embedded newlines
+   * verbatim, and the subject line is untouched.
    */
-  readonly commitAllWithPrefix: (prefix: string) => Effect.Effect<void, Error>
+  readonly commitAllWithPrefix: (message: string) => Effect.Effect<void, Error>
   readonly softResetTo: (ref: string) => Effect.Effect<void, Error>
   /**
    * `git commit --allow-empty -m <message>` — commits whatever is CURRENTLY

--- a/src/Lsp.ts
+++ b/src/Lsp.ts
@@ -306,6 +306,7 @@ export const buildFileModeMap = (
         processDiff: "",
         lastDiff: "",
         processCost: 0,
+        processCostByModel: [],
         read: (path: string) => {
           throw new Error(
             `"file:" is not readable while building the path→mode map (path: ${path})`,

--- a/src/Lsp.ts
+++ b/src/Lsp.ts
@@ -305,6 +305,7 @@ export const buildFileModeMap = (
         actor: "",
         processDiff: "",
         lastDiff: "",
+        processCost: 0,
         read: (path: string) => {
           throw new Error(
             `"file:" is not readable while building the path→mode map (path: ${path})`,

--- a/src/PatternTemplates.test.ts
+++ b/src/PatternTemplates.test.ts
@@ -10,6 +10,7 @@ const baseContext = (overrides: Partial<TemplateContext> = {}): TemplateContext 
   processDiff: "diff --git a/x.ts b/x.ts\n+added\n",
   lastDiff: "diff --git a/y.ts b/y.ts\n+last\n",
   processCost: 0,
+  processCostByModel: [],
   read: (path: string) => {
     if (path.endsWith("missing.md"))
       throw new Error(`ENOENT: no such file or directory, open '${path}'`)
@@ -55,6 +56,19 @@ describe("renderStateTemplate — the full variable set", () => {
       baseContext({ processCost: 8421 }),
     )
     expect(out).toBe("Total tokens: 8421")
+  })
+
+  it("iterates it.processCostByModel — the per-model breakdown (e.g. for a squash commit message)", () => {
+    const out = renderStateTemplate(
+      "<% it.processCostByModel.forEach(function(m){ %><%= m.model %>=<%= m.cost %>;<% }) %>",
+      baseContext({
+        processCostByModel: [
+          { model: "haiku", cost: 300 },
+          { model: "opus", cost: 200 },
+        ],
+      }),
+    )
+    expect(out).toBe("haiku=300;opus=200;")
   })
 
   it("`it.vars` is always a plain object, even when empty — usable via `in` checks", () => {

--- a/src/PatternTemplates.test.ts
+++ b/src/PatternTemplates.test.ts
@@ -9,6 +9,7 @@ const baseContext = (overrides: Partial<TemplateContext> = {}): TemplateContext 
   actor: "agent",
   processDiff: "diff --git a/x.ts b/x.ts\n+added\n",
   lastDiff: "diff --git a/y.ts b/y.ts\n+last\n",
+  processCost: 0,
   read: (path: string) => {
     if (path.endsWith("missing.md"))
       throw new Error(`ENOENT: no such file or directory, open '${path}'`)
@@ -46,6 +47,14 @@ describe("renderStateTemplate — the full variable set", () => {
   it("renders the merged `it.vars` map by name", () => {
     const out = renderStateTemplate("greeting=<%= it.vars.greeting %>", baseContext())
     expect(out).toBe("greeting=hi")
+  })
+
+  it("renders it.processCost — the accumulated token cost (e.g. for a squash commit message)", () => {
+    const out = renderStateTemplate(
+      "Total tokens: <%= it.processCost %>",
+      baseContext({ processCost: 8421 }),
+    )
+    expect(out).toBe("Total tokens: 8421")
   })
 
   it("`it.vars` is always a plain object, even when empty — usable via `in` checks", () => {

--- a/src/PatternTemplates.ts
+++ b/src/PatternTemplates.ts
@@ -45,10 +45,17 @@ export interface TemplateContext {
    * one is being performed (so a `commit:` squash template rendered against
    * the PENDING tree sees the whole-process total, including the squashing
    * step itself). `0` when nothing has been recorded. Always a number —
-   * assembled by `src/Edge.ts` (`computeProcessRun`'s `totalCost` plus the
-   * step's own `--cost`), never config-derived like `it.vars`.
+   * assembled by `src/Edge.ts`, never config-derived like `it.vars`.
    */
   readonly processCost: number
+  /**
+   * The same accumulated cost broken down per model — one `{ model, cost }`
+   * entry per distinct `--model` tag recorded this process (a cost recorded
+   * with no `--model` is grouped under `"unspecified"`), highest-cost first.
+   * A `commit:` squash template iterates it to list the tokens each model
+   * spent across the whole feature. Empty when nothing has been recorded.
+   */
+  readonly processCostByModel: readonly { readonly model: string; readonly cost: number }[]
   /** Read a working-tree file (pending contents, not HEAD's) by repo-relative path. Throws for a missing/unreadable path — that throw is the render failure the plan's `commit:` refusal rule depends on. */
   readonly read: (path: string) => string
   /**

--- a/src/PatternTemplates.ts
+++ b/src/PatternTemplates.ts
@@ -38,6 +38,17 @@ export interface TemplateContext {
   readonly processDiff: string
   /** The diff of the last transition alone. */
   readonly lastDiff: string
+  /**
+   * The total token cost accumulated over the current process: the sum of
+   * every `Gtd-Cost:` trailer on the process's turn commits (recorded by
+   * `gtd step <actor> --cost=<n>`), plus the cost of the in-flight step when
+   * one is being performed (so a `commit:` squash template rendered against
+   * the PENDING tree sees the whole-process total, including the squashing
+   * step itself). `0` when nothing has been recorded. Always a number —
+   * assembled by `src/Edge.ts` (`computeProcessRun`'s `totalCost` plus the
+   * step's own `--cost`), never config-derived like `it.vars`.
+   */
+  readonly processCost: number
   /** Read a working-tree file (pending contents, not HEAD's) by repo-relative path. Throws for a missing/unreadable path — that throw is the render failure the plan's `commit:` refusal rule depends on. */
   readonly read: (path: string) => string
   /**

--- a/src/program.ts
+++ b/src/program.ts
@@ -40,7 +40,9 @@ const HELP_TEXT = `Usage: gtd [command] [options]
 Commands:
   step <actor>     Authenticate as <actor>, match the resolved rest's
                    declared patterns against the pending changes, and commit
-                   (or squash) the one resulting transition
+                   (or squash) the one resulting transition. Pass
+                   --cost=<n> to record the just-finished invocation's token
+                   cost on the turn commit (summed into it.processCost)
   next             Print the resolved rest's rendered script/prompt/message
                    (no mutation)
   run              Execute the resolved rest's emitted script, then step its
@@ -54,6 +56,7 @@ Commands:
 
 Options:
   --json           Output structured JSON instead of plain text
+  --cost=<n>       (gtd step only) record the invocation's token cost
   --version, -v    Print version and exit
   --help, -h       Print this help and exit
 `
@@ -84,6 +87,29 @@ type ProgramRequirements =
 /** Non-flag positional arguments past the subcommand name (argv[3..]). */
 const commandArgs = (argv: readonly string[]): string[] =>
   argv.slice(3).filter((a) => a.length > 0 && !a.startsWith("--"))
+
+const COST_FLAG = "--cost="
+
+/**
+ * Parse the optional `--cost=<n>` flag (only `gtd step` accepts it — see
+ * `makeProgram`). `<n>` is the token cost of the invocation that produced the
+ * pending changes, recorded as a `Gtd-Cost:` trailer on the turn commit. Must
+ * be a non-negative finite number; a bare `--cost` (no `=`) or a non-numeric/
+ * negative value is a usage error. Returns `undefined` when the flag is absent.
+ */
+const parseCostFlag = (argv: readonly string[]): Effect.Effect<number | undefined, Error> => {
+  if (argv.slice(2).includes("--cost")) {
+    return Effect.fail(new Error("gtd: --cost requires a value — use --cost=<number>"))
+  }
+  const flag = argv.slice(2).find((a) => a.startsWith(COST_FLAG))
+  if (flag === undefined) return Effect.succeed(undefined)
+  const raw = flag.slice(COST_FLAG.length)
+  const n = Number(raw)
+  if (raw.trim() === "" || !Number.isFinite(n) || n < 0) {
+    return Effect.fail(new Error(`gtd: --cost must be a non-negative number — got "${raw}"`))
+  }
+  return Effect.succeed(n)
+}
 
 /** Rejects extra positional arguments for a subcommand that takes none (`status`, `run`). */
 const rejectExtraArgs = (command: string, argv: readonly string[]): Effect.Effect<void, Error> => {
@@ -177,8 +203,9 @@ const resolveRestContext = (
  */
 const stepAsActor = (
   invoker: string,
+  cost?: number,
 ): Effect.Effect<
-  { readonly state: string; readonly subject: string | null },
+  { readonly state: string; readonly subject: string | null; readonly cost: number | null },
   Error,
   ProgramRequirements
 > =>
@@ -203,7 +230,7 @@ const stepAsActor = (
     }
 
     if (decision.kind === "noop") {
-      return { state: decision.state, subject: null }
+      return { state: decision.state, subject: null, cost: null }
     }
 
     const executable: ExecutableDecision = decision
@@ -215,19 +242,30 @@ const stepAsActor = (
       invoker,
       run,
       vars,
+      cost ?? 0,
     )
-    const outcome = yield* executeDecision(git, run, executable, context)
-    return { state: rest.state, subject: outcome.kind === "noop" ? null : outcome.subject }
+    const outcome = yield* executeDecision(git, run, executable, context, cost)
+    return {
+      state: rest.state,
+      subject: outcome.kind === "noop" ? null : outcome.subject,
+      cost: cost ?? null,
+    }
   })
 
 /** Renders `stepAsActor`'s result the same way for both `gtd step` and `gtd run`. */
 const reportStepResult = (
-  result: { readonly state: string; readonly subject: string | null },
+  result: { readonly state: string; readonly subject: string | null; readonly cost: number | null },
   json: boolean,
   write: (chunk: string) => void,
 ): void => {
   if (json) {
-    write(JSON.stringify({ state: result.state, subject: result.subject }) + "\n")
+    write(
+      JSON.stringify({
+        state: result.state,
+        subject: result.subject,
+        ...(result.cost !== null ? { cost: result.cost } : {}),
+      }) + "\n",
+    )
   } else {
     write(
       result.subject !== null
@@ -237,11 +275,12 @@ const reportStepResult = (
   }
 }
 
-/** `gtd step <actor>`: authenticate as `<actor>` and perform the one resulting transition. */
+/** `gtd step <actor> [--cost=<n>]`: authenticate as `<actor>` and perform the one resulting transition, recording `--cost` as a `Gtd-Cost:` trailer. */
 const runStepCommand = (
   argv: readonly string[],
   json: boolean,
   write: (chunk: string) => void,
+  cost: number | undefined,
 ): Effect.Effect<void, Error, ProgramRequirements> =>
   Effect.gen(function* () {
     const args = commandArgs(argv)
@@ -253,7 +292,7 @@ const runStepCommand = (
         new Error(`gtd step: too many arguments — expected one actor, got: ${args.join(", ")}`),
       )
     }
-    const result = yield* stepAsActor(args[0]!)
+    const result = yield* stepAsActor(args[0]!, cost)
     reportStepResult(result, json, write)
   })
 
@@ -342,13 +381,14 @@ const computeStatusChanges = (
     return { status: change.status, path: change.path, pattern: matchedRow?.[0] ?? null }
   })
 
-/** `gtd status --json`'s emission — `{state, actor, changes, model?, file?, mode?}`. */
+/** `gtd status --json`'s emission — `{state, actor, changes, model?, file?, mode?, cost?}`. */
 const writeStatusJson = (
   write: (chunk: string) => void,
   rest: ResolvedRest,
   statusChanges: readonly StatusChange[],
   model: string | undefined,
   file: string | undefined,
+  cost: number,
 ): void => {
   write(
     JSON.stringify({
@@ -358,22 +398,25 @@ const writeStatusJson = (
       ...(model !== undefined ? { model } : {}),
       ...(file !== undefined ? { file } : {}),
       ...(rest.stateDef.mode !== undefined ? { mode: rest.stateDef.mode } : {}),
+      ...(cost > 0 ? { cost } : {}),
     }) + "\n",
   )
 }
 
-/** `gtd status`'s plain-text emission — `State:`/`Awaits:`/`Model:`/`File:`/`Mode:`/`Pending:` lines. */
+/** `gtd status`'s plain-text emission — `State:`/`Awaits:`/`Model:`/`File:`/`Mode:`/`Cost:`/`Pending:` lines. */
 const writeStatusPlain = (
   write: (chunk: string) => void,
   rest: ResolvedRest,
   statusChanges: readonly StatusChange[],
   model: string | undefined,
   file: string | undefined,
+  cost: number,
 ): void => {
   const lines = [`State: ${rest.state}`, `Awaits: ${rest.actor}`]
   if (model !== undefined) lines.push(`Model: ${model}`)
   if (file !== undefined) lines.push(`File: ${file}`)
   if (rest.stateDef.mode !== undefined) lines.push(`Mode: ${rest.stateDef.mode}`)
+  if (cost > 0) lines.push(`Cost: ${cost}`)
   if (statusChanges.length === 0) {
     lines.push("Pending: (clean)")
   } else {
@@ -400,9 +443,9 @@ const runStatusCommand = (
     const file = yield* renderFile(rest.stateDef, context)
     const statusChanges = computeStatusChanges(rest.stateDef.on ?? [], changes)
     if (json) {
-      writeStatusJson(write, rest, statusChanges, model, file)
+      writeStatusJson(write, rest, statusChanges, model, file, context.processCost)
     } else {
-      writeStatusPlain(write, rest, statusChanges, model, file)
+      writeStatusPlain(write, rest, statusChanges, model, file, context.processCost)
     }
   })
 
@@ -505,10 +548,11 @@ const dispatchKnownSubcommand = (
   argv: readonly string[],
   json: boolean,
   write: (chunk: string) => void,
+  cost: number | undefined,
 ): Effect.Effect<void, Error, ProgramRequirements> => {
   switch (sub) {
     case "step":
-      return runStepCommand(argv, json, write)
+      return runStepCommand(argv, json, write, cost)
     case "next":
       return runNextCommand(json, write)
     case "run":
@@ -558,13 +602,28 @@ export function makeProgram(
     if (runVersionOrHelp(argv, write)) return
 
     // Reject unknown `--` options up front: a typo like `--jsn` must not
-    // silently degrade to plain-text mode. `--json` is the only long option;
-    // `--version`/`--help` (and their short forms) short-circuited above.
-    const unknownOption = argv.slice(2).find((a) => a.startsWith("--") && a !== "--json")
+    // silently degrade to plain-text mode. `--json` and `--cost=<n>` are the
+    // only long options; `--version`/`--help` (and their short forms)
+    // short-circuited above. A bare `--cost` (no `=`) is left for
+    // `parseCostFlag` to reject with a value-specific message.
+    const unknownOption = argv
+      .slice(2)
+      .find(
+        (a) => a.startsWith("--") && a !== "--json" && a !== "--cost" && !a.startsWith(COST_FLAG),
+      )
     if (unknownOption !== undefined) {
       return yield* Effect.fail(
         new Error(`gtd: unknown option '${unknownOption}' — see \`gtd --help\``),
       )
+    }
+
+    // `--cost` is orthogonal to `--json` but only meaningful to `gtd step`:
+    // it records the just-finished invocation's token cost as a `Gtd-Cost:`
+    // trailer on the turn commit. Reject it on every other command rather
+    // than silently ignoring it (same discipline as `--json` on `format`).
+    const cost = yield* parseCostFlag(argv)
+    if (cost !== undefined && positional !== "step") {
+      return yield* Effect.fail(new Error("gtd: --cost is only valid for `gtd step`"))
     }
 
     if (positional === "format") {
@@ -585,7 +644,7 @@ export function makeProgram(
     // a refused or rejected invocation must never mutate the repository.
     yield* (yield* ConfigInit).ensure
 
-    yield* dispatchKnownSubcommand(sub, argv, json, write)
+    yield* dispatchKnownSubcommand(sub, argv, json, write, cost)
   }).pipe(
     json
       ? Effect.catchAll((error) =>

--- a/src/program.ts
+++ b/src/program.ts
@@ -16,7 +16,9 @@ import {
   renderRest,
   resolveRest,
   resolveVars,
+  UNATTRIBUTED_MODEL,
   type ExecutableDecision,
+  type ModelCost,
   type ProcessRun,
   type ResolvedRest,
 } from "./Edge.js"
@@ -29,6 +31,7 @@ import {
   step,
   type OnEdge,
   type PendingChange,
+  type StepRefusal,
 } from "./PatternMachine.js"
 import type { TemplateContext } from "./PatternTemplates.js"
 
@@ -41,8 +44,9 @@ Commands:
   step <actor>     Authenticate as <actor>, match the resolved rest's
                    declared patterns against the pending changes, and commit
                    (or squash) the one resulting transition. Pass
-                   --cost=<n> to record the just-finished invocation's token
-                   cost on the turn commit (summed into it.processCost)
+                   --cost=<n> (optionally --model=<name>) to record the
+                   just-finished invocation's token cost and model on the
+                   turn commit (summed into it.processCost/processCostByModel)
   next             Print the resolved rest's rendered script/prompt/message
                    (no mutation)
   run              Execute the resolved rest's emitted script, then step its
@@ -57,6 +61,7 @@ Commands:
 Options:
   --json           Output structured JSON instead of plain text
   --cost=<n>       (gtd step only) record the invocation's token cost
+  --model=<name>   (gtd step only, with --cost) tag that cost's model
   --version, -v    Print version and exit
   --help, -h       Print this help and exit
 `
@@ -110,6 +115,62 @@ const parseCostFlag = (argv: readonly string[]): Effect.Effect<number | undefine
   }
   return Effect.succeed(n)
 }
+
+const MODEL_FLAG = "--model="
+
+/**
+ * Parse the optional `--model=<name>` flag (only `gtd step`, and only
+ * alongside `--cost` — see `makeProgram`). `<name>` tags the recorded cost
+ * with the model the invocation ran on, appended to the `Gtd-Cost:` trailer
+ * and grouped in `it.processCostByModel`. Must be non-empty and single-line
+ * (it rides on one trailer line); a bare `--model` (no `=`) or an empty/
+ * multiline value is a usage error. Returns `undefined` when the flag is absent.
+ */
+const parseModelFlag = (argv: readonly string[]): Effect.Effect<string | undefined, Error> => {
+  if (argv.slice(2).includes("--model")) {
+    return Effect.fail(new Error("gtd: --model requires a value — use --model=<name>"))
+  }
+  const flag = argv.slice(2).find((a) => a.startsWith(MODEL_FLAG))
+  if (flag === undefined) return Effect.succeed(undefined)
+  const raw = flag.slice(MODEL_FLAG.length)
+  if (raw.trim() === "" || /[\r\n]/.test(raw)) {
+    return Effect.fail(new Error("gtd: --model must be a non-empty, single-line value"))
+  }
+  return Effect.succeed(raw)
+}
+
+/**
+ * Parse and validate the `--cost`/`--model` step flags together. Both are
+ * orthogonal to `--json` but only meaningful to `gtd step` — rejected on any
+ * other command rather than silently ignored (same discipline as `--json` on
+ * `format`) — and `--model` requires `--cost` (a model tag with no token count
+ * records nothing to sum).
+ */
+const parseStepFlags = (
+  argv: readonly string[],
+  positional: string | undefined,
+): Effect.Effect<
+  { readonly cost: number | undefined; readonly model: string | undefined },
+  Error
+> =>
+  Effect.gen(function* () {
+    const cost = yield* parseCostFlag(argv)
+    const model = yield* parseModelFlag(argv)
+    if (cost !== undefined && positional !== "step") {
+      return yield* Effect.fail(new Error("gtd: --cost is only valid for `gtd step`"))
+    }
+    if (model !== undefined && positional !== "step") {
+      return yield* Effect.fail(new Error("gtd: --model is only valid for `gtd step`"))
+    }
+    if (model !== undefined && cost === undefined) {
+      return yield* Effect.fail(
+        new Error(
+          "gtd: --model requires --cost — it tags the recorded cost with the model that ran",
+        ),
+      )
+    }
+    return { cost, model }
+  })
 
 /** Rejects extra positional arguments for a subcommand that takes none (`status`, `run`). */
 const rejectExtraArgs = (command: string, argv: readonly string[]): Effect.Effect<void, Error> => {
@@ -193,6 +254,14 @@ const resolveRestContext = (
     return { rest, run, context }
   })
 
+/** The user-facing message for a `step` refusal — out-of-turn names the awaited actor, no-match names every declared pattern. */
+const formatStepRefusal = (invoker: string, refusal: StepRefusal): string =>
+  refusal.reason === "out-of-turn"
+    ? `gtd step ${invoker}: out of turn — "${refusal.state}" awaits ${refusal.awaits}`
+    : `gtd step ${invoker}: no declared pattern matches the pending changes at "${refusal.state}" — declared patterns: ${
+        refusal.patterns.length > 0 ? refusal.patterns.join(", ") : "(none)"
+      }`
+
 /**
  * Authenticate `invoker` against the resolved rest and perform the one
  * resulting transition (commit or squash), shared by `gtd step` and
@@ -204,8 +273,14 @@ const resolveRestContext = (
 const stepAsActor = (
   invoker: string,
   cost?: number,
+  model?: string,
 ): Effect.Effect<
-  { readonly state: string; readonly subject: string | null; readonly cost: number | null },
+  {
+    readonly state: string
+    readonly subject: string | null
+    readonly cost: number | null
+    readonly model: string | null
+  },
   Error,
   ProgramRequirements
 > =>
@@ -220,17 +295,11 @@ const stepAsActor = (
     const decision = step(rest.def, rest.state, invoker, { changes, processTrace: run.trace })
 
     if (decision.kind === "refusal") {
-      const message =
-        decision.reason === "out-of-turn"
-          ? `gtd step ${invoker}: out of turn — "${decision.state}" awaits ${decision.awaits}`
-          : `gtd step ${invoker}: no declared pattern matches the pending changes at "${decision.state}" — declared patterns: ${
-              decision.patterns.length > 0 ? decision.patterns.join(", ") : "(none)"
-            }`
-      return yield* Effect.fail(new Error(message))
+      return yield* Effect.fail(new Error(formatStepRefusal(invoker, decision)))
     }
 
     if (decision.kind === "noop") {
-      return { state: decision.state, subject: null, cost: null }
+      return { state: decision.state, subject: null, cost: null, model: null }
     }
 
     const executable: ExecutableDecision = decision
@@ -243,18 +312,25 @@ const stepAsActor = (
       run,
       vars,
       cost ?? 0,
+      model,
     )
-    const outcome = yield* executeDecision(git, run, executable, context, cost)
+    const outcome = yield* executeDecision(git, run, executable, context, cost, model)
     return {
       state: rest.state,
       subject: outcome.kind === "noop" ? null : outcome.subject,
       cost: cost ?? null,
+      model: model ?? null,
     }
   })
 
 /** Renders `stepAsActor`'s result the same way for both `gtd step` and `gtd run`. */
 const reportStepResult = (
-  result: { readonly state: string; readonly subject: string | null; readonly cost: number | null },
+  result: {
+    readonly state: string
+    readonly subject: string | null
+    readonly cost: number | null
+    readonly model: string | null
+  },
   json: boolean,
   write: (chunk: string) => void,
 ): void => {
@@ -264,6 +340,7 @@ const reportStepResult = (
         state: result.state,
         subject: result.subject,
         ...(result.cost !== null ? { cost: result.cost } : {}),
+        ...(result.model !== null ? { model: result.model } : {}),
       }) + "\n",
     )
   } else {
@@ -275,12 +352,13 @@ const reportStepResult = (
   }
 }
 
-/** `gtd step <actor> [--cost=<n>]`: authenticate as `<actor>` and perform the one resulting transition, recording `--cost` as a `Gtd-Cost:` trailer. */
+/** `gtd step <actor> [--cost=<n>] [--model=<name>]`: authenticate as `<actor>` and perform the one resulting transition, recording `--cost`/`--model` as a `Gtd-Cost:` trailer. */
 const runStepCommand = (
   argv: readonly string[],
   json: boolean,
   write: (chunk: string) => void,
   cost: number | undefined,
+  model: string | undefined,
 ): Effect.Effect<void, Error, ProgramRequirements> =>
   Effect.gen(function* () {
     const args = commandArgs(argv)
@@ -292,7 +370,7 @@ const runStepCommand = (
         new Error(`gtd step: too many arguments — expected one actor, got: ${args.join(", ")}`),
       )
     }
-    const result = yield* stepAsActor(args[0]!, cost)
+    const result = yield* stepAsActor(args[0]!, cost, model)
     reportStepResult(result, json, write)
   })
 
@@ -381,7 +459,25 @@ const computeStatusChanges = (
     return { status: change.status, path: change.path, pattern: matchedRow?.[0] ?? null }
   })
 
-/** `gtd status --json`'s emission — `{state, actor, changes, model?, file?, mode?, cost?}`. */
+/**
+ * True when the per-model breakdown adds information beyond the `Cost:` total:
+ * more than one model, or a single model that carries an actual `--model` tag
+ * (a lone `unspecified` bucket just restates the total, so it's suppressed).
+ */
+const breakdownIsInformative = (byModel: readonly ModelCost[]): boolean =>
+  byModel.length > 1 || (byModel.length === 1 && byModel[0]!.model !== UNATTRIBUTED_MODEL)
+
+/** The plain-text `Cost:` line(s) for `gtd status` — empty when nothing recorded, plus an indented per-model split when informative. */
+const costStatusLines = (cost: number, byModel: readonly ModelCost[]): string[] => {
+  if (cost <= 0) return []
+  const lines = [`Cost: ${cost}`]
+  if (breakdownIsInformative(byModel)) {
+    for (const m of byModel) lines.push(`  ${m.model}: ${m.cost}`)
+  }
+  return lines
+}
+
+/** `gtd status --json`'s emission — `{state, actor, changes, model?, file?, mode?, cost?, costByModel?}`. */
 const writeStatusJson = (
   write: (chunk: string) => void,
   rest: ResolvedRest,
@@ -389,6 +485,7 @@ const writeStatusJson = (
   model: string | undefined,
   file: string | undefined,
   cost: number,
+  costByModel: readonly ModelCost[],
 ): void => {
   write(
     JSON.stringify({
@@ -399,6 +496,7 @@ const writeStatusJson = (
       ...(file !== undefined ? { file } : {}),
       ...(rest.stateDef.mode !== undefined ? { mode: rest.stateDef.mode } : {}),
       ...(cost > 0 ? { cost } : {}),
+      ...(cost > 0 ? { costByModel } : {}),
     }) + "\n",
   )
 }
@@ -411,12 +509,13 @@ const writeStatusPlain = (
   model: string | undefined,
   file: string | undefined,
   cost: number,
+  costByModel: readonly ModelCost[],
 ): void => {
   const lines = [`State: ${rest.state}`, `Awaits: ${rest.actor}`]
   if (model !== undefined) lines.push(`Model: ${model}`)
   if (file !== undefined) lines.push(`File: ${file}`)
   if (rest.stateDef.mode !== undefined) lines.push(`Mode: ${rest.stateDef.mode}`)
-  if (cost > 0) lines.push(`Cost: ${cost}`)
+  lines.push(...costStatusLines(cost, costByModel))
   if (statusChanges.length === 0) {
     lines.push("Pending: (clean)")
   } else {
@@ -443,9 +542,25 @@ const runStatusCommand = (
     const file = yield* renderFile(rest.stateDef, context)
     const statusChanges = computeStatusChanges(rest.stateDef.on ?? [], changes)
     if (json) {
-      writeStatusJson(write, rest, statusChanges, model, file, context.processCost)
+      writeStatusJson(
+        write,
+        rest,
+        statusChanges,
+        model,
+        file,
+        context.processCost,
+        context.processCostByModel,
+      )
     } else {
-      writeStatusPlain(write, rest, statusChanges, model, file, context.processCost)
+      writeStatusPlain(
+        write,
+        rest,
+        statusChanges,
+        model,
+        file,
+        context.processCost,
+        context.processCostByModel,
+      )
     }
   })
 
@@ -549,10 +664,11 @@ const dispatchKnownSubcommand = (
   json: boolean,
   write: (chunk: string) => void,
   cost: number | undefined,
+  model: string | undefined,
 ): Effect.Effect<void, Error, ProgramRequirements> => {
   switch (sub) {
     case "step":
-      return runStepCommand(argv, json, write, cost)
+      return runStepCommand(argv, json, write, cost, model)
     case "next":
       return runNextCommand(json, write)
     case "run":
@@ -609,7 +725,13 @@ export function makeProgram(
     const unknownOption = argv
       .slice(2)
       .find(
-        (a) => a.startsWith("--") && a !== "--json" && a !== "--cost" && !a.startsWith(COST_FLAG),
+        (a) =>
+          a.startsWith("--") &&
+          a !== "--json" &&
+          a !== "--cost" &&
+          a !== "--model" &&
+          !a.startsWith(COST_FLAG) &&
+          !a.startsWith(MODEL_FLAG),
       )
     if (unknownOption !== undefined) {
       return yield* Effect.fail(
@@ -617,14 +739,9 @@ export function makeProgram(
       )
     }
 
-    // `--cost` is orthogonal to `--json` but only meaningful to `gtd step`:
-    // it records the just-finished invocation's token cost as a `Gtd-Cost:`
-    // trailer on the turn commit. Reject it on every other command rather
-    // than silently ignoring it (same discipline as `--json` on `format`).
-    const cost = yield* parseCostFlag(argv)
-    if (cost !== undefined && positional !== "step") {
-      return yield* Effect.fail(new Error("gtd: --cost is only valid for `gtd step`"))
-    }
+    // `--cost`/`--model` record the just-finished invocation's token cost and
+    // model as a `Gtd-Cost:` trailer on the turn commit (see `parseStepFlags`).
+    const { cost, model } = yield* parseStepFlags(argv, positional)
 
     if (positional === "format") {
       return yield* runFormatCommand(argv, json)
@@ -644,7 +761,7 @@ export function makeProgram(
     // a refused or rejected invocation must never mutate the repository.
     yield* (yield* ConfigInit).ensure
 
-    yield* dispatchKnownSubcommand(sub, argv, json, write, cost)
+    yield* dispatchKnownSubcommand(sub, argv, json, write, cost, model)
   }).pipe(
     json
       ? Effect.catchAll((error) =>

--- a/tests/integration/features/token-cost.feature
+++ b/tests/integration/features/token-cost.feature
@@ -1,0 +1,224 @@
+@inmem
+Feature: Token-cost tracking — gtd step --cost persists a per-turn cost, summed for the squash
+
+  A loop driver knows how many tokens the invocation it just drove cost.
+  `gtd step <actor> --cost=<n>` records that number as a `Gtd-Cost: <n>`
+  trailer on the turn commit (persisted in the git log, one per turn, subject
+  line untouched). `computeProcessRun` sums every such trailer across the
+  current process into `it.processCost`, so a `commit:` squash template can
+  print the whole-process total — the complete token cost of the feature — and
+  `gtd status` can show the running total mid-cycle.
+
+  Scenario: gtd step --cost records a Gtd-Cost trailer on the turn commit, subject untouched
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": building
+          building:
+            actor: agent
+            prompt: "build it"
+            on:
+              "* **": reviewing
+          reviewing:
+            actor: agent
+            prompt: "review it"
+            on:
+              "* **": idle
+      """
+    And a commit "gtd(human): building" that adds "NOTE.md" with:
+      """
+      a note
+      """
+    And a file "src/x.ts" with:
+      """
+      export const x = 1
+      """
+    When I run gtd step agent with "--cost=1450"
+    Then it succeeds
+    And the last commit subject is "gtd(agent): reviewing"
+    And the last commit body contains "Gtd-Cost: 1450"
+
+  Scenario: gtd step --json echoes the recorded cost
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": building
+          building:
+            actor: agent
+            prompt: "build it"
+            on:
+              "* **": idle
+      """
+    And a commit "gtd(human): building" that adds "NOTE.md" with:
+      """
+      a note
+      """
+    And a file "src/x.ts" with:
+      """
+      export const x = 1
+      """
+    When I run gtd step agent with "--cost=1450" and "--json"
+    Then it succeeds
+    And stdout contains "\"subject\":\"gtd(agent): idle\""
+    And stdout contains "\"cost\":1450"
+
+  Scenario: gtd status shows the running process cost, accumulated across turns
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": building
+          building:
+            actor: agent
+            prompt: "build it"
+            on:
+              "* **": reviewing
+          reviewing:
+            actor: agent
+            prompt: "review it"
+            on:
+              "* **": polishing
+          polishing:
+            actor: agent
+            prompt: "polish it"
+            on:
+              "* **": idle
+      """
+    And a commit "gtd(human): building" that adds "NOTE.md" with:
+      """
+      a note
+      """
+    And a file "src/a.ts" with:
+      """
+      export const a = 1
+      """
+    When I run gtd step agent with "--cost=100"
+    Then it succeeds
+    And the last commit subject is "gtd(agent): reviewing"
+    Given a file "src/b.ts" with:
+      """
+      export const b = 2
+      """
+    When I run gtd step agent with "--cost=250"
+    Then it succeeds
+    And the last commit subject is "gtd(agent): polishing"
+    When I run gtd status
+    Then it succeeds
+    And stdout contains "State: polishing"
+    And stdout contains "Cost: 350"
+
+  Scenario: gtd status omits the Cost line when no cost has been recorded
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": building
+          building:
+            actor: agent
+            prompt: "build it"
+            on:
+              "* **": idle
+      """
+    And a commit "gtd(human): building" that adds "NOTE.md" with:
+      """
+      a note
+      """
+    When I run gtd status
+    Then it succeeds
+    And stdout contains "State: building"
+    And stdout does not contain "Cost:"
+
+  Scenario: a squash commit template renders it.processCost — the whole-process total including the squashing step
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": building
+          building:
+            actor: agent
+            prompt: "build it"
+            on:
+              "* **": finishing
+          finishing:
+            actor: agent
+            prompt: "write DONE.md"
+            on:
+              "A DONE.md": done
+              "M DONE.md": done
+          done:
+            commit: |
+              feat: ship it
+
+              Total token cost: <%= it.processCost %>
+      """
+    And a commit "gtd(human): building" that adds "NOTE.md" with:
+      """
+      a note
+      """
+    And a file "src/a.ts" with:
+      """
+      export const a = 1
+      """
+    When I run gtd step agent with "--cost=100"
+    Then it succeeds
+    And the last commit subject is "gtd(agent): finishing"
+    And the last commit body contains "Gtd-Cost: 100"
+    Given a file "DONE.md" with:
+      """
+      shipped
+      """
+    When I run gtd step agent with "--cost=250"
+    Then it succeeds
+    And the last commit subject is "feat: ship it"
+    And the last commit body contains "Total token cost: 350"
+    And the last commit body does not contain "Gtd-Cost:"
+
+  Scenario: --cost is rejected on a non-step command
+    Given a test project
+    When I run gtd status with "--cost=5"
+    Then it fails
+    And stderr contains "gtd: --cost is only valid for `gtd step`"
+
+  Scenario: a bare --cost (no value) is a usage error
+    Given a test project
+    When I run gtd step agent with "--cost"
+    Then it fails
+    And stderr contains "gtd: --cost requires a value"
+
+  Scenario: a non-numeric --cost is a usage error
+    Given a test project
+    When I run gtd step agent with "--cost=lots"
+    Then it fails
+    And stderr contains "gtd: --cost must be a non-negative number"

--- a/tests/integration/features/token-cost.feature
+++ b/tests/integration/features/token-cost.feature
@@ -1,13 +1,15 @@
 @inmem
-Feature: Token-cost tracking — gtd step --cost persists a per-turn cost, summed for the squash
+Feature: Token-cost tracking — gtd step --cost/--model persists per-turn cost, summed for the squash
 
-  A loop driver knows how many tokens the invocation it just drove cost.
-  `gtd step <actor> --cost=<n>` records that number as a `Gtd-Cost: <n>`
-  trailer on the turn commit (persisted in the git log, one per turn, subject
-  line untouched). `computeProcessRun` sums every such trailer across the
-  current process into `it.processCost`, so a `commit:` squash template can
-  print the whole-process total — the complete token cost of the feature — and
-  `gtd status` can show the running total mid-cycle.
+  A loop driver knows how many tokens the invocation it just drove cost, and on
+  which model. `gtd step <actor> --cost=<n> [--model=<name>]` records both as a
+  `Gtd-Cost: <n> <model>` trailer on the turn commit (persisted in the git log,
+  one per turn, subject line untouched). `computeProcessRun` collects every
+  such entry across the current process; a `commit:` squash template renders
+  the whole-process total via `it.processCost` and the per-model breakdown via
+  `it.processCostByModel` — the complete cost of the feature, itemized by model,
+  since tokens alone don't tell you the price. `gtd status` shows the running
+  total (and per-model breakdown) mid-cycle.
 
   Scenario: gtd step --cost records a Gtd-Cost trailer on the turn commit, subject untouched
     Given a test project
@@ -222,3 +224,193 @@ Feature: Token-cost tracking — gtd step --cost persists a per-turn cost, summe
     When I run gtd step agent with "--cost=lots"
     Then it fails
     And stderr contains "gtd: --cost must be a non-negative number"
+
+  Scenario: gtd step --cost --model records the model alongside the cost in the trailer
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": building
+          building:
+            actor: agent
+            prompt: "build it"
+            on:
+              "* **": reviewing
+          reviewing:
+            actor: agent
+            prompt: "review it"
+            on:
+              "* **": idle
+      """
+    And a commit "gtd(human): building" that adds "NOTE.md" with:
+      """
+      a note
+      """
+    And a file "src/x.ts" with:
+      """
+      export const x = 1
+      """
+    When I run gtd step agent with "--cost=1450" and "--model=claude-opus-4-8"
+    Then it succeeds
+    And the last commit subject is "gtd(agent): reviewing"
+    And the last commit body contains "Gtd-Cost: 1450 claude-opus-4-8"
+
+  Scenario: gtd step --json echoes both the recorded cost and model
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": building
+          building:
+            actor: agent
+            prompt: "build it"
+            on:
+              "* **": idle
+      """
+    And a commit "gtd(human): building" that adds "NOTE.md" with:
+      """
+      a note
+      """
+    And a file "src/x.ts" with:
+      """
+      export const x = 1
+      """
+    When I run gtd step agent with "--cost=1450" and "--model=opus" and "--json"
+    Then it succeeds
+    And stdout contains "\"cost\":1450"
+    And stdout contains "\"model\":\"opus\""
+
+  Scenario: gtd status shows the per-model breakdown under the running total
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": building
+          building:
+            actor: agent
+            prompt: "build it"
+            on:
+              "* **": reviewing
+          reviewing:
+            actor: agent
+            prompt: "review it"
+            on:
+              "* **": polishing
+          polishing:
+            actor: agent
+            prompt: "polish it"
+            on:
+              "* **": idle
+      """
+    And a commit "gtd(human): building" that adds "NOTE.md" with:
+      """
+      a note
+      """
+    And a file "src/a.ts" with:
+      """
+      export const a = 1
+      """
+    When I run gtd step agent with "--cost=100" and "--model=haiku"
+    Then it succeeds
+    Given a file "src/b.ts" with:
+      """
+      export const b = 2
+      """
+    When I run gtd step agent with "--cost=250" and "--model=opus"
+    Then it succeeds
+    When I run gtd status
+    Then it succeeds
+    And stdout contains "Cost: 350"
+    And stdout contains "opus: 250"
+    And stdout contains "haiku: 100"
+
+  Scenario: a squash commit template itemizes it.processCostByModel across the whole process
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": building
+          building:
+            actor: agent
+            prompt: "build it"
+            on:
+              "* **": finishing
+          finishing:
+            actor: agent
+            prompt: "write DONE.md"
+            on:
+              "A DONE.md": done
+              "M DONE.md": done
+          done:
+            commit: |
+              feat: ship it
+
+              Total token cost: <%= it.processCost %>
+              <% it.processCostByModel.forEach(function(m){ %>
+              - <%= m.model %>: <%= m.cost %>
+              <% }) %>
+      """
+    And a commit "gtd(human): building" that adds "NOTE.md" with:
+      """
+      a note
+      """
+    And a file "src/a.ts" with:
+      """
+      export const a = 1
+      """
+    When I run gtd step agent with "--cost=100" and "--model=haiku"
+    Then it succeeds
+    And the last commit subject is "gtd(agent): finishing"
+    And the last commit body contains "Gtd-Cost: 100 haiku"
+    Given a file "DONE.md" with:
+      """
+      shipped
+      """
+    When I run gtd step agent with "--cost=250" and "--model=opus"
+    Then it succeeds
+    And the last commit subject is "feat: ship it"
+    And the last commit body contains "Total token cost: 350"
+    And the last commit body contains "- opus: 250"
+    And the last commit body contains "- haiku: 100"
+
+  Scenario: --model is rejected on a non-step command
+    Given a test project
+    When I run gtd status with "--model=opus"
+    Then it fails
+    And stderr contains "gtd: --model is only valid for `gtd step`"
+
+  Scenario: a bare --model (no value) is a usage error
+    Given a test project
+    When I run gtd step agent with "--model"
+    Then it fails
+    And stderr contains "gtd: --model requires a value"
+
+  Scenario: --model without --cost is a usage error
+    Given a test project
+    When I run gtd step agent with "--model=opus"
+    Then it fails
+    And stderr contains "gtd: --model requires --cost"

--- a/tests/integration/support/steps/common.steps.ts
+++ b/tests/integration/support/steps/common.steps.ts
@@ -91,6 +91,13 @@ When("I run gtd step {word} with {string}", async (world: GtdWorld, actor: strin
   await world.runGtd("step", actor, arg)
 })
 
+When(
+  "I run gtd step {word} with {string} and {string}",
+  async (world: GtdWorld, actor: string, arg1: string, arg2: string) => {
+    await world.runGtd("step", actor, arg1, arg2)
+  },
+)
+
 When("I run gtd next", async (world: GtdWorld) => {
   await world.runGtd("next")
 })
@@ -174,6 +181,21 @@ Then("the last commit subject is {string}", (world: GtdWorld, subject: string) =
 Then("the git log contains {string}", (world: GtdWorld, subject: string) => {
   const log = world.gitLog()
   assert.ok(log.includes(subject), `Expected git log to contain "${subject}". Got:\n${log}`)
+})
+
+// The last commit's body (everything after the subject line) — where a
+// `Gtd-Cost:` trailer lands, and where a squash template's rendered body sits.
+Then("the last commit body contains {string}", (world: GtdWorld, text: string) => {
+  const body = world.lastCommitBody()
+  assert.ok(body.includes(text), `Expected last commit body to contain "${text}". Got:\n${body}`)
+})
+
+Then("the last commit body does not contain {string}", (world: GtdWorld, text: string) => {
+  const body = world.lastCommitBody()
+  assert.ok(
+    !body.includes(text),
+    `Expected last commit body NOT to contain "${text}". Got:\n${body}`,
+  )
 })
 
 // ── Git status ───────────────────────────────────────────────────────────────

--- a/tests/integration/support/steps/common.steps.ts
+++ b/tests/integration/support/steps/common.steps.ts
@@ -98,6 +98,13 @@ When(
   },
 )
 
+When(
+  "I run gtd step {word} with {string} and {string} and {string}",
+  async (world: GtdWorld, actor: string, arg1: string, arg2: string, arg3: string) => {
+    await world.runGtd("step", actor, arg1, arg2, arg3)
+  },
+)
+
 When("I run gtd next", async (world: GtdWorld) => {
   await world.runGtd("next")
 })


### PR DESCRIPTION
Add `gtd step <actor> --cost=<n>` to record the token cost of the
invocation that produced the pending changes. The cost is persisted as a
`Gtd-Cost: <n>` trailer on the turn commit (subject line untouched, so
resolution is unaffected), summed across the current process, and exposed
to every template as `it.processCost`.

Its primary use is a `commit:` squash template: `computeProcessRun` sums
the process's turn-commit trailers into `run.totalCost`, and the in-flight
step's own `--cost` is added on top, so a squash message renders the whole
feature's total even though the per-turn trailers collapse with the turns
they rode on. `gtd status` reports the running total (`Cost:` line / `cost`
key, omitted at 0) and `gtd step --json` echoes the recorded number.

The engine stays cost-agnostic — the number is carried and summed at the
edge (Edge.ts), never interpreted; `--cost` is orthogonal to `--json` and
only valid on `gtd step` (a usage error elsewhere, on a bare `--cost`, or
on a non-numeric/negative value).

Docs (STATES.md, cli.md, configuration.md, loop.md, advanced-workflow.md),
the loop skill, and e2e/unit coverage updated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015qUQn5zwSTrJG5MwnYBeTX