### PR TITLE
feat: `gtd review <commitish>` starts a review process at a declared entry state

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ schema stub on first run (see [Configuration](docs/configuration.md#auto-init)).
 gtd is a small **pattern machine**: named states, each awaiting one actor and
 carrying one piece of content (a script, a prompt, a message, or a squash commit
 template), with an ordered set of change-patterns routing to the next state.
-Three commands drive it:
+Four commands drive it:
 
 - **`gtd step <actor>`** — authenticate as `<actor>` and perform the one
   transition the pending changes match.
@@ -64,6 +64,9 @@ Three commands drive it:
   should do, without mutating anything.
 - **`gtd status`** — a dry-run report of the resolved state and which pattern
   each pending change matches.
+- **`gtd review <commitish>`** — start a brand new review process reviewing
+  `<commitish>..HEAD` (e.g. a colleague's PR branch), reusing the workflow's
+  existing review/feedback machinery over that diff.
 
 The loop is one beat, repeated: run `gtd next --json` and dispatch on `kind` —
 `"message"` means it's a human's move (stop and hand off); `"script"` means the
@@ -78,13 +81,15 @@ implementation plan — asking any open question it can't settle itself via a
 deterministic `.gtd/TODO.md` format, validated before it ever reaches you —
 builds it, runs your tests (looping on failures), and hands you a
 `.gtd/REVIEW.md` checkbox review of the cycle's diff: tick a box to approve that
-item, or edit/untick for feedback. Approving rests the cycle back at idle, with
-every turn commit still sitting in history for you to squash however you like
-(or not at all; gtd makes no assumption) — see
-[STATES.md](STATES.md#10-the-bundled-default-workflow) for the full shape. A
-heavier machine — two-phase Q&A planning, an architecture phase, task
-decomposition, a per-task build loop, and a squash finale — is preserved as a
-copy-paste `.gtdrc` example at
+item, or edit/untick for feedback. The same review flow also has a direct entry
+point — `gtd review <commitish>` starts a brand new process reviewing
+`<commitish>..HEAD` with no cycle of its own, e.g. a colleague's PR branch.
+Approving rests the cycle back at idle, with every turn commit still sitting in
+history for you to squash however you like (or not at all; gtd makes no
+assumption) — see [STATES.md](STATES.md#10-the-bundled-default-workflow) for the
+full shape. A heavier machine — two-phase Q&A planning, an architecture phase,
+task decomposition, a per-task build loop, and a squash finale — is preserved as
+a copy-paste `.gtdrc` example at
 [docs/examples/advanced-workflow.md](docs/examples/advanced-workflow.md). The
 workflow itself is just `.gtdrc` config — swap it for your own (see
 [Configuration](docs/configuration.md)).

--- a/STATES.md
+++ b/STATES.md
@@ -34,6 +34,7 @@ A workflow is a set of named **states**. Each state declares:
 | `mode`                                        | Optional, requires `file:`. The associated file's FORMAT: the name of a **steering-file mode** — one of the two built-ins (`qa` \| `review`) or one the workflow declares in `modes:` (a `format:`/`validate:` pair of shell commands — see §12). gtd formats and validates the file with that mode at `gtd validate` and at the `gtd step` capture gate; `gtd lsp` dispatches document symbols/code actions/diagnostics on the built-in names only. A name nothing defines is a load error. Like `model`, this is opaque emitted data — the ENGINE never branches on it. **Forbidden on a commit state.**                                                                                                                                                                                                                                                                             |
 | `reviewWindow: true`                          | Optional boolean. While the machine RESTS at this state, gtd opens a **review checkout window** — HEAD and the index are rewound to the review base with the working tree untouched, so the whole `base..HEAD` diff surfaces as ordinary uncommitted changes in the editor's git integration; it closes automatically once the machine rests anywhere else (see §11). The pure engine never observes it. **Forbidden on a commit state.**                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | `reviewBase: true`                            | Optional boolean. Marks the state whose most-recent in-process commit anchors the review window's diff base (`base..HEAD`); absent any such state, the base is the process start (§11). Like `reviewWindow`, history-derived edge data the engine never reads. **Forbidden on a commit state.**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `reviewEntry: true`                           | Optional boolean. Marks the (at most one) state `gtd review <commitish>` enters to start a BRAND NEW process reviewing `<commitish>..HEAD` — e.g. a colleague's PR branch with no gtd process of its own (§11). The pure engine never reads it either; the mechanism (resolving `<commitish>`, writing the entry commit, recording its hash as a `Gtd-Review-Base:` trailer) lives entirely at the edge. **Forbidden on a commit state and on the initial state.**                                                                                                                                                                                                                                                                                                                                                                                                                     |
 
 **Emission:** `gtd next --json`/`gtd status --json` gain optional `memory`
 (rendered), `file` (rendered) and `mode` (verbatim) keys, omitted — never `null`
@@ -226,6 +227,22 @@ starts a fresh one-commit history, a workflow commit entering the initial state
 process with an empty trace right after it, and an unrecognized HEAD starting a
 new process (§5) also begins with an empty trace.
 
+**The diff base vs. the trace boundary.** `computeProcessRun` produces both the
+process's trace boundary (`startParentHash`, above — what bounds `retry`
+counting and the squash reset target, §8) and a separate **diff base**
+(`diffBase`), the commit every rendered process diff (`it.processDiff`) and the
+review checkout window's default base (§11) compare against. The two normally
+coincide. They diverge only when the process's own OLDEST commit — its very
+first turn — carries a `Gtd-Review-Base: <hash>` trailer:
+`gtd review <commitish>` (§11) writes exactly such a commit when it starts a new
+process, recording `<commitish>`'s resolved hash there. `diffBase` then becomes
+that hash instead of the boundary parent, while the trace boundary itself is
+untouched (the entry commit's own parent is a non-workflow commit — e.g. a
+colleague's PR branch commit — so the ordinary boundary rule above already stops
+the trace walk there). This is how one workflow-authored value re-points the
+whole existing diff/review machinery at `<commitish>..HEAD` with no duplicated
+logic.
+
 ## 8. The squash lifecycle
 
 A **commit state** (`commit:` content, no `actor`, no `on`) is final. A
@@ -338,6 +355,13 @@ it. `File` names the workflow's own `vars:` entry the state's `file:` renders
 rests there for human review, gtd opens a review checkout window over the whole
 cycle diff (no `reviewBase` state is declared, so the base is the cycle's
 process boundary). See §11.
+
+`reviewing` additionally declares **`reviewEntry: true`**:
+`gtd review <commitish>` (a clean tree resting at `idle`) starts a brand new
+process there directly, reviewing `<commitish>..HEAD` — e.g. a colleague's PR
+branch — through this exact same `reviewing` → `await-review` → feedback-lap
+machinery, with the `await-review` review checkout window then opening over that
+same range. See §11.
 
 There is no squash — the cycle ends at human approval, an empty
 `gtd(human): idle` turn commit that rests the machine back at its own initial
@@ -481,12 +505,13 @@ working tree untouched, so the entire `base..HEAD` diff re-appears as
 uncommitted changes. The real head is preserved under `refs/gtd/review-head`
 (the base under `refs/gtd/review-base`) so nothing is lost.
 
-**The base.** By default it is the process start (the same boundary
-`computeProcessRun` uses — see §7), so the window shows the whole current cycle.
-A workflow can narrow it by marking an earlier state **`reviewBase: true`**: the
-most-recent in-process commit that entered such a state becomes the base, so
-only work committed after that milestone surfaces (planning-doc churn before it
-stays committed and out of view).
+**The base.** By default it is the process's diff base (`computeProcessRun`'s
+`diffBase` — see §7), so the window shows the whole current cycle — or, for a
+process `gtd review <commitish>` started (below), `<commitish>..HEAD`. A
+workflow can narrow it further by marking an earlier state
+**`reviewBase: true`**: the most-recent in-process commit that entered such a
+state becomes the base, so only work committed after that milestone surfaces
+(planning-doc churn before it stays committed and out of view).
 
 **Open / close lifecycle.** The pure engine (§5–§8) never observes an open
 window — it is opened and closed entirely at the edge (`src/ReviewWindow.ts`),
@@ -510,6 +535,40 @@ by the next invocation's close. The close fails loudly (leaving the refs in
 place) only if HEAD has moved off the reviewed branch — a `--mixed` reset there
 would rewrite the wrong branch's tip; the error message spells out the manual
 recovery.
+
+**The review entry point (`gtd review <commitish>`).** Everything above
+describes a review that a workflow's OWN cycle triggers (`reviewWindow: true`/
+`reviewBase: true`). A state may separately declare **`reviewEntry: true`** (at
+most one, never a commit state, never the initial state — §1/§9): the state
+`gtd review <commitish>` enters to start a BRAND NEW process reviewing someone
+else's work with no gtd process of its own — a colleague's PR branch pushed on
+top of a shared base is the motivating case.
+
+`gtd review <commitish>` requires resting at the workflow's initial state with a
+clean tree (any process already underway, or a dirty tree, refuses), and
+requires the active workflow to declare a `reviewEntry` state (otherwise it is a
+usage error). It then resolves `<commitish>` — it must name an ancestor of HEAD
+other than HEAD itself — and writes ONE ordinary empty turn commit,
+`gtd(human): <review-entry-state>`, carrying the resolved commit's full hash as
+a `Gtd-Review-Base: <hash>` trailer (mirroring how `gtd step --cost` writes its
+own `Gtd-Cost:` trailer — see §6). Nothing else is special about this commit: it
+resolves (§5) exactly like any other `gtd(human): <state>` turn.
+
+`computeProcessRun` (§7) reads that trailer back off the process's own oldest
+commit and uses it as the process's `diffBase` — the ordinary trace-boundary
+rule already stops the trace walk at the entry commit's parent (a non-workflow,
+non-gtd commit), so nothing about retry counting or the squash reset target
+changes. Only the diff base moves. From here on, the ENTIRE existing review flow
+is reused unmodified: the review-entry state's own prompt/message and `on`
+routing run exactly as declared, `it.processDiff` covers `<commitish>..HEAD`,
+and if a downstream state (the bundled default's `await-review`) declares
+`reviewWindow: true`, the checkout window opens over that same range — zero
+duplicated logic, one re-pointed value.
+
+The bundled default declares `reviewEntry: true` on `reviewing` itself (see
+§10): `gtd review <commitish>` hands the agent a `<commitish>..HEAD` diff to
+turn into a `.gtd/REVIEW.md` exactly as it would for an ordinary cycle's
+`checking` → `reviewing` handoff.
 
 `.gtd/` workflow plumbing (the review doc, plan/feedback files) is pinned back
 to the real head's index while the window is open, so the editor's unstaged view

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,6 +10,11 @@ Commands:
                    --cost=<n> (optionally --model=<name>) to record the
                    just-finished invocation's token cost and model on the
                    turn commit (summed into it.processCost/processCostByModel)
+  review <commitish>
+                   Start a NEW review process at the workflow's declared
+                   review-entry state (reviewEntry: true), reviewing
+                   <commitish>..HEAD — e.g. a colleague's PR branch. Requires
+                   a clean tree resting at the workflow's initial state
   next             Print the resolved rest's rendered script/prompt/message
                    (no mutation)
   run              Execute the resolved rest's emitted script, then step its
@@ -102,6 +107,49 @@ not passed):
   "model": "claude-opus-4-8"
 }
 ```
+
+## `gtd review <commitish> [--json]`
+
+Starts a BRAND NEW review process at the active workflow's declared
+`reviewEntry: true` state (see
+[STATES.md §11](../STATES.md#11-the-review-checkout-window)), reviewing
+`<commitish>..HEAD` — e.g. a colleague's PR branch pushed on top of a shared
+base, with no gtd process of its own. Reuses the workflow's existing
+review/feedback machinery unmodified; there is no separate review-entry command
+surface to keep in sync.
+
+Requires, in order (any failure is a plain refusal — exit non-zero, nothing
+written):
+
+- the machine currently resting at the workflow's **initial state** (a plain
+  non-gtd branch resolves there via the inert-subject rule — the normal case; a
+  process already underway refuses);
+- a **clean working tree**;
+- the active workflow declaring a **`reviewEntry: true`** state (otherwise:
+  `gtd review: the active workflow declares no review entry state`);
+- `<commitish>` resolving to a commit, being an **ancestor of HEAD**, and
+  **differing from HEAD** (nothing to review otherwise).
+
+On success, writes ONE empty commit, `gtd(human): <review-entry-state>`,
+carrying the resolved commit's full hash as a `Gtd-Review-Base: <hash>` trailer
+(mirroring how `gtd step --cost` writes its own `Gtd-Cost:` trailer). Everything
+downstream that renders a diff — `it.processDiff`, and the review checkout
+window opened by a downstream `reviewWindow: true` state — keys off the
+process's diff base, and this trailer is exactly how that base gets re-pointed
+at `<commitish>..HEAD` (see
+[STATES.md §7](../STATES.md#7-retry)/[§11](../STATES.md#11-the-review-checkout-window)).
+
+Plain-mode output is one line, same shape as `gtd step`:
+
+```
+committed: gtd(human): reviewing
+```
+
+`--json` emits `{state, subject}` — `state` is the entered review-entry state,
+`subject` the bare commit subject (the trailer is not echoed).
+
+Takes exactly one positional argument (`<commitish>`); missing or extra
+arguments are usage errors.
 
 ## `gtd next [--json]`
 
@@ -362,8 +410,8 @@ the plain-text one.
   report, a log file — into the working tree, the tree never goes clean after a
   green run, and the check's `"C"` pattern never fires. Gitignore every path
   your scripts write before wiring gtd into a repo.
-- **Repository root invocation.** Every state subcommand (`step`/`next`/
-  `status`/`mermaid`) must run from the git repository root — the workflow,
-  pending changes, and process history are resolved against the process cwd.
-  `--help`/`--version`, `format`, and `lsp` skip this guard entirely (and any
-  git/`.gtdrc` dependency along with it).
+- **Repository root invocation.** Every state subcommand (`step`/`review`/
+  `next`/`status`/`mermaid`) must run from the git repository root — the
+  workflow, pending changes, and process history are resolved against the
+  process cwd. `--help`/`--version`, `format`, and `lsp` skip this guard
+  entirely (and any git/`.gtdrc` dependency along with it).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -418,6 +418,43 @@ head is preserved under `refs/gtd/review-head` (the base under
 `refs/gtd/review-base`) for the window's lifetime. See
 [STATES.md §11](../STATES.md) for the full lifecycle.
 
+### `reviewEntry:` — the review entry point (`gtd review <commitish>`)
+
+A state may separately declare `reviewEntry: true` (at most one across the whole
+workflow; forbidden on a commit state and on the initial state). It marks the
+state [`gtd review <commitish>`](cli.md#gtd-review-commitish---json) enters to
+start a BRAND NEW process reviewing `<commitish>..HEAD` — e.g. a colleague's PR
+branch with no gtd process of its own — reusing whatever `on`/
+`reviewWindow`/`reviewBase` machinery that state and its downstream states
+already declare, with zero duplicated logic.
+
+```yaml
+workflow:
+  states:
+    # …
+    review:
+      actor: agent
+      reviewEntry: true # `gtd review <commitish>` starts a new process here
+      prompt: summarize <%~ it.processDiff %> for a human to check
+      on:
+        "* **": await-review
+```
+
+`gtd review <commitish>` requires resting at the workflow's initial state with a
+clean tree, and requires the active workflow to declare a `reviewEntry` state.
+It resolves `<commitish>` (which must name an ancestor of HEAD other than HEAD
+itself) and writes one empty `gtd(human): <review-entry-state>` turn commit
+carrying the resolved hash as a `Gtd-Review-Base:` trailer — read back by
+`computeProcessRun` to override the new process's diff base (`it.startCommit`
+and `it.processDiff` then cover `<commitish>..HEAD`, and a downstream
+`reviewWindow: true` state's checkout window opens over that same range). The
+process's `retry`/squash trace boundary is untouched: the entry commit's own
+parent is a non-workflow commit, so the ordinary boundary rule already stops
+there. See [STATES.md §11](../STATES.md#11-the-review-checkout-window) for the
+full mechanism.
+
+The bundled default enables `reviewEntry: true` on `reviewing` itself.
+
 ### Template variables
 
 Every `script`/`prompt`/`message`/`commit`/`model`/`memory`/`file` template is
@@ -425,7 +462,7 @@ rendered as an Eta template (`it.<name>`) with:
 
 | Variable             | Meaning                                                                                                                                                                                                                                                                                                                                    |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `startCommit`        | The hash the current process started from (before its first turn).                                                                                                                                                                                                                                                                         |
+| `startCommit`        | The current process's diff base — normally the process start, but re-pointed to `<commitish>`'s hash for a process `gtd review <commitish>` started (see ["`reviewEntry:`"](#reviewentry--the-review-entry-point-gtd-review-commitish)).                                                                                                   |
 | `currentCommit`      | HEAD's hash at render time.                                                                                                                                                                                                                                                                                                                |
 | `previousCommit`     | The hash before the last transition (HEAD's parent, in-process).                                                                                                                                                                                                                                                                           |
 | `state`              | The state whose content is being rendered.                                                                                                                                                                                                                                                                                                 |

--- a/docs/examples/advanced-workflow.md
+++ b/docs/examples/advanced-workflow.md
@@ -23,7 +23,10 @@ Compared to the simplified bundled default, this machine adds:
   `checking`/`fixing` loop, until the queue empties.
 - **Agent-prepared review** — `reviewing` has the agent write `.gtd/REVIEW.md`
   summarizing the full cycle diff for a human to check before `await-review`
-  resolves an approval or feedback.
+  resolves an approval or feedback. `reviewing` also declares
+  `reviewEntry: true`, so `gtd review <commitish>` can start a review process
+  here directly over `<commitish>..HEAD` (e.g. a colleague's PR branch) — see
+  [STATES.md §11](../../STATES.md#11-the-review-checkout-window).
 - **A squash finale** — approval at `await-review` moves to `squashing` (the
   agent authors `.gtd/COMMIT_MSG.md`) and then `done`, a `commit:` state that
   squashes the whole cycle into one commit. The simplified bundled default drops
@@ -333,6 +336,10 @@ workflow:
       file: <%= it.vars.reviewFile %>
       mode: review
       model: smart
+      # A second way in: `gtd review <commitish>` (clean tree, resting at the
+      # initial state) enters here directly over <commitish>..HEAD — see
+      # STATES.md §11.
+      reviewEntry: true
       prompt: |
         You are an autonomous coding agent. `.gtd/` holds this workflow's own
         state — never create, edit, or delete anything under `.gtd/` except

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -71,9 +71,16 @@ upgrading.
   (see
   [docs/design/steering-file-validation-command.md](design/steering-file-validation-command.md)
   and [STATES.md §12](../STATES.md)).
-- **`gtd review <target>`.** Gone; the v3 command surface is `step` / `next` /
-  `run` / `status` / `validate` / `mermaid` / `lsp` (see
-  [CLI reference](cli.md)).
+- **`gtd review <target>`.** Gone in the initial v3 rewrite (the command surface
+  was `step` / `next` / `run` / `status` / `validate` / `mermaid` / `lsp`), then
+  RETURNED in this version with different, narrower semantics: it no longer
+  inspects an arbitrary target the way v2 did — it starts a brand NEW review
+  process at a workflow-declared `reviewEntry: true` state, reviewing
+  `<target>..HEAD` (e.g. a colleague's PR branch with no gtd process of its own)
+  by writing one empty entry commit with a `Gtd-Review-Base:` trailer and
+  reusing the workflow's existing review/feedback machinery unmodified — see
+  [STATES.md §11](../STATES.md#11-the-review-checkout-window) and
+  [CLI reference](cli.md#gtd-review-commitish---json).
 - **`gtd format <file>`, and the bundled prettier with it.** gtd no longer
   formats anything on its own: a steering-file mode declares its own `format:`
   SHELL COMMAND, so a project brings whatever formatter it already uses. Adding

--- a/schema.json
+++ b/schema.json
@@ -136,6 +136,10 @@
               "reviewBase": {
                 "type": "boolean",
                 "description": "Marks the state whose most-recent in-process commit anchors the review window's diff base; absent any, the base is the process start. Forbidden on a commit state."
+              },
+              "reviewEntry": {
+                "type": "boolean",
+                "description": "Marks the (at most one) state `gtd review <commitish>` enters to start a brand new process reviewing <commitish>..HEAD. Forbidden on a commit state and on the initial state."
               }
             }
           }

--- a/src/ConfigSchema.ts
+++ b/src/ConfigSchema.ts
@@ -175,6 +175,11 @@ const stateJsonSchema = {
       description:
         "Marks the state whose most-recent in-process commit anchors the review window's diff base; absent any, the base is the process start. Forbidden on a commit state.",
     },
+    reviewEntry: {
+      type: "boolean",
+      description:
+        "Marks the (at most one) state `gtd review <commitish>` enters to start a brand new process reviewing <commitish>..HEAD. Forbidden on a commit state and on the initial state.",
+    },
   },
 } as const
 

--- a/src/Edge.test.ts
+++ b/src/Edge.test.ts
@@ -15,6 +15,8 @@ import {
   toTemplateEdges,
   UNATTRIBUTED_MODEL,
   withCostTrailer,
+  withReviewBaseTrailer,
+  parseReviewBaseTrailer,
 } from "./Edge.js"
 import type { TemplateContext } from "./PatternTemplates.js"
 import type { StateDef, WorkflowDefinition } from "./PatternMachine.js"
@@ -76,6 +78,7 @@ describe("computeProcessRun", () => {
     expect(result).toEqual({
       startHash: "",
       startParentHash: "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+      diffBase: "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
       trace: [],
       costEntries: [],
     })
@@ -95,6 +98,7 @@ describe("computeProcessRun", () => {
     expect(result).toEqual({
       startHash: "h1",
       startParentHash: "h0",
+      diffBase: "h0",
       trace: ["grilling", "building"],
       costEntries: [],
     })
@@ -120,7 +124,13 @@ describe("computeProcessRun", () => {
       commitHistory: () => Effect.succeed(history),
     })
     const result = await run(computeProcessRun(git, def))
-    expect(result).toEqual({ startHash: "h0", startParentHash: "h0", trace: [], costEntries: [] })
+    expect(result).toEqual({
+      startHash: "h0",
+      startParentHash: "h0",
+      diffBase: "h0",
+      trace: [],
+      costEntries: [],
+    })
   })
 
   it("(b) a commit entering the initial state mid-history is ALSO a process boundary, excluded from the newer process's trace — [boundary, …cycle1…, gtd(human): idle, gtd(human): grilling, gtd(agent): building]", async () => {
@@ -139,6 +149,7 @@ describe("computeProcessRun", () => {
     expect(result).toEqual({
       startHash: "h3",
       startParentHash: "h2",
+      diffBase: "h2",
       trace: ["grilling", "building"],
       costEntries: [],
     })
@@ -155,7 +166,13 @@ describe("computeProcessRun", () => {
       commitHistory: () => Effect.succeed(history),
     })
     const result = await run(computeProcessRun(git, def))
-    expect(result).toEqual({ startHash: "h2", startParentHash: "h2", trace: [], costEntries: [] })
+    expect(result).toEqual({
+      startHash: "h2",
+      startParentHash: "h2",
+      diffBase: "h2",
+      trace: [],
+      costEntries: [],
+    })
   })
 
   it("(d) retry counting resets across an idle boundary — a state entered 3x before the idle entry counts 0 after", async () => {
@@ -218,6 +235,63 @@ describe("computeProcessRun", () => {
       { cost: 50, model: UNATTRIBUTED_MODEL },
     ])
   })
+
+  it("a `Gtd-Review-Base:` trailer on the process's OLDEST commit overrides `diffBase`, leaving the trace/retry boundary (`startParentHash`) untouched — the `gtd review <commitish>` entry commit", async () => {
+    const history = [
+      // A plain, non-workflow commit — e.g. a colleague's PR branch commit —
+      // is the trace boundary (excluded, like any other boundary commit).
+      { hash: "h0", message: "feat: add calculator", removedErrors: false, touched: [] },
+      {
+        hash: "h1",
+        message: "gtd(human): reviewing\n\nGtd-Review-Base: deadbeef",
+        removedErrors: false,
+        touched: [],
+      },
+    ]
+    const git = stubGit({
+      hasCommits: () => Effect.succeed(true),
+      commitHistory: () => Effect.succeed(history),
+    })
+    const result = await run(computeProcessRun(git, def))
+    expect(result.trace).toEqual(["reviewing"])
+    expect(result.startParentHash).toBe("h0")
+    expect(result.diffBase).toBe("deadbeef")
+  })
+
+  it("a `Gtd-Review-Base:` trailer on a LATER turn (not the process's oldest commit) is never consulted for the override", async () => {
+    const history = [
+      { hash: "h0", message: "feat: add calculator", removedErrors: false, touched: [] },
+      { hash: "h1", message: "gtd(human): reviewing", removedErrors: false, touched: [] },
+      // A later turn happens to carry a trailer that LOOKS like the review-base
+      // one — never mistaken for the process's own entry commit.
+      {
+        hash: "h2",
+        message: "gtd(human): await-review\n\nGtd-Review-Base: not-the-real-base",
+        removedErrors: false,
+        touched: [],
+      },
+    ]
+    const git = stubGit({
+      hasCommits: () => Effect.succeed(true),
+      commitHistory: () => Effect.succeed(history),
+    })
+    const result = await run(computeProcessRun(git, def))
+    expect(result.diffBase).toBe(result.startParentHash)
+    expect(result.diffBase).toBe("h0")
+  })
+
+  it("with no `Gtd-Review-Base:` trailer, `diffBase` defaults to `startParentHash` (the ordinary case)", async () => {
+    const history = [
+      { hash: "h0", message: "chore: init", removedErrors: false, touched: [] },
+      { hash: "h1", message: "gtd(human): grilling", removedErrors: false, touched: [] },
+    ]
+    const git = stubGit({
+      hasCommits: () => Effect.succeed(true),
+      commitHistory: () => Effect.succeed(history),
+    })
+    const result = await run(computeProcessRun(git, def))
+    expect(result.diffBase).toBe(result.startParentHash)
+  })
 })
 
 describe("pendingChanges", () => {
@@ -266,7 +340,13 @@ describe("executeDecision", () => {
     const outcome = await run(
       executeDecision(
         git,
-        { startHash: "s", startParentHash: "p", trace: ["grilling"], costEntries: [] },
+        {
+          startHash: "s",
+          startParentHash: "p",
+          diffBase: "p",
+          trace: ["grilling"],
+          costEntries: [],
+        },
         {
           kind: "commit",
           subject: "gtd(human): grilling-answer",
@@ -287,7 +367,13 @@ describe("executeDecision", () => {
     const outcome = await run(
       executeDecision(
         git,
-        { startHash: "s", startParentHash: "p", trace: ["grilling"], costEntries: [] },
+        {
+          startHash: "s",
+          startParentHash: "p",
+          diffBase: "p",
+          trace: ["grilling"],
+          costEntries: [],
+        },
         {
           kind: "commit",
           subject: "gtd(agent): building",
@@ -316,7 +402,13 @@ describe("executeDecision", () => {
     const outcome = await run(
       executeDecision(
         git,
-        { startHash: "s", startParentHash: "parent-hash", trace: ["squashing"], costEntries: [] },
+        {
+          startHash: "s",
+          startParentHash: "parent-hash",
+          diffBase: "parent-hash",
+          trace: ["squashing"],
+          costEntries: [],
+        },
         { kind: "squash", state: "done", template: "feat: <%= it.state %>" },
         context({ state: "done" }),
       ),
@@ -332,7 +424,13 @@ describe("executeDecision", () => {
     const decision = await run(
       executeDecision(
         git,
-        { startHash: "s", startParentHash: "parent-hash", trace: [], costEntries: [] },
+        {
+          startHash: "s",
+          startParentHash: "parent-hash",
+          diffBase: "parent-hash",
+          trace: [],
+          costEntries: [],
+        },
         { kind: "squash", state: "done", template: '<%~ it.read("missing.md") %>' },
         context(),
       ),
@@ -349,7 +447,7 @@ describe("executeDecision", () => {
     const outcome = await run(
       executeDecision(
         git,
-        { startHash: "s", startParentHash: "p", trace: [], costEntries: [] },
+        { startHash: "s", startParentHash: "p", diffBase: "p", trace: [], costEntries: [] },
         { kind: "noop", state: "idle" },
         context(),
       ),
@@ -406,6 +504,27 @@ describe("parseCostTrailers", () => {
     expect(parseCostTrailers(["x\n\nGtd-Cost: not-a-number", "y\n\nGtd-Cost: 10"])).toEqual([
       { cost: 10, model: UNATTRIBUTED_MODEL },
     ])
+  })
+})
+
+describe("withReviewBaseTrailer", () => {
+  it("appends a `Gtd-Review-Base:` trailer after a blank line, leaving the subject as the first line", () => {
+    const message = withReviewBaseTrailer("gtd(human): reviewing", "abc123")
+    expect(message).toBe("gtd(human): reviewing\n\nGtd-Review-Base: abc123")
+    expect(message.split("\n")[0]).toBe("gtd(human): reviewing")
+  })
+})
+
+describe("parseReviewBaseTrailer", () => {
+  it("reads the hash back off a message carrying the trailer", () => {
+    expect(parseReviewBaseTrailer("gtd(human): reviewing\n\nGtd-Review-Base: abc123")).toBe(
+      "abc123",
+    )
+  })
+
+  it("is undefined when the message carries no such trailer", () => {
+    expect(parseReviewBaseTrailer("gtd(human): reviewing")).toBeUndefined()
+    expect(parseReviewBaseTrailer("chore: init\n\nGtd-Cost: 10")).toBeUndefined()
   })
 })
 

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -101,6 +101,50 @@ export const parseCostTrailers = (messages: readonly string[]): CostEntry[] => {
   return entries
 }
 
+// ── Review-base trailer ──────────────────────────────────────────────────────
+//
+// `gtd review <commitish>` (`src/program.ts`) starts a brand NEW review
+// process by writing an ordinary empty turn commit into the workflow's
+// declared review-entry state (`StateDef.reviewEntry` — see
+// `PatternMachine.reviewEntryStateOf`), carrying the resolved `<commitish>`'s
+// full hash as a `Gtd-Review-Base:` trailer. `computeProcessRun` reads that
+// trailer back off the process's own first (oldest) commit to override the
+// run's DIFF base (`ProcessRun.diffBase`) — everything downstream that
+// renders a diff (`it.processDiff`, the review checkout window's default
+// base) keys off that one value, so re-pointing it makes the whole existing
+// review flow (reviewing → await-review → feedback laps) operate over
+// `<commitish>..HEAD` with no duplicated logic. The process's TRACE/retry
+// boundary (`startParentHash`) is UNCHANGED by this — the entry commit's own
+// parent is a non-workflow commit (a plain PR-branch commit), so the
+// existing boundary rule already stops the trace walk there; only the DIFF
+// base moves.
+
+const REVIEW_BASE_TRAILER_PREFIX = "Gtd-Review-Base: "
+// One `Gtd-Review-Base: <hash>` trailer line — mirrors `COST_TRAILER_RE`'s
+// shape/placement (a blank line, then the trailer, below the untouched
+// subject), but carries a single bare token (the resolved commitish's full
+// hash) rather than a number/model pair.
+const REVIEW_BASE_TRAILER_RE = /^Gtd-Review-Base:[ \t]*(\S+)[ \t]*$/m
+
+/**
+ * Append a `Gtd-Review-Base: <base>` trailer (after a blank line) to a commit
+ * `subject` — the entry commit `gtd review <commitish>` writes to start a new
+ * review process. Mirrors `withCostTrailer`'s placement: the subject (first
+ * line) is untouched, so `parseStateSubject`/`resolveState` read it back
+ * exactly like any other turn commit.
+ */
+export const withReviewBaseTrailer = (subject: string, base: string): string =>
+  `${subject}\n\n${REVIEW_BASE_TRAILER_PREFIX}${base}`
+
+/**
+ * The `Gtd-Review-Base: <hash>` trailer recorded on a `gtd review <commitish>`
+ * entry commit (see `withReviewBaseTrailer`), or `undefined` when `message`
+ * carries none. Read back by `computeProcessRun` — ONLY off the process's
+ * first (oldest) commit — to override the run's diff base.
+ */
+export const parseReviewBaseTrailer = (message: string): string | undefined =>
+  REVIEW_BASE_TRAILER_RE.exec(message)?.[1]
+
 /** The total token cost across the given entries (`0` when none). */
 export const totalCostOf = (entries: readonly CostEntry[]): number =>
   entries.reduce((sum, entry) => sum + entry.cost, 0)
@@ -169,8 +213,19 @@ export const pendingChanges = (
 export interface ProcessRun {
   /** The run's first commit's hash, or HEAD's own hash when the run is empty (no turn has landed yet this process). */
   readonly startHash: string
-  /** The parent of the run's first commit — `EMPTY_TREE` when the run covers the whole history. The squash reset target. */
+  /** The parent of the run's first commit — `EMPTY_TREE` when the run covers the whole history. The squash reset target — this is the process's TRACE/retry boundary, never overridden by a `Gtd-Review-Base:` trailer (see `diffBase`). */
   readonly startParentHash: string
+  /**
+   * The base a rendered process diff (`it.processDiff`) or the review
+   * checkout window's default base compares against: normally identical to
+   * `startParentHash`, but overridden to a `Gtd-Review-Base: <hash>`
+   * trailer's hash when the process's FIRST (oldest) commit carries one (see
+   * `withReviewBaseTrailer`/`parseReviewBaseTrailer` — written by
+   * `gtd review <commitish>`, `src/program.ts`). The trace/retry boundary
+   * itself is untouched by this; only which commit a diff/window compares
+   * against moves.
+   */
+  readonly diffBase: string
   /** State names entered so far this process, oldest→newest (empty when no turn has landed yet). */
   readonly trace: readonly StateName[]
   /** Every `Gtd-Cost:` entry recorded on the process's turn commits — summed into `it.processCost` and grouped into `it.processCostByModel` (empty when none were recorded). */
@@ -203,7 +258,13 @@ export const computeProcessRun = (
   Effect.gen(function* () {
     const hasCommits = yield* git.hasCommits()
     if (!hasCommits)
-      return { startHash: "", startParentHash: EMPTY_TREE, trace: [], costEntries: [] }
+      return {
+        startHash: "",
+        startParentHash: EMPTY_TREE,
+        diffBase: EMPTY_TREE,
+        trace: [],
+        costEntries: [],
+      }
 
     const initialState = initialStateOf(def)
     const history = yield* git.commitHistory() // oldest -> newest, full first-parent history
@@ -220,7 +281,13 @@ export const computeProcessRun = (
     const startParentHash = i >= 0 ? history[i]!.hash : EMPTY_TREE
     const startHash =
       startIdx < history.length ? history[startIdx]!.hash : history[history.length - 1]!.hash
-    return { startHash, startParentHash, trace, costEntries }
+    // Only the process's OLDEST commit (its entry commit, when `gtd review`
+    // started this process) is ever consulted for the override — a later
+    // turn's message is never mistaken for it.
+    const reviewBaseOverride =
+      processCommits.length > 0 ? parseReviewBaseTrailer(processCommits[0]!.message) : undefined
+    const diffBase = reviewBaseOverride ?? startParentHash
+    return { startHash, startParentHash, diffBase, trace, costEntries }
   })
 
 // ── Variables (`it.vars`) ────────────────────────────────────────────────────
@@ -290,7 +357,7 @@ export const buildTemplateContext = (
           .pipe(Effect.catchAll(() => Effect.succeed(run.startParentHash)))
       : ""
     const committedDiff = yield* git
-      .diffRef(run.startParentHash)
+      .diffRef(run.diffBase)
       .pipe(Effect.catchAll(() => Effect.succeed("")))
     const pendingDiff = yield* git.diffHead().pipe(Effect.catchAll(() => Effect.succeed("")))
     const processDiff = [committedDiff, pendingDiff].filter((d) => d.trim().length > 0).join("\n\n")
@@ -306,7 +373,7 @@ export const buildTemplateContext = (
         : []
     const allCostEntries = [...run.costEntries, ...stepEntry]
     return {
-      startCommit: run.startHash,
+      startCommit: run.diffBase,
       currentCommit,
       previousCommit,
       state,

--- a/src/PatternConfig.test.ts
+++ b/src/PatternConfig.test.ts
@@ -533,6 +533,30 @@ describe("compileWorkflowConfig — config-shape validation", () => {
     expect("reviewBase" in definition.states.b!).toBe(false)
   })
 
+  it("rejects a non-boolean reviewEntry", () => {
+    expect(() =>
+      compileWorkflowConfig(
+        { states: { a: { actor: "human", message: "hi", initial: true, reviewEntry: "yes" } } },
+        "/dir",
+      ),
+    ).toThrowError(/state "a": "reviewEntry" must be a boolean/)
+  })
+
+  it("compiles a `reviewEntry` boolean onto the StateDef (false omitted)", () => {
+    const shape = (reviewEntry: boolean) => ({
+      states: {
+        a: { actor: "human", message: "hi", initial: true, on: { "* *": "b" } },
+        b: { actor: "human", message: "review", reviewEntry, on: { C: "a" } },
+      },
+    })
+    const { definition: withTrue } = compileWorkflowConfig(shape(true), "/dir")
+    expect(withTrue.states.b!.reviewEntry).toBe(true)
+
+    const { definition: withFalse } = compileWorkflowConfig(shape(false), "/dir")
+    // `false` compiles away — never lands on the StateDef.
+    expect("reviewEntry" in withFalse.states.b!).toBe(false)
+  })
+
   it("rejects zero content keys and more than one content key", () => {
     expect(() =>
       compileWorkflowConfig({ states: { a: { actor: "human", initial: true } } }, "/dir"),

--- a/src/PatternConfig.ts
+++ b/src/PatternConfig.ts
@@ -239,6 +239,7 @@ const KNOWN_STATE_KEYS: ReadonlySet<string> = new Set([
   "mode",
   "reviewWindow",
   "reviewBase",
+  "reviewEntry",
 ])
 
 const KNOWN_TOP_KEYS: ReadonlySet<string> = new Set(["vars", "states", "modes"])
@@ -472,7 +473,7 @@ const compileInitial = (
 ): true | undefined => compileBooleanFlag(raw, "initial", name, errors)
 
 /**
- * A boolean state flag (`initial`/`reviewWindow`/`reviewBase`): `true` only
+ * A boolean state flag (`initial`/`reviewWindow`/`reviewBase`/`reviewEntry`): `true` only
  * when the raw value is the literal `true`; a non-boolean is a config error;
  * `false` (or absent) compiles away to `undefined` so it never lands in the
  * `StateDef` — `false` and "unset" mean the same thing for every such flag.
@@ -505,6 +506,7 @@ interface StateParts {
   readonly mode: StateMode | undefined
   readonly reviewWindow: true | undefined
   readonly reviewBase: true | undefined
+  readonly reviewEntry: true | undefined
 }
 
 const assembleContentFields = (
@@ -548,6 +550,7 @@ const assembleStateDef = (parts: StateParts): StateDef => ({
     mode: parts.mode,
     reviewWindow: parts.reviewWindow,
     reviewBase: parts.reviewBase,
+    reviewEntry: parts.reviewEntry,
   }),
   ...assembleContentFields(parts.content),
 })
@@ -581,6 +584,7 @@ const compileState = (
     mode: compileMode(raw, name, errors),
     reviewWindow: compileBooleanFlag(raw, "reviewWindow", name, errors),
     reviewBase: compileBooleanFlag(raw, "reviewBase", name, errors),
+    reviewEntry: compileBooleanFlag(raw, "reviewEntry", name, errors),
   })
 }
 

--- a/src/PatternMachine.test.ts
+++ b/src/PatternMachine.test.ts
@@ -10,6 +10,7 @@ import {
   parsePattern,
   parseStateSubject,
   resolveState,
+  reviewEntryStateOf,
   stateSubject,
   step,
   validateDefinition,
@@ -139,6 +140,30 @@ describe("isReviewWindowState / isReviewBaseState", () => {
   it("is false for an unknown state name", () => {
     expect(isReviewWindowState(def, "ghost")).toBe(false)
     expect(isReviewBaseState(def, "ghost")).toBe(false)
+  })
+})
+
+describe("reviewEntryStateOf", () => {
+  it("returns the one state name declaring `reviewEntry: true`", () => {
+    const def: WorkflowDefinition = {
+      states: {
+        idle: { actor: "human", message: "x", initial: true, on: [["* *", "review"]] },
+        review: {
+          actor: "agent",
+          prompt: "review",
+          reviewEntry: true,
+          on: [["* *", "idle"]],
+        },
+      },
+    }
+    expect(reviewEntryStateOf(def)).toBe("review")
+  })
+
+  it("is undefined when no state declares `reviewEntry`", () => {
+    const def: WorkflowDefinition = {
+      states: { idle: { actor: "human", message: "x", initial: true } },
+    }
+    expect(reviewEntryStateOf(def)).toBeUndefined()
   })
 })
 
@@ -1022,6 +1047,47 @@ describe("validateDefinition", () => {
       },
     })
     expect(errors).toContain('state "b": a commit state cannot declare "reviewBase"')
+  })
+
+  it("accepts a non-commit, non-initial state declaring `reviewEntry`", () => {
+    const errors = validateDefinition({
+      states: {
+        a: { actor: "h", message: "x", initial: true, on: [["* *", "b"]] },
+        b: { actor: "h", message: "review", reviewEntry: true, on: [["C", "a"]] },
+      },
+    })
+    expect(errors).toEqual([])
+  })
+
+  it("rejects a commit state that declares `reviewEntry`", () => {
+    const errors = validateDefinition({
+      states: {
+        a: { actor: "h", message: "x", initial: true, on: [["* *", "b"]] },
+        b: { commit: "chore: b", reviewEntry: true },
+      },
+    })
+    expect(errors).toContain('state "b": a commit state cannot declare "reviewEntry"')
+  })
+
+  it("rejects the initial state declaring `reviewEntry`", () => {
+    const errors = validateDefinition({
+      states: {
+        a: { actor: "h", message: "x", initial: true, reviewEntry: true, on: [["* *", "b"]] },
+        b: { actor: "h", message: "y", on: [["C", "a"]] },
+      },
+    })
+    expect(errors).toContain('state "a": the initial state cannot declare "reviewEntry"')
+  })
+
+  it("rejects more than one state declaring `reviewEntry`", () => {
+    const errors = validateDefinition({
+      states: {
+        a: { actor: "h", message: "x", initial: true, on: [["* *", "b"]] },
+        b: { actor: "h", message: "y", reviewEntry: true, on: [["* *", "c"]] },
+        c: { actor: "h", message: "z", reviewEntry: true, on: [["C", "a"]] },
+      },
+    })
+    expect(errors).toContain('at most one state may declare "reviewEntry" (found 2: b, c)')
   })
 
   it("aggregates a bad `file`/`mode` alongside other unrelated findings", () => {

--- a/src/PatternMachine.ts
+++ b/src/PatternMachine.ts
@@ -152,6 +152,21 @@ export interface StateDef {
    * a commit state (see `validateDefinition`).
    */
   readonly reviewBase?: boolean
+  /**
+   * Optional. Marks the state `gtd review <commitish>` (`src/program.ts`)
+   * enters to start a brand NEW process reviewing `<commitish>..HEAD` (e.g. a
+   * colleague's PR branch) — reusing whatever `on`/`reviewWindow`/`reviewBase`
+   * machinery that state and its downstream states already declare, with zero
+   * duplicated logic. At most one state may declare it; forbidden on a commit
+   * state (never at rest — see `validateDefinition`) and on the initial state
+   * (a review entry is a DELIBERATE, distinct starting point from the
+   * workflow's ordinary "no active cycle" rest, so the two must stay
+   * distinguishable). This module's PURE functions never read it — the
+   * mechanism (writing the entry commit, resolving `<commitish>`, recording
+   * its hash as a `Gtd-Review-Base:` trailer) lives entirely at the edge
+   * (`src/Edge.ts`/`src/program.ts`); see `reviewEntryStateOf`.
+   */
+  readonly reviewEntry?: boolean
 }
 
 /**
@@ -244,6 +259,14 @@ export const isReviewWindowState = (def: WorkflowDefinition, state: StateName): 
 /** True when `state` anchors the review window's diff base (see `StateDef.reviewBase`). Safe for an unknown state name (returns `false`). */
 export const isReviewBaseState = (def: WorkflowDefinition, state: StateName): boolean =>
   def.states[state]?.reviewBase === true
+
+/** The workflow's declared review-entry state name (see `StateDef.reviewEntry`) — `gtd review <commitish>` (`src/program.ts`) enters this state to start a new review process. `undefined` when no state declares one; `validateDefinition` guarantees at most one does, so the first (only) match wins. */
+export const reviewEntryStateOf = (def: WorkflowDefinition): StateName | undefined => {
+  for (const [name, state] of Object.entries(def.states)) {
+    if (state.reviewEntry === true) return name
+  }
+  return undefined
+}
 
 // ── Commit-subject grammar ───────────────────────────────────────────────────
 
@@ -787,6 +810,42 @@ const validateReviewWindow = (name: string, state: StateDef): string[] => {
   return errors
 }
 
+/**
+ * `reviewEntry`, when present, is forbidden on a commit state (never at
+ * rest — same rule family as `reviewWindow`/`reviewBase`) and on the initial
+ * state: a review entry is a deliberate, distinct starting point from the
+ * workflow's ordinary "no active cycle" rest (`gtd review` itself REQUIRES
+ * resting at the initial state before it will act — see `src/program.ts` —
+ * so the two must stay distinguishable rather than collapsing into one).
+ * The at-most-one-state rule is checked separately, over the whole
+ * definition (see `validateReviewEntryUniqueness`), since it isn't a
+ * per-state finding.
+ */
+const validateReviewEntry = (name: string, state: StateDef): string[] => {
+  if (state.reviewEntry === undefined) return []
+  const errors: string[] = []
+  if (isCommitState(state)) {
+    errors.push(`state "${name}": a commit state cannot declare "reviewEntry"`)
+  }
+  if (state.initial === true) {
+    errors.push(`state "${name}": the initial state cannot declare "reviewEntry"`)
+  }
+  return errors
+}
+
+/** At most one state may declare `reviewEntry: true` — `gtd review <commitish>` (`src/program.ts`) needs a single, unambiguous state name to enter (see `reviewEntryStateOf`). */
+const validateReviewEntryUniqueness = (
+  def: WorkflowDefinition,
+  names: readonly string[],
+): string[] => {
+  const entryNames = names.filter((name) => def.states[name]!.reviewEntry === true)
+  return entryNames.length > 1
+    ? [
+        `at most one state may declare "reviewEntry" (found ${entryNames.length}: ${entryNames.join(", ")})`,
+      ]
+    : []
+}
+
 /** Every `on` row parses, and its target names a defined state. */
 const validateOnEdges = (name: string, state: StateDef, names: readonly string[]): string[] => {
   const errors: string[] = []
@@ -872,6 +931,7 @@ const validateState = (
     ...validateFile(name, state),
     ...validateMode(def, name, state),
     ...validateReviewWindow(name, state),
+    ...validateReviewEntry(name, state),
   ]
 }
 
@@ -894,9 +954,11 @@ const validateState = (
  * `knownModes`), requires a sibling `file`, and is never declared on a commit
  * state; every `modes:` entry declares at least one non-blank
  * `format`/`validate` command; `reviewWindow`/`reviewBase`, when
- * present, are never declared on a commit state; every state is reachable from
- * the initial state by walking `on` targets and `retry.otherwise` redirects
- * (checked only when the initial-state rule itself passed — see
+ * present, are never declared on a commit state; `reviewEntry`, when present,
+ * is never declared on a commit state or the initial state, and at most one
+ * state across the whole workflow may declare it; every state is reachable
+ * from the initial state by walking `on` targets and `retry.otherwise`
+ * redirects (checked only when the initial-state rule itself passed — see
  * `validateReachability`).
  */
 export const validateDefinition = (def: WorkflowDefinition): readonly string[] => {
@@ -908,6 +970,7 @@ export const validateDefinition = (def: WorkflowDefinition): readonly string[] =
     ...initialErrors,
     ...validateModes(def),
     ...names.flatMap((name) => validateState(def, name, names)),
+    ...validateReviewEntryUniqueness(def, names),
     ...(initialErrors.length === 0 ? validateReachability(def, names) : []),
   ]
 }

--- a/src/ReviewWindow.ts
+++ b/src/ReviewWindow.ts
@@ -123,10 +123,12 @@ export const closeReviewWindow: Effect.Effect<{ readonly closed: boolean }, Erro
  * subcommand.
  *
  * The base is the most-recent in-process `reviewBase` commit
- * (`reviewBaseHash`) or, absent any such state, the process start
- * (`startParentHash`). When that resolves to the empty tree (a process with no
- * prior commit) or to HEAD itself (an empty process), there is nothing to
- * surface and the window stays closed.
+ * (`reviewBaseHash`) or, absent any such state, the process's diff base
+ * (`run.diffBase` — the process start, `startParentHash`, unless a
+ * `gtd review <commitish>` entry commit overrode it via a `Gtd-Review-Base:`
+ * trailer, see `computeProcessRun`). When that resolves to the empty tree (a
+ * process with no prior commit) or to HEAD itself (an empty process), there
+ * is nothing to surface and the window stays closed.
  *
  * Ordering is crash-safe: base ref → head ref → mixed reset → `.gtd/` index
  * pin → intent-to-add. A crash before the head-ref write leaves only a stale
@@ -151,7 +153,7 @@ export const openReviewWindow: Effect.Effect<
 
   const run = yield* computeProcessRun(git, def)
   const explicitBase = yield* reviewBaseHash(git, def, run)
-  const base = explicitBase ?? run.startParentHash
+  const base = explicitBase ?? run.diffBase
   const headHash = yield* git.resolveRef("HEAD")
   // No real base commit to rewind to (whole-history process), or an empty
   // process with nothing committed yet — nothing to surface, so stay closed.

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -17,6 +17,8 @@ import { GitService } from "./Git.js"
 import { WorktreeReader } from "./WorktreeReader.js"
 import { defaultWorkflowDefinition } from "./workflows/default.js"
 import { makeProgram } from "./program.js"
+import { InMemRepo } from "../tests/integration/support/inmem/Repo.js"
+import { inMemoryLayers } from "../tests/integration/support/inmem/layers.js"
 
 // GitService whose every method fails — proves the flag handler never calls git.
 const failingGitLayer = Layer.succeed(GitService, {
@@ -214,6 +216,140 @@ describe("the retired `gtd format` subcommand", () => {
   it("is absent from the help text", async () => {
     const { output } = await runFlag("--help")
     expect(output).not.toContain("format <file>")
+  })
+})
+
+describe("gtd review <commitish> — subcommand guards", () => {
+  // Unlike the flag-only tests above, `gtd review`'s guards need a real
+  // (in-memory) repo to resolve against — a plain "must not be called"
+  // stub can't tell a clean-tree-at-idle rest from a dirty/mid-process one.
+  // Mirrors the precedent in src/Git.test.ts (InMemRepo + inMemoryLayers, no
+  // subprocess). Full happy-path coverage (the entered state, the review
+  // checkout window opening downstream, feedback laps, …) lives in
+  // tests/integration/features/review-entry.feature.
+
+  const seededRepo = (): InMemRepo => {
+    const repo = new InMemRepo()
+    repo.writeFile(".gitignore", "node_modules\n")
+    repo.writeFile("README.md", "# test project\n")
+    repo.commitAllWithPrefix("chore: initial commit")
+    return repo
+  }
+
+  const runReview = async (
+    repo: InMemRepo,
+    ...args: string[]
+  ): Promise<{ output: string; exit: Exit.Exit<void, Error> }> => {
+    let output = ""
+    const write = (chunk: string) => {
+      output += chunk
+    }
+    const argv = ["node", "gtd.js", "review", ...args]
+    const exit = await Effect.runPromiseExit(
+      makeProgram({ argv, write }).pipe(Effect.provide(inMemoryLayers(repo))),
+    )
+    return { output, exit }
+  }
+
+  it("is a known subcommand — appears in --help", async () => {
+    const { output } = await runFlag("--help")
+    expect(output).toContain("review <commitish>")
+  })
+
+  it("missing <commitish> argument is a usage error, nothing committed", async () => {
+    const repo = seededRepo()
+    const before = repo.commitHistory().length
+    const { exit } = await runReview(repo)
+    expect(Exit.isSuccess(exit)).toBe(false)
+    expect(repo.commitHistory()).toHaveLength(before)
+  })
+
+  it("more than one positional argument is a usage error", async () => {
+    const repo = seededRepo()
+    const base = repo.commitHistory()[0]!.hash
+    const { exit } = await runReview(repo, base, "extra")
+    expect(Exit.isSuccess(exit)).toBe(false)
+  })
+
+  it("a dirty working tree refuses, nothing committed", async () => {
+    const repo = seededRepo()
+    const base = repo.commitHistory()[0]!.hash
+    repo.writeFile("scratch.txt", "uncommitted\n")
+    const before = repo.commitHistory().length
+    const { exit } = await runReview(repo, base)
+    expect(Exit.isSuccess(exit)).toBe(false)
+    expect(repo.commitHistory()).toHaveLength(before)
+  })
+
+  it("a process already underway (not resting at the initial state) refuses", async () => {
+    const repo = seededRepo()
+    const base = repo.commitHistory()[0]!.hash
+    repo.writeFile(".gtd/TODO.md", "sketch\n")
+    repo.commitAllWithPrefix("gtd(human): grilling")
+    const before = repo.commitHistory().length
+    const { exit } = await runReview(repo, base)
+    expect(Exit.isSuccess(exit)).toBe(false)
+    expect(repo.commitHistory()).toHaveLength(before)
+  })
+
+  it("<commitish> equal to HEAD refuses — nothing to review", async () => {
+    const repo = seededRepo()
+    const head = repo.commitHistory()[0]!.hash
+    const before = repo.commitHistory().length
+    const { exit } = await runReview(repo, head)
+    expect(Exit.isSuccess(exit)).toBe(false)
+    expect(repo.commitHistory()).toHaveLength(before)
+  })
+
+  it("a workflow declaring no reviewEntry state fails with a clear usage error", async () => {
+    const repo = seededRepo()
+    // A minimal custom workflow with no `reviewEntry:` anywhere, COMMITTED
+    // (not left pending) so the clean-tree guard passes and this test
+    // exercises the reviewEntry guard specifically.
+    repo.writeFile(
+      ".gtdrc.yaml",
+      [
+        "workflow:",
+        "  states:",
+        "    idle:",
+        "      actor: human",
+        "      initial: true",
+        "      message: hi",
+        "      on:",
+        '        "* **": working',
+        "    working:",
+        "      actor: agent",
+        "      prompt: go",
+        "      on:",
+        '        "* **": idle',
+        "",
+      ].join("\n"),
+    )
+    repo.commitAllWithPrefix("chore: add custom workflow")
+    const base = repo.commitHistory()[0]!.hash
+    const { exit } = await runReview(repo, base)
+    expect(Exit.isSuccess(exit)).toBe(false)
+    if (Exit.isFailure(exit)) {
+      expect(String(exit.cause)).toContain("declares no review entry state")
+    }
+  })
+
+  it("the happy path writes one empty entry commit with a Gtd-Review-Base trailer, resting at the bundled default's review-entry state (reviewing)", async () => {
+    const repo = seededRepo()
+    const base = repo.commitHistory()[0]!.hash
+    // A colleague's PR branch: ordinary commits on top of the base, no gtd
+    // process of its own.
+    repo.writeFile("src/calc.ts", "export const add = (a: number, b: number) => a + b\n")
+    repo.commitAllWithPrefix("feat: add calculator")
+    const before = repo.commitHistory().length
+
+    const { output, exit } = await runReview(repo, base)
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(output).toContain("committed: gtd(human): reviewing")
+    expect(repo.commitHistory()).toHaveLength(before + 1)
+    expect(repo.lastCommitSubject()).toBe("gtd(human): reviewing")
+    const message = repo.commitHistory().at(-1)!.message
+    expect(message).toContain(`Gtd-Review-Base: ${base}`)
   })
 })
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -19,6 +19,7 @@ import {
   resolveVars,
   toTemplateEdges,
   UNATTRIBUTED_MODEL,
+  withReviewBaseTrailer,
   type ExecutableDecision,
   type ModelCost,
   type ProcessRun,
@@ -34,8 +35,11 @@ import {
   unknownModeMessage,
 } from "./SteeringMode.js"
 import {
+  initialStateOf,
   matchesPattern,
   parsePattern,
+  reviewEntryStateOf,
+  stateSubject,
   step,
   type OnEdge,
   type PendingChange,
@@ -55,6 +59,11 @@ Commands:
                    --cost=<n> (optionally --model=<name>) to record the
                    just-finished invocation's token cost and model on the
                    turn commit (summed into it.processCost/processCostByModel)
+  review <commitish>
+                   Start a NEW review process at the workflow's declared
+                   review-entry state (reviewEntry: true), reviewing
+                   <commitish>..HEAD — e.g. a colleague's PR branch. Requires
+                   a clean tree resting at the workflow's initial state
   next             Print the resolved rest's rendered script/prompt/message
                    (no mutation)
   status           Print the resolved rest's state/actor and which declared
@@ -367,6 +376,96 @@ const runStepCommand = (
     }
     const result = yield* stepAsActor(args[0]!, cost, model)
     reportStepResult(result, json, write)
+  })
+
+/**
+ * `gtd review <commitish>`: start a brand NEW review process at the active
+ * workflow's declared `reviewEntry: true` state (see
+ * `PatternMachine.reviewEntryStateOf`), reviewing `<commitish>..HEAD` — e.g. a
+ * colleague's PR branch pushed on top of a shared base, with no gtd process of
+ * its own. Writes an ordinary EMPTY turn commit
+ * (`gtd(human): <review-entry-state>`) carrying the resolved `<commitish>`'s
+ * full hash as a `Gtd-Review-Base:` trailer (`withReviewBaseTrailer`) —
+ * `computeProcessRun` reads that trailer back off this same commit (its
+ * process's own oldest) to override the new process's diff base, so the
+ * ENTIRE existing review flow (reviewing → await-review → feedback laps, the
+ * `await-review` review checkout window) operates over `<commitish>..HEAD`
+ * with zero duplicated logic — see `src/Edge.ts`/`src/ReviewWindow.ts`.
+ *
+ * Any failure below is a plain refusal: nothing is written.
+ *
+ * a. The machine must currently rest at the workflow's INITIAL state — a
+ *    plain non-gtd branch (the normal case) resolves there via the
+ *    inert-subject rule (STATES.md §5); a process already underway refuses.
+ * b. The working tree must be clean.
+ * c. The active workflow must declare a `reviewEntry: true` state.
+ * d. `<commitish>` must resolve to a commit, be an ancestor of HEAD, and
+ *    differ from HEAD (nothing to review otherwise).
+ */
+const runReviewCommand = (
+  argv: readonly string[],
+  json: boolean,
+  write: (chunk: string) => void,
+): Effect.Effect<void, Error, ProgramRequirements> =>
+  Effect.gen(function* () {
+    const args = commandArgs(argv)
+    if (args.length === 0) {
+      return yield* Effect.fail(new Error("gtd review: missing <commitish> argument"))
+    }
+    if (args.length > 1) {
+      return yield* Effect.fail(
+        new Error(
+          `gtd review: too many arguments — expected one <commitish>, got: ${args.join(", ")}`,
+        ),
+      )
+    }
+    const commitish = args[0]!
+
+    const git = yield* GitService
+    const rest = yield* resolveRest()
+    if (rest.state !== initialStateOf(rest.def)) {
+      return yield* Effect.fail(
+        new Error(
+          `gtd review: a process is already underway (resting at "${rest.state}") — finish or abandon it before starting a review`,
+        ),
+      )
+    }
+
+    const changes = yield* pendingChanges(git)
+    if (changes.length > 0) {
+      return yield* Effect.fail(
+        new Error("gtd review: the working tree must be clean before starting a review"),
+      )
+    }
+
+    const entryState = reviewEntryStateOf(rest.def)
+    if (entryState === undefined) {
+      return yield* Effect.fail(
+        new Error("gtd review: the active workflow declares no review entry state"),
+      )
+    }
+
+    const resolvedBase = yield* git
+      .resolveRef(commitish)
+      .pipe(
+        Effect.mapError(() => new Error(`gtd review: "${commitish}" does not resolve to a commit`)),
+      )
+    const headHash = yield* git.resolveRef("HEAD")
+    if (resolvedBase === headHash) {
+      return yield* Effect.fail(new Error(`gtd review: "${commitish}" is HEAD — nothing to review`))
+    }
+    const isBaseAncestor = yield* git.isAncestor(resolvedBase, "HEAD")
+    if (!isBaseAncestor) {
+      return yield* Effect.fail(new Error(`gtd review: "${commitish}" is not an ancestor of HEAD`))
+    }
+
+    const subject = stateSubject("human", entryState)
+    yield* git.commitAsIs(withReviewBaseTrailer(subject, resolvedBase))
+    if (json) {
+      write(JSON.stringify({ state: entryState, subject }) + "\n")
+    } else {
+      write(`committed: ${subject}\n`)
+    }
   })
 
 /**
@@ -713,7 +812,7 @@ const runMermaidCommand = (
     write(renderMermaid(config.workflow))
   })
 
-const KNOWN_SUBCOMMANDS = ["step", "next", "status", "validate", "mermaid"] as const
+const KNOWN_SUBCOMMANDS = ["step", "review", "next", "status", "validate", "mermaid"] as const
 type KnownSubcommand = (typeof KNOWN_SUBCOMMANDS)[number]
 
 /**
@@ -794,6 +893,8 @@ const dispatchKnownSubcommand = (
   switch (sub) {
     case "step":
       return runStepCommand(argv, json, write, cost, model)
+    case "review":
+      return runReviewCommand(argv, json, write)
     case "next":
       return runNextCommand(json, write)
     case "status":

--- a/src/workflows/default.yaml
+++ b/src/workflows/default.yaml
@@ -39,7 +39,13 @@
 #   checking (green) -> reviewing (agent, prompt): writes .gtd/REVIEW.md in
 #     the checkbox review format, grouping the cycle's full diff into
 #     reviewable chunks; its `file:`/`mode:` (REVIEW.md/`review`) makes that
-#     format checkable, so it self-validates before finishing.
+#     format checkable, so it self-validates before finishing. `reviewing`
+#     ALSO declares `reviewEntry: true` — a second way in: `gtd review
+#     <commitish>` (a clean tree resting at idle) writes an empty
+#     `gtd(human): reviewing` entry commit carrying <commitish>'s hash as a
+#     `Gtd-Review-Base:` trailer, starting a brand new process that reviews
+#     <commitish>..HEAD (e.g. a colleague's PR branch) through this exact same
+#     reviewing/await-review/feedback-lap machinery.
 #   reviewing -> await-review (human, message): tick a pointer's `- [
 #     ]` to `- [x]` to approve that item; deleting .gtd/REVIEW.md outright is
 #     the power-user approve-everything shortcut; anything else pending
