### PR TITLE
fix(review): squash message describes only the review's own fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ just those changes), and a full sign-off collapses the whole cycle into one
 commit (a **squash finale** whose message an agent drafts). The same review tail
 also has a direct entry point — `gtd review <commitish>` starts a brand new
 process reviewing `<commitish>..HEAD` with no cycle of its own, e.g. a
-colleague's PR branch. See
+colleague's PR branch. Its squash keeps and describes only the fixes made
+_during_ the review (not the reviewed changeset); a clean sign-off with no fixes
+becomes an empty `chore: human review` commit. See
 [STATES.md](STATES.md#10-the-bundled-workflow-template) for the full shape. The
 workflow is just `.gtdrc` config — edit it or write your own (see
 [Configuration](docs/configuration.md)). Every agent state routes its model

--- a/STATES.md
+++ b/STATES.md
@@ -447,12 +447,23 @@ items (no Q&A), deletes the feedback file, and re-enters `checking` →
 last round (§11).
 
 **The squash finale.** A full sign-off reaches `squashing` (agent), which writes
-`.gtd/COMMIT_MSG.md` with one conventional-commits message for the whole cycle;
-entering the `done` commit state squashes every turn commit since the process
-start into that one commit (with a token-cost trailer, §8) and discards the
-message file. The squash commit carries a NON-workflow subject, so it is the
-process boundary (§7): the next cycle's `retry` counts, `startCommit`, and diffs
-never reach back across it.
+`.gtd/COMMIT_MSG.md` with one conventional-commits message; entering the `done`
+commit state squashes every turn commit since the process start into that one
+commit (with a token-cost trailer, §8) and discards the message file. The squash
+commit carries a NON-workflow subject, so it is the process boundary (§7): the
+next cycle's `retry` counts, `startCommit`, and diffs never reach back across
+it.
+
+The message describes **`it.retainedDiff`, not `it.processDiff`** — the diff the
+squash actually KEEPS, based at the process's own trace boundary
+(`startParentHash`), which a `Gtd-Review-Base:` trailer never overrides (§11).
+For a normal build cycle the two coincide (whole feature). For a
+`gtd review <commitish>` process, `it.processDiff` covers the reviewed
+`<commitish>..HEAD` but the squash only retains the fixes made DURING the
+review; `it.retainedDiff` is exactly those, and the prompt renders it in place
+of the full changeset. When it is empty — a clean sign-off with no fixes — the
+prompt instead instructs a fixed `chore: human review` message, so the squash is
+an empty commit that records the sign-off without restating the reviewed work.
 
 ### Walkthrough — the advanced flow
 
@@ -599,6 +610,11 @@ routing run exactly as declared, `it.processDiff` covers `<commitish>..HEAD`,
 and if a downstream state (the bundled default's `await-review`) declares
 `reviewWindow: true`, the checkout window opens over that same range — zero
 duplicated logic, one re-pointed value.
+
+Because the trailer moves ONLY `diffBase`, not `startParentHash`, the squash
+reset target and thus `it.retainedDiff` stay anchored at the review process's
+own start — so the squash keeps and describes only the fixes made during the
+review, never the reviewed changeset itself (§10, the squash finale).
 
 The bundled default declares `reviewEntry: true` on `reviewing` itself (see
 §10): `gtd review <commitish>` hands the agent a `<commitish>..HEAD` diff to

--- a/src/Edge.test.ts
+++ b/src/Edge.test.ts
@@ -323,6 +323,7 @@ const context = (overrides: Partial<TemplateContext> = {}): TemplateContext => (
   actor: "agent",
   processDiff: "",
   reviewDiff: "",
+  retainedDiff: "",
   lastDiff: "",
   processCost: 0,
   processCostByModel: [],

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -393,6 +393,16 @@ export const buildTemplateContext = (
       committedDiff,
     )
     const reviewDiff = joinDiffs(committedReviewDiff, pendingDiff)
+    // `retainedDiff` is based at the process's trace/retry boundary
+    // (`startParentHash`) — what a squash actually keeps — NOT `diffBase`,
+    // which a `Gtd-Review-Base:` trailer can push back past the review's own
+    // start. They coincide for a normal cycle (`committedDiff` already covers
+    // it); only a `gtd review` process needs the narrower re-diff.
+    const committedRetainedDiff =
+      run.diffBase === run.startParentHash
+        ? committedDiff
+        : yield* git.diffRef(run.startParentHash).pipe(Effect.catchAll(() => Effect.succeed("")))
+    const retainedDiff = joinDiffs(committedRetainedDiff, pendingDiff)
     const lastDiff =
       run.trace.length > 0
         ? yield* git.commitDiff(currentCommit).pipe(Effect.catchAll(() => Effect.succeed("")))
@@ -412,6 +422,7 @@ export const buildTemplateContext = (
       actor,
       processDiff,
       reviewDiff,
+      retainedDiff,
       lastDiff,
       processCost: totalCostOf(allCostEntries),
       processCostByModel: costByModel(allCostEntries),

--- a/src/Lsp.ts
+++ b/src/Lsp.ts
@@ -313,6 +313,7 @@ export const buildFileModeMap = (
         actor: "",
         processDiff: "",
         reviewDiff: "",
+        retainedDiff: "",
         lastDiff: "",
         processCost: 0,
         processCostByModel: [],

--- a/src/PatternTemplates.test.ts
+++ b/src/PatternTemplates.test.ts
@@ -11,6 +11,7 @@ const baseContext = (overrides: Partial<TemplateContext> = {}): TemplateContext 
   actor: "agent",
   processDiff: "diff --git a/x.ts b/x.ts\n+added\n",
   reviewDiff: "diff --git a/x.ts b/x.ts\n+added\n",
+  retainedDiff: "diff --git a/x.ts b/x.ts\n+added\n",
   lastDiff: "diff --git a/y.ts b/y.ts\n+last\n",
   processCost: 0,
   processCostByModel: [],

--- a/src/PatternTemplates.ts
+++ b/src/PatternTemplates.ts
@@ -58,6 +58,20 @@ export interface TemplateContext {
    * review of a cycle) — assembled by `src/Edge.ts`.
    */
   readonly reviewDiff: string
+  /**
+   * The diff a squash would KEEP: `startParentHash..HEAD` plus the pending
+   * working-tree diff — the current process's OWN commits, based at its
+   * trace/retry boundary (`ProcessRun.startParentHash`), which a
+   * `Gtd-Review-Base:` trailer NEVER overrides. Equal to `processDiff` for a
+   * normal cycle (there `diffBase == startParentHash`); for a `gtd review`
+   * process it narrows to just the review's own feedback commits — what the
+   * squash commit actually retains — instead of the whole reviewed changeset.
+   * A squash `commit:` template renders its message from THIS, not
+   * `processDiff`, so the message describes what the commit contains. Empty
+   * when the review made no changes (a clean sign-off). Assembled by
+   * `src/Edge.ts`.
+   */
+  readonly retainedDiff: string
   /** The diff of the last transition alone. */
   readonly lastDiff: string
   /**

--- a/src/SteeringMode.test.ts
+++ b/src/SteeringMode.test.ts
@@ -31,6 +31,7 @@ const context = (vars: Record<string, string> = {}): TemplateContext => ({
   actor: "agent",
   processDiff: "",
   reviewDiff: "",
+  retainedDiff: "",
   lastDiff: "",
   processCost: 0,
   processCostByModel: [],

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -766,21 +766,32 @@ states:
       anything under `.gtd/` except `<%= it.vars.commitMsgFile %>`, which this
       prompt tells you to write.
 
+      Leave `<%= it.vars.commitMsgFile %>` uncommitted and finish your turn —
+      entering this file squashes everything this process retains into one
+      commit using its content as the message. The diff below is exactly what
+      that commit will contain: `it.retainedDiff`, the changes THIS process
+      made (its trace/retry boundary onward). For a normal build cycle that is
+      the whole feature; for a `gtd review` process it is only the fixes made
+      during the review — NOT the changeset that was under review.
+      <% if (it.retainedDiff.trim()) { %>
+
       Write `<%= it.vars.commitMsgFile %>` with ONE conventional-commits message
-      for the entire cycle (subject line `type(scope): subject`, imperative
+      for the changes below (subject line `type(scope): subject`, imperative
       mood, <= 72 characters; a body explaining the why, trade-offs, and key
       decisions). Plain text, no markdown wrapper.
 
-      Leave `<%= it.vars.commitMsgFile %>` uncommitted and finish your turn —
-      entering this file squashes the whole cycle into one commit using its
-      content as the message.
-      <% if (it.processDiff.trim()) { %>
-
-      ## Full cycle diff
+      ## Retained diff
 
       ```diff
-      <%~ it.processDiff %>
+      <%~ it.retainedDiff %>
       ```
+      <% } else { %>
+
+      This process retained NO changes (a clean review sign-off with no fixes).
+      Write `<%= it.vars.commitMsgFile %>` with exactly this one line and
+      nothing else:
+
+      chore: human review
       <% } %>
     on:
       "A .gtd/COMMIT_MSG.md": done

--- a/tests/integration/features/review-entry.feature
+++ b/tests/integration/features/review-entry.feature
@@ -119,6 +119,45 @@ Feature: gtd review <commitish> — start a review process from an ordinary bran
     And stdout contains "src/calc.ts"
     And stdout contains "src/fix.ts"
 
+  Scenario: squashing a review process describes only the review's own fixes (it.retainedDiff), not the reviewed changeset
+    # The squash resets to the process's OWN boundary (startParentHash — the
+    # reviewed commit), so its message must describe only what it keeps: the
+    # fixes made DURING the review, not the whole changeset under review. That
+    # base is never pushed back by the Gtd-Review-Base: trailer the way
+    # it.processDiff's is.
+    Given a commit "feat: add calculator" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    When I run gtd with args "review base"
+    Then it succeeds
+    # A fix authored during the review, then the human signs off into squashing.
+    Given a commit "gtd(agent): reviewing" that adds "src/fix.ts" with:
+      """
+      export const fixed = true
+      """
+    And an empty commit "gtd(human): reviewing → squashing"
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "## Retained diff"
+    And stdout contains "src/fix.ts"
+    And stdout does not contain "src/calc.ts"
+
+  Scenario: a clean review sign-off with no fixes squashes to a "chore: human review" commit
+    Given a commit "feat: add calculator" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    When I run gtd with args "review base"
+    Then it succeeds
+    # No fix authored — the human signs off straight into squashing.
+    And an empty commit "gtd(human): reviewing → squashing"
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "chore: human review"
+    And stdout does not contain "## Retained diff"
+    And stdout does not contain "src/calc.ts"
+
   Scenario: the review checkout window at await-review spans <commitish>..HEAD
     Given a commit "feat: add calculator" that adds "src/calc.ts" with:
       """

--- a/tests/integration/support/steps/common.steps.ts
+++ b/tests/integration/support/steps/common.steps.ts
@@ -73,6 +73,20 @@ Given(
   },
 )
 
+// A commit that changes NOTHING — subject only, no file touched (like a gtd
+// workflow turn that only advances state). Maps to one `git commit
+// --allow-empty`; composable anywhere the commit-builder steps are.
+Given("an empty commit {string}", (world: GtdWorld, message: string) => {
+  if (world.tier === "inmem") {
+    world.repo!.commitAllWithPrefix(message)
+  } else {
+    execFileSync("git", ["commit", "-q", "--allow-empty", "-m", message], {
+      cwd: world.repoDir,
+      stdio: "pipe",
+    })
+  }
+})
+
 // Commits everything currently in the working tree under one chore commit —
 // the "I've reviewed the scaffold, now commit it" move a human makes after
 // `gtd init`, so the machine starts from a clean tree at the initial state.


### PR DESCRIPTION
## Problem

When a `gtd review <commitish>` process reaches its squash finale, the squash commit only *keeps* the review's own commits — it soft-resets to `run.startParentHash`, the review process's trace boundary, which a `Gtd-Review-Base:` trailer never overrides. But the `squashing` prompt fed the agent `it.processDiff`, which is based at `run.diffBase` — pushed back to the *reviewed* base by that trailer.

Result: the squash **message** described the entire reviewed changeset, while the squash **commit** contained only the review delta. A clean sign-off with no fixes produced an (essentially empty) commit whose message still restated the whole reviewed work.

This only affects `gtd review` processes; a normal build cycle is unchanged (there `diffBase == startParentHash`).

## Fix

Add a `retainedDiff` template field based at `startParentHash` — the diff the squash actually keeps:

- **`src/PatternTemplates.ts`** — new documented `TemplateContext.retainedDiff`.
- **`src/Edge.ts`** — `buildTemplateContext` computes it; reuses the already-computed `committedDiff` for normal cycles, re-diffs from `startParentHash` only when the two bases diverge.
- **`src/workflows/unified.yaml`** — the `squashing` prompt renders `it.retainedDiff` instead of `it.processDiff`; when empty (a clean sign-off) it instructs a fixed `chore: human review` message (`commitAsIs` already passes `--allow-empty`).
- **`src/Lsp.ts`** + 3 test literals — carry the new field.

## Tests

- New generic `an empty commit {string}` step.
- Two `@inmem` scenarios in `review-entry.feature`:
  - a review with a fix → message covers only the fix, not the reviewed code;
  - a clean sign-off → `chore: human review`, no retained diff.

## Docs

STATES.md §10 (squash finale) + §11 (`gtd review`), and README.

## Verification

typecheck ✅ · 432 unit ✅ · 165 e2e ✅ (incl. the 2 new scenarios) · lint ✅ · format ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)