### PR TITLE
feat(subject): show `<from> → <to>` transition in step commit subjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ No chat scrollback. No lost sessions. No infinite fix loops. Just git.
 - **Bounded, not runaway.** Fix attempts are capped (`retry` on a state). When
   the cap is hit, gtd redirects to a human gate instead of burning tokens
   rewriting the same test for the 47th time.
-- **Your call on history.** Every intermediate `gtd(actor): state` commit is a
-  real, attributed commit — nothing hidden in chat. Squash them into one
+- **Your call on history.** Every intermediate `gtd(actor): from → to` commit is
+  a real, attributed commit — the subject names both the state the work was done
+  in and where it advanced to, nothing hidden in chat. Squash them into one
   conventional commit if you want that (an interactive rebase, an amend, a PR's
   squash-merge, or a custom workflow with a `commit:` finale), or don't — gtd
   makes no assumption.

--- a/STATES.md
+++ b/STATES.md
@@ -132,21 +132,31 @@ source of truth, no prose that can drift from the `on` map.
 Every commit a `gtd step <actor>` invocation authors carries the subject:
 
 ```
-gtd(<actor>): <state>
+gtd(<actor>): <from> → <to>
 ```
 
-`<actor>` is **who authored the step** — the invoker — and `<state>` is the
-state being **entered**. History is therefore an attributed state trace:
-`git log --oneline` reads as who did what, when.
+`<actor>` is **who authored the step** — the invoker — `<from>` is the state the
+authored changes were made **in**, and `<to>` is the state being **entered**.
+Naming both ends means `git log --oneline` reads as _what each commit did_ (the
+work done in `<from>`) rather than only where the machine is headed — the diff a
+commit carries belongs to `<from>`, not `<to>`. When there is no meaningful
+source — a self-loop (`<from>` == `<to>`) or a manual entry like `gtd review` —
+the subject collapses to the bare `gtd(<actor>): <to>` form. History is
+therefore an attributed state trace: who did what, from where, when.
 
