### PR TITLE
feat(review): classify feedback into instructions before building

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,12 @@ which steering file you create:
 Both flows converge on the same tail: an agent hands you a `.gtd/REVIEW.md`
 checkbox review of the diff — tick a box as you review each hunk (ticking just
 records "I read this"), and leave a **comment** to request changes: a note on a
-line, or a direct code edit. Any comment sends a build + re-review round (a
-re-review covering only the follow-through, and a hand-edit is treated as your
-own fix the agent completes without reverting your lines); ticking every box
+line, an inline `// TODO`-style comment in the code, or a direct code edit. Any
+comment sends a build + re-review round — an agent first turns your comments
+into an explicit instruction list, then a build turn implements it (a re-review
+then covers only the follow-through, and a hand-edit is treated as your own fix
+the agent completes without reverting your lines; a comment can't be silently
+dropped — a build turn that addresses nothing is refused). Ticking every box
 with no comment is the sign-off, which collapses the whole cycle into one commit
 (a **squash finale** whose message an agent drafts). Stepping with a box still
 unticked and no comment is refused (finish reviewing first), as is deleting

--- a/STATES.md
+++ b/STATES.md
@@ -350,15 +350,25 @@ which decides from the step's content: a **full sign-off** (every box ticked, no
 note in `.gtd/REVIEW.md`, no code edit) is the only path to the **squash
 finale** (`squashing` → `done`), which collapses the whole cycle into one commit
 whose message an agent drafts. **Feedback** — any note in `.gtd/REVIEW.md`
