### PR TITLE
fix: gtd init no longer refuses when only an ancestor config exists

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,7 +73,8 @@ fails with `gtd: no workflow configured — run \`gtd init <simple|advanced>\` �
 
 The file is written **uncommitted**; review and commit it before your first
 `gtd step` (an uncommitted `.gtdrc.json` is a pending change the initial state
-would otherwise capture). `gtd init` refuses if any gtd config already exists,
+would otherwise capture). `gtd init` refuses if the repo root already has its
+own gtd config (a global/ancestor config, e.g. `~/.gtdrc`, does not count),
 requires the repository root, and — with `gtd lsp` — is one of the two commands
 that run with no workflow configured. `--json` prints
 `{"written":".gtdrc.json","workflow":"<name>"}`. See

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -668,10 +668,11 @@ chosen bundled template's whole workflow inline under a `workflow:` key, plus a
 
 The file is written **uncommitted** — review it, then commit it before your
 first `gtd step` (an uncommitted `.gtdrc.json` is a pending change the initial
-state's `* **` edge would otherwise capture). `gtd init` refuses if any gtd
-config already exists (remove it first to re-init), requires the repository
-root, and is one of the two commands (with `gtd lsp`) that run with no workflow
-configured. A state command run before `gtd init` fails with:
+state's `* **` edge would otherwise capture). `gtd init` refuses if the repo
+root already has its OWN gtd config (remove it first to re-init; a
+global/ancestor config such as `~/.gtdrc` does not count), requires the
+repository root, and is one of the two commands (with `gtd lsp`) that run with
+no workflow configured. A state command run before `gtd init` fails with:
 
 ```
 gtd: no workflow configured — run `gtd init <simple|advanced>` to create .gtdrc.json

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -99,6 +99,23 @@ const SEARCH_PLACES = [
 ]
 
 /**
+ * The shared cosmiconfig explorer used by every config lookup. `searchStrategy:
+ * 'none'` makes `.search(dir)` inspect only that single directory (no internal
+ * walking), so callers drive the cwd→home walk themselves via `walkUp`.
+ */
+const makeExplorer = () =>
+  cosmiconfig("gtd", {
+    searchPlaces: SEARCH_PLACES,
+    searchStrategy: "none",
+    loaders: {
+      noExt: yamlLoader, // .gtdrc (extensionless) — YAML is a JSON superset
+      ".json": jsonLoader,
+      ".yaml": yamlLoader,
+      ".yml": yamlLoader,
+    },
+  })
+
+/**
  * Load and deep-merge every config level from cwd up the directory chain.
  * Innermost (cwd) wins. Returns the merged plain object (undecoded).
  */
@@ -108,18 +125,7 @@ const loadMerged = (root: string): Effect.Effect<Record<string, unknown>, Error>
       const home = homedir()
       const chain = walkUp(root, home)
 
-      // `searchStrategy: 'none'` makes `.search(dir)` inspect only that single
-      // directory (no internal walking), so we collect every level deterministically.
-      const explorer = cosmiconfig("gtd", {
-        searchPlaces: SEARCH_PLACES,
-        searchStrategy: "none",
-        loaders: {
-          noExt: yamlLoader, // .gtdrc (extensionless) — YAML is a JSON superset
-          ".json": jsonLoader,
-          ".yaml": yamlLoader,
-          ".yml": yamlLoader,
-        },
-      })
+      const explorer = makeExplorer()
 
       // Collect outermost→innermost so merging in order makes innermost win.
       const levels: Array<Record<string, unknown>> = []
@@ -142,33 +148,16 @@ const loadMerged = (root: string): Effect.Effect<Record<string, unknown>, Error>
   })
 
 /**
- * Reuses the same `walkUp` + `searchStrategy: "none"` cosmiconfig explorer as
- * `loadMerged` to detect whether ANY level of the cwd→root walk carries a gtd
- * config. Returns `true` on the first non-empty `search(dir)` result. Exported
- * so `gtd init` (src/program.ts) can refuse to overwrite an existing config.
+ * Detect whether a gtd config lives at THIS single directory — no `walkUp`, so
+ * a global `~/.gtdrc` or an ancestor project's config does NOT count. Exported
+ * so `gtd init` (src/program.ts) refuses only when it would overwrite the
+ * repo's OWN config, not when a global default layer merely exists upstream.
  */
-export const anyConfigPresent = (root: string): Effect.Effect<boolean, Error> =>
+export const configPresentAt = (dir: string): Effect.Effect<boolean, Error> =>
   Effect.tryPromise({
     try: async () => {
-      const home = homedir()
-      const chain = walkUp(root, home)
-
-      const explorer = cosmiconfig("gtd", {
-        searchPlaces: SEARCH_PLACES,
-        searchStrategy: "none",
-        loaders: {
-          noExt: yamlLoader,
-          ".json": jsonLoader,
-          ".yaml": yamlLoader,
-          ".yml": yamlLoader,
-        },
-      })
-
-      for (const dir of chain) {
-        const result = await explorer.search(dir)
-        if (result && !result.isEmpty) return true
-      }
-      return false
+      const result = await makeExplorer().search(dir)
+      return Boolean(result && !result.isEmpty)
     },
     catch: (e) => (e instanceof Error ? e : new Error(String(e))),
   })

