### PR TITLE
feat: gtd init extracts agent prompts to editable gtd-prompts/*.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ Then scaffold a workflow for the repo — run once:
 gtd init simple      # or: gtd init advanced
 ```
 
-This writes a `.gtdrc.json` with the chosen workflow inline (review and commit
-it). gtd ships **no** default workflow: a state command run before `gtd init`
-fails, pointing you back here. See
-[Configuration](docs/configuration.md#gtd-init) for the two templates.
+This writes a `.gtdrc.json` for the chosen workflow, with each agent state's
+prompt saved as an editable Markdown file under `gtd-prompts/` and referenced
+from the config (review and commit both). Edit a prompt by editing its
+`gtd-prompts/*.md` file — no config edit needed. gtd ships **no** default
+workflow: a state command run before `gtd init` fails, pointing you back here.
+See [Configuration](docs/configuration.md#gtd-init) for the two templates.
 
 ## How it works
 

--- a/STATES.md
+++ b/STATES.md
@@ -314,9 +314,13 @@ anything touches the repository. See
 gtd ships **no** default workflow — a repo scaffolds one with
 `gtd init <simple|advanced>` (see
 [Configuration](docs/configuration.md#gtd-init)), which writes the chosen
-bundled template inline into `.gtdrc.json`. This section walks through the
-**`simple`** template (`src/workflows/simple.yaml`); the **`advanced`** template
-(`src/workflows/advanced.yaml`) is the fuller machine walked through at
+bundled template into `.gtdrc.json` — each agent state's `prompt:` extracted to
+an editable `gtd-prompts/<state>.md` file the config references via `./`
+([auto-inlined at load](docs/configuration.md#content-values-inline-or-a-file-reference)),
+with human `message:`/check `script:` bodies left inline. This section walks
+through the **`simple`** template (`src/workflows/simple.yaml`); the
+**`advanced`** template (`src/workflows/advanced.yaml`) is the fuller machine
+walked through at
 [docs/examples/advanced-workflow.md](docs/examples/advanced-workflow.md). Both
 compile through the exact same compiler a custom `workflow:` key goes through —
 no privileged code path.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,9 +5,11 @@ Usage: gtd [command] [options]
 
 Commands:
   init <workflow>  Scaffold a .gtdrc.json for this repo with the chosen
-                   bundled workflow inline (one of: simple, advanced). Run
-                   once per repo; refuses if a gtd config already exists.
-                   Leaves the file uncommitted for you to review and commit
+                   bundled workflow (one of: simple, advanced); its agent
+                   prompts are written as editable Markdown under gtd-prompts/
+                   and referenced from the config. Run once per repo; refuses
+                   if a gtd config already exists. Leaves the files uncommitted
+                   for you to review and commit
   step <actor>     Authenticate as <actor>, match the resolved rest's
                    declared patterns against the pending changes, and commit
                    (or squash) the one resulting transition. Pass

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,9 +3,10 @@
 gtd reads a required `.gtdrc` config file via
 [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig). gtd ships **no**
 default workflow: scaffold one for the repo with [`gtd init`](#gtd-init) (once),
-which writes a `.gtdrc.json` carrying a bundled workflow template inline. A
-state command run with no `workflow:` configured fails, pointing you at
-`gtd init`. Supported filenames (searched in this order):
+which writes a `.gtdrc.json` for a bundled workflow template (with its agent
+prompts as editable Markdown under `gtd-prompts/`). A state command run with no
+`workflow:` configured fails, pointing you at `gtd init`. Supported filenames
+(searched in this order):
 
 - `.gtdrc`
 - `.gtdrc.json`
@@ -659,8 +660,15 @@ gtd init simple      # or: gtd init advanced
 ```
 
 `gtd init <workflow>` writes a `.gtdrc.json` at the repository root with the
-chosen bundled template's whole workflow inline under a `workflow:` key, plus a
-`$schema` link (so editors pick up completion/validation). The two templates:
+chosen bundled template's workflow under a `workflow:` key, plus a `$schema`
+link (so editors pick up completion/validation). Each **agent state's prompt**
+is written as a standalone Markdown file under `gtd-prompts/<state>.md` and the
+config references it via a `./gtd-prompts/<state>.md`
+[file reference](#content-values-inline-or-a-file-reference) — gtd inlines it at
+load time, so a prompt is editable Markdown and editing it changes the workflow
+with no config edit. Human `message:` blocks and check `script:` bodies stay
+inline in the config (they are workflow mechanics, not prompts). The two
+templates:
 
 - **`simple`** — the 10-state machine walked through in
   [STATES.md §10](../STATES.md#10-the-bundled-workflow-templates): idle →
@@ -671,13 +679,14 @@ chosen bundled template's whole workflow inline under a `workflow:` key, plus a
   walked through at
   [docs/examples/advanced-workflow.md](examples/advanced-workflow.md).
 
-The file is written **uncommitted** — review it, then commit it before your
-first `gtd step` (an uncommitted `.gtdrc.json` is a pending change the initial
-state's `* **` edge would otherwise capture). `gtd init` refuses if the repo
-root already has its OWN gtd config (remove it first to re-init; a
-global/ancestor config such as `~/.gtdrc` does not count), requires the
-repository root, and is one of the two commands (with `gtd lsp`) that run with
-no workflow configured. A state command run before `gtd init` fails with:
+The files are written **uncommitted** — review them, then commit `.gtdrc.json`
+and `gtd-prompts/` before your first `gtd step` (an uncommitted file is a
+pending change the initial state's `* **` edge would otherwise capture).
+`gtd init` refuses if the repo root already has its OWN gtd config (remove it
+first to re-init; a global/ancestor config such as `~/.gtdrc` does not count),
+requires the repository root, and is one of the two commands (with `gtd lsp`)
+that run with no workflow configured. A state command run before `gtd init`
+fails with:
 
 ```
 gtd: no workflow configured — run `gtd init <simple|advanced>` to create .gtdrc.json

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -129,7 +129,8 @@ upgrading each repo must scaffold one **once**:
 gtd init simple      # or: gtd init advanced
 ```
 
-`gtd init simple` writes a `.gtdrc.json` with the `simple` template inline: a
+`gtd init simple` writes a `.gtdrc.json` for the `simple` template (its agent
+prompts extracted to editable `gtd-prompts/*.md` files the config references): a
 single-shot `grilling` plan, direct `building`, a `checking`/`fixing` loop, and
 a direct-diff `await-review` that rests the cycle back at `idle` on approval —
 no squash; every turn commit stays in history for you to squash however you
@@ -139,10 +140,10 @@ like, or not at all (see
 ⇄ architecting-answer / decompose / picking / reviewing machine — including a
 squash finale — walked through at
 [docs/examples/advanced-workflow.md](examples/advanced-workflow.md). Review and
-commit the generated `.gtdrc.json`, then continue from a settled `idle`
-boundary. **Note:** a repo relying on earlier gtd's auto-created `.gtdrc.json`
-`$schema` stub (which carried no `workflow:`) will now fail until you `gtd init`
-— the stub alone is no longer enough.
+commit the generated `.gtdrc.json` (and its `gtd-prompts/` directory), then
+continue from a settled `idle` boundary. **Note:** a repo relying on earlier
+gtd's auto-created `.gtdrc.json` `$schema` stub (which carried no `workflow:`)
+will now fail until you `gtd init` — the stub alone is no longer enough.
 
 A repo that customized v2's `workflow:` key (actors, gates, guard vocabulary,
 ladders) needs to rewrite it from scratch in the v3 schema — see

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,11 +1,12 @@
 import { createRequire } from "node:module"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import { FileSystem } from "@effect/platform"
 import { Effect, Either } from "effect"
 import { configPresentAt, ConfigService } from "./Config.js"
 import {
   isWorkflowTemplateName,
-  renderInitConfig,
+  PROMPTS_DIR,
+  renderInitScaffold,
   WORKFLOW_TEMPLATE_NAMES,
 } from "./workflows/templates.js"
 import { Cwd } from "./Cwd.js"
@@ -60,9 +61,11 @@ const HELP_TEXT = `Usage: gtd [command] [options]
 
 Commands:
   init <workflow>  Scaffold a .gtdrc.json for this repo with the chosen
-                   bundled workflow inline (one of: simple, advanced). Run
-                   once per repo; refuses if a gtd config already exists.
-                   Leaves the file uncommitted for you to review and commit
+                   bundled workflow (one of: simple, advanced); its agent
+                   prompts are written as editable Markdown under gtd-prompts/
+                   and referenced from the config. Run once per repo; refuses
+                   if a gtd config already exists. Leaves the files uncommitted
+                   for you to review and commit
   step <actor>     Authenticate as <actor>, match the resolved rest's
                    declared patterns against the pending changes, and commit
                    (or squash) the one resulting transition. Pass
@@ -237,9 +240,12 @@ const initWorkflowChoices = (): string => `choose one of: ${WORKFLOW_TEMPLATE_NA
  * the ONE command that must run with no workflow configured yet: it needs no
  * `ConfigService` (which would throw the "no workflow" error pre-init) and no
  * review window. It still runs the repo-root guard (it writes `.gtdrc.json` at
- * the root) and refuses to clobber an existing config. The file is left
- * UNCOMMITTED, so the message warns to commit it before the first `gtd step`
- * (an uncommitted config is a pending change the initial state's `* **` edge
+ * the root) and refuses to clobber an existing config. It also writes each
+ * agent state's prompt as a standalone `gtd-prompts/<state>.md` file the config
+ * references via `./` (see `renderInitScaffold`), so prompts are editable
+ * Markdown rather than JSON-escaped strings. Everything is left UNCOMMITTED, so
+ * the message warns to commit it all before the first `gtd step` (an
+ * uncommitted config/prompt is a pending change the initial state's `* **` edge
  * would otherwise capture).
  */
 const runInitCommand = (
@@ -272,17 +278,33 @@ const runInitCommand = (
         new Error("gtd init: a gtd config already exists — remove it before re-initializing"),
       )
     }
