### PR TITLE
feat: route bundled workflow models through plannerModel/coderModel vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,11 @@ machine — two-phase Q&A planning, an architecture phase, task decomposition, a
 per-task build loop, and a squash finale — walked through at
 [docs/examples/advanced-workflow.md](docs/examples/advanced-workflow.md). Either
 way the workflow is just `.gtdrc` config — edit it or write your own (see
-[Configuration](docs/configuration.md)).
+[Configuration](docs/configuration.md)). Both templates route every agent
+state's model through two `vars` tiers — `plannerModel` (heavier planning and
+review) and `coderModel` (the coding turns) — so you can repoint the models
+globally in one place (a `vars:` edit or a `GTD_VAR_plannerModel` override)
+instead of per state.
 
 `gtd-loop`, installed alongside `gtd`, is a ready-to-run driver for the whole
 protocol — point it at a repo and it runs the loop until it's your turn. See

--- a/STATES.md
+++ b/STATES.md
@@ -335,9 +335,9 @@ and §12):
 | `idle` (initial)  | human | message | `* **` → `grilling`                                                                                                     | —                  | —       | —        | —                   | —        |
 | `grilling`        | agent | prompt  | `* **` → `grilling-answer`                                                                                              | —                  | `smart` | `plan`   | `vars.todoFile`     | `qa`     |
 | `grilling-answer` | human | message | `C` → `building`; `* **` → `grilling`                                                                                   | —                  | —       | —        | `vars.todoFile`     | `qa`     |
-| `building`        | agent | prompt  | `* **` → `checking`                                                                                                     | —                  | —       | `build`  | `vars.todoFile`     | `qa`     |
+| `building`        | agent | prompt  | `* **` → `checking`                                                                                                     | —                  | `base`  | `build`  | `vars.todoFile`     | `qa`     |
 | `checking`        | check | script  | `A .gtd/FEEDBACK.md` → `fixing`; `M .gtd/FEEDBACK.md` → `fixing`; `D .gtd/FEEDBACK.md` → `reviewing`; `C` → `reviewing` | —                  | —       | —        | —                   | —        |
-| `fixing`          | agent | prompt  | `* **` → `checking`                                                                                                     | max 3 → `escalate` | —       | `fix`    | `vars.feedbackFile` | —        |
+| `fixing`          | agent | prompt  | `* **` → `checking`                                                                                                     | max 3 → `escalate` | `base`  | `fix`    | `vars.feedbackFile` | —        |
 | `escalate`        | human | message | `* **` → `checking`                                                                                                     | —                  | —       | —        | `vars.feedbackFile` | —        |
 | `reviewing`       | agent | prompt  | `* **` → `await-review`                                                                                                 | —                  | `smart` | `review` | `vars.reviewFile`   | `review` |
 | `await-review`    | human | message | `D .gtd/REVIEW.md` → `idle`; `M .gtd/REVIEW.md` → `review-deciding`; `* **` → `grilling`                                | —                  | —       | —        | `vars.reviewFile`   | `review` |
@@ -428,12 +428,12 @@ process's retry trace unaffected by counting rules other than "how many times
 has `fixing` itself been entered").
 
 **Review — REVIEW.md checkboxes.** A green `checking` run moves to `reviewing`
-(agent, `model: smart`), which writes `.gtd/REVIEW.md` grouping the cycle's full
-diff into reviewable chunks, in the exact checkbox-pointer format
-`src/ReviewDoc.ts`'s parser defines (header `# Review: <short-hash>`, a
-`<!-- base: <hash> -->` comment, `##` chunks each with
-`- [ ] ./path#line — note` pointers). Like `grilling`, `reviewing` declares a
-`file:`/`mode:` pair (`.gtd/REVIEW.md`/`review`), so it self-validates that
+(agent, `model: vars.plannerModel`, default `smart`), which writes
+`.gtd/REVIEW.md` grouping the cycle's full diff into reviewable chunks, in the
+exact checkbox-pointer format `src/ReviewDoc.ts`'s parser defines (header
+`# Review: <short-hash>`, a `<!-- base: <hash> -->` comment, `##` chunks each
+with `- [ ] ./path#line — note` pointers). Like `grilling`, `reviewing` declares
+a `file:`/`mode:` pair (`.gtd/REVIEW.md`/`review`), so it self-validates that
 format with `gtd validate` before finishing (see §12) and its turn steps
 straight to `await-review`. At `await-review`, a human ticks a pointer's `- [ ]`
 to `- [x]` to approve that item; deleting `.gtd/REVIEW.md` outright is the
