### PR TITLE
feat(lsp): go-to-definition from a REVIEW.md hunk line into the file

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,14 +144,16 @@ importantly: gitignore everything your scripts write.
 
 Editor integration: `gtd lsp` starts an LSP server over stdio for `.gtd/`
 steering files — symbols and check/uncheck actions over a `review`-mode file's
-chunks, symbols over a `qa`-mode file's open questions, diagnostics for both
-(live as you edit), and a `gtd.openSteeringFile` command that jumps to the
-current state's steering file. Config-driven via each state's `file:`/`mode:`
-(see [CLI reference](docs/cli.md#gtd-lsp)) — falls back to basename dispatch
-(`TODO.md`/`REVIEW.md`) with no config in sight. Those two formats are gtd's
-built-in steering-file MODES — validators, not formatters: a mode's `format:`
-and `validate:` are shell commands a workflow (or a project's `.gtdrc`) declares
-for itself, so you bring your own formatter and your own checkers (see
+chunks, go-to-definition from a `review`-mode hunk line into the file it points
+at (at its `#line`), symbols over a `qa`-mode file's open questions, diagnostics
+for both (live as you edit), and a `gtd.openSteeringFile` command that jumps to
+the current state's steering file. Config-driven via each state's
+`file:`/`mode:` (see [CLI reference](docs/cli.md#gtd-lsp)) — falls back to
+basename dispatch (`TODO.md`/`REVIEW.md`) with no config in sight. Those two
+formats are gtd's built-in steering-file MODES — validators, not formatters: a
+mode's `format:` and `validate:` are shell commands a workflow (or a project's
+`.gtdrc`) declares for itself, so you bring your own formatter and your own
+checkers (see
 [Configuration](docs/configuration.md#modes--pluggable-steering-file-modes)).
 Both halves are enforced by `gtd validate` and the `gtd step` gate.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -391,9 +391,12 @@ are rejected).
 
 Starts an LSP server over stdio for `.gtd/` steering files — document symbols
 for a `qa`-mode file's open questions and a `review`-mode file's review
-chunks/hunks, code actions to check/uncheck a hunk or a whole chunk, and
-diagnostics publishing the same parser findings `gtd validate` reports (see
-`src/OpenQuestions.ts` / `src/ReviewDoc.ts` and
+chunks/hunks, code actions to check/uncheck a hunk or a whole chunk,
+go-to-definition (`textDocument/definition`) from a `review`-mode hunk pointer
+line into the file it points at (at its 1-based `#line`, or the top of the file
+for a bare `./path`; the `./`-relative path resolves against the repo's git
+toplevel), and diagnostics publishing the same parser findings `gtd validate`
+reports (see `src/OpenQuestions.ts` / `src/ReviewDoc.ts` and
 [STATES.md §12](../STATES.md#12-steering-file-validation-gtd-validate)).
 
 **Config-driven** (see

--- a/src/Lsp.test.ts
+++ b/src/Lsp.test.ts
@@ -7,6 +7,7 @@ import {
   toggleHunkEdit,
   toggleChunkEdits,
   reviewCodeActions,
+  hunkDefinitionLocation,
   basenameFallbackMode,
   buildFileModeMap,
   modeForDocument,
@@ -180,6 +181,38 @@ describe("reviewCodeActions", () => {
       end: { line: 5, character: 0 },
     })
     expect(actions[0]?.edit?.changes?.[uri]).toBeDefined()
+  })
+})
+
+describe("hunkDefinitionLocation", () => {
+  const root = "/repo"
+
+  it("jumps to the hunk's file at its 1-based #line, mapped to a 0-based position", () => {
+    // line 6: "- [x] ./src/calc.ts#5 — subtract" → src/calc.ts at 0-based line 4
+    const location = hunkDefinitionLocation(reviewDoc, 6, root)
+    expect(location?.uri).toBe("file:///repo/src/calc.ts")
+    expect(location?.range.start).toEqual({ line: 4, character: 0 })
+    expect(location?.range.end).toEqual({ line: 4, character: 0 })
+  })
+
+  it("lands at the top of the file for a bare ./path with no #line", () => {
+    const doc = [
+      "# Review: abc1234",
+      "<!-- base: abc -->",
+      "",
+      "## C",
+      "",
+      "- [ ] ./src/bare.ts",
+    ].join("\n")
+    const location = hunkDefinitionLocation(doc, 5, root)
+    expect(location?.uri).toBe("file:///repo/src/bare.ts")
+    expect(location?.range.start).toEqual({ line: 0, character: 0 })
+  })
+
+  it("returns undefined when the line is not a hunk pointer (heading, prose, blank)", () => {
+    expect(hunkDefinitionLocation(reviewDoc, 3, root)).toBeUndefined() // "## Add calculator"
+    expect(hunkDefinitionLocation(reviewDoc, 0, root)).toBeUndefined() // "# Review: ..."
+    expect(hunkDefinitionLocation(reviewDoc, 2, root)).toBeUndefined() // blank
   })
 })
 

--- a/src/Lsp.ts
+++ b/src/Lsp.ts
@@ -1,11 +1,22 @@
 /**
  * LSP server for `.gtd/` steering files — document symbols for a `qa`-mode
  * file's open questions and a `review`-mode file's review chunks/hunks, code
- * actions to check/uncheck a hunk or a whole chunk, and diagnostics publishing
- * the same parsers' `errors` the `gtd validate` CLI command reports (see
- * `src/OpenQuestions.ts` / `src/ReviewDoc.ts`'s module docs — those parsers
- * are each format's single source of truth, shared by this server and the
- * command).
+ * actions to check/uncheck a hunk or a whole chunk, go-to-definition from a
+ * `review`-mode hunk line into the file it points at, and diagnostics
+ * publishing the same parsers' `errors` the `gtd validate` CLI command reports
+ * (see `src/OpenQuestions.ts` / `src/ReviewDoc.ts`'s module docs — those
+ * parsers are each format's single source of truth, shared by this server and
+ * the command).
+ *
+ * GO-TO-DEFINITION (`textDocument/definition`, `review`-mode only): the cursor
+ * on a hunk pointer line (`- [ ] ./src/foo.ts#42`) jumps to `./src/foo.ts` at
+ * line 42 (`hunkDefinitionLocation`). The `./`-relative path resolves against
+ * the git toplevel of the file's own directory (`tryGitTopLevel`), falling
+ * back to the workspace root — never the document's own `.gtd/` directory — so
+ * a repo-root-relative diff path lands correctly even with no workspace folder
+ * open; no target is returned when neither anchor resolves. The `#line` is
+ * 1-based (a bare `./path` lands at the top of the file); the target file is
+ * not stat-ed, so a stale pointer still jumps and the editor reports the miss.
  *
  * CONFIG-DRIVEN (see `docs/design/state-file-association.md` §3): the server
  * locates the active gtd config the SAME way the CLI does (`ConfigService`'s
@@ -57,11 +68,13 @@ import {
   SymbolKind,
   type CodeAction,
   type CodeActionParams,
+  type DefinitionParams,
   type Diagnostic,
   type DocumentSymbol,
   type DocumentSymbolParams,
   type ExecuteCommandParams,
   type InitializeParams,
+  type Location,
   type Range,
   type TextEdit,
 } from "vscode-languageserver/node"
@@ -265,6 +278,39 @@ export const reviewCodeActions = (uri: string, content: string, range: Range): C
   return actions
 }
 
+/**
+ * Go-to-definition target for a `.gtd/REVIEW.md` hunk line: the file the hunk
+ * pointer at `line` (0-based, `params.position.line`) points into. `root` is
+ * the repo the `./`-relative hunk paths were authored against (the git
+ * toplevel of REVIEW.md's directory — see `resolveDefinitionRoot`). Returns
+ * `undefined` when `line` isn't a parsed hunk pointer (a heading, prose, or a
+ * malformed line has no `sourceLine`), so the provider yields no target there.
+ *
+ * The `#line` in a pointer is 1-based (git/human line numbers); LSP positions
+ * are 0-based, so it maps to `line - 1`. A bare `./path` with no `#line` lands
+ * at the top of the file (line 0). The range is collapsed (a cursor, not a
+ * selection) and the target file is NOT stat-ed — a stale/deleted/`../`-escaping
+ * path still returns a Location and the editor reports the miss itself. Pure —
+ * no git, no protocol, unit-testable directly.
+ */
+export const hunkDefinitionLocation = (
+  content: string,
+  line: number,
+  root: string,
+): Location | undefined => {
+  const { changesets } = parseReviewDoc(content)
+  const hunk = changesets.flatMap((chunk) => chunk.files).find((file) => file.sourceLine === line)
+  if (!hunk) return undefined
+  const targetLine = hunk.line !== undefined ? hunk.line - 1 : 0
+  return {
+    uri: pathToFileURL(resolvePath(root, hunk.path)).toString(),
+    range: {
+      start: { line: targetLine, character: 0 },
+      end: { line: targetLine, character: 0 },
+    },
+  }
+}
+
 // ── Config-driven path→mode dispatch (pure) ─────────────────────────────────
 
 /** The basename dispatch this server has always had — the fallback for any path the active workflow's `file:` map doesn't cover (or when no config resolves at all). */
@@ -442,6 +488,27 @@ const loadModeMap = async (
 }
 
 /**
+ * The git working-tree root of `dir` (`git rev-parse --show-toplevel`), or
+ * `undefined` when `dir` is outside any repository. This is the anchor a
+ * hunk's `./`-relative path resolves against — the repo the review diff's
+ * paths were authored against (`GitService.topLevel()`, the same op the CLI
+ * uses). Any failure resolves to `undefined` so the caller can fall back to
+ * the workspace root.
+ */
+const tryGitTopLevel = async (dir: string): Promise<string | undefined> => {
+  try {
+    return await Effect.runPromise(
+      GitService.pipe(
+        Effect.flatMap((git) => git.topLevel()),
+        Effect.provide(gitLayerForRoot(dir)),
+      ),
+    )
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Resolve the CURRENT state/actor and its `file:` (rendered), exactly like
  * the CLI (`resolveRest`/`computeProcessRun`/`buildTemplateContext` — the
  * same `src/Edge.ts` helpers `gtd status`/`gtd next` call), scoped to `root`.
@@ -506,6 +573,7 @@ export const startLspServer = (): Effect.Effect<void, Error> =>
           textDocumentSync: TextDocumentSyncKind.Incremental,
           documentSymbolProvider: true,
           codeActionProvider: true,
+          definitionProvider: true,
           executeCommandProvider: { commands: [OPEN_STEERING_FILE_COMMAND] },
         },
       }
@@ -531,6 +599,16 @@ export const startLspServer = (): Effect.Effect<void, Error> =>
       const map = await loadModeMap(rootFor(document.uri), warn)
       if (modeForDocument(document.uri, map) !== "review") return []
       return reviewCodeActions(document.uri, document.getText(), params.range)
+    })
+
+    connection.onDefinition(async (params: DefinitionParams) => {
+      const document = documents.get(params.textDocument.uri)
+      if (!document) return []
+      const map = await loadModeMap(rootFor(document.uri), warn)
+      if (modeForDocument(document.uri, map) !== "review") return []
+      const root = (await tryGitTopLevel(dirname(fileURLToPath(document.uri)))) ?? workspaceRoot
+      if (root === undefined) return []
+      return hunkDefinitionLocation(document.getText(), params.position.line, root) ?? []
     })
 
     connection.onExecuteCommand(async (params: ExecuteCommandParams) => {

--- a/tests/integration/features/lsp.feature
+++ b/tests/integration/features/lsp.feature
@@ -11,8 +11,10 @@ Feature: gtd lsp — the steering-file LSP server (stdio)
   for a CUSTOM-named `qa` file mapped via a real `.gtdrc` `file:`/`mode:`
   pair, and the `gtd.openSteeringFile` executeCommand resolving a
   hand-authored current state and asking the client to show its steering
-  file (`window/showDocument`). Real subprocess I/O (spawn + stdio JSON-RPC
-  framing), so this runs @live.
+  file (`window/showDocument`). A final scenario proves go-to-definition: a
+  `textDocument/definition` on a `.gtd/REVIEW.md` hunk pointer line returns a
+  `Location` in the referenced file at its `#line` (basename fallback). Real
+  subprocess I/O (spawn + stdio JSON-RPC framing), so this runs @live.
 
   Scenario: the initialize handshake succeeds and advertises symbol/code-action support
     Given a test project
@@ -106,3 +108,22 @@ Feature: gtd lsp — the steering-file LSP server (stdio)
     When the LSP client sends a workspace/executeCommand request for "gtd.openSteeringFile"
     Then the LSP response has no error
     And the LSP client received a window/showDocument request for ".gtd/PLAN.md"
+
+  Scenario: initialize advertises definition support and a definition on a hunk line jumps into the file
+    Given a test project
+    And an LSP server started in the test project
+    When the LSP client sends an initialize request
+    Then the LSP response has no error
+    And the LSP response result has a "definitionProvider" capability
+    When the LSP client requests a definition at line 6 in ".gtd/REVIEW.md" containing:
+      """
+      # Review: abc1234
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add calculator
+
+      - [ ] ./src/calc.ts#1
+      - [x] ./src/calc.ts#5 — subtract
+      """
+    Then the LSP response has no error
+    And the LSP response result points to "src/calc.ts" at line 4

--- a/tests/integration/support/steps/lsp.steps.ts
+++ b/tests/integration/support/steps/lsp.steps.ts
@@ -164,6 +164,41 @@ When(
 )
 
 When(
+  "the LSP client requests a definition at line {int} in {string} containing:",
+  async (world: GtdWorld, line: number, path: string, content: string) => {
+    const client = clients.get(world)!
+    const uri = pathToFileURL(join(world.repoDir, path)).toString()
+    notify(client, "textDocument/didOpen", {
+      textDocument: { uri, languageId: "markdown", version: 1, text: content },
+    })
+    const response = await request(client, "textDocument/definition", {
+      textDocument: { uri },
+      position: { line, character: 0 },
+    })
+    ;(world as unknown as { lspLastResponse: JsonRpcResponse }).lspLastResponse = response
+  },
+)
+
+Then(
+  "the LSP response result points to {string} at line {int}",
+  (world: GtdWorld, path: string, line: number) => {
+    const response = (world as unknown as { lspLastResponse: JsonRpcResponse }).lspLastResponse
+    const result = response.result as
+      | { uri: string; range: { start: { line: number } } }
+      | ReadonlyArray<{ uri: string; range: { start: { line: number } } }>
+    const location = Array.isArray(result) ? result[0] : result
+    assert.ok(location, `Expected a definition Location, got: ${JSON.stringify(response.result)}`)
+    // The server anchors on the git toplevel (symlink-resolved on macOS), so
+    // match the trailing path rather than the exact temp-dir prefix.
+    assert.ok(
+      location.uri.endsWith(`/${path}`),
+      `Expected a Location ending in "/${path}", got: ${location.uri}`,
+    )
+    assert.strictEqual(location.range.start.line, line)
+  },
+)
+
+When(
   "the LSP client sends a workspace\\/executeCommand request for {string}",
   async (world: GtdWorld, command: string) => {
     const client = clients.get(world)!


### PR DESCRIPTION
## What

Adds a `textDocument/definition` provider to the `gtd lsp` server. In a `review`-mode file (`.gtd/REVIEW.md`), placing the cursor on a hunk pointer line — `- [ ] ./src/foo.ts#42 — note` — and invoking **Go to Definition** (F12 / `gd` / Ctrl-click) jumps into `./src/foo.ts` at line 42.

## Design decisions

- **Mechanism**: `textDocument/definition` (the universal "goto" gesture), registered as `definitionProvider: true`. `review`-mode only — `qa`/TODO.md has no file pointers.
- **Activation**: anywhere on a hunk line (matched by `sourceLine === position.line`, mirroring `reviewCodeActions`); headings/prose/blank lines return no target.
- **Path anchor**: `./`-relative hunk paths are git-diff style (repo-root-relative), so they resolve against `git rev-parse --show-toplevel` of the file's own directory, falling back to the workspace root — **never** the document's own `.gtd/` dir (which would silently mis-resolve `./src/foo.ts` to `.gtd/src/foo.ts`). No anchor → no target.
- **Target**: collapsed cursor at `line - 1` (1-based `#line` → 0-based LSP); bare `./path` → top of file. The target is **not** stat-ed — a stale/deleted pointer still jumps and the editor reports the miss.

## Structure

Pure `hunkDefinitionLocation(content, line, root)` helper + an `onDefinition` edge handler, mirroring the existing pure/edge `onCodeAction` split.

## Tests

- `Lsp.test.ts`: `#line` off-by-one, bare-`./path` fallback, non-hunk line → `undefined`.
- New `@live` `lsp.feature` scenario: `definitionProvider` advertised + a definition request on a hunk line returns the right file + line.
- Full suite green: 435 unit tests, all 5 LSP e2e scenarios, lint, format, typecheck.

## Docs

Updated `Lsp.ts` + `lsp.feature` docstrings, README, and `docs/cli.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)