@@ -352,6 +358,12 @@ states:
     # diff (inlined into its prompt) with a fresh perspective, not the
     # builder's or fixer's working memory.
     memory: review
+    # `gtd review <commitish>` (a plain non-gtd branch, e.g. a colleague's PR)
+    # enters here directly, recording the resolved base as a `Gtd-Review-Base:`
+    # trailer on its empty entry commit — everything below then reuses the
+    # existing reviewing/await-review/feedback-lap machinery unmodified over
+    # <commitish>..HEAD (see STATES.md §11).
+    reviewEntry: true
     prompt: |
       You are an autonomous coding agent. `.gtd/` holds this workflow's own
       state — never create, edit, or delete anything under `.gtd/` except

--- a/tests/integration/features/command-surface.feature
+++ b/tests/integration/features/command-surface.feature
@@ -1,10 +1,10 @@
 @inmem
 Feature: Command surface — bare gtd, unknown subcommands, --help, --version
 
-  gtd v3 exposes `step <actor>`, `next`, `status`, `mermaid`, `format`,
-  and `lsp` as its subcommands. Bare `gtd` (no subcommand) is a usage error.
-  `--help` and `--version` short-circuit before any repo-state work and exit 0
-  everywhere, including outside a workflow state.
+  gtd v3 exposes `step <actor>`, `review <commitish>`, `next`, `status`,
+  `mermaid`, `format`, and `lsp` as its subcommands. Bare `gtd` (no subcommand)
+  is a usage error. `--help` and `--version` short-circuit before any
+  repo-state work and exit 0 everywhere, including outside a workflow state.
 
   Scenario: Bare gtd fails with usage help and authors nothing
     Given a test project