--- a/src/program.ts
+++ b/src/program.ts
@@ -2,7 +2,7 @@ import { createRequire } from "node:module"
 import { join } from "node:path"
 import { FileSystem } from "@effect/platform"
 import { Effect, Either } from "effect"
-import { anyConfigPresent, ConfigService } from "./Config.js"
+import { configPresentAt, ConfigService } from "./Config.js"
 import {
   isWorkflowTemplateName,
   renderInitConfig,
@@ -267,7 +267,7 @@ const runInitCommand = (
     const fs = yield* FileSystem.FileSystem
     yield* assertRunningFromRepoRoot(git, fs)
     const { root } = yield* Cwd
-    if (yield* anyConfigPresent(root)) {
+    if (yield* configPresentAt(root)) {
       return yield* Effect.fail(
         new Error("gtd init: a gtd config already exists — remove it before re-initializing"),
       )

--- a/tests/integration/features/init.feature
+++ b/tests/integration/features/init.feature
@@ -54,6 +54,16 @@ Feature: gtd init — scaffold a .gtdrc.json from a bundled workflow template
     Then it fails
     And stderr contains "already exists"
 
+  # Regression: an ancestor/global config (e.g. ~/.gtdrc) must not block init —
+  # the guard checks only the repo root, not the whole cwd→home walk.
+  Scenario: gtd init succeeds when only an ancestor directory carries a gtd config
+    Given a test project nested under a directory that already has a gtd config
+    When I run gtd with args "init simple"
+    Then it succeeds
+    And stdout contains "Wrote .gtdrc.json"
+    And ".gtdrc.json" exists
+    And ".gtdrc.json" contains "\"workflow\""
+
   Scenario: a state command with no workflow configured fails with the init hint
     Given a test project
     When I run gtd status

--- a/tests/integration/helpers/project-setup.ts
+++ b/tests/integration/helpers/project-setup.ts
@@ -13,13 +13,8 @@ function writeFile(dir: string, path: string, content: string) {
   writeFileSync(full, content)
 }
 
-/**
- * Bare-bones git repo with one initial commit. Tests build on top using the
- * `Given …` steps.
- */
-export function createTestProject(): string {
-  const dir = mkdtempSync(join(tmpdir(), "gtd-test-"))
-
+/** Initialise `dir` as a bare-bones git repo with one initial commit. */
+function initGitRepo(dir: string): void {
   git(dir, "init", "-q")
   git(dir, "config", "user.name", "Test")
   git(dir, "config", "user.email", "test@test.com")
@@ -30,6 +25,31 @@ export function createTestProject(): string {
 
   git(dir, "add", "-A")
   git(dir, "commit", "-q", "-m", "chore: initial commit")
+}
 
+/**
+ * Bare-bones git repo with one initial commit. Tests build on top using the
+ * `Given …` steps.
+ */
+export function createTestProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gtd-test-"))
+  initGitRepo(dir)
   return dir
+}
+
+/**
+ * Like `createTestProject`, but the repo lives one level DOWN inside a fresh
+ * outer directory carrying its own `.gtdrc.json` — modelling a global/ancestor
+ * gtd config (e.g. `~/.gtdrc`) sitting above a repo. Returns both dirs so the
+ * caller drives gtd from `repo` and cleans up `outer`. The ancestor config is a
+ * non-empty object (so cosmiconfig counts it as present) that `gtd init` must
+ * ignore, since it scaffolds the repo's OWN config, not the ancestor's.
+ */
+export function createTestProjectUnderConfiguredAncestor(): { outer: string; repo: string } {
+  const outer = mkdtempSync(join(tmpdir(), "gtd-ancestor-"))
+  writeFileSync(join(outer, ".gtdrc.json"), '{"vars":{"fromAncestor":"1"}}\n')
+  const repo = join(outer, "repo")
+  mkdirSync(repo, { recursive: true })
+  initGitRepo(repo)
+  return { outer, repo }
 }

--- a/tests/integration/support/hooks.ts
+++ b/tests/integration/support/hooks.ts
@@ -28,14 +28,10 @@ After(async (world: GtdWorld) => {
   }
 
   // Live tier: remove the temp repo dir (and any purpose-built ancestor dir).
-  if (world.repoDir) {
-    if (process.env["KEEP_TEST_REPO"] === "1") {
-      process.stderr.write(`Test repo preserved at: ${world.repoDir}\n`)
-    } else {
-      rmSync(world.repoDir, { recursive: true, force: true })
-      if (world.extraCleanupDir) {
-        rmSync(world.extraCleanupDir, { recursive: true, force: true })
-      }
-    }
+  const keep = process.env["KEEP_TEST_REPO"] === "1"
+  const dirs = [world.repoDir, world.extraCleanupDir].filter(Boolean) as string[]
+  for (const dir of dirs) {
+    if (keep) process.stderr.write(`Test repo preserved at: ${dir}\n`)
+    else rmSync(dir, { recursive: true, force: true })
   }
 })

--- a/tests/integration/support/hooks.ts
+++ b/tests/integration/support/hooks.ts
@@ -27,12 +27,15 @@ After(async (world: GtdWorld) => {
     return
   }
 
-  // Live tier: remove the temp repo dir.
+  // Live tier: remove the temp repo dir (and any purpose-built ancestor dir).
   if (world.repoDir) {
     if (process.env["KEEP_TEST_REPO"] === "1") {
       process.stderr.write(`Test repo preserved at: ${world.repoDir}\n`)
     } else {
       rmSync(world.repoDir, { recursive: true, force: true })
+      if (world.extraCleanupDir) {
+        rmSync(world.extraCleanupDir, { recursive: true, force: true })
+      }
     }
   }
 })

--- a/tests/integration/support/steps/config.steps.ts
+++ b/tests/integration/support/steps/config.steps.ts
@@ -4,6 +4,24 @@ import { writeFileSync, mkdirSync } from "node:fs"
 import { join } from "node:path"
 import type { GtdWorld } from "../world.js"
 import { isWorkflowTemplateName, renderInitConfig } from "../../../../src/workflows/templates.js"
+import { createTestProjectUnderConfiguredAncestor } from "../../helpers/project-setup.js"
+
+// A test project whose PARENT directory already carries a `.gtdrc.json` —
+// modelling a global/ancestor config (e.g. `~/.gtdrc`) above the repo. @live
+// only, because the guard under test (`gtd init`'s `configPresentAt`) reads the
+// real filesystem via cosmiconfig; the point is that an ancestor config must
+// NOT count as "this repo already has a config".
+Given(
+  "a test project nested under a directory that already has a gtd config",
+  (world: GtdWorld) => {
+    if (world.tier !== "live") {
+      throw new Error("this step models a real ancestor config and requires an @live scenario")
+    }
+    const { outer, repo } = createTestProjectUnderConfiguredAncestor()
+    world.repoDir = repo
+    world.extraCleanupDir = outer
+  },
+)
 
 // Writes a gtd config file inside the test repo and commits it. `pathOrDir` is
 // resolved relative to repoDir. A trailing "/" (or ".") means "write `.gtdrc`

--- a/tests/integration/support/world.ts
+++ b/tests/integration/support/world.ts
@@ -23,6 +23,8 @@ export class GtdWorld extends QuickPickleWorld {
   }
 
   repoDir!: string
+  /** An extra directory (an ancestor of `repoDir`) the After hook must also remove — set when a scenario nests the repo under a purpose-built parent. */
+  extraCleanupDir: string | undefined = undefined
   /** In-memory repo for the `inmem` tier. When set, file/git ops use this instead of repoDir. */
   repo: InMemRepo | undefined = undefined
   /** Which execution tier is active for this scenario. Set by the Before hook. */


### PR DESCRIPTION
## Problem

`gtd init` refused to scaffold a `.gtdrc.json` whenever a gtd config existed **anywhere up the cwd→home chain**, not just in the repo itself. A global `~/.gtdrc.json` (e.g. one carrying model defaults) therefore blocked `gtd init` in *every* repository beneath the home directory:

```
gtd: gtd init: a gtd config already exists — remove it before re-initializing
```

The guard called `anyConfigPresent(root)`, which reused the same `walkUp` (cwd→home) that config *merging* uses. But a global/ancestor config is a layering source by design — it should never count as "this repo already has a config".

## Fix

- **`src/Config.ts`** — replace `anyConfigPresent` (now unused) with `configPresentAt(dir)`: a single `search(dir)` with no `walkUp`. Extract the shared cosmiconfig setup into `makeExplorer()` (was duplicated three ways).
- **`src/program.ts`** — `runInitCommand` calls `configPresentAt(root)`, refusing only when the repo root has its *own* config.
- **`docs/cli.md`, `docs/configuration.md`** — correct the "refuses if any gtd config exists" wording.

## Tests

New `@live` regression scenario in `init.feature` — a repo nested under a directory that already carries a `.gtdrc.json` — backed by a composable `Given a test project nested under a directory that already has a gtd config` step and a `createTestProjectUnderConfiguredAncestor` helper.

All green: 411 unit + 153 e2e, lint/format/typecheck clean. Also verified against a real repo under a home-level `~/.gtdrc.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)