### PR TITLE
feat(init): seed a top-level modes: Prettier suggestion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,14 +118,18 @@ a project plugs its own into a mode's `format:`).
 - **`src/program.ts`** — CLI dispatch (`init`/`step`/`next`/`status`/`validate`/
   `mermaid`; `lsp` and `init` dispatched BEFORE the config-reading path so they
   run with no workflow configured). `runInitCommand` writes
-  `renderInitConfig(name)` to `.gtdrc.json` (uncommitted), guarded by
-  `anyConfigPresent` + the repo-root check. Calls `Edge.ts` for everything
-  IO-shaped; calls `PatternMachine.ts`'s pure `step`/`matchesPattern`/
-  `parsePattern` directly where no IO is needed (e.g. `gtd status`'s per-change
-  pattern report).
+  `renderInitScaffold(name)` to `.gtdrc.json` (uncommitted) — the base config
+  plus externalized `gtd-prompts/` files and a seeded top-level `modes:`
+  Prettier suggestion (`MODES_SUGGESTION`) — guarded by `anyConfigPresent` + the
+  repo-root check. Calls `Edge.ts` for everything IO-shaped; calls
+  `PatternMachine.ts`'s pure `step`/`matchesPattern`/ `parsePattern` directly
+  where no IO is needed (e.g. `gtd status`'s per-change pattern report).
 - **`src/workflows/{simple,advanced}.yaml` + `templates.ts`** — the two bundled
   workflow templates `gtd init` scaffolds, plus `templates.ts` (the
-  `WORKFLOW_TEMPLATES` map, `renderInitConfig` for the `.gtdrc.json` write, and
+  `WORKFLOW_TEMPLATES` map, `renderInitScaffold` for the `.gtdrc.json` write —
+  which seeds the top-level `modes:` Prettier suggestion, `MODES_SUGGESTION`;
+  `renderInitConfig` is the hermetic base form reused by the
+  `Given the "…" workflow` test fixture and stays modes-free — and
   `compileTemplate` for tests/mermaid) — compiled through the exact same
   `compileWorkflowConfig` path, no privileged code path. Every content string in
   the templates MUST be inline (no `./`-relative file references): they ship

--- a/README.md
+++ b/README.md
@@ -57,9 +57,13 @@ gtd init simple      # or: gtd init advanced
 This writes a `.gtdrc.json` for the chosen workflow, with each agent state's
 prompt saved as an editable Markdown file under `gtd-prompts/` and referenced
 from the config (review and commit both). Edit a prompt by editing its
-`gtd-prompts/*.md` file — no config edit needed. gtd ships **no** default
-workflow: a state command run before `gtd init` fails, pointing you back here.
-See [Configuration](docs/configuration.md#gtd-init) for the two templates.
+`gtd-prompts/*.md` file — no config edit needed. It also seeds a top-level
+`modes:` block suggesting **Prettier** as the steering-file formatter
+(`npx prettier --write` for the built-in `qa`/`review` modes — format only, so
+gtd still validates); edit or drop it freely (swap in dprint, a script, or
+delete the key). gtd ships **no** default workflow: a state command run before
+`gtd init` fails, pointing you back here. See
+[Configuration](docs/configuration.md#gtd-init) for the two templates.
 
 ## How it works
 

--- a/STATES.md
+++ b/STATES.md
@@ -633,7 +633,11 @@ source of truth (their unit tests are the format's spec tests; the same parsers
 back the LSP's live diagnostics, `src/Lsp.ts`). They are available in every
 workflow without being declared — and they are validators ONLY: **gtd ships no
 formatter**, so `qa`/`review` reformat nothing until a project gives them a
-`format:` command.
+`format:` command. `gtd init` seeds one by default: the scaffolded `.gtdrc.json`
+carries a top-level `modes:` block suggesting `npx prettier --write` as the
+`format:` for both (validation still gtd's own) — an ordinary declared layer the
+project edits or drops, not privileged machinery (see
+[docs/configuration.md](docs/configuration.md#modes--pluggable-steering-file-modes)).
 
 The two halves resolve **independently**, each from the first layer that
 provides it (`resolveSteeringMode` in `src/SteeringMode.ts`) — so extending a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -371,8 +371,10 @@ So for a state declaring `mode: qa`:
 That is what makes the built-in modes extensible rather than all-or-nothing —
 and the top-level key means a project can plug its formatter into whichever
 workflow it scaffolded (`gtd init simple`/`advanced`) without re-declaring a
-`modes:` block on the workflow itself. Add it alongside the `workflow:` key in
-your `.gtdrc.json`:
+`modes:` block on the workflow itself. **`gtd init` seeds exactly this block by
+default** (the Prettier suggestion below), so a fresh repo already formats its
+steering files — edit or drop it to taste. It sits alongside the `workflow:` key
+in your `.gtdrc.json`:
 
 ```jsonc
 // .gtdrc.json — the workflow from `gtd init`, plus your own markdown formatter
@@ -673,8 +675,26 @@ config references it via a `./gtd-prompts/<state>.md`
 [file reference](#content-values-inline-or-a-file-reference) — gtd inlines it at
 load time, so a prompt is editable Markdown and editing it changes the workflow
 with no config edit. Human `message:` blocks and check `script:` bodies stay
-inline in the config (they are workflow mechanics, not prompts). The two
-templates:
+inline in the config (they are workflow mechanics, not prompts).
+
+It also seeds a top-level [`modes:`](#modes--pluggable-steering-file-modes)
+block as a ready-to-edit suggestion — a Prettier `format:` for each built-in
+steering-file mode the templates use:
+
+```jsonc
+"modes": {
+  "qa": { "format": "npx prettier --write <%= it.file %>" },
+  "review": { "format": "npx prettier --write <%= it.file %>" }
+}
+```
+
+Only `format:` is declared, so gtd's built-in `qa`/`review` validators still do
+the validating (the two halves layer independently). gtd ships no formatter, so
+this is the one default it suggests: a fresh repo auto-formats its steering
+files out of the box, and you edit or drop the block freely (swap Prettier for
+dprint, point at a script, or delete the key).
+
+The two templates:
 
 - **`simple`** — the 10-state machine walked through in
   [STATES.md §10](../STATES.md#10-the-bundled-workflow-templates): idle →

--- a/src/workflows/templates.test.ts
+++ b/src/workflows/templates.test.ts
@@ -3,6 +3,7 @@ import { validateDefinition } from "../PatternMachine.js"
 import {
   compileTemplate,
   isWorkflowTemplateName,
+  MODES_SUGGESTION,
   PROMPTS_DIR,
   renderInitConfig,
   renderInitScaffold,
@@ -103,6 +104,26 @@ describe("bundled workflow templates", () => {
         const parsed = JSON.parse(config) as { $schema: string }
         expect(parsed.$schema).toBe(SCHEMA_URL)
         expect(config.endsWith("\n")).toBe(true)
+      })
+
+      it("seeds the top-level `modes:` Prettier suggestion for qa/review (format only)", () => {
+        const { config } = renderInitScaffold(name)
+        const parsed = JSON.parse(config) as { modes?: unknown }
+        // Seeded as a ready-to-edit default so a fresh project auto-formats its
+        // steering files (see MODES_SUGGESTION) — format only, keeping gtd's
+        // built-in qa/review validators.
+        expect(parsed.modes).toEqual(MODES_SUGGESTION)
+        expect(MODES_SUGGESTION.qa.format).toContain("prettier")
+        expect(MODES_SUGGESTION.review.format).toContain("prettier")
+        expect(MODES_SUGGESTION.qa).not.toHaveProperty("validate")
+        expect(MODES_SUGGESTION.review).not.toHaveProperty("validate")
+      })
+
+      it("does NOT seed `modes:` in the hermetic base config (renderInitConfig)", () => {
+        // renderInitConfig doubles as the `Given the "…" workflow` test fixture;
+        // it must stay modes-free so gate scenarios never shell out to Prettier.
+        const parsed = JSON.parse(renderInitConfig(name)) as { modes?: unknown }
+        expect(parsed.modes).toBeUndefined()
       })
     })
   }

--- a/src/workflows/templates.ts
+++ b/src/workflows/templates.ts
@@ -20,6 +20,28 @@ export const SCHEMA_URL = "https://raw.githubusercontent.com/pmelab/gtd/main/sch
 export const PROMPTS_DIR = "gtd-prompts"
 
 /**
+ * The top-level `modes:` block `gtd init` SEEDS into the scaffolded
+ * `.gtdrc.json` as a ready-to-edit suggestion: a `format:` command for each
+ * built-in steering-file mode the bundled templates use (`qa` for the plan /
+ * open-questions files, `review` for REVIEW.md), so a fresh project's steering
+ * files are auto-formatted with Prettier before gtd validates them. Only
+ * `format:` is declared — gtd's built-in `qa`/`review` validators still do the
+ * validating (the two halves layer independently — see STATES.md §12 /
+ * docs/configuration.md `modes:`). gtd ships no formatter, so this is the one
+ * place a default is suggested; a project edits or drops it freely (swap
+ * Prettier for dprint, point at a script, delete the key).
+ *
+ * Seeded only by `renderInitScaffold` (the real `gtd init` write path), NOT by
+ * `renderInitConfig`: the latter is reused as a hermetic test fixture (the
+ * `Given the "…" workflow` step) that must not depend on Prettier being
+ * installed or spawn a subprocess at every steering-file gate.
+ */
+export const MODES_SUGGESTION = {
+  qa: { format: "npx prettier --write <%= it.file %>" },
+  review: { format: "npx prettier --write <%= it.file %>" },
+} as const
+
+/**
  * The bundled workflow templates `gtd init <name>` can scaffold, keyed by the
  * name the user passes. Each value is the raw YAML text of the template file,
  * imported as a string (tsdown's `.yaml` text loader / the vitest `rawMd`
@@ -41,12 +63,19 @@ export const isWorkflowTemplateName = (name: string): name is WorkflowTemplateNa
   Object.prototype.hasOwnProperty.call(WORKFLOW_TEMPLATES, name)
 
 /**
- * Render the `.gtdrc.json` `gtd init <name>` writes: a `$schema` link (so
- * editors pick up completion/validation) plus the template's whole workflow
- * object nested under a `workflow:` key — exactly the shape a hand-authored
- * `.gtdrc` `workflow:` value takes (`{ vars, states }`). The template's
- * multi-line prompts/scripts become `\n`-escaped JSON strings; the config
- * loader parses them back identically to the YAML source.
+ * Render the fully-inline BASE `.gtdrc.json` for a bundled template: a
+ * `$schema` link (so editors pick up completion/validation) plus the template's
+ * whole workflow object nested under a `workflow:` key — exactly the shape a
+ * hand-authored `.gtdrc` `workflow:` value takes (`{ vars, states }`). The
+ * template's multi-line prompts/scripts become `\n`-escaped JSON strings; the
+ * config loader parses them back identically to the YAML source.
+ *
+ * This is NOT the exact file `gtd init` writes — the real write path
+ * (`renderInitScaffold`) additionally externalizes agent prompts and seeds the
+ * top-level `modes:` Prettier suggestion (`MODES_SUGGESTION`). This base form is
+ * kept modes-free so it doubles as a hermetic test fixture (the
+ * `Given the "…" workflow` step) whose steering-file gates never shell out to
+ * Prettier.
  */
 export const renderInitConfig = (name: WorkflowTemplateName): string => {
   const workflow = parseYaml(WORKFLOW_TEMPLATES[name]) as unknown
@@ -63,7 +92,7 @@ export interface ScaffoldPromptFile {
 
 /** The files `gtd init <name>` writes: the `.gtdrc.json` text plus one Markdown file per agent prompt. */
 export interface InitScaffold {
-  /** The `.gtdrc.json` contents, with each agent state's `prompt:` rewritten to a `./gtd-prompts/<state>.md` file reference. */
+  /** The `.gtdrc.json` contents, with each agent state's `prompt:` rewritten to a `./gtd-prompts/<state>.md` file reference and a top-level `modes:` Prettier suggestion seeded (see `MODES_SUGGESTION`). */
   readonly config: string
   /** The extracted prompt files, one per agent (`prompt:`) state, in declaration order. */
   readonly prompts: readonly ScaffoldPromptFile[]
@@ -81,6 +110,12 @@ export interface InitScaffold {
  * (they are workflow mechanics, not prompts). The bundled YAML template itself
  * stays fully inline (it ships inside the single-file bundle); this function is
  * the only place the split happens, at scaffold time.
+ *
+ * It also seeds a top-level `modes:` block (`MODES_SUGGESTION`) — a ready-to-
+ * edit Prettier `format:` for the built-in `qa`/`review` steering-file modes —
+ * so a fresh project auto-formats its steering files out of the box. This lives
+ * here rather than in `renderInitConfig` so the latter stays a hermetic test
+ * fixture (see `MODES_SUGGESTION`).
  */
 export const renderInitScaffold = (name: WorkflowTemplateName): InitScaffold => {
   const workflow = parseYaml(WORKFLOW_TEMPLATES[name]) as {
@@ -94,7 +129,8 @@ export const renderInitScaffold = (name: WorkflowTemplateName): InitScaffold => 
       state.prompt = `./${path}`
     }
   }
-  const config = JSON.stringify({ $schema: SCHEMA_URL, workflow }, null, 2) + "\n"
+  const config =
+    JSON.stringify({ $schema: SCHEMA_URL, modes: MODES_SUGGESTION, workflow }, null, 2) + "\n"
   return { config, prompts }
 }
 

--- a/tests/integration/features/init.feature
+++ b/tests/integration/features/init.feature
@@ -20,6 +20,10 @@ Feature: gtd init — scaffold a .gtdrc.json from a bundled workflow template
     And ".gtdrc.json" contains "\"$schema\""
     And ".gtdrc.json" contains "\"workflow\""
     And ".gtdrc.json" contains "review-deciding"
+    # A ready-to-edit top-level `modes:` block seeds a Prettier formatter for the
+    # built-in qa/review steering-file modes (format only — gtd still validates).
+    And ".gtdrc.json" contains "\"modes\""
+    And ".gtdrc.json" contains "npx prettier --write"
     # Left uncommitted — HEAD is still the project's own initial commit.
     And the last commit subject is "chore: initial commit"
 


### PR DESCRIPTION
## What

`gtd init` now seeds a ready-to-edit top-level `modes:` block into the scaffolded `.gtdrc.json`:

```jsonc
"modes": {
  "qa": { "format": "npx prettier --write <%= it.file %>" },
  "review": { "format": "npx prettier --write <%= it.file %>" }
}
```

A `format:` command for each built-in steering-file mode the bundled templates use (`qa` for plan/open-questions files, `review` for REVIEW.md). **Format only** — gtd's built-in `qa`/`review` validators still validate (the two halves layer independently). So a fresh repo auto-formats its steering files with Prettier out of the box, and a project edits or drops the block freely (swap in dprint, point at a script, delete the key).

Previously gtd shipped no formatter and users had to hand-add this block — it was already the documented recommendation, now it's the default.

## How

- New `MODES_SUGGESTION` constant in `src/workflows/templates.ts`, injected by `renderInitScaffold` (the real `gtd init` write path).
- Deliberately **not** added to `renderInitConfig`: that function doubles as the hermetic `Given the "…" workflow` e2e fixture reused by every steering-gate scenario, which must not shell out to Prettier (or depend on it being installed). Divergence documented in both functions' docstrings and `AGENTS.md`.

## Tests

- `templates.test.ts`: asserts the scaffold seeds `MODES_SUGGESTION` (format-only, prettier) and that `renderInitConfig` stays modes-free.
- `init.feature`: asserts the real `gtd init` output contains `"modes"` / `npx prettier --write`.
- Full unit (424) + e2e (159) suites green; the @live init scenario exercises loading the seeded `modes:` block.

## Docs

README, `docs/configuration.md` (`gtd init` + `modes:` sections), `STATES.md` §12, `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)