+    const toError = (e: unknown): Error => (e instanceof Error ? e : new Error(String(e)))
+    const scaffold = renderInitScaffold(name)
     yield* fs
-      .writeFileString(join(root, ".gtdrc.json"), renderInitConfig(name))
-      .pipe(Effect.mapError((e) => (e instanceof Error ? e : new Error(String(e)))))
+      .writeFileString(join(root, ".gtdrc.json"), scaffold.config)
+      .pipe(Effect.mapError(toError))
+    for (const prompt of scaffold.prompts) {
+      const full = join(root, prompt.path)
+      yield* fs.makeDirectory(dirname(full), { recursive: true }).pipe(Effect.mapError(toError))
+      yield* fs.writeFileString(full, prompt.content).pipe(Effect.mapError(toError))
+    }
     if (json) {
-      write(JSON.stringify({ written: ".gtdrc.json", workflow: name }) + "\n")
-    } else {
       write(
-        `Wrote .gtdrc.json with the "${name}" workflow.\n\n` +
-          `Review and commit it before starting: an uncommitted .gtdrc.json counts as a\n` +
-          `pending change, so the initial state would capture it on the first step. Once\n` +
-          `committed, run \`gtd step human\` to begin.\n`,
+        JSON.stringify({
+          written: ".gtdrc.json",
+          workflow: name,
+          prompts: scaffold.prompts.map((p) => p.path),
+        }) + "\n",
+      )
+    } else {
+      const promptCount = scaffold.prompts.length
+      write(
+        `Wrote .gtdrc.json with the "${name}" workflow, and its ${promptCount} agent ` +
+          `prompt${promptCount === 1 ? "" : "s"} as editable Markdown under ${PROMPTS_DIR}/ ` +
+          `(referenced from the config).\n\n` +
+          `Review and commit them before starting: an uncommitted .gtdrc.json (or prompt\n` +
+          `file) counts as a pending change, so the initial state would capture it on the\n` +
+          `first step. Once committed, run \`gtd step human\` to begin.\n`,
       )
     }
   })