@@ -29,6 +29,7 @@ Feature: Command surface — bare gtd, unknown subcommands, --help, --version
     When I run gtd with "--help"
     Then it succeeds
     And stdout contains "step <actor>"
+    And stdout contains "review <commitish>"
     And stdout contains "next"
 
   Scenario: --version prints the version and exits 0

--- a/tests/integration/features/review-entry.feature
+++ b/tests/integration/features/review-entry.feature
@@ -1,0 +1,142 @@
+@inmem
+Feature: gtd review <commitish> — start a review process from an ordinary branch
+
+  A workflow may declare `reviewEntry: true` on (at most) one state (STATES.md
+  §1/§11). `gtd review <commitish>` starts a BRAND NEW gtd process there,
+  reviewing `<commitish>..HEAD` — e.g. a colleague's PR branch pushed on top of
+  a shared base, with no gtd process of its own — by writing ONE empty
+  `gtd(human): <review-entry-state>` commit carrying the resolved base's full
+  hash as a `Gtd-Review-Base:` trailer. Everything downstream (the bundled
+  default's `reviewing` → `await-review` → feedback laps, and the
+  `await-review` review checkout window) then operates over that diff with no
+  duplicated logic. The bundled default declares `reviewEntry: true` on
+  `reviewing` itself.
+
+  Background:
+    Given a test project
+    And I mark the current commit as "base"
+
+  Scenario: happy path — a colleague's PR branch reviewed from its shared base, resting at reviewing
+    Given a commit "feat: add calculator" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    When I run gtd with args "review base"
+    Then it succeeds
+    And the last commit subject is "gtd(human): reviewing"
+    And the last commit body contains "Gtd-Review-Base:"
+    And the last commit body contains the hash of "base"
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "## Full cycle diff"
+    And stdout contains "src/calc.ts"
+    And stdout contains "add = (a: number, b: number)"
+
+  Scenario: fails with a clear usage error when the active workflow declares no review entry state
+    Given a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "do it"
+            on:
+              "* **": idle
+      """
+    When I run gtd with args "review base"
+    Then it fails
+    And stderr contains "declares no review entry state"
+
+  Scenario: refuses on a dirty working tree, authoring nothing
+    Given a file "scratch.txt" with:
+      """
+      not committed yet
+      """
+    And I record the commit count
+    When I run gtd with args "review base"
+    Then it fails
+    And the commit count is unchanged
+
+  Scenario: refuses when a gtd process is already underway
+    Given a file ".gtd/TODO.md" with:
+      """
+      a sketch
+      """
+    And I run gtd step human
+    And I record the commit count
+    When I run gtd with args "review base"
+    Then it fails
+    And the commit count is unchanged
+
+  Scenario: refuses when <commitish> is HEAD itself — nothing to review
+    Given I record the commit count
+    When I run gtd with args "review HEAD"
+    Then it fails
+    And the commit count is unchanged
+
+  Scenario: refuses when <commitish> is not an ancestor of HEAD
+    Given a commit "feat: add calculator" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And I mark the current commit as "unrelated-tip"
+    And I hard-reset to "base"
+    And a commit "feat: add tests instead" that adds "src/calc.test.ts" with:
+      """
+      import { add } from "./calc"
+      test("adds", () => expect(add(1, 2)).toBe(3))
+      """
+    And I record the commit count
+    When I run gtd with args "review unrelated-tip"
+    Then it fails
+    And stderr contains "is not an ancestor of HEAD"
+    And the commit count is unchanged
+
+  Scenario: a later turn's diff still includes both the original PR change and a subsequent fix
+    Given a commit "feat: add calculator" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    When I run gtd with args "review base"
+    Then it succeeds
+    # Simulate a fix landing in a later turn of the SAME process (never
+    # crossing the idle boundary, so the process's diff base stays anchored
+    # at "base") — the diff base is history-derived, not tied to any one
+    # turn's own content.
+    Given a commit "gtd(agent): reviewing" that adds "src/fix.ts" with:
+      """
+      export const fixed = true
+      """
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "src/calc.ts"
+    And stdout contains "src/fix.ts"
+
+  Scenario: the review checkout window at await-review spans <commitish>..HEAD
+    Given a commit "feat: add calculator" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And I run gtd with args "review base"
+    And a commit "gtd(agent): await-review" that adds ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: 0000000 -->
+
+      ## calc
+      - [ ] ./src/calc.ts#1 — looks good
+      """
+    When I run gtd next
+    Then it succeeds
+    And the git ref "refs/gtd/review-head" exists
+    # HEAD rests at "base" — the process's diff base — surfacing the whole
+    # <commitish>..HEAD diff as ordinary uncommitted changes.
+    And the last commit subject is "chore: initial commit"
+    And the git status contains "src/calc.ts"

