### PR TITLE
fix(workflows): keep bundled check scripts valid after Eta autoTrim

### DIFF
--- a/src/PatternTemplates.test.ts
+++ b/src/PatternTemplates.test.ts
@@ -1,5 +1,7 @@
+import { execFileSync } from "node:child_process"
 import { describe, expect, it } from "vitest"
 import { renderStateTemplate, type TemplateContext } from "./PatternTemplates.js"
+import { compileTemplate } from "./workflows/templates.js"
 
 const baseContext = (overrides: Partial<TemplateContext> = {}): TemplateContext => ({
   startCommit: "aaa111",
@@ -157,4 +159,32 @@ describe("renderStateTemplate — no filesystem template resolution", () => {
     const out = renderStateTemplate("just <%= it.actor %> text, no includes", baseContext())
     expect(out).toBe("just agent text, no includes")
   })
+})
+
+describe("renderStateTemplate — bundled `script` states render to valid bash", () => {
+  // Regression: Eta's default autoTrim slurps the newline after every
+  // `<%~ %>` tag. A `script` line ending in an interpolation therefore glued
+  // the next line's `else`/`fi` onto it (e.g. `rm -f .gtd/FEEDBACK.mdfi`),
+  // leaving the enclosing `if` unterminated — the driver died with
+  // "syntax error: unexpected end of file" and the check turn never ran. Every
+  // bundled `script` must survive `bash -n` after rendering with real vars.
+  const { definition, vars } = compileTemplate()
+  const scriptStates = Object.entries(definition.states).filter(([, s]) => s.script)
+
+  it("covers every bundled script state (guards against a state being dropped)", () => {
+    expect(scriptStates.map(([name]) => name).sort()).toEqual([
+      "adv-checking",
+      "checking",
+      "closing",
+      "picking",
+      "review-deciding",
+    ])
+  })
+
+  for (const [name, state] of scriptStates) {
+    it(`\`${name}\` renders to syntactically valid bash`, () => {
+      const rendered = renderStateTemplate(state.script!, baseContext({ state: name, vars }))
+      expect(() => execFileSync("bash", ["-n"], { input: rendered })).not.toThrow()
+    })
+  }
 })

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -346,11 +346,16 @@ states:
       # MEANS (another package to build vs. the queue closing out to review) is
       # decided by this state's own `on` rules at capture time — never here.
       set +e