--- a/src/workflows/advanced.yaml
+++ b/src/workflows/advanced.yaml
@@ -18,6 +18,15 @@
 # disk at RUNTIME. `advanced.yaml` is imported as raw text (tsdown's `.yaml`
 # text loader / the vitest rawMd transform), so this module never touches the
 # filesystem.
+#
+# `gtd init advanced` DERIVES the scaffolded `.gtdrc.json` from this inline
+# source (src/workflows/templates.ts `renderInitScaffold`): each agent state's
+# `prompt:` below is written out as an editable `gtd-prompts/<state>.md` file
+# and the config value is rewritten to a `./gtd-prompts/<state>.md` reference
+# `compileWorkflowConfig` inlines back at load time. Human `message:`/check
+# `script:` bodies and the `done` `commit:` template stay inline in the config.
+# This YAML stays fully inline regardless — the split happens only at scaffold
+# time, on real disk.
 
 vars:
   testCommand: npm test

--- a/src/workflows/simple.yaml
+++ b/src/workflows/simple.yaml
@@ -12,12 +12,18 @@
 # Every content string below is INLINE (no `./`-relative file references):
 # the bundled templates ship inside a single-file build
 # (`dist/gtd.bundle.mjs`), so their content must already be resolved at BUILD
-# time rather than read from disk at RUNTIME — the same reason
-# `src/prompts/*.md` are imported through tsdown's `.md`-as-text loader
-# instead of read via `fs` at runtime. `simple.yaml` itself is imported the
-# same way (tsdown/vitest both treat `.yaml` as text — see
+# time rather than read from disk at RUNTIME. `simple.yaml` itself is imported
+# as raw text (tsdown/vitest both treat `.yaml` as text — see
 # tsdown.config.ts / tests/vitest.rawMd.ts), so this file never needs a
 # sibling prompts/ directory to exist on disk once installed.
