### PR TITLE
feat: gtd-loop captures the human's pending edit as its opening move

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,7 @@
       "Bash(gtd next*)",
       "Bash(gtd status*)",
       "Bash(gtd mermaid*)",
+      "Bash(gtd version*)",
       "Bash(npm run build)",
       "mcp__github__actions_list"
     ],

--- a/README.md
+++ b/README.md
@@ -113,7 +113,10 @@ globally in one place (a `vars:` edit or a `GTD_VAR_plannerModel` override)
 instead of per state.
 
 `gtd-loop`, installed alongside `gtd`, is a ready-to-run driver for the whole
-protocol — point it at a repo and it runs the loop until it's your turn. See
+protocol — point it at a repo and it runs the loop until it's your turn. It is
+the only command you run: at a gate you edit files (answer a plan question, tick
+a review box, fix code) and re-launch it, and it captures your edit as its
+opening move before driving on — so you never run `gtd step human` by hand. See
 [Driving the loop](docs/loop.md).
 
 Before wiring gtd into a repo, note the

--- a/bin/gtd-loop
+++ b/bin/gtd-loop
@@ -64,6 +64,35 @@ run_agent_turn() {
     GTD_LOOP_SESSION_ID="$session_id" GTD_LOOP_MEMORY_RESUME="$do_resume" bash -c "$cmd"
 }
 
+# Opening move: capture the human's pending edit so gtd-loop is the ONLY command
+# a human runs. A human acts at a gate by editing files (a plan answer, a review
+# tick, a code fix) and re-launching the loop — they should never have to run
+# `gtd step human` by hand first. So before driving, if the machine currently
+# rests at a human gate, step the human once to commit whatever they left, then
+# fall into the loop below from the resulting state.
+#
+# We peek with the pure, mutation-free `gtd next --json` and step ONLY when it
+# reports a human rest (`kind == "message"`): at an agent/check rest
+# `gtd step human` would refuse out-of-turn (non-zero, aborting under `set -e`),
+# and a mid-cycle restart must simply resume driving, not fail. A clean gate is
+# a harmless no-op; a genuine refusal there (a malformed steering file, or an
+# edit no `on` pattern accepts) is surfaced and stops the loop rather than being
+# driven past.
+if ! peek_json="$(gtd next --json 2>&1)"; then
+  echo "gtd-loop: could not determine the next step:" >&2
+  echo "$peek_json" >&2
+  echo "Run \`gtd status\` to inspect the repo." >&2
+  exit 1
+fi
+if [[ "$(jq -r .kind <<<"$peek_json")" == "message" ]]; then
+  if ! step_out="$(gtd step human 2>&1)"; then
+    echo "gtd-loop: could not capture your changes at the human gate:" >&2
+    echo "$step_out" >&2
+    echo "Fix the reported issue and re-run gtd-loop." >&2
+    exit 1
+  fi
+fi
+
 while true; do
   if ! next_json="$(gtd next --json 2>&1)"; then
     echo "gtd-loop: could not determine the next step:" >&2

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -28,8 +28,11 @@ A loop is a simple cycle:
 2. Repeat until a `"message"` rest halts the loop, or a zero-commit script step
    at idle settles it (the green terminal signal).
 
-A human acts by editing files (e.g. writing/editing `.gtd/TODO.md`, fixing code)
-and then running `gtd step human` to capture the edit as their turn.
+A human acts by editing files (e.g. writing/editing `.gtd/TODO.md`, fixing
+code); `gtd step human` captures the edit as their turn. A driver can run that
+capture for the human as its opening move (see below), so re-launching the loop
+is the only thing the human ever does — at a gate they edit and re-run, and the
+loop picks their change up.
 
 ```bash
 gtd next --json   # ask who's up and what they should do
@@ -46,7 +49,9 @@ A minimal bash implementation of the pinned protocol, driving an agent CLI (e.g.
 `claude -p`) against `gtd next --json` output. This is the authoritative
 reference for what a loop driver must do; keep any other implementation
 (including `skills/loop/SKILL.md`) consistent with it rather than editing both
-independently. `bin/gtd-loop` is this exact script, packaged as the `gtd-loop`
+independently. Both open with the same move — capture the human's pending edit
+when the machine rests at a `"message"` gate — so `gtd-loop` is the only command
+a human runs. `bin/gtd-loop` is this exact script, packaged as the `gtd-loop`
 binary, with four additions: it stops with a diagnostic if the same `"prompt"`
 state/content repeat with no progress (see `skills/loop/SKILL.md`'s "Stall
 detection"); it lets `GTD_LOOP_AGENT_CMD` swap in any coding agent CLI in place
@@ -60,6 +65,17 @@ same-scope turns and starting fresh when the scope changes.
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
+
+# Opening move: if the machine rests at a human gate, capture the human's
+# pending edit first, so re-launching the loop is the ONLY thing a human does
+# (they never run `gtd step human` by hand). Peek with the pure `gtd next
+# --json` and step only at a `"message"` rest — at an agent/check rest
+# `gtd step human` would refuse out-of-turn, and a mid-cycle restart must just
+# resume driving. A clean gate is a no-op; a genuine refusal (malformed steering
+# file, unrecognized edit) stops the loop instead of being driven past.
+if [[ "$(gtd next --json | jq -r .kind)" == "message" ]]; then
+  gtd step human >/dev/null
+fi
 
 while true; do
   next_json="$(gtd next --json)"