+      # Hoist the NEXT path once, at the TOP: Eta's autoTrim eats the newline
+      # after an interpolation tag, so no tag may be the last token on a line —
+      # it would glue the next line's `else`/`fi` onto it and break the script.
+      # Below this point everything is plain bash.
+      nextFile="<%~ it.vars.nextFile %>"
       next=$(ls <%~ it.vars.packagesDir %>/*.md 2>/dev/null | head -n 1)
       if [ -n "$next" ]; then
-        printf '%s' "$next" > <%~ it.vars.nextFile %>
+        printf '%s' "$next" > "$nextFile"
       else
-        rm -f <%~ it.vars.nextFile %>
+        rm -f "$nextFile"
       fi
     on:
       "D .gtd/NEXT.md": reviewing
@@ -390,18 +395,23 @@ states:
       # green run cleans it up. The `on` rules decide what that means.
       set +e
       mkdir -p .gtd
+      # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
+      # newline after an interpolation tag, so no tag may be the last token on
+      # a line — it would glue the next line's `else`/`fi` onto it and break
+      # the script. Below this point everything is plain bash.
+      feedback="<%~ it.vars.feedbackFile %>"
       <%~ it.vars.testCommand %> > .gtd/.check-output 2>&1
       code=$?
       if [ "$code" -ne 0 ]; then
         if [ -s .gtd/.check-output ]; then
-          mv .gtd/.check-output <%~ it.vars.feedbackFile %>
+          mv .gtd/.check-output "$feedback"
         else
           rm -f .gtd/.check-output
-          printf 'the test command failed with exit code %s and produced no output.' "$code" > <%~ it.vars.feedbackFile %>
+          printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
       else
         rm -f .gtd/.check-output
-        rm -f <%~ it.vars.feedbackFile %>
+        rm -f "$feedback"
       fi
     on:
       "A .gtd/FEEDBACK.md": adv-fixing
@@ -541,18 +551,23 @@ states:
       # green run cleans it up. The `on` rules decide what that means.
       set +e
       mkdir -p .gtd
+      # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
+      # newline after an interpolation tag, so no tag may be the last token on
+      # a line — it would glue the next line's `else`/`fi` onto it and break
+      # the script. Below this point everything is plain bash.
+      feedback="<%~ it.vars.feedbackFile %>"
       <%~ it.vars.testCommand %> > .gtd/.check-output 2>&1
       code=$?
       if [ "$code" -ne 0 ]; then
         if [ -s .gtd/.check-output ]; then
-          mv .gtd/.check-output <%~ it.vars.feedbackFile %>
+          mv .gtd/.check-output "$feedback"
         else
           rm -f .gtd/.check-output
-          printf 'the test command failed with exit code %s and produced no output.' "$code" > <%~ it.vars.feedbackFile %>
+          printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
       else
         rm -f .gtd/.check-output
-        rm -f <%~ it.vars.feedbackFile %>
+        rm -f "$feedback"
       fi
     on:
       "A .gtd/FEEDBACK.md": fixing
@@ -701,14 +716,20 @@ states:
       # feedback, not mistaken for a sign-off.
       set +e
       mkdir -p .gtd
-      if grep -qE '^[[:space:]]*-[[:space:]]*\[[[:space:]]*\]' <%~ it.vars.reviewFile %> 2>/dev/null; then
+      # Hoist the review paths once, at the TOP: Eta's autoTrim eats the
+      # newline after an interpolation tag, so no tag may be the last token on a
+      # line — it would glue the next line onto it and break the script. Below
+      # this point everything is plain bash.
+      reviewFile="<%~ it.vars.reviewFile %>"
+      reviewFeedbackFile="<%~ it.vars.reviewFeedbackFile %>"
+      if grep -qE '^[[:space:]]*-[[:space:]]*\[[[:space:]]*\]' "$reviewFile" 2>/dev/null; then
         {
           echo "Feedback from review — address these before continuing:"
           echo
-          grep -E '^[[:space:]]*-[[:space:]]*\[[[:space:]]*\]' <%~ it.vars.reviewFile %>
-        } > <%~ it.vars.reviewFeedbackFile %>
+          grep -E '^[[:space:]]*-[[:space:]]*\[[[:space:]]*\]' "$reviewFile"
+        } > "$reviewFeedbackFile"
       fi
-      rm -f <%~ it.vars.reviewFile %>
+      rm -f "$reviewFile"
     on:
       "A .gtd/REVIEW_FEEDBACK.md": feedback-building
       "M .gtd/REVIEW_FEEDBACK.md": feedback-building


### PR DESCRIPTION
## Problem

Running the bundled workflow's `check` turn died with:

```
bash: -c: line 15: syntax error: unexpected end of file
gtd step check: no declared pattern matches the pending changes at "checking"
```

Root cause: `renderStateTemplate` uses a bare `new Eta()`, whose default `autoTrim` **slurps the newline immediately after every `<%~ … %>` tag**. Any `script:` line that *ended* in an interpolation had the next line's bash keyword glued onto it. In the `checking` script the closing `fi` was consumed:

```bash
  rm -f <%~ it.vars.feedbackFile %>   # \n fi
  # rendered as:
  rm -f .gtd/FEEDBACK.mdfi            # ← the `fi` is gone
```

…leaving the enclosing `if` unterminated → bash refuses the whole script → the check never runs, and the only thing in the tree is a stale `.gtd/.check-output`, which matches none of `checking`'s `on` patterns. The loop wedges at `checking`.

This affected **four** script states with a line-final tag: `checking`, `adv-checking`, `picking`, `review-deciding`. `closing` was already safe (its tag is mid-line). No existing test caught it — `gtd-loop.feature` uses a minimal *single-line* check script, so it never exercised the bundled multi-line `if/else/fi`.

## Fix

`autoTrim` is load-bearing for the templates' `<% forEach %>`/`<% } %>` control blocks (and the interpolations even hand-append `"\n"` to compensate), so flipping it globally would mean rewriting every template. Instead, in each affected script, **hoist the interpolated path into a shell variable at the top** so no `<%~ %>` tag is ever the last token on a line — and the rest of the script is plain bash.

## Test

Adds a regression test that renders **every** bundled `script` state with real vars and asserts it survives `bash -n`, plus a guard that lists the covered states so a newly added script state can't silently escape the check. Full suite (`npm test`) green.

## Note

Already-scaffolded repos have the old broken script inlined in their `.gtdrc.json` (`gtd init` writes it inline), so they won't pick up this fix until re-scaffolded — worth calling out in release notes.