### PR TITLE
feat(review): comments drive the feedback loop, not unticked boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,15 +116,20 @@ which steering file you create:
   per-package **agentic review** that verifies the package against its spec.
 
 Both flows converge on the same tail: an agent hands you a `.gtd/REVIEW.md`
-checkbox review of the diff — tick a box to sign off an item, edit/untick for
-feedback (which sends only the unaddressed items back to build and re-review
-just those changes), and a full sign-off collapses the whole cycle into one
-commit (a **squash finale** whose message an agent drafts). The same review tail
-also has a direct entry point — `gtd review <commitish>` starts a brand new
-process reviewing `<commitish>..HEAD` with no cycle of its own, e.g. a
-colleague's PR branch. Its squash keeps and describes only the fixes made
-_during_ the review (not the reviewed changeset); a clean sign-off with no fixes
-becomes an empty `chore: human review` commit. See
+checkbox review of the diff — tick a box as you review each hunk (ticking just
+records "I read this"), and leave a **comment** to request changes: a note on a
+line, or a direct code edit. Any comment sends a build + re-review round (a
+re-review covering only the follow-through, and a hand-edit is treated as your
+own fix the agent completes without reverting your lines); ticking every box
+with no comment is the sign-off, which collapses the whole cycle into one commit
+(a **squash finale** whose message an agent drafts). Stepping with a box still
+unticked and no comment is refused (finish reviewing first), as is deleting
+`.gtd/REVIEW.md`. The same review tail also has a direct entry point —
+`gtd review <commitish>` starts a brand new process reviewing
+`<commitish>..HEAD` with no cycle of its own, e.g. a colleague's PR branch. Its
+squash keeps and describes only the fixes made _during_ the review (not the
+reviewed changeset); a clean sign-off with no fixes becomes an empty
+`chore: human review` commit. See
 [STATES.md](STATES.md#10-the-bundled-workflow-template) for the full shape. The
 workflow is just `.gtdrc` config — edit it or write your own (see
 [Configuration](docs/configuration.md)). Every agent state routes its model

--- a/STATES.md
+++ b/STATES.md
@@ -343,15 +343,22 @@ creates:
   per-package agentic `spec-review` gate.
 
 Both converge at `reviewing` → `await-review` (also the direct
-`gtd review <commitish>` entry, via `reviewEntry: true` on `reviewing`). From
-there a **full sign-off** (tick every box, or delete `.gtd/REVIEW.md`) is the
-only path to the **squash finale** (`squashing` → `done`), which collapses the
-whole cycle into one commit whose message an agent drafts. A **partial
-sign-off** routes the still-unticked items through `review-deciding` into
+`gtd review <commitish>` entry, via `reviewEntry: true` on `reviewing`). Ticking
+a `- [ ]` box means only "I reviewed this hunk"; a **comment** — not an unticked
+box — is what asks for changes. Every human step routes to `review-deciding`,
+which decides from the step's content: a **full sign-off** (every box ticked, no
+note in `.gtd/REVIEW.md`, no code edit) is the only path to the **squash
+finale** (`squashing` → `done`), which collapses the whole cycle into one commit
+whose message an agent drafts. **Feedback** — any note in `.gtd/REVIEW.md`
+beyond a tick, OR a hand-edit to code — routes through `review-deciding` into
 `.gtd/REVIEW_FEEDBACK.md` → `feedback-building` → `checking` → `reviewing`,
 which regenerates an **incremental** review (`reviewBase: true` on
-`review-deciding` scopes it to `last-review..HEAD`). A **code-only edit** at
-`await-review` routes to `checking` to re-test and re-review the manual fix.
+`review-deciding` scopes it to `last-review..HEAD`, i.e. the agent's
+follow-through, not the reviewer's own edit). A code edit counts as the
+reviewer's own fix: `feedback-building` completes the follow-through it implies
+and never reverts their lines. Two dead ends never commit — the **sign-off
+gate** (`src/program.ts`, an edge like the review window) refuses a step that
+leaves a box unticked with no comment, and a deleted `.gtd/REVIEW.md`.
 
 Steering-file formats
 (`.gtd/TODO.md`/`.gtd/REQUIREMENTS.md`/`.gtd/ARCHITECTURE.md` open questions,
@@ -362,21 +369,21 @@ machine: the producing agent self-validates with `gtd validate` before finishing
 **Entry + shared states** (the simple flow and the tail all three entries
 share):
 
-| State               | Actor | Content | `on`                                                                                                          | Retry              | Model   | Memory   | File / Mode                  |
-| ------------------- | ----- | ------- | ------------------------------------------------------------------------------------------------------------- | ------------------ | ------- | -------- | ---------------------------- |
-| `idle` (initial)    | human | message | `* .gtd/REQUIREMENTS.md` → `adv-grilling`; `* **` → `grilling`                                                | —                  | —       | —        | —                            |
-| `grilling`          | agent | prompt  | `* **` → `grilling-answer`                                                                                    | —                  | `smart` | `plan`   | `vars.todoFile` / `qa`       |
-| `grilling-answer`   | human | message | `C` → `building`; `* **` → `grilling`                                                                         | —                  | —       | —        | `vars.todoFile` / `qa`       |
-| `building`          | agent | prompt  | `* **` → `checking`                                                                                           | —                  | `base`  | `build`  | `vars.todoFile` / `qa`       |
-| `checking`          | check | script  | `A`/`M .gtd/FEEDBACK.md` → `fixing`; `D .gtd/FEEDBACK.md` → `reviewing`; `C` → `reviewing`                    | —                  | —       | —        | —                            |
-| `fixing`            | agent | prompt  | `* **` → `checking`                                                                                           | max 3 → `escalate` | `base`  | `fix`    | `vars.feedbackFile`          |
-| `escalate`          | human | message | `* **` → `checking`                                                                                           | —                  | —       | —        | `vars.feedbackFile`          |
-| `reviewing`         | agent | prompt  | `* **` → `await-review`                                                                                       | —                  | `smart` | `review` | `vars.reviewFile` / `review` |
-| `await-review`      | human | message | `D .gtd/REVIEW.md` → `squashing`; `M .gtd/REVIEW.md` → `review-deciding`; `* **` → `checking`                 | —                  | —       | —        | `vars.reviewFile` / `review` |
-| `review-deciding`   | check | script  | `A`/`M .gtd/REVIEW_FEEDBACK.md` → `feedback-building`; `D .gtd/REVIEW.md` → `squashing`; `C` → `await-review` | —                  | —       | —        | `vars.reviewFile` / `review` |
-| `feedback-building` | agent | prompt  | `* **` → `checking`                                                                                           | —                  | `base`  | `build`  | `vars.reviewFeedbackFile`    |
-| `squashing`         | agent | prompt  | `A`/`M .gtd/COMMIT_MSG.md` → `done`                                                                           | —                  | `base`  | `build`  | `vars.commitMsgFile`         |
-| `done`              | —     | commit  | — (commit state: squash ends the process)                                                                     | —                  | —       | —        | —                            |
+| State               | Actor | Content | `on`                                                                                                           | Retry              | Model   | Memory   | File / Mode                  |
+| ------------------- | ----- | ------- | -------------------------------------------------------------------------------------------------------------- | ------------------ | ------- | -------- | ---------------------------- |
+| `idle` (initial)    | human | message | `* .gtd/REQUIREMENTS.md` → `adv-grilling`; `* **` → `grilling`                                                 | —                  | —       | —        | —                            |
+| `grilling`          | agent | prompt  | `* **` → `grilling-answer`                                                                                     | —                  | `smart` | `plan`   | `vars.todoFile` / `qa`       |
+| `grilling-answer`   | human | message | `C` → `building`; `* **` → `grilling`                                                                          | —                  | —       | —        | `vars.todoFile` / `qa`       |
+| `building`          | agent | prompt  | `* **` → `checking`                                                                                            | —                  | `base`  | `build`  | `vars.todoFile` / `qa`       |
+| `checking`          | check | script  | `A`/`M .gtd/FEEDBACK.md` → `fixing`; `D .gtd/FEEDBACK.md` → `reviewing`; `C` → `reviewing`                     | —                  | —       | —        | —                            |
+| `fixing`            | agent | prompt  | `* **` → `checking`                                                                                            | max 3 → `escalate` | `base`  | `fix`    | `vars.feedbackFile`          |
+| `escalate`          | human | message | `* **` → `checking`                                                                                            | —                  | —       | —        | `vars.feedbackFile`          |
+| `reviewing`         | agent | prompt  | `* **` → `await-review`                                                                                        | —                  | `smart` | `review` | `vars.reviewFile` / `review` |
+| `await-review`      | human | message | `* **` → `review-deciding` (+ edge sign-off gate: refuses a deleted `REVIEW.md` / an unticked-no-comment step) | —                  | —       | —        | `vars.reviewFile` / `review` |
+| `review-deciding`   | check | script  | `A`/`M .gtd/REVIEW_FEEDBACK.md` → `feedback-building`; `D .gtd/REVIEW.md` → `squashing`                        | —                  | —       | —        | `vars.reviewFile` / `review` |
+| `feedback-building` | agent | prompt  | `* **` → `checking`                                                                                            | —                  | `base`  | `build`  | `vars.reviewFeedbackFile`    |
+| `squashing`         | agent | prompt  | `A`/`M .gtd/COMMIT_MSG.md` → `done`                                                                            | —                  | `base`  | `build`  | `vars.commitMsgFile`         |
+| `done`              | —     | commit  | — (commit state: squash ends the process)                                                                      | —                  | —       | —        | —                            |
 
 `await-review` declares **`reviewWindow: true`** and `review-deciding`
 **`reviewBase: true`** (§11); `reviewing` declares **`reviewEntry: true`**.
@@ -430,21 +437,34 @@ to the `escalate` human gate.
 **Review — REVIEW.md checkboxes.** `reviewing` (agent, `plannerModel`) writes
 `.gtd/REVIEW.md` grouping the diff into reviewable chunks in the exact
 checkbox-pointer format `src/ReviewDoc.ts` defines, self-validates it, and steps
-to `await-review`. There a human ticks a `- [ ]` to `- [x]` to sign off an item.
-Deleting `.gtd/REVIEW.md` outright is the power-user full-sign-off shortcut
-(`D .gtd/REVIEW.md` → `squashing`). Any other `M .gtd/REVIEW.md` step routes to
-`review-deciding` (declared **before** the catch-all, so a step that also
-touches code still goes to the decider); a code-only edit that leaves
-`.gtd/REVIEW.md` untouched goes to `checking` to re-test and re-review the
-manual fix. `review-deciding` is deterministic: if no unticked `- [ ]` remains,
-it removes `.gtd/REVIEW.md` (`D .gtd/REVIEW.md` → `squashing`); otherwise it
-extracts the still-unticked pointers (with their notes) into
-`.gtd/REVIEW_FEEDBACK.md` and removes `.gtd/REVIEW.md` — the
+to `await-review`. There a human ticks a `- [ ]` to `- [x]` as they review each
+hunk — ticking records only "I read this", it is not sign-off. What asks for
+changes is a **comment**: a note left on a `.gtd/REVIEW.md` line, or a direct
+code edit. Every human step routes to `review-deciding` (`* **`);
+`review-deciding` is deterministic and decides from the step's content. It is a
+**feedback** round when the human left a comment — a change to `.gtd/REVIEW.md`
+beyond a `[ ]`→`[x]` tick (detected by comparing the reviewer's copy against the
+agent's original, `HEAD^`, with checkbox state normalized away), OR a hand-edit
+to any non-`.gtd/` file this round (its own commit's file list). It then writes
+those into `.gtd/REVIEW_FEEDBACK.md` and removes `.gtd/REVIEW.md` — the
 `A`/`M .gtd/REVIEW_FEEDBACK.md` row is declared **first** so a feedback round
-wins over the sign-off pattern. `feedback-building` implements exactly those
-items (no Q&A), deletes the feedback file, and re-enters `checking` →
-`reviewing`, which regenerates a review scoped to just the changes since the
-last round (§11).
+wins over the sign-off pattern. Otherwise (every box ticked, no note, no code)
+it just removes `.gtd/REVIEW.md` (`D .gtd/REVIEW.md` → `squashing`).
+`feedback-building` implements exactly those items (no Q&A) — completing the
+follow-through any hand-edited code implies and never reverting the reviewer's
+own lines — deletes the feedback file, and re-enters `checking` → `reviewing`,
+which regenerates a review scoped to just the changes since the last round
+(§11).
+
+Two content-shaped dead ends a file-pattern edge can't tell apart never commit:
+the **sign-off gate** (`enforceReviewSignoffGate` in `src/program.ts` — an edge
+like the review window, invisible to the pure engine, keyed on the resting
+state's `reviewWindow: true` + `mode: review`) inspects the pending step BEFORE
+it commits and refuses a **deleted** `.gtd/REVIEW.md` (ticking is the sign-off
+gesture now, not deletion) and an **unfinished** review (only tick-flips, a box
+still `- [ ]`, and no comment of any kind — committing it would corrupt the
+incremental review base, so the reviewer is told to finish first and the window
+stays open).
 
 **The squash finale.** A full sign-off reaches `squashing` (agent), which writes
 `.gtd/COMMIT_MSG.md` with one conventional-commits message; entering the `done`
@@ -569,8 +589,10 @@ bracketing every state subcommand (`step`/`next`/`status`):
   base — and why a reviewer's own edits, made while the window was open, land as
   the resting state's ordinary pending changes and are captured by its `on`
   patterns like any other diff (in the unified template, a code edit at
-  `await-review` routes to `checking` to re-test and re-review; deleting
-  `.gtd/REVIEW.md` signs off into the squash finale).
+  `await-review` is feedback — it routes through `review-deciding` into a
+  build + re-review round; ticking every box with no comment signs off into the
+  squash finale, while a deleted `.gtd/REVIEW.md` is refused by the sign-off
+  gate — see §10).
 - **Re-arm last.** After the subcommand finishes — on success, on refusal, and
   after read-only commands too — gtd re-opens the window if the resolved rest
   declares `reviewWindow: true`. Every command participates, so the editor's

--- a/src/Edge.test.ts
+++ b/src/Edge.test.ts
@@ -36,6 +36,7 @@ const notImplemented = (name: string) => () =>
 /** A `GitOperations` stub with every method failing by default — tests override just what they exercise, so an unexpected call fails loudly instead of silently succeeding. */
 const stubGit = (overrides: Partial<GitOperations>): GitOperations => ({
   diffHead: notImplemented("diffHead"),
+  readFileAtRef: notImplemented("readFileAtRef"),
   lastCommitSubject: notImplemented("lastCommitSubject"),
   hasCommits: notImplemented("hasCommits"),
   diffRef: notImplemented("diffRef"),

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -62,6 +62,13 @@ export interface GitReaderOperations {
     exclude?: ReadonlyArray<string>,
   ) => Effect.Effect<string, Error>
   /**
+   * `git show <ref>:<path>` — the verbatim contents of `path` as it stood at
+   * `ref`. Fails when the path does not exist at that ref (callers that expect
+   * an absent file — e.g. the review sign-off gate comparing a reviewer's edit
+   * against the agent's original — handle it with an explicit `catchAll`).
+   */
+  readonly readFileAtRef: (ref: string, path: string) => Effect.Effect<string, Error>
+  /**
    * The pending working-tree changes vs HEAD, as `{path, status}` pairs —
    * tracked modifications (`git diff --name-status HEAD`) unioned with
    * untracked files (reported as `status: "A"`), deduplicated by path. Same
@@ -344,6 +351,8 @@ const makeGitImpl = (executor: CommandExecutor.CommandExecutor, root: string): G
 
         return renderDiff(files)
       }),
+
+    readFileAtRef: (ref: string, path: string) => exec("git", "show", `${ref}:${path}`),
 
     commitDiff: (hash: string, exclude: ReadonlyArray<string> = []) =>
       Effect.gen(function* () {

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -26,6 +26,7 @@ const failingGitLayer = Layer.succeed(GitService, {
   lastCommitSubject: () =>
     Effect.fail(new Error("GitService must not be called for --version/--help")),
   resolveRef: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
+  readFileAtRef: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   readRefOption: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   isAncestor: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   topLevel: () => Effect.fail(new Error("GitService must not be called for --version/--help")),

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -16,7 +16,7 @@ import { EnvVars } from "./EnvVars.js"
 import { GitService } from "./Git.js"
 import { WorktreeReader } from "./WorktreeReader.js"
 import { compileTemplate, renderInitConfig } from "./workflows/templates.js"
-import { cliErrorLine, makeProgram } from "./program.js"
+import { classifyReviewSignoff, cliErrorLine, makeProgram } from "./program.js"
 import { InMemRepo } from "../tests/integration/support/inmem/Repo.js"
 import { inMemoryLayers } from "../tests/integration/support/inmem/layers.js"
 
@@ -407,5 +407,62 @@ describe("cliErrorLine", () => {
 
   it("stringifies a non-Error and prefixes it", () => {
     expect(cliErrorLine("boom")).toBe("gtd: boom")
+  })
+})
+
+describe("classifyReviewSignoff", () => {
+  const base = {
+    file: ".gtd/REVIEW.md",
+    stateName: "await-review",
+    invoker: "human",
+    reviewDocDeleted: false,
+    hasCodeChange: false,
+  }
+  const twoUnticked = "## C\n- [ ] ./a.ts#1\n- [ ] ./b.ts#1\n"
+  const allTicked = "## C\n- [x] ./a.ts#1\n- [x] ./b.ts#1\n"
+
+  it("refuses a deleted review doc", () => {
+    const v = classifyReviewSignoff({
+      ...base,
+      reviewDocDeleted: true,
+      original: twoUnticked,
+      current: "",
+    })
+    expect(v.kind).toBe("refuse")
+    if (v.kind === "refuse") expect(v.reason).toContain("was deleted")
+  })
+
+  it("allows a code edit (a comment) even with boxes unticked", () => {
+    const v = classifyReviewSignoff({
+      ...base,
+      hasCodeChange: true,
+      original: twoUnticked,
+      current: twoUnticked,
+    })
+    expect(v).toEqual({ kind: "allow" })
+  })
+
+  it("allows a note — the doc differs beyond a tick — even with a box left unticked", () => {
+    const v = classifyReviewSignoff({
+      ...base,
+      original: twoUnticked,
+      current: "## C\n- [x] ./a.ts#1\n- [ ] ./b.ts#1 — please rename\n",
+    })
+    expect(v).toEqual({ kind: "allow" })
+  })
+
+  it("allows a clean sign-off: every box ticked, no note, no code", () => {
+    const v = classifyReviewSignoff({ ...base, original: twoUnticked, current: allTicked })
+    expect(v).toEqual({ kind: "allow" })
+  })
+
+  it("refuses an unfinished review: only tick-flips, a box still unticked, no comment", () => {
+    const v = classifyReviewSignoff({
+      ...base,
+      original: twoUnticked,
+      current: "## C\n- [x] ./a.ts#1\n- [ ] ./b.ts#1\n",
+    })
+    expect(v.kind).toBe("refuse")
+    if (v.kind === "refuse") expect(v.reason).toContain("1 review item(s) still unticked")
   })
 })

--- a/src/program.ts
+++ b/src/program.ts
@@ -38,6 +38,7 @@ import {
 } from "./SteeringMode.js"
 import {
   initialStateOf,
+  isReviewWindowState,
   matchesPattern,
   parsePattern,
   reviewEntryStateOf,
@@ -416,6 +417,9 @@ const stepAsActor = (
     // tidy, well-formed file. Invalid content refuses the step (see the helper,
     // which no-ops for a squash and when there is nothing to validate).
     yield* enforceSteeringGate(worktree.read, invoker, rest, context, decision.kind)
+    // Review sign-off gate (edge): refuse a deleted review doc or an unfinished
+    // review with no comment before either can commit (see the helper).
+    yield* enforceReviewSignoffGate(worktree.read, invoker, rest, context, changes, decision.kind)
     const outcome = yield* executeDecision(git, run, executable, context, cost, model)
     return {
       state: rest.state,
@@ -697,6 +701,81 @@ const enforceSteeringGate = (
         ),
       )
     }
+  })
+
+/** The `mode:` name of gtd's built-in REVIEW.md checkbox validator — the only mode the sign-off gate below understands. */
+const REVIEW_MODE = "review"
+
+/** Normalize every markdown checkbox to a single placeholder so a pure `[ ]`→`[x]` tick is invisible to a text comparison; any surviving difference is a human note. */
+const normalizeCheckboxes = (content: string): string => content.replace(/\[[ xX]\]/g, "[_]")
+
+/**
+ * The review sign-off gate (edge, not engine — like the review window it lives
+ * at `src/program.ts`, and the pure `PatternMachine.step` never sees it). At a
+ * review gate (a `reviewWindow: true` state with `mode: review`, i.e. the
+ * unified template's `await-review`), the ROUTING is uniform — every human step
+ * goes to `review-deciding`, which decides sign-off vs. feedback from the step's
+ * content. But two content-shaped dead ends a file-pattern edge can't
+ * distinguish must never commit, so this gate inspects the pending step BEFORE
+ * `executeDecision` and REFUSES them:
+ *
+ * - a DELETED review doc (`git status` shows it removed) — ticking is the
+ *   sign-off gesture now, not deletion; and
+ * - an UNFINISHED review — only checkbox flips, a box still `- [ ]`, and no
+ *   comment of any kind (no note in the doc, no code edit). Committing it would
+ *   corrupt the incremental review base (`review-deciding` is the `reviewBase`
+ *   anchor), so the reviewer is told to finish first — the window stays open.
+ *
+ * Everything else — a code edit, a real note (the doc differs beyond a tick), or
+ * a complete all-ticked no-comment sign-off — passes through to
+ * `review-deciding`. A no-op when the state is not a review gate, or the
+ * decision is a squash/no-op.
+ */
+const enforceReviewSignoffGate = (
+  worktreeRead: (path: string) => string,
+  invoker: string,
+  rest: ResolvedRest,
+  context: TemplateContext,
+  changes: readonly PendingChange[],
+  kind: ExecutableDecision["kind"],
+): Effect.Effect<void, Error, FileSystem.FileSystem | Cwd | GitService> =>
+  Effect.gen(function* () {
+    if (kind !== "commit") return
+    if (!isReviewWindowState(rest.def, rest.state) || rest.stateDef.mode !== REVIEW_MODE) return
+    const file = yield* renderFile(rest.stateDef, context)
+    if (file === undefined) return
+
+    // Deleting the review doc is no longer a sign-off gesture — refuse it.
+    if (changes.some((c) => c.path === file && c.status === "D")) {
+      return yield* Effect.fail(
+        new Error(
+          `gtd step ${invoker}: ${file} was deleted at "${rest.state}" — restore it and tick the boxes to sign off, or leave a note (or edit code) to request changes.`,
+        ),
+      )
+    }
+    // Any code edit is a comment (the reviewer's own fix) — a feedback round.
+    if (changes.some((c) => !c.path.startsWith(".gtd/"))) return
+    // A note is any edit to the review doc beyond a checkbox flip — a feedback
+    // round. Compare the agent's committed original (HEAD) against the working
+    // copy with checkbox state normalized away.
+    const git = yield* GitService
+    const original = yield* git
+      .readFileAtRef("HEAD", file)
+      .pipe(Effect.catchAll(() => Effect.succeed("")))
+    const current = yield* Effect.try(() => worktreeRead(file)).pipe(
+      Effect.catchAll(() => Effect.succeed("")),
+    )
+    if (normalizeCheckboxes(original) !== normalizeCheckboxes(current)) return
+    // Only checkbox flips, no comment: a sign-off needs EVERY box ticked.
+    const unticked = current.match(/^[ \t]*-[ \t]*\[[ \t]*\]/gm)
+    if (unticked !== null && unticked.length > 0) {
+      return yield* Effect.fail(
+        new Error(
+          `gtd step ${invoker}: ${unticked.length} review item(s) still unticked and no comment at "${rest.state}" — finish reviewing (tick every box), or leave a note (or edit code) to request a change.`,
+        ),
+      )
+    }
+    // Every box ticked, no note, no code: a clean sign-off — allow it through.
   })
 
 /**

--- a/src/program.ts
+++ b/src/program.ts
@@ -709,6 +709,54 @@ const REVIEW_MODE = "review"
 /** Normalize every markdown checkbox to a single placeholder so a pure `[ ]`→`[x]` tick is invisible to a text comparison; any surviving difference is a human note. */
 const normalizeCheckboxes = (content: string): string => content.replace(/\[[ xX]\]/g, "[_]")
 
+/** The verdict of the pure `classifyReviewSignoff` — `allow` lets the step commit, `refuse` fails it with `reason`. */
+export type ReviewSignoffVerdict =
+  | { readonly kind: "allow" }
+  | { readonly kind: "refuse"; readonly reason: string }
+
+/**
+ * The PURE core of the review sign-off gate (see `enforceReviewSignoffGate`).
+ * Given the agent's `original` review doc, the reviewer's `current` copy,
+ * whether a non-`.gtd/` file changed this step (`hasCodeChange`), and whether
+ * the doc was deleted (`reviewDocDeleted`), decide whether the step may commit.
+ * A comment — a code edit, or a note (the doc differs beyond a `[ ]`→`[x]` tick)
+ * — is always allowed (it becomes a feedback round). Two dead ends refuse: a
+ * deleted doc, and an all-tick-flip step that still leaves a box unticked with
+ * no comment (an unfinished review). Kept separate from the Effect so it is
+ * directly unit-tested (see program.test.ts).
+ */
+export const classifyReviewSignoff = (input: {
+  readonly file: string
+  readonly stateName: string
+  readonly invoker: string
+  readonly reviewDocDeleted: boolean
+  readonly hasCodeChange: boolean
+  readonly original: string
+  readonly current: string
+}): ReviewSignoffVerdict => {
+  if (input.reviewDocDeleted) {
+    return {
+      kind: "refuse",
+      reason: `gtd step ${input.invoker}: ${input.file} was deleted at "${input.stateName}" — restore it and tick the boxes to sign off, or leave a note (or edit code) to request changes.`,
+    }
+  }
+  // A comment — a code edit, or a note (doc differs beyond a checkbox flip) — is
+  // a feedback round; let it commit.
+  if (input.hasCodeChange) return { kind: "allow" }
+  if (normalizeCheckboxes(input.original) !== normalizeCheckboxes(input.current)) {
+    return { kind: "allow" }
+  }
+  // Only checkbox flips, no comment: a sign-off needs EVERY box ticked.
+  const unticked = input.current.match(/^[ \t]*-[ \t]*\[[ \t]*\]/gm)?.length ?? 0
+  if (unticked > 0) {
+    return {
+      kind: "refuse",
+      reason: `gtd step ${input.invoker}: ${unticked} review item(s) still unticked and no comment at "${input.stateName}" — finish reviewing (tick every box), or leave a note (or edit code) to request a change.`,
+    }
+  }
+  return { kind: "allow" }
+}
+
 /**
  * The review sign-off gate (edge, not engine — like the review window it lives
  * at `src/program.ts`, and the pure `PatternMachine.step` never sees it). At a
@@ -716,20 +764,10 @@ const normalizeCheckboxes = (content: string): string => content.replace(/\[[ xX
  * unified template's `await-review`), the ROUTING is uniform — every human step
  * goes to `review-deciding`, which decides sign-off vs. feedback from the step's
  * content. But two content-shaped dead ends a file-pattern edge can't
- * distinguish must never commit, so this gate inspects the pending step BEFORE
- * `executeDecision` and REFUSES them:
- *
- * - a DELETED review doc (`git status` shows it removed) — ticking is the
- *   sign-off gesture now, not deletion; and
- * - an UNFINISHED review — only checkbox flips, a box still `- [ ]`, and no
- *   comment of any kind (no note in the doc, no code edit). Committing it would
- *   corrupt the incremental review base (`review-deciding` is the `reviewBase`
- *   anchor), so the reviewer is told to finish first — the window stays open.
- *
- * Everything else — a code edit, a real note (the doc differs beyond a tick), or
- * a complete all-ticked no-comment sign-off — passes through to
- * `review-deciding`. A no-op when the state is not a review gate, or the
- * decision is a squash/no-op.
+ * distinguish must never commit, so this gate gathers the step's shape and hands
+ * it to the pure `classifyReviewSignoff` BEFORE `executeDecision`, failing on a
+ * `refuse` verdict. A no-op when the state is not a review gate, or the decision
+ * is a squash/no-op.
  */
 const enforceReviewSignoffGate = (
   worktreeRead: (path: string) => string,
@@ -745,19 +783,6 @@ const enforceReviewSignoffGate = (
     const file = yield* renderFile(rest.stateDef, context)
     if (file === undefined) return
 
-    // Deleting the review doc is no longer a sign-off gesture — refuse it.
-    if (changes.some((c) => c.path === file && c.status === "D")) {
-      return yield* Effect.fail(
-        new Error(
-          `gtd step ${invoker}: ${file} was deleted at "${rest.state}" — restore it and tick the boxes to sign off, or leave a note (or edit code) to request changes.`,
-        ),
-      )
-    }
-    // Any code edit is a comment (the reviewer's own fix) — a feedback round.
-    if (changes.some((c) => !c.path.startsWith(".gtd/"))) return
-    // A note is any edit to the review doc beyond a checkbox flip — a feedback
-    // round. Compare the agent's committed original (HEAD) against the working
-    // copy with checkbox state normalized away.
     const git = yield* GitService
     const original = yield* git
       .readFileAtRef("HEAD", file)
@@ -765,17 +790,16 @@ const enforceReviewSignoffGate = (
     const current = yield* Effect.try(() => worktreeRead(file)).pipe(
       Effect.catchAll(() => Effect.succeed("")),
     )
-    if (normalizeCheckboxes(original) !== normalizeCheckboxes(current)) return
-    // Only checkbox flips, no comment: a sign-off needs EVERY box ticked.
-    const unticked = current.match(/^[ \t]*-[ \t]*\[[ \t]*\]/gm)
-    if (unticked !== null && unticked.length > 0) {
-      return yield* Effect.fail(
-        new Error(
-          `gtd step ${invoker}: ${unticked.length} review item(s) still unticked and no comment at "${rest.state}" — finish reviewing (tick every box), or leave a note (or edit code) to request a change.`,
-        ),
-      )
-    }
-    // Every box ticked, no note, no code: a clean sign-off — allow it through.
+    const verdict = classifyReviewSignoff({
+      file,
+      stateName: rest.state,
+      invoker,
+      reviewDocDeleted: changes.some((c) => c.path === file && c.status === "D"),
+      hasCodeChange: changes.some((c) => !c.path.startsWith(".gtd/")),
+      original,
+      current,
+    })
+    if (verdict.kind === "refuse") return yield* Effect.fail(new Error(verdict.reason))
   })
 
 /**

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -26,18 +26,27 @@
 # A third entry, `gtd review <commitish>`, jumps straight to `reviewing`
 # (reviewEntry) to review a foreign branch through the same shared tail.
 #
-# All three converge at `reviewing` -> `await-review`. From there:
-#   * full sign-off (tick every box, or delete REVIEW.md) -> squashing -> done
-#     (the ONLY path to the finale — the whole cycle collapses into one commit).
-#   * partial sign-off / notes -> review-deciding extracts the unticked items
-#     into REVIEW_FEEDBACK.md -> feedback-building implements them -> checking
-#     -> reviewing regenerates an INCREMENTAL REVIEW.md (review-deciding carries
-#     `reviewBase: true`, so each feedback round's review + checkout window
-#     covers only `last-review..HEAD`) -> await-review, looping until sign-off.
-#   * a code-only human edit (REVIEW.md untouched) -> checking -> reviewing.
+# All three converge at `reviewing` -> `await-review`. Ticking a REVIEW.md box
+# means only "I reviewed this hunk"; a COMMENT (not an unticked box) is what asks
+# for changes. Every human step at `await-review` goes to `review-deciding`,
+# which inspects the step and routes:
+#   * no comment (every box ticked, no REVIEW.md note, no code edit) -> the diff
+#     is a bare REVIEW.md deletion -> squashing -> done (the ONLY path to the
+#     finale — the whole cycle collapses into one commit).
+#   * any comment — a note in REVIEW.md OR a hand-edit to code — ->
+#     review-deciding writes REVIEW_FEEDBACK.md -> feedback-building implements
+#     it (completing any code the human hand-edited, never reverting their
+#     lines) -> checking -> reviewing regenerates an INCREMENTAL REVIEW.md
+#     (review-deciding carries `reviewBase: true`, so each feedback round's
+#     review + checkout window covers only `last-review..HEAD`, i.e. the agent's
+#     follow-through, not the human's own edit) -> await-review, looping until
+#     sign-off.
+# Two dead ends never commit: the sign-off gate (src/program.ts) REFUSES a step
+# that leaves a box unticked with no comment (finish reviewing first) and a
+# deleted REVIEW.md (restore it and tick the boxes).
 #
 # The shared health segment (`checking`/`fixing`/`escalate`) serves the simple
-# build, the feedback loop, and code-only edits — its green edge targets
+# build and the feedback loop — its green edge targets
 # `reviewing`. The advanced per-package loop keeps its OWN health triple
 # (`adv-checking`/`adv-fixing`/`adv-escalate`) because its green edge targets
 # the per-package `spec-review` gate instead.
@@ -668,33 +677,36 @@ states:
     # so a feedback round shows only `last-review..HEAD` — or the process start
     # on the first review) with the working tree untouched, surfacing the diff
     # as ordinary uncommitted changes. It closes on the next invocation.
+    #
+    # Every human step here routes to `review-deciding`, which decides sign-off
+    # vs. feedback from the step's CONTENT (a comment, not a tick). Ticking a box
+    # only records "I reviewed this hunk". Two dead ends can't be told apart by a
+    # file-pattern edge, so the sign-off gate (`enforceReviewSignoffGate` in
+    # src/program.ts) catches them BEFORE the step commits and refuses: an
+    # unfinished review (a box still `- [ ]` with no comment) and a deleted
+    # REVIEW.md.
     reviewWindow: true
     message: |
       `<%= it.vars.reviewFile %>` holds the review record for the cycle — one
-      `- [ ]` checkbox per reviewable item, grouped into chunks.
+      `- [ ]` checkbox per reviewable item, grouped into chunks. Tick a box
+      (`- [x]`) as you review each hunk; ticking only records that you've read
+      it, it is not sign-off.
 
-      What each change does next (then run `gtd step human`):
-      <% it.edges.forEach(function (e) { if (e.describe) { %>
-      <%~ "- " + e.describe + "\n" %>
-      <% } }) %>
+      When you've been through the whole diff, run `gtd step human`:
+
+      - Tick EVERY box and leave no comment — no note in
+        `<%= it.vars.reviewFile %>`, no code edit — to sign off and collapse the
+        cycle into one commit (**squashing**).
+      - Leave a comment to request changes — a note on a
+        `<%= it.vars.reviewFile %>` line, or a direct code edit — to send it to a
+        build + re-review round (**review-deciding** → **feedback-building**). A
+        code edit counts as your own fix: the agent completes the follow-through
+        it implies and never reverts your lines.
+
+      Stepping with a box still unticked and no comment is refused (finish
+      reviewing first); so is deleting `<%= it.vars.reviewFile %>`.
     on:
-      "D .gtd/REVIEW.md":
-        to: squashing
-        describe: >-
-          Delete `.gtd/REVIEW.md` outright to sign off on the whole cycle at
-          once and collapse it into one commit (**squashing**).
-      "M .gtd/REVIEW.md":
-        to: review-deciding
-        describe: >-
-          Edit `.gtd/REVIEW.md` — tick a `- [ ]` box to `- [x]` to sign off that
-          item, or add notes — to hand it to a deterministic check
-          (**review-deciding**) that squashes when every box is ticked, or sends
-          the still-unticked items back for another build+review round.
-      "* **":
-        to: checking
-        describe: >-
-          Change only code, leaving `.gtd/REVIEW.md` untouched, to re-run the
-          tests on your manual fix and re-review it (**checking**).
+      "* **": review-deciding
 
   review-deciding:
     actor: check
@@ -707,26 +719,55 @@ states:
     reviewBase: true
     script: |
       #!/usr/bin/env bash
-      # gtd check turn — if REVIEW.md still has any unticked "- [ ]" pointer,
-      # extract those pointers (with their notes) into REVIEW_FEEDBACK.md;
-      # either way, remove REVIEW.md. What the resulting diff MEANS (feedback
-      # round vs. full sign-off) is decided by this state's own `on` rules. The
-      # A/M REVIEW_FEEDBACK.md rows are declared BEFORE the D REVIEW.md row so a
-      # feedback round — which always also deletes REVIEW.md — is captured as
-      # feedback, not mistaken for a sign-off.
+      # gtd check turn — decide the human's review step from its CONTENT. HEAD is
+      # the human's `await-review -> review-deciding` commit; HEAD^ is the
+      # `reviewing` commit that wrote the agent's original REVIEW.md (the sign-off
+      # gate refuses an incomplete step, so review-deciding is entered exactly
+      # once per round — nothing commits in between). It is FEEDBACK when the
+      # human left a comment: a note in REVIEW.md (any edit beyond a "[ ]"->"[x]"
+      # tick) OR a hand-edit to any non-.gtd/ file this round. Otherwise it is a
+      # clean sign-off. Either way, remove REVIEW.md; what the resulting diff
+      # MEANS is decided by this state's own `on` rules — the A/M
+      # REVIEW_FEEDBACK.md rows are declared BEFORE the D REVIEW.md row so a
+      # feedback round (which also deletes REVIEW.md) is captured as feedback,
+      # not mistaken for a sign-off.
       set +e
       mkdir -p .gtd
-      # Hoist the review paths once, at the TOP: Eta's autoTrim eats the
-      # newline after an interpolation tag, so no tag may be the last token on a
-      # line — it would glue the next line onto it and break the script. Below
-      # this point everything is plain bash.
+      # Hoist the paths once, at the TOP: Eta's autoTrim eats the newline after
+      # an interpolation tag, so no tag may be the last token on a line — it
+      # would glue the next line onto it and break the script. Below this point
+      # everything is plain bash.
       reviewFile="<%~ it.vars.reviewFile %>"
       reviewFeedbackFile="<%~ it.vars.reviewFeedbackFile %>"
-      if grep -qE '^[[:space:]]*-[[:space:]]*\[[[:space:]]*\]' "$reviewFile" 2>/dev/null; then
+      # Which non-.gtd/ files did the human hand-edit this round?
+      codeFiles=$(git diff-tree --no-commit-id --name-only -r HEAD | grep -v '^\.gtd/')
+      # A note is any REVIEW.md change beyond a checkbox flip: normalize every
+      # "[ ]"/"[x]" to a placeholder, then compare the agent's original (HEAD^)
+      # against the human's version (HEAD).
+      notes=""
+      before=$(git show "HEAD^:$reviewFile" 2>/dev/null | sed -E 's/\[[ xX]\]/[_]/g')
+      after=$(git show "HEAD:$reviewFile" 2>/dev/null | sed -E 's/\[[ xX]\]/[_]/g')
+      if [ "$before" != "$after" ]; then notes=1; fi
+      if [ -n "$codeFiles" ] || [ -n "$notes" ]; then
         {
-          echo "Feedback from review — address these before continuing:"
-          echo
-          grep -E '^[[:space:]]*-[[:space:]]*\[[[:space:]]*\]' "$reviewFile"
+          echo "Review feedback to address, then delete this file. The human reviewed the diff and asked for the changes below."
+          echo "Build on their own edits: complete only the follow-through each change implies (callers, tests, types, docs). Treat any lines the human wrote as final — never revert or rewrite them."
+          if [ -n "$notes" ]; then
+            echo
+            echo "## Notes left in the review (ticked items are approved — act on the notes)"
+            echo
+            echo '```diff'
+            git show HEAD --format= -- "$reviewFile"
+            echo '```'
+          fi
+          if [ -n "$codeFiles" ]; then
+            echo
+            echo "## Code the human hand-edited this round — already committed, build on top"
+            echo
+            echo '```diff'
+            git show HEAD --format= -- $codeFiles
+            echo '```'
+          fi
         } > "$reviewFeedbackFile"
       fi
       rm -f "$reviewFile"
@@ -734,7 +775,6 @@ states:
       "A .gtd/REVIEW_FEEDBACK.md": feedback-building
       "M .gtd/REVIEW_FEEDBACK.md": feedback-building
       "D .gtd/REVIEW.md": squashing
-      "C": await-review
 
   feedback-building:
     actor: agent
@@ -750,8 +790,12 @@ states:
       The review feedback to address is: <%~ it.read(it.vars.reviewFeedbackFile) %>
 
       Implement exactly those changes — no Q&A, no re-planning. Use TDD
-      discipline. Delete `<%= it.vars.reviewFeedbackFile %>` once every item is
-      addressed. Leave everything else uncommitted and finish your turn.
+      discipline. When the feedback includes code the human hand-edited this
+      round, that edit is ALREADY committed: treat their lines as final, build ON
+      TOP of them to complete only the follow-through they imply (callers, tests,
+      types, docs), and never revert or rewrite what they changed. Delete
+      `<%= it.vars.reviewFeedbackFile %>` once every item is addressed. Leave
+      everything else uncommitted and finish your turn.
     on:
       "* **": checking
 

--- a/tests/integration/features/default-workflow.feature
+++ b/tests/integration/features/default-workflow.feature
@@ -5,9 +5,11 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
   (started by creating `.gtd/TODO.md`) through the SHARED tail: the
   grilling/answer planning loop, a check/fix round, the fix-retry-escalate path
   once `fixing`'s cap (max 3) is reached, the human review gate and its
-  `review-deciding` arbiter (partial-tick feedback vs. full sign-off), the
-  delete-shortcut sign-off, and the SQUASH finale (`squashing` → `done`) that
-  every entry point shares — the only path to which is full sign-off.
+  `review-deciding` arbiter (a COMMENT — a note or a code edit — is feedback; an
+  all-ticked no-comment step is sign-off), the sign-off gate's refusals (an
+  unfinished review, a deleted REVIEW.md), and the SQUASH finale (`squashing` →
+  `done`) that every entry point shares — the only path to which is full
+  sign-off.
 
   Steering-file formats (TODO.md open questions, REVIEW.md checkboxes) are not
   validated by an in-machine state — the producing agent self-validates via
@@ -97,8 +99,9 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
     Then it succeeds
     And stdout contains "State: await-review"
 
-    # await-review: partial-tick feedback — a note without ticking the box
-    # routes to the decider (not the catch-all)
+    # await-review: a COMMENT is feedback — here a note added to the line (the
+    # box may be ticked or not; the note is the signal). Every human step routes
+    # to the decider.
     Given ".gtd/REVIEW.md" is modified to:
       """
       # Review: abc1234
@@ -106,20 +109,22 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
 
       ## Add thing.ts
 
-      - [ ] ./src/thing.ts#1 — new export — also add a doc comment
+      - [x] ./src/thing.ts#1 — new export — also add a doc comment
       """
     When I run gtd step human
     Then it succeeds
     And the last commit subject is "gtd(human): await-review → review-deciding"
 
-    # review-deciding: extracts the unticked pointer into REVIEW_FEEDBACK.md,
-    # removes REVIEW.md — the A/M REVIEW_FEEDBACK.md row is declared before the
-    # D REVIEW.md row so a feedback round wins
+    # review-deciding: the note is a change to REVIEW.md beyond a tick, so it
+    # writes REVIEW_FEEDBACK.md and removes REVIEW.md — the A/M REVIEW_FEEDBACK.md
+    # row is declared before the D REVIEW.md row so a feedback round wins
     Given a file ".gtd/REVIEW_FEEDBACK.md" with:
       """
-      Feedback from review — address these before continuing:
+      Review feedback to address, then delete this file.
 
-      - [ ] ./src/thing.ts#1 — new export — also add a doc comment
+      ## Notes left in the review (ticked items are approved — act on the notes)
+
+      - [x] ./src/thing.ts#1 — new export — also add a doc comment
       """
     And the file ".gtd/REVIEW.md" is deleted
     When I run gtd step check
@@ -158,8 +163,8 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
     Then it succeeds
     And stdout contains "State: await-review"
 
-    # await-review: tick every box — the decider sees no unticked pointer and
-    # removes REVIEW.md, routing to the squash finale
+    # await-review: tick every box and leave no comment — the decider sees no
+    # note and no code edit, removes REVIEW.md, routing to the squash finale
     Given ".gtd/REVIEW.md" is modified to:
       """
       # Review: def5678
@@ -293,7 +298,7 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
     Then it succeeds
     And the last commit subject is "gtd(check): checking → escalate"
 
-  Scenario: deleting REVIEW.md outright at await-review is the power-user sign-off shortcut, routing straight to the squash finale
+  Scenario: deleting REVIEW.md at await-review is refused — sign off by ticking every box, not by deleting
     Given a test project
     And the workflow
     And a commit "gtd(check): await-review" that adds ".gtd/REVIEW.md" with:
@@ -307,11 +312,43 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
       """
     Given the file ".gtd/REVIEW.md" is deleted
     When I run gtd step human
-    Then it succeeds
-    And the last commit subject is "gtd(human): await-review → squashing"
-    And ".gtd/REVIEW.md" does not exist
+    Then it fails
+    And stderr contains "was deleted"
+    # Nothing committed — the refusal re-arms the review window, so the cycle
+    # stays at the gate for the reviewer to restore + tick.
+    And the git ref "refs/gtd/review-head" exists
 
-  Scenario: at await-review, gtd next surfaces which change routes where — the human gate's route list, rendered from its `on` edge descriptions
+  Scenario: stepping at await-review with a box still unticked and no comment is refused — finish reviewing first
+    Given a test project
+    And the workflow
+    And a commit "gtd(check): await-review" that adds ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Chunk
+
+      - [ ] ./src/a.ts#1
+      - [ ] ./src/b.ts#1
+      """
+    # Tick only the first item, leave the second, add no note and no code edit.
+    Given ".gtd/REVIEW.md" is modified to:
+      """
+      # Review: abc1234
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Chunk
+
+      - [x] ./src/a.ts#1
+      - [ ] ./src/b.ts#1
+      """
+    When I run gtd step human
+    Then it fails
+    And stderr contains "still unticked and no comment"
+    # Nothing committed — the window re-arms, keeping the reviewer at the gate.
+    And the git ref "refs/gtd/review-head" exists
+
+  Scenario: at await-review, gtd next surfaces the sign-off vs. feedback contract in its human-gate message
     Given a test project
     And the workflow
     And a commit "gtd(check): await-review" that adds ".gtd/REVIEW.md" with:
@@ -325,11 +362,11 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
       """
     When I run gtd next
     Then it succeeds
-    And stdout contains "What each change does next (then run `gtd step human`):"
-    And stdout contains "- Delete `.gtd/REVIEW.md` outright to sign off on the whole cycle"
-    And stdout contains "- Change only code, leaving `.gtd/REVIEW.md` untouched"
+    And stdout contains "Tick EVERY box and leave no comment"
+    And stdout contains "Leave a comment to request changes"
+    And stdout contains "no comment is refused"
 
-  Scenario: a code-only edit at await-review (REVIEW.md untouched) re-runs the tests on the manual fix (checking)
+  Scenario: a code edit at await-review is feedback — it routes to review-deciding (which turns it into a fix + re-review round)
     Given a test project
     And the workflow
     And a commit "gtd(check): await-review" that adds ".gtd/REVIEW.md" with:
@@ -347,7 +384,7 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): await-review → checking"
+    And the last commit subject is "gtd(human): await-review → review-deciding"
 
   Scenario: an approved cycle's squash commit is a process boundary — a fresh cycle's fixing retry budget doesn't pool with a previous cycle's
     Given a test project

--- a/tests/integration/features/review-window.feature
+++ b/tests/integration/features/review-window.feature
@@ -61,17 +61,35 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
     And the git ref "refs/gtd/review-head" exists
     And the last commit subject is "chore: init gtd workflow"
 
-  Scenario: Deleting the review doc signs off — the window closes and routes to the squash finale
+  Scenario: Deleting the review doc is refused — the window stays open, nothing commits
     Given I run gtd next
     And the file ".gtd/REVIEW.md" is deleted
     When I run gtd step human
-    Then it succeeds
-    And the last commit subject is "gtd(human): await-review → squashing"
-    And the git ref "refs/gtd/review-head" does not exist
-    And the git ref "refs/gtd/review-base" does not exist
-    And ".gtd/REVIEW.md" does not exist
+    Then it fails
+    And stderr contains "was deleted"
+    # Nothing committed; the window re-arms so the reviewer can restore + tick.
+    And the git ref "refs/gtd/review-head" exists
+    And the last commit subject is "chore: init gtd workflow"
 
-  Scenario: Reviewer code edits close the window and route to a re-test + re-review
+  Scenario: Ticking every box with no comment signs off — the window closes and routes to review-deciding
+    Given I run gtd next
+    And ".gtd/REVIEW.md" is modified to:
+      """
+      # Review: abc1234
+
+      <!-- base: 0000000 -->
+
+      ## calc
+      - [x] ./src/calc.ts#1 — new add function
+      """
+    When I run gtd step human
+    Then it succeeds
+    # Every box ticked, no note, no code edit — a clean sign-off hands to the
+    # deterministic check, which collapses the cycle from there.
+    And the last commit subject is "gtd(human): await-review → review-deciding"
+    And the git ref "refs/gtd/review-head" does not exist
+
+  Scenario: Reviewer code edits are feedback — the window closes and routes to review-deciding
     Given I run gtd next
     And "src/calc.ts" is modified to:
       """
@@ -80,9 +98,9 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
       """
     When I run gtd step human
     Then it succeeds
-    # A code edit with REVIEW.md untouched re-runs the tests on the manual fix
-    # and re-reviews it (checking).
-    And the last commit subject is "gtd(human): await-review → checking"
+    # A code edit is a comment: it routes to the deterministic review check,
+    # which turns it into a build + re-review round.
+    And the last commit subject is "gtd(human): await-review → review-deciding"
     And the git ref "refs/gtd/review-head" does not exist
 
   Scenario: Read-only commands re-arm the window on their way out

--- a/tests/integration/support/inmem/layers.ts
+++ b/tests/integration/support/inmem/layers.ts
@@ -111,6 +111,13 @@ const makeGitReaderOps = (repo: InMemRepo): GitReaderOperations => ({
       : Effect.fail(new Error(`Cannot resolve ref: ${ref}`))
   },
 
+  readFileAtRef: (ref: string, path: string) => {
+    const content = repo.fileAtRef(ref, path)
+    return content !== null
+      ? Effect.succeed(content)
+      : Effect.fail(new Error(`path not found at ${ref}: ${path}`))
+  },
+
   readRefOption: (ref: string) => {
     const hash = repo.resolveRef(ref)
     return Effect.succeed(hash !== null ? Option.some(hash) : Option.none<string>())


### PR DESCRIPTION
## Problem

At the review gate, a developer's natural habit is to **tick every hunk as they read it**. Under the old rules, ticking a box *was* the sign-off gesture, so ticking everything (even while intending to request changes) collapsed the whole cycle into a squash and silently dropped the intent. This actually happened on a real branch.

## New semantics

Ticking now means only **"I reviewed this hunk."** What asks for changes is a **comment**:

| Human step at `await-review` | Outcome |
|---|---|
| every box `[x]`, no note, no code edit | **squash** (sign-off) |
| any note in `REVIEW.md` (beyond a tick) **or** any code edit | **feedback round** |
| a box still `[ ]` with no comment | **refused** — finish reviewing first (window stays open) |
| `REVIEW.md` deleted | **refused** — restore it and tick the boxes |

A hand-edited code change is treated as the reviewer's **own fix**: `feedback-building` completes the follow-through it implies (callers, tests, types, docs) and **never reverts their lines**. The incremental re-review covers only the agent's follow-through, not the reviewer's own edit (`review-deciding` stays the `reviewBase` anchor).

## How

- **`src/workflows/unified.yaml`** — `await-review` routes every step to `review-deciding`, which decides sign-off vs. feedback from the step's *content* (a note = any `REVIEW.md` change beyond a `[ ]`→`[x]` tick, compared against the agent's original with checkbox state normalized; code = any non-`.gtd/` file in the step's commit). `feedback-building` gets build-on-top / never-revert framing.
- **`src/program.ts`** — `enforceReviewSignoffGate`, a pre-commit edge gate (in the spirit of the review window / steering gate, invisible to the pure engine) that refuses the two content-shaped dead ends a file-pattern edge can't distinguish: a deleted `REVIEW.md`, and an unfinished review with no comment (committing which would corrupt the incremental review base).
- **`src/Git.ts`** — `readFileAtRef` primitive (`git show <ref>:<path>`) for the gate's note comparison.
- **Docs** — STATES.md §10/§11 and README updated.
- **Tests** — `default-workflow.feature` / `review-window.feature` now cover the sign-off, note-feedback, code-edit-feedback, and both refusal paths. The rewritten `review-deciding` bash script was verified against a real git repo (note / sign-off / code-edit cases).

Full suite (format, lint, unit, e2e) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)