@@ -457,10 +457,15 @@ idle-entering commit that closes the cycle is also this workflow's only process
 boundary besides an unrecognized HEAD (§7): the NEXT cycle's `retry` counts,
 `startCommit`, and diffs never reach back across it.
 
-`grilling` and `reviewing` — the heavier one-shot planning/reviewing turns —
-both declare `model: smart`, an opaque hint `gtd next`/`gtd status` `--json`
-emit verbatim for the driving loop to map onto its harness. Every other state
-leaves `model` unset, so the harness's own default applies.
+Every agent state draws its `model` from one of two `vars` tiers rather than a
+hardcoded string, so the tiers repoint in one place (the template's `vars:`, a
+top-level `.gtdrc` `vars:` key, or a `GTD_VAR_` override): `plannerModel`
+(default `smart`) for the heavier one-shot planning/reviewing turns (`grilling`,
+`reviewing`), `coderModel` (default `base`) for the coding turns (`building`,
+`fixing`). Both are opaque hints `gtd next`/`gtd status` `--json` emit verbatim
+(the resolved value, e.g. `smart`/`base`) for the driving loop to map onto its
+harness. The check/human states declare no `model`, so the harness default
+applies there.
 
 The four agent states also declare a `memory:` scope label — `grilling: plan`,
 `building: build`, `fixing: fix`, `reviewing: review` — another opaque hint the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -540,7 +540,12 @@ layers, **later wins**:
    workflow author's declared defaults. The `simple` template declares
    `vars: { testCommand: "npm test" }`, read by `checking`'s script as
    `<%~ it.vars.testCommand %>` (see
-   [STATES.md §10](../STATES.md#10-the-bundled-workflow-templates)).
+   [STATES.md §10](../STATES.md#10-the-bundled-workflow-templates)). Both
+   bundled templates also declare two model-tier vars — `plannerModel` (default
+   `smart`) and `coderModel` (default `base`) — that every agent state's
+   `model:` resolves through (`model: <%= it.vars.plannerModel %>`), so
+   repointing one var here (or via layer 2/3 below) changes every state on that
+   tier at once.
 2. **A top-level `.gtdrc` `vars:` key** (a sibling of `workflow:`, NOT nested
    inside it) — per-repo tuning without redefining the whole workflow. Subject
    to the same cwd→home deep merge as everything else in `.gtdrc` (innermost

--- a/docs/examples/advanced-workflow.md
+++ b/docs/examples/advanced-workflow.md
@@ -62,15 +62,15 @@ slots into.
 | `grilling-answer`     | human | message | `C` → `architecting`; `* **` → `grilling`                                         | —                  | —       | `vars.todoFile`         | `qa`     |
 | `architecting`        | agent | prompt  | `* **` → `architecting-answer`                                                    | —                  | `smart` | `vars.architectureFile` | `qa`     |
 | `architecting-answer` | human | message | `C` → `decompose`; `* **` → `architecting`                                        | —                  | —       | `vars.architectureFile` | `qa`     |
-| `decompose`           | agent | prompt  | `* .gtd/tasks/**` → `picking`                                                     | —                  | —       | —                       | —        |
+| `decompose`           | agent | prompt  | `* .gtd/tasks/**` → `picking`                                                     | —                  | `base`  | —                       | —        |
 | `picking`             | check | script  | `D .gtd/NEXT.md` → `reviewing`; `* .gtd/NEXT.md` → `building`; `C` → `reviewing`  | —                  | —       | —                       | —        |
-| `building`            | agent | prompt  | `* **` → `checking`                                                               | —                  | —       | —                       | —        |
+| `building`            | agent | prompt  | `* **` → `checking`                                                               | —                  | `base`  | —                       | —        |
 | `checking`            | check | script  | `A .gtd/FEEDBACK.md` → `fixing`; `M .gtd/FEEDBACK.md` → `fixing`; `C` → `picking` | —                  | —       | —                       | —        |
-| `fixing`              | agent | prompt  | `* **` → `checking`                                                               | max 3 → `escalate` | —       | `vars.feedbackFile`     | —        |
+| `fixing`              | agent | prompt  | `* **` → `checking`                                                               | max 3 → `escalate` | `base`  | `vars.feedbackFile`     | —        |
 | `escalate`            | human | message | `* **` → `checking`                                                               | —                  | —       | `vars.feedbackFile`     | —        |
 | `reviewing`           | agent | prompt  | `* .gtd/REVIEW.md` → `await-review`                                               | —                  | `smart` | `vars.reviewFile`       | `review` |
 | `await-review`        | human | message | `D .gtd/REVIEW.md` → `squashing`; `* **` → `grilling`                             | —                  | —       | `vars.reviewFile`       | `review` |
-| `squashing`           | agent | prompt  | `A .gtd/COMMIT_MSG.md` → `done`; `M .gtd/COMMIT_MSG.md` → `done`                  | —                  | —       | —                       | —        |
+| `squashing`           | agent | prompt  | `A .gtd/COMMIT_MSG.md` → `done`; `M .gtd/COMMIT_MSG.md` → `done`                  | —                  | `base`  | —                       | —        |
 | `done`                | —     | commit  | (final — squashes the whole cycle, message read from `.gtd/COMMIT_MSG.md`)        | —                  | —       |
 
 ## The `.gtdrc` recipe
@@ -83,6 +83,11 @@ workflow:
     architectureFile: .gtd/ARCHITECTURE.md
     reviewFile: .gtd/REVIEW.md
     feedbackFile: .gtd/FEEDBACK.md
+    # The two model tiers every agent state draws from — opaque harness hints,
+    # repointed here (or via a top-level .gtdrc `vars:` / `GTD_VAR_` override)
+    # to change every state on that tier at once.
+    plannerModel: smart
+    coderModel: base
 
   states:
     idle:
@@ -102,11 +107,12 @@ workflow:
       mode: qa
       # `model` is an opaque harness hint — gtd never interprets this string, it
       # only passes it through to `gtd next --json`/`gtd status --json` so the
-      # driving loop can map it onto whatever models its agent harness
-      # provides. "smart" here just names the harness-chosen tier for the
-      # heavier planning/reviewing turns; states without a `model` use the
-      # harness's default.
-      model: smart
+      # driving loop can map it onto whatever models its agent harness provides.
+      # Every agent state draws its tier from a `vars` model entry (see `vars:`
+      # above): `plannerModel` (default "smart") for the one-shot planning/
+      # architecting/reviewing turns, `coderModel` (default "base") for the
+      # decompose/build/fix/squash turns.
+      model: <%= it.vars.plannerModel %>
       prompt: |
         You are an autonomous coding agent. `.gtd/` holds this workflow's own
         state (plans, task specs, review records) — never create, edit, or
@@ -155,7 +161,7 @@ workflow:
       actor: agent
       file: <%= it.vars.architectureFile %>
       mode: qa
-      model: smart
+      model: <%= it.vars.plannerModel %>
       prompt: |
         You are an autonomous coding agent. `.gtd/` holds this workflow's own
         state — never create, edit, or delete anything under `.gtd/` except
@@ -201,6 +207,7 @@ workflow:
 
     decompose:
       actor: agent
+      model: <%= it.vars.coderModel %>
       prompt: |
         You are an autonomous coding agent. `.gtd/` holds this workflow's own
         state — never create, edit, or delete anything under `.gtd/` except the
@@ -249,6 +256,7 @@ workflow:
 
     building:
       actor: agent
+      model: <%= it.vars.coderModel %>
       prompt: |
         You are an autonomous coding agent. `.gtd/` holds this workflow's own
         state — never create or edit anything under `.gtd/` except deleting the
@@ -303,6 +311,7 @@ workflow:
     fixing:
       actor: agent
       file: <%= it.vars.feedbackFile %>
+      model: <%= it.vars.coderModel %>
       retry:
         max: 3
         otherwise: escalate
@@ -338,7 +347,7 @@ workflow:
       actor: agent
       file: <%= it.vars.reviewFile %>
       mode: review
-      model: smart
+      model: <%= it.vars.plannerModel %>
       # A second way in: `gtd review <commitish>` (clean tree, resting at the
       # initial state) enters here directly over <commitish>..HEAD — see
       # STATES.md §11.
@@ -388,6 +397,7 @@ workflow:
 
     squashing:
       actor: agent
+      model: <%= it.vars.coderModel %>
       prompt: |
         You are an autonomous coding agent. The cycle is approved and done.
         `.gtd/` holds this workflow's own state — never create, edit, or delete

--- a/src/workflows/advanced.yaml
+++ b/src/workflows/advanced.yaml
@@ -25,6 +25,12 @@ vars:
   architectureFile: .gtd/ARCHITECTURE.md
   reviewFile: .gtd/REVIEW.md
   feedbackFile: .gtd/FEEDBACK.md
+  # The two model tiers every agent state draws from (see the model comment at
+  # `grilling` below). Both are opaque harness hints — repoint them here (or
+  # via a top-level `.gtdrc` `vars:` key / a `GTD_VAR_plannerModel` env var) to
+  # change every state on that tier at once.
+  plannerModel: smart
+  coderModel: base
 
 states:
   idle:
@@ -44,11 +50,13 @@ states:
     mode: qa
     # `model` is an opaque harness hint — gtd never interprets this string, it
     # only passes it through to `gtd next --json`/`gtd status --json` so the
-    # driving loop can map it onto whatever models its agent harness
-    # provides. "smart" here just names the harness-chosen tier for the
-    # heavier planning/reviewing turns; states without a `model` use the
-    # harness's default.
-    model: smart
+    # driving loop can map it onto whatever models its agent harness provides.
+    # Every agent state draws its tier from a `vars` model entry (see `vars:`
+    # above) so the tiers repoint in one place: `plannerModel` (default
+    # "smart") names the heavier tier for the one-shot planning/architecting/
+    # reviewing turns, `coderModel` (default "base") the tier for the
+    # decompose/build/fix/squash turns.
+    model: <%= it.vars.plannerModel %>
     prompt: |
       You are an autonomous coding agent. `.gtd/` holds this workflow's own
       state (plans, task specs, review records) — never create, edit, or
@@ -97,7 +105,7 @@ states:
     actor: agent
     file: <%= it.vars.architectureFile %>
     mode: qa
-    model: smart
+    model: <%= it.vars.plannerModel %>
     prompt: |
       You are an autonomous coding agent. `.gtd/` holds this workflow's own
       state — never create, edit, or delete anything under `.gtd/` except
@@ -143,6 +151,7 @@ states:
 
   decompose:
     actor: agent
+    model: <%= it.vars.coderModel %>
     prompt: |
       You are an autonomous coding agent. `.gtd/` holds this workflow's own
       state — never create, edit, or delete anything under `.gtd/` except the
@@ -191,6 +200,7 @@ states:
 
   building:
     actor: agent
+    model: <%= it.vars.coderModel %>
     prompt: |
       You are an autonomous coding agent. `.gtd/` holds this workflow's own
       state — never create or edit anything under `.gtd/` except deleting the
@@ -245,6 +255,7 @@ states:
   fixing:
     actor: agent
     file: <%= it.vars.feedbackFile %>
+    model: <%= it.vars.coderModel %>
     retry:
       max: 3
       otherwise: escalate
@@ -280,7 +291,7 @@ states:
     actor: agent
     file: <%= it.vars.reviewFile %>
     mode: review
-    model: smart
+    model: <%= it.vars.plannerModel %>
     # A direct entry point: `gtd review <commitish>` starts a fresh review
     # process here over `<commitish>..HEAD` (e.g. a colleague's PR branch).
     reviewEntry: true
@@ -329,6 +340,7 @@ states:
 
   squashing:
     actor: agent
+    model: <%= it.vars.coderModel %>
     prompt: |
       You are an autonomous coding agent. The cycle is approved and done.
       `.gtd/` holds this workflow's own state — never create, edit, or delete

--- a/src/workflows/simple.yaml
+++ b/src/workflows/simple.yaml
@@ -94,9 +94,12 @@
 # is only ever handed a tidy, well-formed file. The same parsers back the LSP's
 # live diagnostics (src/Lsp.ts).
 #
-# `grilling` and `reviewing` both declare `model: smart` — an opaque harness
-# hint (see the comment at `grilling` below) for their heavier one-shot
-# planning/reviewing turns. Every other state is unset (harness default).
+# Every agent state draws its `model` from a `vars` tier entry (see `vars:`
+# below and the comment at `grilling`) rather than a hardcoded string, so both
+# tiers repoint in one place: `plannerModel` (default "smart") for the heavier
+# one-shot planning/reviewing turns (`grilling`, `reviewing`), `coderModel`
+# (default "base") for the coding turns (`building`, `fixing`). Both are opaque
+# hints the driving loop maps onto its harness.
 #
 # The four agent states each declare a `memory:` scope label (`plan`,
 # `build`, `fix`, `review` — see the comment at `grilling` below) — another
@@ -139,6 +142,12 @@ vars:
   todoFile: .gtd/TODO.md
   reviewFile: .gtd/REVIEW.md
   feedbackFile: .gtd/FEEDBACK.md
+  # The two model tiers every agent state draws from (see the model comment at
+  # `grilling` below). Both are opaque harness hints — repoint them here (or
+  # via a top-level `.gtdrc` `vars:` key / a `GTD_VAR_plannerModel` env var) to
+  # change every state on that tier at once.
+  plannerModel: smart
+  coderModel: base
 
 states:
   idle:
@@ -176,11 +185,12 @@ states:
     mode: qa
     # `model` is an opaque harness hint — gtd never interprets this string, it
     # only passes it through to `gtd next --json`/`gtd status --json` so the
-    # driving loop can map it onto whatever models its agent harness
-    # provides. "smart" here just names the harness-chosen tier for the
-    # heavier planning turn; states without a `model` use the harness's
-    # default.
-    model: smart
+    # driving loop can map it onto whatever models its agent harness provides.
+    # Every agent state draws its tier from a `vars` model entry (see `vars:`
+    # above) so the tiers repoint in one place: `plannerModel` (default
+    # "smart") names the heavier tier for the one-shot planning/reviewing
+    # turns, `coderModel` (default "base") the tier for the coding turns.
+    model: <%= it.vars.plannerModel %>
     # `memory` is an opaque memory-scope label — gtd never interprets it, it
     # only passes it through to `gtd next --json`/`gtd status --json` so a
     # memory-aware driving loop can decide when an agent turn continues from
@@ -247,6 +257,7 @@ states:
     actor: agent
     file: <%= it.vars.todoFile %>
     mode: qa
+    model: <%= it.vars.coderModel %>
     # A distinct memory scope from `plan`: implementation starts fresh, with
     # the plan already settled in `.gtd/TODO.md` (which this prompt reads
     # below) rather than carried in the planner's working memory.
@@ -311,6 +322,7 @@ states:
   fixing:
     actor: agent
     file: <%= it.vars.feedbackFile %>
+    model: <%= it.vars.coderModel %>
     # Its own memory scope: the fix loop re-enters `fixing` around `checking`
     # (up to the retry cap), so labelling every attempt `fix` lets the agent
     # remember what it already tried across the loop; a green check moves on
@@ -356,7 +368,7 @@ states:
     actor: agent
     file: <%= it.vars.reviewFile %>
     mode: review
-    model: smart
+    model: <%= it.vars.plannerModel %>
     # A distinct memory scope again: the reviewer looks at the cycle's full
     # diff (inlined into its prompt) with a fresh perspective, not the
     # builder's or fixer's working memory.

--- a/tests/integration/features/templates-vars.feature
+++ b/tests/integration/features/templates-vars.feature
@@ -286,3 +286,40 @@ Feature: "it.vars" — the three-layer merged variable map every template sees
     Then it succeeds
     And stdout contains "\"state\":\"working\""
     And stdout contains "\"memory\":\"plan\""
+
+  Scenario: the simple template resolves a planner-tier state's model from "vars.plannerModel"
+    Given a test project
+    And the "simple" workflow
+    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+      """
+      a sketch
+      """
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"state\":\"grilling\""
+    And stdout contains "\"model\":\"smart\""
+
+  Scenario: the simple template resolves a coder-tier state's model from "vars.coderModel"
+    Given a test project
+    And the "simple" workflow
+    And a commit "gtd(agent): building" that adds ".gtd/TODO.md" with:
+      """
+      the plan
+      """
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"state\":\"building\""
+    And stdout contains "\"model\":\"base\""
+
+  Scenario: a "GTD_VAR_plannerModel" override repoints every planner-tier state at once
+    Given a test project
+    And the "simple" workflow
+    And a commit "gtd(human): grilling" that adds ".gtd/TODO.md" with:
+      """
+      a sketch
+      """
+    And an environment variable "GTD_VAR_plannerModel" set to "opus"
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"model\":\"opus\""
+    And stdout does not contain "\"model\":\"smart\""


### PR DESCRIPTION
## What

Both bundled workflow templates (`simple`, `advanced`) now draw every agent state's `model:` from one of two `vars` tiers, instead of hardcoding `model: smart` on some states and leaving the coding states unset:

| Tier | Default | States |
| ---- | ------- | ------ |
| `plannerModel` | `smart` | `grilling`, `architecting` (advanced), `reviewing` — the heavier one-shot planning/reviewing turns |
| `coderModel` | `base` | `building`, `fixing`, plus `decompose`/`squashing` (advanced) — the coding turns |

Every agent state references its tier via `model: <%= it.vars.plannerModel %>` / `<%= it.vars.coderModel %>`, so repointing a tier in **one place** — a template `vars:` edit, a top-level `.gtdrc` `vars:` key, or a `GTD_VAR_plannerModel`/`GTD_VAR_coderModel` override — changes every state on that tier at once.

## Why

Previously changing the model meant editing each state's `model:` individually, and the coding states had no knob at all (they fell back to the harness default). This makes model selection a single global lever per tier.

## Behavior change

The coding states (`building`, `fixing`, `decompose`, `squashing`) previously emitted **no** `model` (harness default); they now emit the `coderModel` tier (`base`). The planner states' rendered value is unchanged (`smart`). Both values remain opaque hints the driving loop maps onto its harness.

## Scope

The engine already renders `model:` through the same `it.vars` template context as content (`Edge.ts` `renderModel`) — so this is a **template + docs change with no engine work**.

- `src/workflows/{simple,advanced}.yaml` — the two templates
- `STATES.md §10`, `docs/examples/advanced-workflow.md`, `docs/configuration.md`, `README.md`
- `tests/integration/features/templates-vars.feature` — 3 new scenarios pinning the tier defaults and a `GTD_VAR_` override

## Testing

`format:check`, `typecheck`, `lint`, unit, and all 156 e2e scenarios pass (incl. the 3 new ones). Manually verified both templates: `grilling` → `smart`, `building`/`squashing` → `base`, and `GTD_VAR_coderModel=haiku` → `haiku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)