+#
+# `gtd init simple` DERIVES the scaffolded `.gtdrc.json` from this inline
+# source (src/workflows/templates.ts `renderInitScaffold`): each agent state's
+# `prompt:` below is written out as an editable `gtd-prompts/<state>.md` file
+# and the config value is rewritten to a `./gtd-prompts/<state>.md` reference
+# `compileWorkflowConfig` inlines back at load time. Human `message:`/check
+# `script:` bodies stay inline in the config. This YAML stays fully inline
+# regardless — the split happens only at scaffold time, on real disk.
 #
 # States, in cycle order — 10 states, no squash:
 #   idle (initial, human, message)

--- a/src/workflows/templates.test.ts
+++ b/src/workflows/templates.test.ts
@@ -3,10 +3,20 @@ import { validateDefinition } from "../PatternMachine.js"
 import {
   compileTemplate,
   isWorkflowTemplateName,
+  PROMPTS_DIR,
   renderInitConfig,
+  renderInitScaffold,
   SCHEMA_URL,
   WORKFLOW_TEMPLATE_NAMES,
 } from "./templates.js"
+
+/** Shape of a scaffolded config's `workflow.states` after prompt extraction. */
+type ScaffoldStates = Record<
+  string,
+  { prompt?: string; message?: string; script?: string; commit?: string }
+>
+const scaffoldStates = (config: string): ScaffoldStates =>
+  (JSON.parse(config) as { workflow: { states: ScaffoldStates } }).workflow.states
 
 describe("bundled workflow templates", () => {
   it("ships exactly the `simple` and `advanced` templates", () => {
@@ -30,6 +40,57 @@ describe("bundled workflow templates", () => {
       // The rendered config round-trips through the compiler exactly like a
       // hand-authored `.gtdrc` `workflow:` value.
       expect(rendered.endsWith("\n")).toBe(true)
+    })
+  }
+
+  for (const name of WORKFLOW_TEMPLATE_NAMES) {
+    describe(`renderInitScaffold for "${name}"`, () => {
+      it("extracts every agent prompt to a gtd-prompts/<state>.md file and references it from the config", () => {
+        const { config, prompts } = renderInitScaffold(name)
+        const states = scaffoldStates(config)
+        // The inline reference form the template test above already validates
+        // is the source of truth for which states carry a `prompt:`.
+        const inlineStates = scaffoldStates(renderInitConfig(name))
+        const promptStates = Object.entries(inlineStates)
+          .filter(([, s]) => typeof s.prompt === "string")
+          .map(([stateName]) => stateName)
+
+        expect(promptStates.length).toBeGreaterThan(0)
+        expect(prompts.map((p) => p.path).sort()).toEqual(
+          promptStates.map((s) => `${PROMPTS_DIR}/${s}.md`).sort(),
+        )
+        for (const stateName of promptStates) {
+          const path = `${PROMPTS_DIR}/${stateName}.md`
+          // Config value is rewritten to a `./`-relative file reference…
+          expect(states[stateName]!.prompt).toBe(`./${path}`)
+          // …and the extracted file's content is the inline prompt verbatim.
+          const file = prompts.find((p) => p.path === path)
+          expect(file?.content).toBe(inlineStates[stateName]!.prompt)
+        }
+      })
+
+      it("leaves human messages and check scripts inline in the config", () => {
+        const states = scaffoldStates(renderInitScaffold(name).config)
+        for (const state of Object.values(states)) {
+          expect(state.message?.startsWith("./")).not.toBe(true)
+          expect(state.script?.startsWith("./")).not.toBe(true)
+          expect(state.commit?.startsWith("./")).not.toBe(true)
+        }
+        // Every non-prompt content value is still present verbatim (not a ref).
+        const inline = scaffoldStates(renderInitConfig(name))
+        for (const [stateName, s] of Object.entries(inline)) {
+          if (s.message !== undefined) expect(states[stateName]!.message).toBe(s.message)
+          if (s.script !== undefined) expect(states[stateName]!.script).toBe(s.script)
+          if (s.commit !== undefined) expect(states[stateName]!.commit).toBe(s.commit)
+        }
+      })
+
+      it("keeps the $schema key first and ends with a newline", () => {
+        const { config } = renderInitScaffold(name)
+        const parsed = JSON.parse(config) as { $schema: string }
+        expect(parsed.$schema).toBe(SCHEMA_URL)
+        expect(config.endsWith("\n")).toBe(true)
+      })
     })
   }
 

--- a/src/workflows/templates.ts
+++ b/src/workflows/templates.ts
@@ -10,6 +10,16 @@ import simpleYaml from "./simple.yaml"
 export const SCHEMA_URL = "https://raw.githubusercontent.com/pmelab/gtd/main/schema.json"
 
 /**
+ * The repo-root-relative directory `gtd init` writes each agent state's prompt
+ * into as a standalone, editable Markdown file (see `renderInitScaffold`). The
+ * scaffolded `.gtdrc.json` references these via `./gtd-prompts/<state>.md`
+ * content-value file references, which `compileWorkflowConfig` inlines at load
+ * time (`resolveContent` in `src/PatternConfig.ts`) — so editing a prompt file
+ * changes the workflow with no config edit.
+ */
+export const PROMPTS_DIR = "gtd-prompts"
+
+/**
  * The bundled workflow templates `gtd init <name>` can scaffold, keyed by the
  * name the user passes. Each value is the raw YAML text of the template file,
  * imported as a string (tsdown's `.yaml` text loader / the vitest `rawMd`
@@ -41,6 +51,51 @@ export const isWorkflowTemplateName = (name: string): name is WorkflowTemplateNa
 export const renderInitConfig = (name: WorkflowTemplateName): string => {
   const workflow = parseYaml(WORKFLOW_TEMPLATES[name]) as unknown
   return JSON.stringify({ $schema: SCHEMA_URL, workflow }, null, 2) + "\n"
+}
+
+/** One agent prompt `gtd init` writes out as a standalone Markdown file. */
+export interface ScaffoldPromptFile {
+  /** Repo-root-relative path, e.g. `gtd-prompts/grilling.md`. */
+  readonly path: string
+  /** The prompt body, verbatim from the bundled template's inline `prompt:`. */
+  readonly content: string
+}
+
+/** The files `gtd init <name>` writes: the `.gtdrc.json` text plus one Markdown file per agent prompt. */
+export interface InitScaffold {
+  /** The `.gtdrc.json` contents, with each agent state's `prompt:` rewritten to a `./gtd-prompts/<state>.md` file reference. */
+  readonly config: string
+  /** The extracted prompt files, one per agent (`prompt:`) state, in declaration order. */
+  readonly prompts: readonly ScaffoldPromptFile[]
+}
+
+/**
+ * Render everything `gtd init <name>` writes. Like `renderInitConfig`, but each
+ * agent state's inline `prompt:` is EXTRACTED into a standalone
+ * `gtd-prompts/<state>.md` file and the config value is rewritten to a
+ * `./gtd-prompts/<state>.md` file reference — `compileWorkflowConfig` inlines
+ * it back at load time (`resolveContent`), so the workflow behaves identically
+ * to the fully-inline `renderInitConfig` form while the prompts stay editable
+ * as ordinary Markdown. Only `prompt:` content is externalized: human
+ * `message:` blocks and check `script:` bodies remain inline in the config
+ * (they are workflow mechanics, not prompts). The bundled YAML template itself
+ * stays fully inline (it ships inside the single-file bundle); this function is
+ * the only place the split happens, at scaffold time.
+ */
+export const renderInitScaffold = (name: WorkflowTemplateName): InitScaffold => {
+  const workflow = parseYaml(WORKFLOW_TEMPLATES[name]) as {
+    states?: Record<string, Record<string, unknown>>
+  }
+  const prompts: ScaffoldPromptFile[] = []
+  for (const [stateName, state] of Object.entries(workflow.states ?? {})) {
+    if (typeof state.prompt === "string") {
+      const path = `${PROMPTS_DIR}/${stateName}.md`
+      prompts.push({ path, content: state.prompt })
+      state.prompt = `./${path}`
+    }
+  }
+  const config = JSON.stringify({ $schema: SCHEMA_URL, workflow }, null, 2) + "\n"
+  return { config, prompts }
 }
 
 /**

--- a/tests/integration/features/init.feature
+++ b/tests/integration/features/init.feature
@@ -14,6 +14,7 @@ Feature: gtd init — scaffold a .gtdrc.json from a bundled workflow template
     When I run gtd with args "init simple"
     Then it succeeds
     And stdout contains "Wrote .gtdrc.json"
+    And stdout contains "gtd-prompts/"
     And stdout contains "commit"
     And ".gtdrc.json" exists
     And ".gtdrc.json" contains "\"$schema\""
@@ -21,6 +22,44 @@ Feature: gtd init — scaffold a .gtdrc.json from a bundled workflow template
     And ".gtdrc.json" contains "review-deciding"
     # Left uncommitted — HEAD is still the project's own initial commit.
     And the last commit subject is "chore: initial commit"
+
+  # Each agent state's prompt is extracted to gtd-prompts/<state>.md and the
+  # config references it via a ./ file reference; human messages and check
+  # scripts stay inline in the config.
+  Scenario: gtd init simple extracts agent prompts to gtd-prompts/ and references them
+    Given a test project
+    When I run gtd with args "init simple"
+    Then it succeeds
+    And "gtd-prompts/grilling.md" exists
+    And "gtd-prompts/grilling.md" contains "autonomous coding agent"
+    And "gtd-prompts/building.md" exists
+    And "gtd-prompts/fixing.md" exists
+    And "gtd-prompts/reviewing.md" exists
+    And ".gtdrc.json" contains "./gtd-prompts/grilling.md"
+    # idle is a human message, checking is a script — both stay inline.
+    And "gtd-prompts/idle.md" does not exist
+    And "gtd-prompts/checking.md" does not exist
+    And ".gtdrc.json" contains "No active gtd cycle"
+
+  # The extracted files are LIVE: gtd inlines them at load time, so editing a
+  # prompt file changes the workflow with no config edit.
+  Scenario: the workflow resolves an edited prompt file at runtime
+    Given a test project
+    When I run gtd with args "init simple"
+    Then it succeeds
+    Given "gtd-prompts/grilling.md" is modified to:
+      """
+      SENTINEL edited grilling prompt body
+      """
+    And the working tree is committed
+    And a file ".gtd/TODO.md" with:
+      """
+      build a small widget
+      """
+    When I run gtd step human
+    Then it succeeds
+    When I run gtd next
+    Then stdout contains "SENTINEL edited grilling prompt body"
 
   Scenario: gtd init advanced writes the fuller machine (architecting, decompose, squash finale)
     Given a test project
@@ -30,6 +69,10 @@ Feature: gtd init — scaffold a .gtdrc.json from a bundled workflow template
     And ".gtdrc.json" contains "architecting"
     And ".gtdrc.json" contains "decompose"
     And ".gtdrc.json" contains "squashing"
+    And "gtd-prompts/architecting.md" exists
+    And "gtd-prompts/decompose.md" exists
+    And "gtd-prompts/squashing.md" exists
+    And ".gtdrc.json" contains "./gtd-prompts/grilling.md"
 
   Scenario: gtd init with no workflow argument is a usage error listing the choices
     Given a test project

--- a/tests/integration/support/steps/common.steps.ts
+++ b/tests/integration/support/steps/common.steps.ts
@@ -73,6 +73,23 @@ Given(
   },
 )
 
+// Commits everything currently in the working tree under one chore commit —
+// the "I've reviewed the scaffold, now commit it" move a human makes after
+// `gtd init`, so the machine starts from a clean tree at the initial state.
+// Composable with any preceding file edits (e.g. editing an extracted
+// `gtd-prompts/*.md` before committing).
+Given("the working tree is committed", (world: GtdWorld) => {
+  if (world.tier === "inmem") {
+    world.repo!.commitAllWithPrefix("chore: commit working tree")
+  } else {
+    execFileSync("git", ["add", "-A"], { cwd: world.repoDir, stdio: "pipe" })
+    execFileSync("git", ["commit", "-q", "-m", "chore: commit working tree"], {
+      cwd: world.repoDir,
+      stdio: "pipe",
+    })
+  }
+})
+
 // Bookmarks the CURRENT commit under a name a later step can reference as a
 // `<commitish>` (e.g. `gtd review <name>`) — a repo-local ref, exactly like
 // `git branch <name>` (real git) or a plain named ref (in-memory). Composable


### PR DESCRIPTION
## What

`gtd init <workflow>` now writes each **agent state's prompt** as a standalone Markdown file under `gtd-prompts/<state>.md` and references it from `.gtdrc.json` via a `./gtd-prompts/<state>.md` file reference. Human `message:` blocks and check `script:` bodies stay inline (they're mechanics, not prompts).

```
$ gtd init simple
Wrote .gtdrc.json with the "simple" workflow, and its 4 agent prompts as
editable Markdown under gtd-prompts/ (referenced from the config).

gtd-prompts/{grilling,building,fixing,reviewing}.md
.gtdrc.json → "prompt": "./gtd-prompts/grilling.md"
```

## How

Reuses the existing file-reference machinery — `compileWorkflowConfig`'s `resolveContent` already inlines any `./`-prefixed content value at load time. So behavior is identical to the old fully-inline form, but a prompt is now editable Markdown; editing `gtd-prompts/grilling.md` changes the workflow with no config edit.

The bundled YAML templates stay **fully inline** (they ship inside the single-file `dist/gtd.bundle.mjs`); `renderInitScaffold` is the only place the split happens, at scaffold time on real disk.

- `src/workflows/templates.ts` — new `renderInitScaffold(name)` → `{ config, prompts[] }`; kept inline `renderInitConfig` for the `@inmem` test setup step (which can't resolve real-disk refs).
- `src/program.ts` — `runInitCommand` writes `.gtdrc.json` + each prompt file; updated success message, `--json` output (`prompts: [...]`), and help text.

## Tests

All green: **417 unit + 158 e2e**, typecheck, lint, format, fallow.

- `templates.test.ts` — prompts extracted + referenced, content verbatim, messages/scripts/commit stay inline.
- `init.feature` — new assertions on both templates + a new `@live` scenario that edits `gtd-prompts/grilling.md` to a sentinel, commits, drives to `grilling`, and confirms `gtd next` renders the edited file (proves runtime resolution).
- `common.steps.ts` — new composable `Given the working tree is committed` step.

## Docs

Updated `README.md`, `docs/configuration.md`, `docs/cli.md`, `docs/upgrading.md`, `STATES.md §10`, and both template YAML header comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)