-**Resolution reads back only `<state>`.** The subject's actor is checked only
-against the workflow's closed-world set of _every_ declared actor (not
-specifically the resolved state's own declared actor) — see §5. This is what
-makes a cross-actor handoff resolve correctly: a human stepping out of a
-human-awaited state into an agent-awaited one writes
-`gtd(human): <agent-state>`, and the next invocation must still resolve that
-subject to `<agent-state>` so the agent — that state's own actor — is now
-correctly recognized as awaited.
+**Resolution reads back only `<to>`** (the segment after the last `→`; the bare
+form is read as `<to>` directly). The `<from>` prefix is human context and is
+never consulted. The subject's actor is checked only against the workflow's
+closed-world set of _every_ declared actor (not specifically the resolved
+state's own declared actor) — see §5. This is what makes a cross-actor handoff
+resolve correctly: a human stepping out of a human-awaited state into an
+agent-awaited one writes `gtd(human): <human-state> → <agent-state>`, and the
+next invocation must still resolve that subject to `<agent-state>` so the agent
+— that state's own actor — is now correctly recognized as awaited.
+
+> Legacy note: pre-existing bare `gtd(<actor>): <state>` commits (from before
+> the transition prefix) still parse — the bare form _is_ the no-source form —
+> so old history and old fixtures resolve exactly as they always did.
 
 ## 5. Resolution
 
@@ -154,14 +164,14 @@ correctly recognized as awaited.
 next = f(HEAD's commit subject)
 ```
 
-Parse HEAD's subject as `gtd(<actor>): <state>`. The state resolves to `<state>`
-unless any of the following holds, in which case it resolves to the workflow's
-**initial state** instead:
+Parse HEAD's subject as `gtd(<actor>): <from> → <to>` (or the bare
+`gtd(<actor>): <to>`). The state resolves to `<to>` unless any of the following
+holds, in which case it resolves to the workflow's **initial state** instead:
 
-- the subject doesn't parse as `gtd(<actor>): <state>` at all (a plain commit, a
+- the subject doesn't parse as `gtd(<actor>): …` at all (a plain commit, a
   v1/v2-style `gtd: <label>` subject, anything non-`gtd`),
-- `<state>` doesn't name a state this workflow declares,
-- `<state>` names a **commit** state (a process never rests there — see §8),
+- `<to>` doesn't name a state this workflow declares,
+- `<to>` names a **commit** state (a process never rests there — see §8),
 - `<actor>` doesn't name any actor this workflow declares (the closed-world
   check from §4).
 
@@ -185,17 +195,18 @@ all also resolves to the initial state.
   relies on: opening every iteration with a step before the actor has acted must
   never author junk.
 - **Commit** (or **squash**, see §8) — a pattern fired. Everything pending is
-  committed as `gtd(<invoker>): <to>`, where `<to>` is the matched target after
-  retry redirection (§7) — unless `<to>` is a commit state, in which case the
-  process squashes instead of committing a turn.
+  committed as `gtd(<invoker>): <from> → <to>`, where `<from>` is the resolved
+  state the changes were made in and `<to>` is the matched target after retry
+  redirection (§7) — unless `<to>` is a commit state, in which case the process
+  squashes instead of committing a turn.
 
 **Token cost.** `gtd step <actor> --cost=<n> [--model=<name>]` records the token
 cost of the invocation that produced the pending changes — and the model it ran
 on — as a `Gtd-Cost: <n> <model>` trailer on the turn commit: a blank line then
-the trailer, below the untouched `gtd(<actor>): <state>` subject, so resolution
-(§5) is unaffected. The edge (`src/Edge.ts`) collects every such trailer across
-the current process, summing them into `it.processCost` and grouping them by
-model into `it.processCostByModel` (see §8 and
+the trailer, below the untouched `gtd(<actor>): <from> → <to>` subject, so
+resolution (§5) is unaffected. The edge (`src/Edge.ts`) collects every such
+trailer across the current process, summing them into `it.processCost` and
+grouping them by model into `it.processCostByModel` (see §8 and
 [Configuration: Token cost](docs/configuration.md#token-cost)); the engine never
 interprets the number or the model name, it only carries, sums, and groups them.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -116,7 +116,7 @@ to `--json`.
 Plain-mode output is one line:
 
 ```
-committed: gtd(human): grilling
+committed: gtd(human): idle → grilling
 ```
 
 or, at a no-op:
@@ -131,8 +131,8 @@ not passed):
 
 ```json
 {
-  "state": "grilling",
-  "subject": "gtd(human): grilling",
+  "state": "idle",
+  "subject": "gtd(human): idle → grilling",
   "cost": 1450,
   "model": "claude-opus-4-8"
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -498,11 +498,11 @@ A loop driver that knows how many tokens the invocation it just drove cost — a
 on which model — can record both with
 `gtd step <actor> --cost=<n> [--model=<name>]` (`<n>` a non-negative number).
 gtd appends them to that turn's commit as a `Gtd-Cost: <n> <model>` trailer — a
-blank line then the trailer, below the untouched `gtd(<actor>): <state>` subject
-— so the per-turn cost and model are persisted in the git log:
+blank line then the trailer, below the untouched `gtd(<actor>): <from> → <to>`
+subject — so the per-turn cost and model are persisted in the git log:
 
 ```
-gtd(agent): reviewing
+gtd(agent): building → reviewing
 
 Gtd-Cost: 1450 claude-opus-4-8
 ```

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -11,15 +11,15 @@ ordered map of change-patterns to next states.
 
 **All pre-v3 history is unrecognized and resolves to the initial state, by
 design — v1 and v2 subjects alike.** v3's `resolveState`
-(`src/PatternMachine.ts`) only recognizes its own `gtd(<actor>): <state>`
-subject naming a state and an actor the active workflow currently declares;
-everything else — a v1 `gtd: grilling`, a v2 `gtd(agent): building`, a plain
-`chore: …` commit, anything from a foreign repo — parses as unrecognized and
-lands at the workflow's initial state (`idle` in the `simple` template). There
-is no special-casing for "this looks like an old gtd commit": the mechanism is
-exactly the same one that already made v1 history inert to v2, and v2 history
-inert to a differently-configured workflow — v3 just applies it uniformly to all
-prior history instead of drawing a v1/v2 line.
+(`src/PatternMachine.ts`) only recognizes its own `gtd(<actor>): <from> → <to>`
+subject (or the bare `gtd(<actor>): <to>`) naming a state and an actor the
+active workflow currently declares; everything else — a v1 `gtd: grilling`, a v2
+`gtd(agent): building`, a plain `chore: …` commit, anything from a foreign repo
+— parses as unrecognized and lands at the workflow's initial state (`idle` in
+the `simple` template). There is no special-casing for "this looks like an old
+gtd commit": the mechanism is exactly the same one that already made v1 history
+inert to v2, and v2 history inert to a differently-configured workflow — v3 just
+applies it uniformly to all prior history instead of drawing a v1/v2 line.
 
 **Finish or squash any in-flight cycle first.** A repo mid-cycle on v1 or v2 has
 no v3-shaped commit backing its steering files; upgrading mid-cycle lands cold

--- a/skills/authoring/SKILL.md
+++ b/skills/authoring/SKILL.md
@@ -88,8 +88,9 @@ states:
 
 `actor` is a **plain string** — no closed vocabulary. `gtd step <actor>`
 authenticates against it, and it becomes the commit subject
-`gtd(<actor>): <state>`. Common actors: `human`, `agent`, `check`. Invent your
-own freely; the set of valid actors is derived from what your states declare.
+`gtd(<actor>): <from> → <to>`. Common actors: `human`, `agent`, `check`. Invent
+your own freely; the set of valid actors is derived from what your states
+declare.
 
 ### Content kinds — exactly one per state
 
@@ -138,7 +139,8 @@ on:
 At `gtd step <actor>`, the engine decides:
 
 - **Commit** — a pattern fired: everything pending is committed as
-  `gtd(<actor>): <target>` and the machine advances.
+  `gtd(<actor>): <from> → <target>` (the state stepped from, then the matched
+  target) and the machine advances.
 - **No-op** — clean tree AND no `C` row: zero commits, exit 0. This is the
   **default and it is deliberate** — the loop opens each iteration with a step
   before the actor has acted, so a clean step must author nothing unless you

--- a/src/PatternMachine.test.ts
+++ b/src/PatternMachine.test.ts
@@ -170,7 +170,7 @@ describe("reviewEntryStateOf", () => {
 // ── Commit-subject grammar ────────────────────────────────────────────────────
 
 describe("stateSubject / parseStateSubject round trip", () => {
-  it("round-trips actor/state pairs", () => {
+  it("round-trips actor/state pairs (no source)", () => {
     expect(parseStateSubject(stateSubject("human", "grilling"))).toEqual({
       actor: "human",
       state: "grilling",
@@ -181,10 +181,32 @@ describe("stateSubject / parseStateSubject round trip", () => {
     })
   })
 
+  it("renders and round-trips a <from> → <to> transition, resolving to <to>", () => {
+    const subject = stateSubject("builder", "checking", "building")
+    expect(subject).toBe("gtd(builder): building → checking")
+    expect(parseStateSubject(subject)).toEqual({
+      actor: "builder",
+      state: "checking",
+      from: "building",
+    })
+  })
+
+  it("collapses a self-loop (from === to) to the bare form", () => {
+    expect(stateSubject("builder", "building", "building")).toBe("gtd(builder): building")
+  })
+
+  it("still reads legacy bare `gtd(<actor>): <state>` subjects as the entered state", () => {
+    expect(parseStateSubject("gtd(agent): await-review")).toEqual({
+      actor: "agent",
+      state: "await-review",
+    })
+  })
+
   it("tolerates surrounding whitespace", () => {
-    expect(parseStateSubject("  gtd(human): grilling  \n")).toEqual({
+    expect(parseStateSubject("  gtd(human): building → grilling  \n")).toEqual({
       actor: "human",
       state: "grilling",
+      from: "building",
     })
   })
 
@@ -448,8 +470,8 @@ describe("step + resolveState — cross-actor handoff attribution", () => {
     expect(decision).toEqual({
       kind: "commit",
       // The subject carries "human" (the invoker), not "working"'s own
-      // declared actor ("agent").
-      subject: "gtd(human): working",
+      // declared actor ("agent"), prefixed with the "idle" source state.
+      subject: "gtd(human): idle → working",
       actor: "human",
       from: "idle",
       to: "working",
@@ -512,9 +534,9 @@ describe("step — clean tree", () => {
     expect(decision).toEqual({
       kind: "commit",
       // The subject carries the INVOKER's actor ("agent"), not "idle"'s own
-      // declared actor ("human") — resolveState reads the state name alone,
+      // declared actor ("human") — resolveState reads the entered state alone,
       // so this still resolves back to "idle" on the next invocation.
-      subject: "gtd(agent): idle",
+      subject: "gtd(agent): working → idle",
       actor: "agent",
       from: "working",
       to: "idle",
@@ -595,7 +617,7 @@ describe("step — retry redirection", () => {
       kind: "commit",
       // The subject carries the INVOKER's actor ("agent"), not "checking"'s
       // own declared actor ("check").
-      subject: "gtd(agent): checking",
+      subject: "gtd(agent): fixing → checking",
       actor: "agent",
       from: "fixing",
       to: "checking",
@@ -613,7 +635,7 @@ describe("step — retry redirection", () => {
       kind: "commit",
       // The subject carries the INVOKER's actor ("agent"), not "escalate"'s
       // own declared actor ("human").
-      subject: "gtd(agent): escalate",
+      subject: "gtd(agent): fixing → escalate",
       actor: "agent",
       from: "fixing",
       to: "escalate",
@@ -629,7 +651,7 @@ describe("step — retry redirection", () => {
     })
     expect(decision).toEqual({
       kind: "commit",
-      subject: "gtd(agent): escalate",
+      subject: "gtd(agent): fixing → escalate",
       actor: "agent",
       from: "fixing",
       to: "escalate",
@@ -643,7 +665,7 @@ describe("step — retry redirection", () => {
     })
     expect(decision).toEqual({
       kind: "commit",
-      subject: "gtd(agent): checking",
+      subject: "gtd(agent): fixing → checking",
       actor: "agent",
       from: "fixing",
       to: "checking",

--- a/src/PatternMachine.ts
+++ b/src/PatternMachine.ts
@@ -270,33 +270,53 @@ export const reviewEntryStateOf = (def: WorkflowDefinition): StateName | undefin
 
 // ── Commit-subject grammar ───────────────────────────────────────────────────
 
-/**
- * `gtd(<actor>): <state>` — the subject a step commit carries. Per decision
- * 2, `<actor>` is WHO AUTHORED THE STEP (the invoker), and `<state>` is the
- * state being ENTERED; `resolveState` reads back only the state name.
- */
-export const stateSubject = (actor: Actor, state: StateName): string => `gtd(${actor}): ${state}`
+/** The ` → ` that separates a transition subject's source state from its target. */
+const TRANSITION_SEP = " → "
 
-/** A parsed `gtd(<actor>): <state>` subject — `actor` is the step's author (the invoker), not necessarily `state`'s own declared actor. */
+/**
+ * `gtd(<actor>): <from> → <to>` — the subject a step commit carries. Per
+ * decision 2, `<actor>` is WHO AUTHORED THE STEP (the invoker); `<to>` is the
+ * state being ENTERED and `<from>` the state the authored changes were made
+ * in, so the subject reads as what this commit DID, not just where the machine
+ * is headed. `from` is optional: when it is omitted or equals `to` (a
+ * self-loop, or a manual entry like `gtd review` that has no meaningful
+ * source), the subject collapses to the bare `gtd(<actor>): <to>` form.
+ * `resolveState` reads back only `<to>` — the ` → ` prefix is human context.
+ */
+export const stateSubject = (actor: Actor, to: StateName, from?: StateName): string =>
+  from === undefined || from === to
+    ? `gtd(${actor}): ${to}`
+    : `gtd(${actor}): ${from}${TRANSITION_SEP}${to}`
+
+/** A parsed `gtd(<actor>): <from> → <to>` subject — `actor` is the step's author (the invoker), not necessarily `state`'s own declared actor; `state` is the entered state (`<to>`), `from` the source when the subject carried one. */
 export interface ParsedStateSubject {
   readonly actor: Actor
   readonly state: StateName
+  readonly from?: StateName
 }
 
 const SUBJECT_RE = /^gtd\(([^()]+)\): (.+)$/
 
 /**
- * Parse a raw commit subject as `gtd(<actor>): <state>`. Returns `undefined`
- * for anything else (non-gtd, malformed, or missing either half) — never
- * throws. Trims surrounding whitespace before matching.
+ * Parse a raw commit subject as `gtd(<actor>): <from> → <to>` (or the bare
+ * `gtd(<actor>): <to>` form). Returns `undefined` for anything else (non-gtd,
+ * malformed, or missing either half) — never throws. Trims surrounding
+ * whitespace before matching. `state` is always the ENTERED state (`<to>`, the
+ * segment after the last ` → `); the pre-arrow segment, when present, is
+ * surfaced as `from` for display but is never consulted by `resolveState`.
  */
 export const parseStateSubject = (subject: string): ParsedStateSubject | undefined => {
   const match = SUBJECT_RE.exec(subject.trim())
   if (match === null) return undefined
   const actor = match[1]
-  const state = match[2]
-  if (actor === undefined || actor === "" || state === undefined || state === "") return undefined
-  return { actor, state }
+  const rest = match[2]
+  if (actor === undefined || actor === "" || rest === undefined || rest === "") return undefined
+  const sepIndex = rest.lastIndexOf(TRANSITION_SEP)
+  if (sepIndex === -1) return { actor, state: rest }
+  const from = rest.slice(0, sepIndex)
+  const state = rest.slice(sepIndex + TRANSITION_SEP.length)
+  if (from === "" || state === "") return undefined
+  return { actor, state, from }
 }
 
 // ── Resolve ──────────────────────────────────────────────────────────────────
@@ -511,10 +531,12 @@ export interface StepNoOp {
 }
 
 /**
- * Commit everything pending as `gtd(<actor>): <to>` (the target after any
- * retry redirection). `actor` is the INVOKER who authored this step — per
+ * Commit everything pending as `gtd(<actor>): <from> → <to>` (the target after
+ * any retry redirection). `actor` is the INVOKER who authored this step — per
  * decision 2, the subject records "the state being ENTERED and who authored
- * the step". This works for a cross-actor handoff (a transition whose target
+ * the step", now prefixed with the `<from>` source so the message describes the
+ * committed changes rather than only the destination. This works for a
+ * cross-actor handoff (a transition whose target
  * is awaited by a different actor than `from`'s) because `resolveState`
  * resolves by STATE NAME ALONE: it never compares the subject's actor against
  * `to`'s own declared actor, so the next invocation lands on `to` regardless
@@ -587,9 +609,9 @@ const applyRetry = (
  * steps are the default, silent case. A match's target is retry-redirected
  * (`applyRetry`) before being classified: a commit-state target yields a
  * `"squash"` decision carrying its `commit` template verbatim; anything
- * else yields a `"commit"` decision naming the `gtd(<invoker>): <to>` subject
- * to write — `<invoker>` is who authored this step, per decision 2, not `to`'s
- * own declared actor (see `StepCommit`'s doc comment). Throws only on a
+ * else yields a `"commit"` decision naming the `gtd(<invoker>): <from> → <to>`
+ * subject to write — `<invoker>` is who authored this step, per decision 2, not
+ * `to`'s own declared actor (see `StepCommit`'s doc comment). Throws only on a
  * structurally invalid call (an undefined
  * `state`, or a commit-state `state` — stepping AT a commit state is a
  * caller error: a commit state ends the process, `resolveState` never rests
@@ -644,10 +666,12 @@ export const step = (
   }
 
   // The written subject names WHO AUTHORED THIS STEP (`invoker`), not the
-  // entered state's own declared actor — see StepCommit's doc comment.
+  // entered state's own declared actor — see StepCommit's doc comment — and
+  // carries the `<from> → <to>` transition so the message reads as what the
+  // commit DID, not just the state it lands in.
   return {
     kind: "commit",
-    subject: stateSubject(invoker, finalTarget),
+    subject: stateSubject(invoker, finalTarget, state),
     actor: invoker,
     from: state,
     to: finalTarget,

--- a/src/workflows/simple.yaml
+++ b/src/workflows/simple.yaml
@@ -75,8 +75,8 @@
 # state) still exists as an ENGINE capability (see STATES.md §8) and is kept
 # as part of the fuller machine at docs/examples/advanced-workflow.md.
 #
-# A `gtd(<actor>): idle` commit — entering the workflow's own initial state —
-# is therefore a PROCESS BOUNDARY (see `computeProcessRun` in src/Edge.ts):
+# A `gtd(<actor>): <from> → idle` commit — entering the workflow's own initial
+# state — is therefore a PROCESS BOUNDARY (see `computeProcessRun` in src/Edge.ts):
 # the next cycle's `retry` counts, `startCommit`, and diffs never reach back
 # across an approved cycle's own idle-entering commit.
 #

--- a/tests/integration/features/advanced-workflow.feature
+++ b/tests/integration/features/advanced-workflow.feature
@@ -57,7 +57,7 @@ Feature: The advanced example's picking arbiter — a per-task queue loop via a 
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): picking"
+    And the last commit subject is "gtd(human): idle → picking"
 
     # picking (task 1 of 2): the arbiter takes the first task file by name
     Given a file ".gtd/NEXT.md" with:
@@ -66,13 +66,13 @@ Feature: The advanced example's picking arbiter — a per-task queue loop via a 
       """
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): building"
+    And the last commit subject is "gtd(check): picking → building"
 
     # building (task 1): implements it, deletes the task file, back to picking
     Given the file ".gtd/tasks/01-a.md" is deleted
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): picking"
+    And the last commit subject is "gtd(agent): building → picking"
 
     # picking (task 2 of 2): overwrites NEXT.md with the one remaining task
     Given ".gtd/NEXT.md" is modified to:
@@ -81,13 +81,13 @@ Feature: The advanced example's picking arbiter — a per-task queue loop via a 
       """
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): building"
+    And the last commit subject is "gtd(check): picking → building"
 
     # building (task 2): implements it, deletes the task file, back to picking
     Given the file ".gtd/tasks/02-b.md" is deleted
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): picking"
+    And the last commit subject is "gtd(agent): building → picking"
 
     # picking: the queue is now empty — deleting NEXT.md matches "D .gtd/NEXT.md"
     # (declared before the wildcard row) and closes the cycle out via "done"
@@ -137,7 +137,7 @@ Feature: The advanced example's picking arbiter — a per-task queue loop via a 
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): picking"
+    And the last commit subject is "gtd(human): idle → picking"
 
     # picking: .gtd/tasks/ was already empty, so a clean step matches "C" directly
     When I run gtd step check

--- a/tests/integration/features/default-workflow.feature
+++ b/tests/integration/features/default-workflow.feature
@@ -32,7 +32,7 @@ Feature: The bundled simple workflow — full cycle journeys
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): grilling"
+    And the last commit subject is "gtd(human): idle → grilling"
 
     # grilling: develops the sketch into a plan (self-validated before the
     # turn ends — see validate.feature) and hands straight to grilling-answer
@@ -48,12 +48,12 @@ Feature: The bundled simple workflow — full cycle journeys
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): grilling-answer"
+    And the last commit subject is "gtd(agent): grilling → grilling-answer"
 
     # grilling-answer: accept the suggested answer with a clean step
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): building"
+    And the last commit subject is "gtd(human): grilling-answer → building"
 
     # building: implements the plan directly, deletes TODO.md when done
     Given the file ".gtd/TODO.md" is deleted
@@ -63,7 +63,7 @@ Feature: The bundled simple workflow — full cycle journeys
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): checking"
+    And the last commit subject is "gtd(agent): building → checking"
 
     # checking (red): a failing run leaves FEEDBACK.md, sends the cycle to fixing
     Given a file ".gtd/FEEDBACK.md" with:
@@ -72,18 +72,18 @@ Feature: The bundled simple workflow — full cycle journeys
       """
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): fixing"
+    And the last commit subject is "gtd(check): checking → fixing"
 
     # fixing: addresses the feedback, deletes it, steps back to checking
     Given the file ".gtd/FEEDBACK.md" is deleted
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): checking"
+    And the last commit subject is "gtd(agent): fixing → checking"
 
     # checking (green): a clean step moves on to reviewing
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): reviewing"
+    And the last commit subject is "gtd(check): checking → reviewing"
 
     # reviewing: writes REVIEW.md (self-validated before the turn ends) and
     # hands straight to await-review
@@ -120,7 +120,7 @@ Feature: The bundled simple workflow — full cycle journeys
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): review-deciding"
+    And the last commit subject is "gtd(human): await-review → review-deciding"
 
     # review-deciding: extracts the unticked pointer into a fresh TODO.md,
     # removes REVIEW.md — the decider always sees both changes, and the
@@ -134,7 +134,7 @@ Feature: The bundled simple workflow — full cycle journeys
     And the file ".gtd/REVIEW.md" is deleted
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): grilling"
+    And the last commit subject is "gtd(check): review-deciding → grilling"
 
     # second lap: grilling -> grilling-answer -> building -> checking (green)
     # -> reviewing -> await-review
@@ -145,10 +145,10 @@ Feature: The bundled simple workflow — full cycle journeys
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): grilling-answer"
+    And the last commit subject is "gtd(agent): grilling → grilling-answer"
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): building"
+    And the last commit subject is "gtd(human): grilling-answer → building"
     Given the file ".gtd/TODO.md" is deleted
     And a file "src/thing.ts" with:
       """
@@ -157,10 +157,10 @@ Feature: The bundled simple workflow — full cycle journeys
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): checking"
+    And the last commit subject is "gtd(agent): building → checking"
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): reviewing"
+    And the last commit subject is "gtd(check): checking → reviewing"
     Given a file ".gtd/REVIEW.md" with:
       """
       # Review: def5678
@@ -193,11 +193,11 @@ Feature: The bundled simple workflow — full cycle journeys
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): review-deciding"
+    And the last commit subject is "gtd(human): await-review → review-deciding"
     Given the file ".gtd/REVIEW.md" is deleted
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): idle"
+    And the last commit subject is "gtd(check): review-deciding → idle"
     And the git status is clean
     And ".gtd/TODO.md" does not exist
     And ".gtd/FEEDBACK.md" does not exist
@@ -218,7 +218,7 @@ Feature: The bundled simple workflow — full cycle journeys
     Given the file ".gtd/FEEDBACK.md" is deleted
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): reviewing"
+    And the last commit subject is "gtd(check): checking → reviewing"
     And ".gtd/FEEDBACK.md" does not exist
 
   Scenario: repeated check failures escalate once fixing's retry cap (3) is reached
@@ -258,7 +258,7 @@ Feature: The bundled simple workflow — full cycle journeys
       """
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): escalate"
+    And the last commit subject is "gtd(check): checking → escalate"
 
   Scenario: deleting REVIEW.md outright at await-review is the power-user approve shortcut, bypassing review-deciding
     Given a test project
@@ -275,7 +275,7 @@ Feature: The bundled simple workflow — full cycle journeys
     Given the file ".gtd/REVIEW.md" is deleted
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): idle"
+    And the last commit subject is "gtd(human): await-review → idle"
     And ".gtd/REVIEW.md" does not exist
 
   Scenario: at await-review, gtd next surfaces which change routes where — the human gate's route list, rendered from its `on` edge descriptions
@@ -314,7 +314,7 @@ Feature: The bundled simple workflow — full cycle journeys
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): grilling"
+    And the last commit subject is "gtd(human): await-review → grilling"
 
   Scenario: an approved cycle's idle-entering commit is a process boundary — a fresh cycle's fixing retry budget doesn't pool with a previous cycle's
     Given a test project
@@ -366,31 +366,31 @@ Feature: The bundled simple workflow — full cycle journeys
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): grilling"
+    And the last commit subject is "gtd(human): idle → grilling"
     Given ".gtd/TODO.md" is modified to:
       """
       Build a second thing. Plan: add src/thing2.ts exporting `thing2`.
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): grilling-answer"
+    And the last commit subject is "gtd(agent): grilling → grilling-answer"
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): building"
+    And the last commit subject is "gtd(human): grilling-answer → building"
     Given a file "src/thing2.ts" with:
       """
       export const thing2 = 1
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): checking"
+    And the last commit subject is "gtd(agent): building → checking"
     Given a file ".gtd/FEEDBACK.md" with:
       """
       cycle 2 attempt 1 failed
       """
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): fixing"
+    And the last commit subject is "gtd(check): checking → fixing"
 
   Scenario: the bundled default's four agent states emit their memory scope labels
     # The scope labels are what lets a memory-aware driver retain memory within

--- a/tests/integration/features/formatting.feature
+++ b/tests/integration/features/formatting.feature
@@ -95,7 +95,7 @@ Feature: Markdown formatting is the project's own tool, plugged into a steering-
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): grilling"
+    And the last commit subject is "gtd(human): grilling-answer → grilling"
     And ".gtd/TODO.md" has no lines longer than 80 characters
 
   Scenario: Pre-commit hook wraps long lines in TODO.md

--- a/tests/integration/features/pattern-matching.feature
+++ b/tests/integration/features/pattern-matching.feature
@@ -37,7 +37,7 @@ Feature: Pattern-matching grammar — statuses, glob depth, declaration order, c
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): added"
+    And the last commit subject is "gtd(human): start → added"
 
   Scenario: an "M" pattern matches only a modified path
     Given a test project
@@ -73,7 +73,7 @@ Feature: Pattern-matching grammar — statuses, glob depth, declaration order, c
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): modified"
+    And the last commit subject is "gtd(human): start → modified"
 
   Scenario: a "D" pattern matches only a deleted path
     Given a test project
@@ -106,7 +106,7 @@ Feature: Pattern-matching grammar — statuses, glob depth, declaration order, c
     And the file "NOTE.md" is deleted
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): deleted"
+    And the last commit subject is "gtd(human): start → deleted"
 
   Scenario: a "*" status pattern matches any change kind
     Given a test project
@@ -130,7 +130,7 @@ Feature: Pattern-matching grammar — statuses, glob depth, declaration order, c
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): any-change"
+    And the last commit subject is "gtd(human): start → any-change"
 
   Scenario: a single-segment glob does not cross a path separator
     Given a test project
@@ -179,7 +179,7 @@ Feature: Pattern-matching grammar — statuses, glob depth, declaration order, c
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): deep"
+    And the last commit subject is "gtd(human): start → deep"
 
   Scenario: the first matching pattern in declaration order wins
     Given a test project
@@ -207,7 +207,7 @@ Feature: Pattern-matching grammar — statuses, glob depth, declaration order, c
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): first-match"
+    And the last commit subject is "gtd(human): start → first-match"
 
   Scenario: the bare "C" token matches only a clean tree
     Given a test project
@@ -227,7 +227,7 @@ Feature: Pattern-matching grammar — statuses, glob depth, declaration order, c
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): settled"
+    And the last commit subject is "gtd(human): start → settled"
 
   Scenario: a clean tree with no declared "C" event is a silent no-op
     Given a test project

--- a/tests/integration/features/refusals.feature
+++ b/tests/integration/features/refusals.feature
@@ -45,7 +45,7 @@ Feature: Refusals — out-of-turn and no-match steps commit nothing
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): working"
+    And the last commit subject is "gtd(human): idle → working"
     Given I record the commit count
     And a file "scratch.txt" with:
       """

--- a/tests/integration/features/retry.feature
+++ b/tests/integration/features/retry.feature
@@ -48,25 +48,25 @@ Feature: Retry redirection — a state's entry cap redirects at write time
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): checking"
+    And the last commit subject is "gtd(human): start → checking"
     Given a file "FEEDBACK.md" with:
       """
       test failed (attempt 1)
       """
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): fixing"
+    And the last commit subject is "gtd(check): checking → fixing"
     Given the file "FEEDBACK.md" is deleted
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): checking"
+    And the last commit subject is "gtd(agent): fixing → checking"
     Given a file "FEEDBACK.md" with:
       """
       test failed (attempt 2)
       """
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): escalate"
+    And the last commit subject is "gtd(check): checking → escalate"
 
   Scenario: a retry cap of 0 redirects on the very first entry attempt
     Given a test project
@@ -108,11 +108,11 @@ Feature: Retry redirection — a state's entry cap redirects at write time
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): checking"
+    And the last commit subject is "gtd(human): start → checking"
     Given a file "FEEDBACK.md" with:
       """
       test failed
       """
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): escalate"
+    And the last commit subject is "gtd(check): checking → escalate"

--- a/tests/integration/features/review-window.feature
+++ b/tests/integration/features/review-window.feature
@@ -66,7 +66,7 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
     And the file ".gtd/REVIEW.md" is deleted
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): idle"
+    And the last commit subject is "gtd(human): await-review → idle"
     And the git ref "refs/gtd/review-head" does not exist
     And the git ref "refs/gtd/review-base" does not exist
     And ".gtd/REVIEW.md" does not exist
@@ -81,7 +81,7 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
     When I run gtd step human
     Then it succeeds
     # A code edit with REVIEW.md untouched is feedback straight to grilling.
-    And the last commit subject is "gtd(human): grilling"
+    And the last commit subject is "gtd(human): await-review → grilling"
     And the git ref "refs/gtd/review-head" does not exist
 
   Scenario: Read-only commands re-arm the window on their way out

--- a/tests/integration/features/smoke.feature
+++ b/tests/integration/features/smoke.feature
@@ -20,24 +20,24 @@ Feature: v3 pattern-machine smoke — simple workflow hops, gtd next --json, cus
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): grilling"
+    And the last commit subject is "gtd(human): idle → grilling"
     Given ".gtd/TODO.md" is modified to:
       """
       Build a thing. Developed into a concrete plan.
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): grilling-answer"
+    And the last commit subject is "gtd(agent): grilling → grilling-answer"
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): building"
+    And the last commit subject is "gtd(human): grilling-answer → building"
     Given a file "src/thing.ts" with:
       """
       export const thing = 1
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): checking"
+    And the last commit subject is "gtd(agent): building → checking"
 
   Scenario: gtd next --json reports state, actor, kind, and content
     Given a test project
@@ -77,7 +77,7 @@ Feature: v3 pattern-machine smoke — simple workflow hops, gtd next --json, cus
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): working"
+    And the last commit subject is "gtd(human): idle → working"
     Given a file "COMMIT_MSG.md" with:
       """
       feat: remember the milk

--- a/tests/integration/features/squash.feature
+++ b/tests/integration/features/squash.feature
@@ -47,17 +47,17 @@ Feature: Commit-state squash — a process collapses to one commit at its final 
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): drafting"
+    And the last commit subject is "gtd(human): idle → drafting"
     Given "DRAFT.md" is modified to:
       """
       v2
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): revising"
+    And the last commit subject is "gtd(agent): drafting → revising"
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): working"
+    And the last commit subject is "gtd(human): revising → working"
     Given a file "COMMIT_MSG.md" with:
       """
       feat: draft workflow

--- a/tests/integration/features/steering-modes.feature
+++ b/tests/integration/features/steering-modes.feature
@@ -223,7 +223,7 @@ Feature: Pluggable steering-file modes — a mode is a format command plus a val
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): idle"
+    And the last commit subject is "gtd(agent): drafting → idle"
 
   Scenario: a failing format command is a hard error — the file is never judged, nothing is committed
     Given a test project

--- a/tests/integration/features/token-cost.feature
+++ b/tests/integration/features/token-cost.feature
@@ -44,7 +44,7 @@ Feature: Token-cost tracking — gtd step --cost/--model persists per-turn cost,
       """
     When I run gtd step agent with "--cost=1450"
     Then it succeeds
-    And the last commit subject is "gtd(agent): reviewing"
+    And the last commit subject is "gtd(agent): building → reviewing"
     And the last commit body contains "Gtd-Cost: 1450"
 
   Scenario: gtd step --json echoes the recorded cost
@@ -75,7 +75,7 @@ Feature: Token-cost tracking — gtd step --cost/--model persists per-turn cost,
       """
     When I run gtd step agent with "--cost=1450" and "--json"
     Then it succeeds
-    And stdout contains "\"subject\":\"gtd(agent): idle\""
+    And stdout contains "\"subject\":\"gtd(agent): building → idle\""
     And stdout contains "\"cost\":1450"
 
   Scenario: gtd status shows the running process cost, accumulated across turns
@@ -116,14 +116,14 @@ Feature: Token-cost tracking — gtd step --cost/--model persists per-turn cost,
       """
     When I run gtd step agent with "--cost=100"
     Then it succeeds
-    And the last commit subject is "gtd(agent): reviewing"
+    And the last commit subject is "gtd(agent): building → reviewing"
     Given a file "src/b.ts" with:
       """
       export const b = 2
       """
     When I run gtd step agent with "--cost=250"
     Then it succeeds
-    And the last commit subject is "gtd(agent): polishing"
+    And the last commit subject is "gtd(agent): reviewing → polishing"
     When I run gtd status
     Then it succeeds
     And stdout contains "State: polishing"
@@ -195,7 +195,7 @@ Feature: Token-cost tracking — gtd step --cost/--model persists per-turn cost,
       """
     When I run gtd step agent with "--cost=100"
     Then it succeeds
-    And the last commit subject is "gtd(agent): finishing"
+    And the last commit subject is "gtd(agent): building → finishing"
     And the last commit body contains "Gtd-Cost: 100"
     Given a file "DONE.md" with:
       """
@@ -258,7 +258,7 @@ Feature: Token-cost tracking — gtd step --cost/--model persists per-turn cost,
       """
     When I run gtd step agent with "--cost=1450" and "--model=claude-opus-4-8"
     Then it succeeds
-    And the last commit subject is "gtd(agent): reviewing"
+    And the last commit subject is "gtd(agent): building → reviewing"
     And the last commit body contains "Gtd-Cost: 1450 claude-opus-4-8"
 
   Scenario: gtd step --json echoes both the recorded cost and model
@@ -384,7 +384,7 @@ Feature: Token-cost tracking — gtd step --cost/--model persists per-turn cost,
       """
     When I run gtd step agent with "--cost=100" and "--model=haiku"
     Then it succeeds
-    And the last commit subject is "gtd(agent): finishing"
+    And the last commit subject is "gtd(agent): building → finishing"
     And the last commit body contains "Gtd-Cost: 100 haiku"
     Given a file "DONE.md" with:
       """

--- a/tests/integration/features/validate.feature
+++ b/tests/integration/features/validate.feature
@@ -183,4 +183,4 @@ Feature: gtd validate — self-validating the resolved rest's steering file
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): grilling"
+    And the last commit subject is "gtd(human): grilling-answer → grilling"


### PR DESCRIPTION
## Problem

Step commits carried only the **destination** state — `gtd(builder): checking` — which never matched the changes actually in the commit. The diff is the work the invoker did in the **source** state, so `git log --oneline` read as a list of where the machine was *headed*, not what each commit *did*.

## Change

Subjects now render the transition:

```
gtd(<actor>): <from> → <to>
```

`git log --oneline` becomes self-explanatory:

```
gtd(human): idle → grilling
gtd(agent): building → checking
gtd(check): checking → reviewing
gtd(human): await-review → idle
```

- `stateSubject(actor, to, from?)` renders it. A self-loop (`from == to`) or a source-less manual entry (`gtd review`) collapses to the bare `gtd(<actor>): <to>` form.
- `parseStateSubject` reads back `<to>` (the segment after the last ` → `) and surfaces `from` for display. **Legacy bare `gtd(<actor>): <state>` subjects still parse** as the no-source form, so old history and fixtures resolve exactly as before.
- The pure engine's `resolveState` and `computeProcessRun` are untouched — both key on `<to>`, so state resolution, retry counting, and process boundaries are unchanged. The edge layer treats the subject as opaque.

## Docs

STATES.md §4/§5/§6, README, `docs/cli.md`, `docs/configuration.md`, `docs/upgrading.md`, the authoring skill, and the `simple.yaml` boundary comment.

## Tests

Unit round-trip covers the transition form, self-loop collapse, and legacy back-compat. Every e2e subject assertion updated to the engine-produced value. Full suite green: format, lint, typecheck, 427 unit, all e2e, fallow (0 above threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)