-beyond a tick, OR a hand-edit to code — routes through `review-deciding` into
-`.gtd/REVIEW_FEEDBACK.md` → `feedback-building` → `checking` → `reviewing`,
-which regenerates an **incremental** review (`reviewBase: true` on
-`review-deciding` scopes it to `last-review..HEAD`, i.e. the agent's
-follow-through, not the reviewer's own edit). A code edit counts as the
-reviewer's own fix: `feedback-building` completes the follow-through it implies
-and never reverts their lines. Two dead ends never commit — the **sign-off
-gate** (`src/program.ts`, an edge like the review window) refuses a step that
-leaves a box unticked with no comment, and a deleted `.gtd/REVIEW.md`.
+beyond a tick, OR a hand-edit to code — routes through `review-deciding`, which
+CAPTURES the raw material into `.gtd/REVIEW_RAW.md` (never interpreting it) →
+`feedback-collecting`, an agent that turns that raw material into an explicit
+instruction list in `.gtd/REVIEW_FEEDBACK.md` → `feedback-building`, which
+IMPLEMENTS the list → `checking` → `reviewing`, which regenerates an
+**incremental** review (`reviewBase: true` on `review-deciding` scopes it to
+`last-review..HEAD`, i.e. the agent's follow-through, not the reviewer's own
+edit). A code edit counts as the reviewer's own fix: the instructions tell
+`feedback-building` to complete the follow-through it implies and never revert
+their lines. Feedback must not silently evaporate, so two dead ends never
+commit: `feedback-collecting` declares no edge for "raw consumed, nothing
+written" (a silent no-op matches no pattern → refused by the pure engine), and
+`feedback-building` declares **`requireProgress: true`** so the edge gate
+(`enforceFeedbackProgressGate`, `src/program.ts`) refuses a turn that just
+deletes the instructions file without doing the work — unless it held a
+`NOTHING ACTIONABLE` sentinel (a legitimately non-actionable round). Two more
+dead ends never commit at the gate before them — the **sign-off gate**
+(`src/program.ts`, an edge like the review window) refuses a step that leaves a
+box unticked with no comment, and a deleted `.gtd/REVIEW.md`.
 
 Steering-file formats
 (`.gtd/TODO.md`/`.gtd/REQUIREMENTS.md`/`.gtd/ARCHITECTURE.md` open questions,
@@ -369,21 +379,22 @@ machine: the producing agent self-validates with `gtd validate` before finishing
 **Entry + shared states** (the simple flow and the tail all three entries
 share):
 
-| State               | Actor | Content | `on`                                                                                                           | Retry              | Model   | Memory   | File / Mode                  |
-| ------------------- | ----- | ------- | -------------------------------------------------------------------------------------------------------------- | ------------------ | ------- | -------- | ---------------------------- |
-| `idle` (initial)    | human | message | `* .gtd/REQUIREMENTS.md` → `adv-grilling`; `* **` → `grilling`                                                 | —                  | —       | —        | —                            |
-| `grilling`          | agent | prompt  | `* **` → `grilling-answer`                                                                                     | —                  | `smart` | `plan`   | `vars.todoFile` / `qa`       |
-| `grilling-answer`   | human | message | `C` → `building`; `* **` → `grilling`                                                                          | —                  | —       | —        | `vars.todoFile` / `qa`       |
-| `building`          | agent | prompt  | `* **` → `checking`                                                                                            | —                  | `base`  | `build`  | `vars.todoFile` / `qa`       |
-| `checking`          | check | script  | `A`/`M .gtd/FEEDBACK.md` → `fixing`; `D .gtd/FEEDBACK.md` → `reviewing`; `C` → `reviewing`                     | —                  | —       | —        | —                            |
-| `fixing`            | agent | prompt  | `* **` → `checking`                                                                                            | max 3 → `escalate` | `base`  | `fix`    | `vars.feedbackFile`          |
-| `escalate`          | human | message | `* **` → `checking`                                                                                            | —                  | —       | —        | `vars.feedbackFile`          |
-| `reviewing`         | agent | prompt  | `* **` → `await-review`                                                                                        | —                  | `smart` | `review` | `vars.reviewFile` / `review` |
-| `await-review`      | human | message | `* **` → `review-deciding` (+ edge sign-off gate: refuses a deleted `REVIEW.md` / an unticked-no-comment step) | —                  | —       | —        | `vars.reviewFile` / `review` |
-| `review-deciding`   | check | script  | `A`/`M .gtd/REVIEW_FEEDBACK.md` → `feedback-building`; `D .gtd/REVIEW.md` → `squashing`                        | —                  | —       | —        | `vars.reviewFile` / `review` |
-| `feedback-building` | agent | prompt  | `* **` → `checking`                                                                                            | —                  | `base`  | `build`  | `vars.reviewFeedbackFile`    |
-| `squashing`         | agent | prompt  | `A`/`M .gtd/COMMIT_MSG.md` → `done`                                                                            | —                  | `base`  | `build`  | `vars.commitMsgFile`         |
-| `done`              | —     | commit  | — (commit state: squash ends the process)                                                                      | —                  | —       | —        | —                            |
+| State                 | Actor | Content | `on`                                                                                                           | Retry              | Model   | Memory   | File / Mode                  |
+| --------------------- | ----- | ------- | -------------------------------------------------------------------------------------------------------------- | ------------------ | ------- | -------- | ---------------------------- |
+| `idle` (initial)      | human | message | `* .gtd/REQUIREMENTS.md` → `adv-grilling`; `* **` → `grilling`                                                 | —                  | —       | —        | —                            |
+| `grilling`            | agent | prompt  | `* **` → `grilling-answer`                                                                                     | —                  | `smart` | `plan`   | `vars.todoFile` / `qa`       |
+| `grilling-answer`     | human | message | `C` → `building`; `* **` → `grilling`                                                                          | —                  | —       | —        | `vars.todoFile` / `qa`       |
+| `building`            | agent | prompt  | `* **` → `checking`                                                                                            | —                  | `base`  | `build`  | `vars.todoFile` / `qa`       |
+| `checking`            | check | script  | `A`/`M .gtd/FEEDBACK.md` → `fixing`; `D .gtd/FEEDBACK.md` → `reviewing`; `C` → `reviewing`                     | —                  | —       | —        | —                            |
+| `fixing`              | agent | prompt  | `* **` → `checking`                                                                                            | max 3 → `escalate` | `base`  | `fix`    | `vars.feedbackFile`          |
+| `escalate`            | human | message | `* **` → `checking`                                                                                            | —                  | —       | —        | `vars.feedbackFile`          |
+| `reviewing`           | agent | prompt  | `* **` → `await-review`                                                                                        | —                  | `smart` | `review` | `vars.reviewFile` / `review` |
+| `await-review`        | human | message | `* **` → `review-deciding` (+ edge sign-off gate: refuses a deleted `REVIEW.md` / an unticked-no-comment step) | —                  | —       | —        | `vars.reviewFile` / `review` |
+| `review-deciding`     | check | script  | `A`/`M .gtd/REVIEW_RAW.md` → `feedback-collecting`; `D .gtd/REVIEW.md` → `squashing`                           | —                  | —       | —        | `vars.reviewFile` / `review` |
+| `feedback-collecting` | agent | prompt  | `A`/`M .gtd/REVIEW_FEEDBACK.md` → `feedback-building`                                                          | —                  | `smart` | `review` | `vars.reviewFeedbackFile`    |
+| `feedback-building`   | agent | prompt  | `* **` → `checking` (+ edge `requireProgress` gate: refuses a work-free delete of the instructions file)       | —                  | `base`  | `build`  | `vars.reviewFeedbackFile`    |
+| `squashing`           | agent | prompt  | `A`/`M .gtd/COMMIT_MSG.md` → `done`                                                                            | —                  | `base`  | `build`  | `vars.commitMsgFile`         |
+| `done`                | —     | commit  | — (commit state: squash ends the process)                                                                      | —                  | —       | —        | —                            |
 
 `await-review` declares **`reviewWindow: true`** and `review-deciding`
 **`reviewBase: true`** (§11); `reviewing` declares **`reviewEntry: true`**.
@@ -445,16 +456,39 @@ code edit. Every human step routes to `review-deciding` (`* **`);
 **feedback** round when the human left a comment — a change to `.gtd/REVIEW.md`
 beyond a `[ ]`→`[x]` tick (detected by comparing the reviewer's copy against the
 agent's original, `HEAD^`, with checkbox state normalized away), OR a hand-edit
-to any non-`.gtd/` file this round (its own commit's file list). It then writes
-those into `.gtd/REVIEW_FEEDBACK.md` and removes `.gtd/REVIEW.md` — the
-`A`/`M .gtd/REVIEW_FEEDBACK.md` row is declared **first** so a feedback round
-wins over the sign-off pattern. Otherwise (every box ticked, no note, no code)
-it just removes `.gtd/REVIEW.md` (`D .gtd/REVIEW.md` → `squashing`).
-`feedback-building` implements exactly those items (no Q&A) — completing the
-follow-through any hand-edited code implies and never reverting the reviewer's
-own lines — deletes the feedback file, and re-enters `checking` → `reviewing`,
-which regenerates a review scoped to just the changes since the last round
-(§11).
+to any non-`.gtd/` file this round (its own commit's file list). It CAPTURES
+that raw material verbatim (the reviewer's `.gtd/REVIEW.md` diff and/or their
+committed code diff) into `.gtd/REVIEW_RAW.md` and removes `.gtd/REVIEW.md` —
+the `A`/`M .gtd/REVIEW_RAW.md` row is declared **first** so a feedback round
+wins over the sign-off pattern. `review-deciding` never INTERPRETS the material;
+it is a mechanical `check`. Otherwise (every box ticked, no note, no code) it
+just removes `.gtd/REVIEW.md` (`D .gtd/REVIEW.md` → `squashing`).
+
+`feedback-collecting` (a `smart`-tier agent) reads `.gtd/REVIEW_RAW.md` and
+turns it into an explicit, flat instruction list in `.gtd/REVIEW_FEEDBACK.md`,
+deleting the raw file. It applies three rules: a note added to `.gtd/REVIEW.md`
+is a mandatory instruction (regardless of tick state); every comment the human
+added to code this round is a mandatory instruction, marked for removal once
+addressed; and every non-comment line they hand-edited is an already-committed
+intent whose lines are final (complete only the follow-through, never revert).
+If nothing is actionable (e.g. the human left only an approving remark) it
+writes a single `NOTHING ACTIONABLE — <reason>` line instead of inventing work.
+`feedback-building` then implements exactly those items (no Q&A) — building on
+the reviewer's own lines, removing every comment it consumed — deletes the
+feedback file, and re-enters `checking` → `reviewing`, which regenerates a
+review scoped to just the changes since the last round (§11).
+
+Feedback must not silently evaporate between these two turns — the original bug
+was feedback captured, then deleted on the next turn with no work done — so both
+interior transitions are guarded. `feedback-collecting` declares no edge for a
+silent no-op (delete the raw file, write no instructions): the diff matches no
+`on` pattern, so the pure engine refuses it. `feedback-building` declares
+**`requireProgress: true`**, and the edge gate (`enforceFeedbackProgressGate` in
+`src/program.ts` — invisible to the pure engine, keyed on the resting state's
+flag) refuses a turn whose only pending change is deleting the instructions
+file, exempting a `NOTHING ACTIONABLE` sentinel (a non-actionable round makes no
+code change by design). A genuine build always produces a code or
+comment-removal edit, so only the work-free discard is refused.
 
 Two content-shaped dead ends a file-pattern edge can't tell apart never commit:
 the **sign-off gate** (`enforceReviewSignoffGate` in `src/program.ts` — an edge

--- a/schema.json
+++ b/schema.json
@@ -140,6 +140,10 @@
               "reviewEntry": {
                 "type": "boolean",
                 "description": "Marks the (at most one) state `gtd review <commitish>` enters to start a brand new process reviewing <commitish>..HEAD. Forbidden on a commit state and on the initial state."
+              },
+              "requireProgress": {
+                "type": "boolean",
+                "description": "When true, a step at this state is refused if its only pending change is deleting the state's own `file:` — a work-free turn that discards its input without addressing it. A `NOTHING ACTIONABLE` sentinel file is exempt (a legitimately non-actionable round makes no code change). Requires a `file:`. Forbidden on a commit state."
               }
             }
           }

--- a/src/ConfigSchema.ts
+++ b/src/ConfigSchema.ts
@@ -181,6 +181,11 @@ const stateJsonSchema = {
       description:
         "Marks the (at most one) state `gtd review <commitish>` enters to start a brand new process reviewing <commitish>..HEAD. Forbidden on a commit state and on the initial state.",
     },
+    requireProgress: {
+      type: "boolean",
+      description:
+        "When true, a step at this state is refused if its only pending change is deleting the state's own `file:` — a work-free turn that discards its input without addressing it. A `NOTHING ACTIONABLE` sentinel file is exempt (a legitimately non-actionable round makes no code change). Requires a `file:`. Forbidden on a commit state.",
+    },
   },
 } as const
 

--- a/src/PatternConfig.test.ts
+++ b/src/PatternConfig.test.ts
@@ -533,6 +533,25 @@ describe("compileWorkflowConfig — config-shape validation", () => {
     expect("reviewBase" in definition.states.b!).toBe(false)
   })
 
+  it("compiles a requireProgress boolean onto the StateDef", () => {
+    const { definition } = compileWorkflowConfig(
+      {
+        states: {
+          a: { actor: "human", message: "hi", initial: true, on: { "* *": "b" } },
+          b: {
+            actor: "agent",
+            prompt: "p",
+            file: ".gtd/F.md",
+            requireProgress: true,
+            on: { "* **": "a" },
+          },
+        },
+      },
+      "/dir",
+    )
+    expect(definition.states.b!.requireProgress).toBe(true)
+  })
+
   it("rejects a non-boolean reviewEntry", () => {
     expect(() =>
       compileWorkflowConfig(

--- a/src/PatternConfig.ts
+++ b/src/PatternConfig.ts
@@ -240,6 +240,7 @@ const KNOWN_STATE_KEYS: ReadonlySet<string> = new Set([
   "reviewWindow",
   "reviewBase",
   "reviewEntry",
+  "requireProgress",
 ])
 
 const KNOWN_TOP_KEYS: ReadonlySet<string> = new Set(["vars", "states", "modes"])
@@ -564,6 +565,7 @@ interface StateParts {
   readonly reviewWindow: true | undefined
   readonly reviewBase: true | undefined
   readonly reviewEntry: true | undefined
+  readonly requireProgress: true | undefined
 }
 
 const assembleContentFields = (
@@ -608,6 +610,7 @@ const assembleStateDef = (parts: StateParts): StateDef => ({
     reviewWindow: parts.reviewWindow,
     reviewBase: parts.reviewBase,
     reviewEntry: parts.reviewEntry,
+    requireProgress: parts.requireProgress,
   }),
   ...assembleContentFields(parts.content),
 })
@@ -643,6 +646,7 @@ const compileState = (
     reviewWindow: compileBooleanFlag(raw, "reviewWindow", name, errors),
     reviewBase: compileBooleanFlag(raw, "reviewBase", name, errors),
     reviewEntry: compileBooleanFlag(raw, "reviewEntry", name, errors),
+    requireProgress: compileBooleanFlag(raw, "requireProgress", name, errors),
   })
 }
 

--- a/src/PatternMachine.test.ts
+++ b/src/PatternMachine.test.ts
@@ -1101,6 +1101,36 @@ describe("validateDefinition", () => {
     expect(errors).toContain('state "a": the initial state cannot declare "reviewEntry"')
   })
 
+  it("accepts a non-commit state declaring `requireProgress` with a `file`", () => {
+    const errors = validateDefinition({
+      states: {
+        a: { actor: "h", message: "x", initial: true, on: [["* *", "b"]] },
+        b: { actor: "a", prompt: "p", file: ".gtd/F.md", requireProgress: true, on: [["C", "a"]] },
+      },
+    })
+    expect(errors).toEqual([])
+  })
+
+  it("rejects `requireProgress` without a `file`", () => {
+    const errors = validateDefinition({
+      states: {
+        a: { actor: "h", message: "x", initial: true, on: [["* *", "b"]] },
+        b: { actor: "a", prompt: "p", requireProgress: true, on: [["C", "a"]] },
+      },
+    })
+    expect(errors).toContain('state "b": "requireProgress" requires "file"')
+  })
+
+  it("rejects a commit state that declares `requireProgress`", () => {
+    const errors = validateDefinition({
+      states: {
+        a: { actor: "h", message: "x", initial: true, on: [["* *", "b"]] },
+        b: { commit: "chore: b", requireProgress: true },
+      },
+    })
+    expect(errors).toContain('state "b": a commit state cannot declare "requireProgress"')
+  })
+
   it("rejects more than one state declaring `reviewEntry`", () => {
     const errors = validateDefinition({
       states: {

--- a/src/PatternMachine.ts
+++ b/src/PatternMachine.ts
@@ -167,6 +167,18 @@ export interface StateDef {
    * (`src/Edge.ts`/`src/program.ts`); see `reviewEntryStateOf`.
    */
   readonly reviewEntry?: boolean
+  /**
+   * Optional. When `true`, a step at this state is REFUSED if its only pending
+   * change is deleting the state's own `file:` — a work-free turn that discards
+   * its input without addressing it (the "review feedback captured then
+   * silently deleted" bug). Like the review window and sign-off gate, the PURE
+   * engine never reads it: the check lives at the edge
+   * (`enforceFeedbackProgressGate` in `src/program.ts`), which also exempts a
+   * `NOTHING ACTIONABLE` sentinel file (a legitimately non-actionable feedback
+   * round that makes no code change). Requires a `file:`; forbidden on a commit
+   * state (never at rest — see `validateDefinition`).
+   */
+  readonly requireProgress?: boolean
 }
 
 /**
@@ -259,6 +271,10 @@ export const isReviewWindowState = (def: WorkflowDefinition, state: StateName): 
 /** True when `state` anchors the review window's diff base (see `StateDef.reviewBase`). Safe for an unknown state name (returns `false`). */
 export const isReviewBaseState = (def: WorkflowDefinition, state: StateName): boolean =>
   def.states[state]?.reviewBase === true
+
+/** True when a step at `state` must be refused if its only change is deleting the state's `file:` (see `StateDef.requireProgress`). Safe for an unknown state name (returns `false`). */
+export const isRequireProgressState = (def: WorkflowDefinition, state: StateName): boolean =>
+  def.states[state]?.requireProgress === true
 
 /** The workflow's declared review-entry state name (see `StateDef.reviewEntry`) — `gtd review <commitish>` (`src/program.ts`) enters this state to start a new review process. `undefined` when no state declares one; `validateDefinition` guarantees at most one does, so the first (only) match wins. */
 export const reviewEntryStateOf = (def: WorkflowDefinition): StateName | undefined => {
@@ -857,6 +873,24 @@ const validateReviewEntry = (name: string, state: StateDef): string[] => {
   return errors
 }
 
+/**
+ * `requireProgress`, when present, is forbidden on a commit state (never at
+ * rest — same rule family as `reviewWindow`/`reviewBase`) and REQUIRES a
+ * `file:`: the edge gate refuses a turn whose sole change is deleting that
+ * file, so a state with no `file:` to name has nothing to guard.
+ */
+const validateRequireProgress = (name: string, state: StateDef): string[] => {
+  if (state.requireProgress === undefined) return []
+  const errors: string[] = []
+  if (isCommitState(state)) {
+    errors.push(`state "${name}": a commit state cannot declare "requireProgress"`)
+  }
+  if (state.file === undefined) {
+    errors.push(`state "${name}": "requireProgress" requires "file"`)
+  }
+  return errors
+}
+
 /** At most one state may declare `reviewEntry: true` — `gtd review <commitish>` (`src/program.ts`) needs a single, unambiguous state name to enter (see `reviewEntryStateOf`). */
 const validateReviewEntryUniqueness = (
   def: WorkflowDefinition,
@@ -956,6 +990,7 @@ const validateState = (
     ...validateMode(def, name, state),
     ...validateReviewWindow(name, state),
     ...validateReviewEntry(name, state),
+    ...validateRequireProgress(name, state),
   ]
 }
 

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -16,7 +16,12 @@ import { EnvVars } from "./EnvVars.js"
 import { GitService } from "./Git.js"
 import { WorktreeReader } from "./WorktreeReader.js"
 import { compileTemplate, renderInitConfig } from "./workflows/templates.js"
-import { classifyReviewSignoff, cliErrorLine, makeProgram } from "./program.js"
+import {
+  classifyFeedbackProgress,
+  classifyReviewSignoff,
+  cliErrorLine,
+  makeProgram,
+} from "./program.js"
 import { InMemRepo } from "../tests/integration/support/inmem/Repo.js"
 import { inMemoryLayers } from "../tests/integration/support/inmem/layers.js"
 
@@ -464,5 +469,51 @@ describe("classifyReviewSignoff", () => {
     })
     expect(v.kind).toBe("refuse")
     if (v.kind === "refuse") expect(v.reason).toContain("1 review item(s) still unticked")
+  })
+})
+
+describe("classifyFeedbackProgress", () => {
+  const base = {
+    file: ".gtd/REVIEW_FEEDBACK.md",
+    stateName: "feedback-building",
+    invoker: "agent",
+    deletedContent: "1. ./a.ts#1 — rename the export\n",
+  }
+  const del = { path: ".gtd/REVIEW_FEEDBACK.md", status: "D" } as const
+
+  it("refuses deleting the instructions file with no code change (the original bug)", () => {
+    const v = classifyFeedbackProgress({ ...base, changes: [del] })
+    expect(v.kind).toBe("refuse")
+    if (v.kind === "refuse") expect(v.reason).toContain("without addressing its instructions")
+  })
+
+  it("allows deleting the file when a code change accompanies it (real work done)", () => {
+    const v = classifyFeedbackProgress({
+      ...base,
+      changes: [del, { path: "src/a.ts", status: "M" }],
+    })
+    expect(v).toEqual({ kind: "allow" })
+  })
+
+  it("allows a NOTHING ACTIONABLE sentinel to be deleted with no code change", () => {
+    const v = classifyFeedbackProgress({
+      ...base,
+      changes: [del],
+      deletedContent: "NOTHING ACTIONABLE — the human left only an approving remark.\n",
+    })
+    expect(v).toEqual({ kind: "allow" })
+  })
+
+  it("allows a turn that does not delete the instructions file", () => {
+    const v = classifyFeedbackProgress({ ...base, changes: [{ path: "src/a.ts", status: "M" }] })
+    expect(v).toEqual({ kind: "allow" })
+  })
+
+  it("treats other .gtd/ churn alongside the delete as no code change (still refused)", () => {
+    const v = classifyFeedbackProgress({
+      ...base,
+      changes: [del, { path: ".gtd/REVIEW_RAW.md", status: "D" }],
+    })
+    expect(v.kind).toBe("refuse")
   })
 })

--- a/src/program.ts
+++ b/src/program.ts
@@ -38,6 +38,7 @@ import {
 } from "./SteeringMode.js"
 import {
   initialStateOf,
+  isRequireProgressState,
   isReviewWindowState,
   matchesPattern,
   parsePattern,
@@ -420,6 +421,10 @@ const stepAsActor = (
     // Review sign-off gate (edge): refuse a deleted review doc or an unfinished
     // review with no comment before either can commit (see the helper).
     yield* enforceReviewSignoffGate(worktree.read, invoker, rest, context, changes, decision.kind)
+    // Feedback-progress gate (edge): at a `requireProgress` state, refuse a
+    // work-free turn that just deletes the instructions file (the "captured
+    // then silently discarded" bug), exempting a NOTHING ACTIONABLE sentinel.
+    yield* enforceFeedbackProgressGate(invoker, rest, context, changes, decision.kind)
     const outcome = yield* executeDecision(git, run, executable, context, cost, model)
     return {
       state: rest.state,
@@ -798,6 +803,74 @@ const enforceReviewSignoffGate = (
       hasCodeChange: changes.some((c) => !c.path.startsWith(".gtd/")),
       original,
       current,
+    })
+    if (verdict.kind === "refuse") return yield* Effect.fail(new Error(verdict.reason))
+  })
+
+/** The one-line marker `feedback-collecting` writes when a review round left nothing actionable — the ONLY content that lets a `requireProgress` state's instructions file be deleted without a code change (see `classifyFeedbackProgress`). */
+const NOTHING_ACTIONABLE_SENTINEL = "NOTHING ACTIONABLE"
+
+/**
+ * The PURE core of the feedback-progress gate (see `enforceFeedbackProgressGate`).
+ * At a `requireProgress` state the `file` is an instruction list the agent must
+ * ADDRESS, then delete. Refuse a turn that deletes the file while touching no
+ * code (`hasCodeChange` false) — the "review feedback captured then silently
+ * discarded" bug. Two escapes ALLOW the step: the file isn't being deleted (the
+ * agent left work, or the list, in place), or there IS a code change alongside
+ * (real work was done). The one delete-with-no-code exception is a
+ * `NOTHING ACTIONABLE` sentinel (`deletedContent`): a legitimately
+ * non-actionable round makes no code change by design. Kept separate from the
+ * Effect so it is directly unit-tested (see program.test.ts).
+ */
+export const classifyFeedbackProgress = (input: {
+  readonly file: string
+  readonly stateName: string
+  readonly invoker: string
+  readonly changes: readonly PendingChange[]
+  readonly deletedContent: string
+}): ReviewSignoffVerdict => {
+  const fileDeleted = input.changes.some((c) => c.path === input.file && c.status === "D")
+  if (!fileDeleted) return { kind: "allow" }
+  const hasCodeChange = input.changes.some((c) => !c.path.startsWith(".gtd/"))
+  if (hasCodeChange) return { kind: "allow" }
+  if (input.deletedContent.trim().startsWith(NOTHING_ACTIONABLE_SENTINEL)) return { kind: "allow" }
+  return {
+    kind: "refuse",
+    reason: `gtd step ${input.invoker}: ${input.file} was deleted at "${input.stateName}" without addressing its instructions — implement the changes it lists (then delete it), don't just remove the file.`,
+  }
+}
+
+/**
+ * The feedback-progress gate (edge, like the sign-off gate above). At a
+ * `requireProgress: true` state (the unified template's `feedback-building`), a
+ * turn that just deletes the instructions file without doing the work it lists
+ * is refused BEFORE it can commit — the pure `classifyFeedbackProgress` decides.
+ * A no-op when the state is not a `requireProgress` state or the decision is a
+ * squash/no-op. The committed (pre-deletion) file content — read once here —
+ * feeds the sentinel exemption.
+ */
+const enforceFeedbackProgressGate = (
+  invoker: string,
+  rest: ResolvedRest,
+  context: TemplateContext,
+  changes: readonly PendingChange[],
+  kind: ExecutableDecision["kind"],
+): Effect.Effect<void, Error, FileSystem.FileSystem | Cwd | GitService> =>
+  Effect.gen(function* () {
+    if (kind !== "commit") return
+    if (!isRequireProgressState(rest.def, rest.state)) return
+    const file = yield* renderFile(rest.stateDef, context)
+    if (file === undefined) return
+    const git = yield* GitService
+    const deletedContent = yield* git
+      .readFileAtRef("HEAD", file)
+      .pipe(Effect.catchAll(() => Effect.succeed("")))
+    const verdict = classifyFeedbackProgress({
+      file,
+      stateName: rest.state,
+      invoker,
+      changes,
+      deletedContent,
     })
     if (verdict.kind === "refuse") return yield* Effect.fail(new Error(verdict.reason))
   })

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -64,6 +64,7 @@ vars:
   packagesDir: .gtd/packages
   nextFile: .gtd/NEXT.md
   reviewFile: .gtd/REVIEW.md
+  reviewRawFile: .gtd/REVIEW_RAW.md
   reviewFeedbackFile: .gtd/REVIEW_FEEDBACK.md
   feedbackFile: .gtd/FEEDBACK.md
   specFeedbackFile: .gtd/SPEC_FEEDBACK.md
@@ -726,11 +727,13 @@ states:
       # once per round — nothing commits in between). It is FEEDBACK when the
       # human left a comment: a note in REVIEW.md (any edit beyond a "[ ]"->"[x]"
       # tick) OR a hand-edit to any non-.gtd/ file this round. Otherwise it is a
-      # clean sign-off. Either way, remove REVIEW.md; what the resulting diff
-      # MEANS is decided by this state's own `on` rules — the A/M
-      # REVIEW_FEEDBACK.md rows are declared BEFORE the D REVIEW.md row so a
-      # feedback round (which also deletes REVIEW.md) is captured as feedback,
-      # not mistaken for a sign-off.
+      # clean sign-off. This turn only CAPTURES the raw material into REVIEW_RAW.md
+      # (the `feedback-collecting` agent then turns it into instructions); it does
+      # NOT interpret it. Either way, remove REVIEW.md; what the resulting diff
+      # MEANS is decided by this state's own `on` rules — the A/M REVIEW_RAW.md
+      # rows are declared BEFORE the D REVIEW.md row so a feedback round (which
+      # also deletes REVIEW.md) is captured as feedback, not mistaken for a
+      # sign-off.
       set +e
       mkdir -p .gtd
       # Hoist the paths once, at the TOP: Eta's autoTrim eats the newline after
@@ -738,7 +741,7 @@ states:
       # would glue the next line onto it and break the script. Below this point
       # everything is plain bash.
       reviewFile="<%~ it.vars.reviewFile %>"
-      reviewFeedbackFile="<%~ it.vars.reviewFeedbackFile %>"
+      reviewRawFile="<%~ it.vars.reviewRawFile %>"
       # Which non-.gtd/ files did the human hand-edit this round?
       codeFiles=$(git diff-tree --no-commit-id --name-only -r HEAD | grep -v '^\.gtd/')
       # A note is any REVIEW.md change beyond a checkbox flip: normalize every
@@ -750,11 +753,10 @@ states:
       if [ "$before" != "$after" ]; then notes=1; fi
       if [ -n "$codeFiles" ] || [ -n "$notes" ]; then
         {
-          echo "Review feedback to address, then delete this file. The human reviewed the diff and asked for the changes below."
-          echo "Build on their own edits: complete only the follow-through each change implies (callers, tests, types, docs). Treat any lines the human wrote as final — never revert or rewrite them."
+          echo "Raw review material captured for classification. The human reviewed the diff and left the feedback below; a downstream agent turns it into an instruction list. This file is machine-captured input, not instructions."
           if [ -n "$notes" ]; then
             echo
-            echo "## Notes left in the review (ticked items are approved — act on the notes)"
+            echo "## Notes the human added to REVIEW.md this round"
             echo
             echo '```diff'
             git show HEAD --format= -- "$reviewFile"
@@ -762,40 +764,107 @@ states:
           fi
           if [ -n "$codeFiles" ]; then
             echo
-            echo "## Code the human hand-edited this round — already committed, build on top"
+            echo "## Files the human hand-edited this round (already committed)"
             echo
             echo '```diff'
             git show HEAD --format= -- $codeFiles
             echo '```'
           fi
-        } > "$reviewFeedbackFile"
+        } > "$reviewRawFile"
       fi
       rm -f "$reviewFile"
     on:
+      "A .gtd/REVIEW_RAW.md": feedback-collecting
+      "M .gtd/REVIEW_RAW.md": feedback-collecting
+      "D .gtd/REVIEW.md": squashing
+
+  feedback-collecting:
+    actor: agent
+    file: <%= it.vars.reviewFeedbackFile %>
+    model: <%= it.vars.plannerModel %>
+    memory: review
+    prompt: |
+      You are an autonomous coding agent turning raw review feedback into an
+      explicit instruction list for a builder. `.gtd/` holds this workflow's own
+      state — never create, edit, or delete anything under `.gtd/` except
+      `<%= it.vars.reviewRawFile %>` (delete it when done) and
+      `<%= it.vars.reviewFeedbackFile %>` (write it). Do NOT change any other
+      file — you classify, you do not build.
+
+      The raw review material is: <%~ it.read(it.vars.reviewRawFile) %>
+
+      Classify every piece of it into `<%= it.vars.reviewFeedbackFile %>` as a
+      flat, numbered instruction list. Each item is `N. ./path/to/file.ts#line —
+      <imperative>`. Read the two RAW sections and apply these rules exactly:
+
+      1. NOTES the human added to REVIEW.md — each note is a MANDATORY change,
+         regardless of whether its checkbox is ticked (ticking means only "I read
+         this hunk", never sign-off). Anchor each to the `./path#line` its review
+         item names (or the chunk it sits under). Emit it as a concrete
+         imperative.
+      2. Every COMMENT the human ADDED this round (a `+` line that is a code
+         comment, in the hand-edited files) is a MANDATORY instruction the human
+         is giving the builder — even a plain-prose one, even if its box is
+         ticked. Emit an imperative to satisfy it and note that the comment line
+         itself must be REMOVED once addressed. If a comment turns out to describe
+         behaviour the code already has, the instruction is still "confirm the
+         code matches and remove the comment line".
+      3. Every NON-comment code line the human hand-edited is an already-committed
+         INTENT, NOT a do-then-delete item. Emit an instruction that names those
+         files and says: their lines are final — complete ONLY the follow-through
+         they imply (callers, tests, types, docs) and NEVER revert or rewrite
+         them. Do not turn their own edit into a task.
+
+      Split each hand-edited hunk per line: comment `+` lines follow rule 2, the
+      surrounding real code follows rule 3.
+
+      If — and only if — nothing in the raw material is actionable (e.g. the human
+      left only an approving remark), write `<%= it.vars.reviewFeedbackFile %>`
+      containing exactly one line: `NOTHING ACTIONABLE — <one-sentence reason>`.
+      Never invent work to satisfy a non-actionable remark.
+
+      Delete `<%= it.vars.reviewRawFile %>`, leave everything else uncommitted,
+      and finish your turn.
+    on:
       "A .gtd/REVIEW_FEEDBACK.md": feedback-building
       "M .gtd/REVIEW_FEEDBACK.md": feedback-building
-      "D .gtd/REVIEW.md": squashing
 
   feedback-building:
     actor: agent
     file: <%= it.vars.reviewFeedbackFile %>
     model: <%= it.vars.coderModel %>
     memory: build
+    # Refuse a work-free turn: a step whose only pending change is deleting the
+    # instructions file (the original "captured then discarded" bug). The edge
+    # gate (`enforceFeedbackProgressGate` in src/program.ts) reads this flag and
+    # exempts a `NOTHING ACTIONABLE` sentinel (a non-actionable review round,
+    # which legitimately makes no code change). The pure engine carries it inert.
+    requireProgress: true
     prompt: |
       You are an autonomous coding agent addressing review feedback. `.gtd/`
       holds this workflow's own state — never create, edit, or delete anything
       under `.gtd/` except `<%= it.vars.reviewFeedbackFile %>`, which this
       prompt tells you to address and then delete.
 
-      The review feedback to address is: <%~ it.read(it.vars.reviewFeedbackFile) %>
+      The instructions to implement are: <%~ it.read(it.vars.reviewFeedbackFile) %>
 
-      Implement exactly those changes — no Q&A, no re-planning. Use TDD
-      discipline. When the feedback includes code the human hand-edited this
-      round, that edit is ALREADY committed: treat their lines as final, build ON
-      TOP of them to complete only the follow-through they imply (callers, tests,
-      types, docs), and never revert or rewrite what they changed. Delete
-      `<%= it.vars.reviewFeedbackFile %>` once every item is addressed. Leave
-      everything else uncommitted and finish your turn.
+      This is a flat instruction list, not a diff — execute every item exactly as
+      written, no Q&A, no re-planning, using TDD discipline:
+
+      - An item that says the human's own lines are final: build ON TOP of them to
+        complete only the follow-through it names (callers, tests, types, docs).
+        NEVER revert or rewrite the lines they already committed.
+      - An item derived from a human comment: satisfy it AND delete that comment
+        line from the code (the human's review comments are transient — none of
+        them survive this round).
+
+      If the file's sole content is a `NOTHING ACTIONABLE` line, make no code
+      change; just delete the instructions file.
+
+      Delete `<%= it.vars.reviewFeedbackFile %>` once every item is addressed.
+      Leave everything else uncommitted and finish your turn. Deleting the
+      instructions file WITHOUT making the changes it asks for is refused — the
+      feedback must actually be addressed.
     on:
       "* **": checking
 

--- a/tests/integration/features/default-workflow.feature
+++ b/tests/integration/features/default-workflow.feature
@@ -116,20 +116,32 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
     And the last commit subject is "gtd(human): await-review → review-deciding"
 
     # review-deciding: the note is a change to REVIEW.md beyond a tick, so it
-    # writes REVIEW_FEEDBACK.md and removes REVIEW.md — the A/M REVIEW_FEEDBACK.md
-    # row is declared before the D REVIEW.md row so a feedback round wins
-    Given a file ".gtd/REVIEW_FEEDBACK.md" with:
+    # CAPTURES the raw material into REVIEW_RAW.md and removes REVIEW.md — the
+    # A/M REVIEW_RAW.md row is declared before the D REVIEW.md row so a feedback
+    # round wins
+    Given a file ".gtd/REVIEW_RAW.md" with:
       """
-      Review feedback to address, then delete this file.
+      Raw review material captured for classification.
 
-      ## Notes left in the review (ticked items are approved — act on the notes)
+      ## Notes the human added to REVIEW.md this round
 
       - [x] ./src/thing.ts#1 — new export — also add a doc comment
       """
     And the file ".gtd/REVIEW.md" is deleted
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): review-deciding → feedback-building"
+    And the last commit subject is "gtd(check): review-deciding → feedback-collecting"
+
+    # feedback-collecting: turns the raw material into an instruction list in
+    # REVIEW_FEEDBACK.md and deletes REVIEW_RAW.md, stepping to feedback-building
+    Given a file ".gtd/REVIEW_FEEDBACK.md" with:
+      """
+      1. ./src/thing.ts#1 — add a doc comment above the new export
+      """
+    And the file ".gtd/REVIEW_RAW.md" is deleted
+    When I run gtd step agent
+    Then it succeeds
+    And the last commit subject is "gtd(agent): feedback-collecting → feedback-building"
 
     # feedback-building: implements the requested change directly (no Q&A),
     # deletes the feedback file, steps to checking

--- a/tests/integration/features/review-feedback-guards.feature
+++ b/tests/integration/features/review-feedback-guards.feature
@@ -1,0 +1,128 @@
+@inmem
+Feature: Review feedback — capture, classification, and the no-op guards
+
+  The review feedback lap of the bundled unified workflow (see STATES.md §10).
+  A human comment at `await-review` routes to `review-deciding`, which CAPTURES
+  the raw material into `.gtd/REVIEW_RAW.md` (never interprets it). The new
+  `feedback-collecting` agent turns that raw material into an explicit
+  instruction list in `.gtd/REVIEW_FEEDBACK.md`; `feedback-building` then
+  IMPLEMENTS the list and deletes it.
+
+  Two no-op guards keep review feedback from silently evaporating (the bug this
+  flow fixes — feedback captured, then deleted on the next turn without being
+  addressed):
+
+  - `feedback-collecting` declares no edge for "raw consumed, nothing written",
+    so a silent no-op (delete REVIEW_RAW.md, write no instructions) matches no
+    pattern and is REFUSED by the pure engine.
+  - `feedback-building` declares `requireProgress: true`, so the edge gate
+    (`enforceFeedbackProgressGate`) REFUSES a turn whose only change is deleting
+    the instructions file — unless it held a `NOTHING ACTIONABLE` sentinel.
+
+  Each check-actor turn (`review-deciding`) is simulated by writing its verdict
+  files and running `gtd step check`; @inmem never executes the scripts.
+
+  Background:
+    Given a test project
+    And the workflow
+    And a commit "gtd(agent): building" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And a commit "gtd(check): await-review" that adds ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: 0000000 -->
+
+      ## calc
+      - [ ] ./src/calc.ts#1 — new add function
+      """
+
+  Scenario: a note flows through capture and classification into a build
+    # await-review: the human leaves a note (a change beyond a tick) → feedback
+    Given ".gtd/REVIEW.md" is modified to:
+      """
+      # Review: abc1234
+
+      <!-- base: 0000000 -->
+
+      ## calc
+      - [x] ./src/calc.ts#1 — new add function — rename `add` to `sum`
+      """
+    When I run gtd step human
+    Then it succeeds
+    And the last commit subject is "gtd(human): await-review → review-deciding"
+
+    # review-deciding: CAPTURES raw material into REVIEW_RAW.md, removes REVIEW.md
+    Given a file ".gtd/REVIEW_RAW.md" with:
+      """
+      Raw review material captured for classification.
+
+      ## Notes the human added to REVIEW.md this round
+
+      - [x] ./src/calc.ts#1 — new add function — rename `add` to `sum`
+      """
+    And the file ".gtd/REVIEW.md" is deleted
+    When I run gtd step check
+    Then it succeeds
+    And the last commit subject is "gtd(check): review-deciding → feedback-collecting"
+
+    # feedback-collecting: raw material → instruction list, deletes the raw file
+    Given a file ".gtd/REVIEW_FEEDBACK.md" with:
+      """
+      1. ./src/calc.ts#1 — rename the exported `add` to `sum`
+      """
+    And the file ".gtd/REVIEW_RAW.md" is deleted
+    When I run gtd step agent
+    Then it succeeds
+    And the last commit subject is "gtd(agent): feedback-collecting → feedback-building"
+
+    # feedback-building: implements the instruction and deletes the file
+    Given "src/calc.ts" is modified to:
+      """
+      export const sum = (a: number, b: number) => a + b
+      """
+    And the file ".gtd/REVIEW_FEEDBACK.md" is deleted
+    When I run gtd step agent
+    Then it succeeds
+    And the last commit subject is "gtd(agent): feedback-building → checking"
+
+  Scenario: feedback-building refuses a work-free turn that just deletes the instructions
+    Given an empty commit "gtd(human): await-review → review-deciding"
+    And a commit "gtd(agent): feedback-collecting → feedback-building" that adds ".gtd/REVIEW_FEEDBACK.md" with:
+      """
+      1. ./src/calc.ts#1 — rename the exported `add` to `sum`
+      """
+    # The BUG behaviour: delete the instructions without doing the work
+    Given the file ".gtd/REVIEW_FEEDBACK.md" is deleted
+    When I run gtd step agent
+    Then it fails
+    And stderr contains "without addressing its instructions"
+
+  Scenario: feedback-building allows deleting a NOTHING ACTIONABLE sentinel with no code change
+    Given an empty commit "gtd(human): await-review → review-deciding"
+    And a commit "gtd(agent): feedback-collecting → feedback-building" that adds ".gtd/REVIEW_FEEDBACK.md" with:
+      """
+      NOTHING ACTIONABLE — the human left only an approving remark.
+      """
+    # A non-actionable round makes no code change; deleting the sentinel is fine
+    Given the file ".gtd/REVIEW_FEEDBACK.md" is deleted
+    When I run gtd step agent
+    Then it succeeds
+    And the last commit subject is "gtd(agent): feedback-building → checking"
+
+  Scenario: feedback-collecting refuses a silent no-op — raw consumed, nothing written
+    Given a commit "gtd(check): review-deciding → feedback-collecting" that adds ".gtd/REVIEW_RAW.md" with:
+      """
+      Raw review material captured for classification.
+
+      ## Notes the human added to REVIEW.md this round
+
+      - [x] ./src/calc.ts#1 — rename `add` to `sum`
+      """
+    # Silent no-op: consume the raw file, produce no instruction list
+    Given the file ".gtd/REVIEW_RAW.md" is deleted
+    When I run gtd step agent
+    Then it fails
+    And stderr contains "no declared pattern matches"


### PR DESCRIPTION
## Problem

Review feedback could be **captured and then silently discarded**. Observed in a real run: the human left inline `// TODO` comments during review; `review-deciding` captured them, and on the very next turn `feedback-building` deleted the feedback file with **zero code changes** — the `// TODO`s were still in the tree.

Two defects lined up:

1. **Mis-routed capture.** The human's code annotations landed in the "already committed, treat as final, never revert" channel, whose directive *forbids* acting on them. A rational agent handed comma-removals + TODO comments under that frame concludes there's no follow-through and does nothing.
2. **No guard.** `feedback-building`'s `on: * ** → checking` accepted a lone `D REVIEW_FEEDBACK.md` as a valid step — "did the work" and "did nothing" were indistinguishable.

## Change

Split the review-feedback lap into an explicit classification step and guard both interior transitions:

```
review-deciding (check) → feedback-collecting (agent) → feedback-building (agent) → checking
   captures raw →            raw → instruction list →      implements the list
   REVIEW_RAW.md             REVIEW_FEEDBACK.md
```

- **`review-deciding`** now captures raw material into `.gtd/REVIEW_RAW.md` (never interpreting it); sign-off (`D REVIEW.md → squashing`) unchanged and still gated.
- **`feedback-collecting`** (new, smart tier) turns raw notes/comments/edits into a flat instruction list: REVIEW.md notes and every human-added code comment become mandatory instructions (comments marked for removal once addressed); non-comment edits stay final "complete the follow-through only" intents; a non-actionable round writes a `NOTHING ACTIONABLE` sentinel instead of inventing work.
- **`feedback-building`** implements the instruction list (no diff to misread) and removes every consumed comment.

### Guards — feedback can no longer evaporate
- `feedback-collecting`'s silent no-op (delete raw, write nothing) matches no `on` pattern → refused by the pure engine.
- `feedback-building` declares a new **`requireProgress: true`** state property; the edge gate `enforceFeedbackProgressGate` refuses a turn whose only change is deleting the instructions file, exempting the `NOTHING ACTIONABLE` sentinel. Its decision is the pure, unit-tested `classifyFeedbackProgress`.

## Tests
- New pure unit tests: `classifyFeedbackProgress` (5 cases), `validateRequireProgress` (3 cases), compiler flag test.
- Updated `default-workflow.feature` for the new path; new `review-feedback-guards.feature` (happy lap, both guards refusing, sentinel exemption).
- Manual @live drive against the built bundle: 17/17 edge-case checks.
- Full `npm test` green (format, typecheck, lint, unit, e2e, health gate).

## Docs
- STATES.md §10 (table + walkthrough), README review-flow description, regenerated `schema.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)