--- a/tests/integration/support/inmem/Repo.ts
+++ b/tests/integration/support/inmem/Repo.ts
@@ -277,6 +277,24 @@ export class InMemRepo {
     // worktree and index unchanged
   }
 
+  /**
+   * `git reset --hard <ref>` — move HEAD, the index, AND the worktree to
+   * `ref`'s commit. Test-SETUP only (no production `GitOperations`
+   * counterpart, unlike `softResetTo`/`mixedResetTo`): used by a scenario to
+   * simulate checking out a DIFFERENT point in history — e.g. to build two
+   * diverging tips off one shared base, so one of them is provably NOT an
+   * ancestor of the other (`gtd review <commitish>`'s ancestor guard).
+   */
+  hardResetTo(ref: string): void {
+    const hash = this.resolveRef(ref)
+    if (!hash) throw new Error(`Cannot resolve ref: ${ref}`)
+    this.head = hash
+    this.branches.set(this.currentBranch, hash)
+    const tree = this.getCommit(hash)?.files ?? new Map()
+    this.index = new Map(tree)
+    this.worktree = new Map(tree)
+  }
+
   /** Internal helper: `discardPending()` uses this after staging the worktree. */
   resetHard(): void {
     const headTree = this.headTree()

--- a/tests/integration/support/steps/common.steps.ts
+++ b/tests/integration/support/steps/common.steps.ts
@@ -73,6 +73,33 @@ Given(
   },
 )
 