--- a/skills/loop/SKILL.md
+++ b/skills/loop/SKILL.md
@@ -22,6 +22,28 @@ has no default command and it is a usage error. Only `gtd next --json` and
   upgraded, re-copy this file from the new version's `skills/loop/SKILL.md` so
   the loop text stays in sync with the CLI it drives.
 
+## Opening move: capture the human's pending edit
+
+Before the first `gtd next --json` beat, make one capturing move so that
+re-launching the loop is the only thing a human ever does. A human acts at a
+gate by editing files (answering a plan question, ticking a review box, fixing
+code) and re-running the loop — they should never have to run `gtd step human`
+by hand first. So:
+
+1. Peek once with `gtd next --json` (it never mutates anything).
+2. **Only if** that peek reports `"kind":"message"` (the machine rests at a
+   human gate), run `gtd step human` to commit whatever the human left pending,
+   then continue into the loop below from the resulting state. A clean gate is a
+   harmless no-op; a human edit is captured as their turn (e.g. accepting a
+   plan's suggested defaults with no edit advances past `grilling-answer`).
+3. If the peek reports any other `kind`, do **not** step human — the machine is
+   mid-cycle at an agent/check rest (a restart after a crash, say), where
+   `gtd step human` would refuse out-of-turn. Just enter the loop and resume
+   driving.
+
+If that `gtd step human` refuses (a malformed steering file, or an edit no `on`
+pattern accepts), surface the message and stop rather than driving past it.
+
 ## The loop
 
 Repeat this cycle until it halts:

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -62,6 +62,65 @@ Feature: gtd-loop — the packaged reference loop driver (v3)
     And the git log contains "chore: calculator done"
     And "src/calc.ts" exists
 
+  Scenario: Captures the human's pending edit at the opening gate, so the human only runs gtd-loop
+    # The machine rests at the initial human gate `idle` (no gtd commit — the
+    # test project's "chore: initial commit" resolves to the initial state) with
+    # an uncommitted NOTE.md sketch. The human never runs `gtd step human`: the
+    # loop's opening move captures the sketch (idle's `* **` -> working), then
+    # drives working -> checking -> done. Without that opening capture the loop
+    # would just print the idle message and exit, so src/calc.ts is the proof it
+    # advanced past the gate on its own.
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Build the package described below: write src/calc.ts exporting add(a, b)."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: |
+              if [ -f src/calc.ts ] && grep -q add src/calc.ts; then rm -f .gtd/FEEDBACK.md; else mkdir -p .gtd && echo "missing add" > .gtd/FEEDBACK.md; fi
+            on:
+              "A .gtd/FEEDBACK.md": working
+              "M .gtd/FEEDBACK.md": working
+              "C": done
+          done:
+            commit: "chore: calculator done"
+      """
+    And a file "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Build the package described below"*)
+          mkdir -p src
+          cat > src/calc.ts <<'CALC'
+      export const add = (a, b) => a + b
+      CALC
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    When I run gtd-loop
+    Then it succeeds
+    And "src/calc.ts" exists
+    And the git log contains "chore: calculator done"
+
   Scenario: Settles instead of looping forever when a script rest makes no progress
     Given a test project
     And a gtd config file at ".gtdrc" with:


### PR DESCRIPTION
## What

Make `gtd-loop` the only command a human runs. Previously, at a human gate the human had to run `gtd step human` by hand to commit their edit and advance, *then* re-run `gtd-loop`. Now the loop does that capture itself as its opening move.

At startup the loop peeks with the pure, mutation-free `gtd next --json`; **only** when it reports a human rest (`kind == "message"`) does it run `gtd step human` to commit whatever the human left pending, then drives on from the resulting state. A mid-cycle rest (agent/check) is left untouched, so a restart just resumes driving rather than refusing out-of-turn.

## Why approach B (peek-then-step)

A naive `gtd step human` at the top would refuse **out-of-turn** at any agent/check rest (checked before pattern-matching), exit non-zero, and abort the loop under `set -e` — breaking every existing `gtd-loop.feature` scenario (they start mid-cycle) and any crash-restart. Peeking first and stepping only at a `message` gate avoids that entirely, needs no engine change, and keeps all tests green.

## Behavior notes

- At the "answer" gates (`grilling-answer`, and `architecting-answer` in the advanced template) a **clean** restart fires the `C` edge = *accept the suggested defaults and advance*. This is the intended UX and the only way to say "go" with the loop as the sole command. `idle`/`escalate`/`await-review` have no `C` row → clean restart is a no-op and just re-shows the gate.
- The review checkout window is safe: `closeReviewWindow` restores the real HEAD before the engine sees the diff, so only the human's genuine tick/edit is captured. Bonus: `await-review → review-deciding → idle/grilling` now runs in one invocation.
- A genuine refusal at a gate (malformed steering file, or an edit no `on` pattern accepts) is surfaced and stops the loop rather than being driven past.

## Changes

- `bin/gtd-loop` — opening peek + conditional `gtd step human`
- `docs/loop.md` — reference driver + prose kept in sync (authoritative reference)
- `skills/loop/SKILL.md` — new "Opening move" section (driver-contract change per AGENTS.md)
- `README.md` — gtd-loop is the only command you run
- `tests/integration/features/gtd-loop.feature` — new `@live` scenario: rests at `idle` with an uncommitted `NOTE.md`, human never runs `gtd step human`, loop captures it and drives through to `chore: calculator done` (fails on the old loop, passes on the new one)
- `.claude/settings.json` — allowlist read-only `gtd version`

## Testing

Full e2e suite green, including the new scenario. `bash -n` on the driver, format check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)