+// Bookmarks the CURRENT commit under a name a later step can reference as a
+// `<commitish>` (e.g. `gtd review <name>`) — a repo-local ref, exactly like
+// `git branch <name>` (real git) or a plain named ref (in-memory). Composable
+// with everything else here: scenarios build normal history around the mark
+// with the ordinary commit-builder steps, then refer back to it by name
+// regardless of how far HEAD has since moved.
+Given("I mark the current commit as {string}", (world: GtdWorld, name: string) => {
+  if (world.tier === "inmem") {
+    world.repo!.updateRef(name, "HEAD")
+  } else {
+    execFileSync("git", ["branch", name], { cwd: world.repoDir, stdio: "pipe" })
+  }
+})
+
+// `git reset --hard <name>` — moves HEAD, the index, AND the worktree back to
+// a previously-marked commit (see the step above), so the NEXT commit-builder
+// step starts a sibling history off that same point rather than continuing
+// the current tip. Used to build two diverging branches off one shared base
+// (e.g. to prove a commit on one is NOT an ancestor of the other).
+Given("I hard-reset to {string}", (world: GtdWorld, name: string) => {
+  if (world.tier === "inmem") {
+    world.repo!.hardResetTo(name)
+  } else {
+    execFileSync("git", ["reset", "--hard", name], { cwd: world.repoDir, stdio: "pipe" })
+  }
+})
+
 // ── Invocation ───────────────────────────────────────────────────────────────
 
 When("I run gtd", async (world: GtdWorld) => {
@@ -195,6 +222,22 @@ Then("the git log contains {string}", (world: GtdWorld, subject: string) => {
 Then("the last commit body contains {string}", (world: GtdWorld, text: string) => {
   const body = world.lastCommitBody()
   assert.ok(body.includes(text), `Expected last commit body to contain "${text}". Got:\n${body}`)
+})
+
+// Resolves `name` (a mark from "I mark the current commit as ..." — or any
+// other commitish) to a hash and checks it appears in the last commit's body —
+// e.g. the `Gtd-Review-Base: <hash>` trailer `gtd review <name>` writes.
+Then("the last commit body contains the hash of {string}", (world: GtdWorld, name: string) => {
+  const hash =
+    world.tier === "inmem"
+      ? world.repo!.resolveRef(name)
+      : execFileSync("git", ["rev-parse", name], { cwd: world.repoDir, encoding: "utf-8" }).trim()
+  assert.ok(hash, `Expected "${name}" to resolve to a commit hash`)
+  const body = world.lastCommitBody()
+  assert.ok(
+    body.includes(hash!),
+    `Expected last commit body to contain the hash of "${name}" (${hash}). Got:\n${body}`,
+  )
 })
 
 Then("the last commit body does not contain {string}", (world: GtdWorld, text: string) => {


### PR DESCRIPTION
## What

A second way to supply the review diff base: `gtd review <commitish>` starts a **brand new gtd process** at a workflow-declared review entry state, reviewing `<commitish>..HEAD` — e.g. a colleague's PR branch with no gtd process of its own. The existing workflow-triggered review (`reviewWindow:` / `reviewBase:`) is unchanged; the whole reviewing → await-review → feedback-lap machinery is reused with zero duplicated logic.

## How

- **`reviewEntry: true`** — new optional state property (at most one state; forbidden on commit and initial states). The bundled default declares it on `reviewing`.
- **`gtd review <commitish>`** — guards (resting at the initial state, clean tree, workflow declares an entry state, base resolves / is an ancestor of HEAD / differs from HEAD), then writes one empty `gtd(human): <state>` turn commit carrying the resolved base as a **`Gtd-Review-Base:` trailer** (same pattern as `Gtd-Cost:`). Any guard failure is a plain refusal — nothing written.
- **`ProcessRun` splits trace start from diff base**: `startParentHash` (trace/retry boundary, squash target) is untouched; new `diffBase` is overridden by the trailer on the process's oldest commit. `it.startCommit`, `it.processDiff`, and the review checkout window's default base all key off `diffBase`, so every downstream consumer operates over `<commitish>..HEAD` automatically.
- Note: `it.startCommit` now renders the diff base rather than the process's first commit — what the review doc's `<!-- base: … -->` marker actually wants; no test asserted the old value.

## Docs & tests

- STATES.md (§1 property table, §7 trailer, §10, §11 entry-point subsection), docs/cli.md, docs/configuration.md, docs/upgrading.md (`gtd review` returns with new semantics), README.
- New `tests/integration/features/review-entry.feature` (8 @inmem scenarios: happy path, no-entry-state failure, dirty-tree / mid-process / HEAD / non-ancestor refusals, multi-lap diff, window spanning `<commitish>..HEAD`) plus unit tests in PatternMachine, PatternConfig, Edge, and program.

Rebased onto v5.0.0 (`gtd run` removal); full `npm test` chain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)