### PR TITLE
feat(lsp): review symbols list only packages with unchecked hunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,12 @@ Before wiring gtd into a repo, note the
 importantly: gitignore everything your scripts write.
 
 Editor integration: `gtd lsp` starts an LSP server over stdio for `.gtd/`
-steering files — symbols and check/uncheck actions over a `review`-mode file's
-chunks, go-to-definition from a `review`-mode hunk line into the file it points
-at (at its `#line`), symbols over a `qa`-mode file's open questions, diagnostics
-for both (live as you edit), and a `gtd.openSteeringFile` command that jumps to
-the current state's steering file. Config-driven via each state's
+steering files — a symbol per `review`-mode chunk that still has an unchecked
+hunk (an outline of the packages left to review) plus check/uncheck actions over
+those chunks, go-to-definition from a `review`-mode hunk line into the file it
+points at (at its `#line`), symbols over a `qa`-mode file's open questions,
+diagnostics for both (live as you edit), and a `gtd.openSteeringFile` command
+that jumps to the current state's steering file. Config-driven via each state's
 `file:`/`mode:` (see [CLI reference](docs/cli.md#gtd-lsp)) — falls back to
 basename dispatch (`TODO.md`/`REVIEW.md`) with no config in sight. Those two
 formats are gtd's built-in steering-file MODES — validators, not formatters: a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -390,13 +390,14 @@ are rejected).
 ## `gtd lsp`
 
 Starts an LSP server over stdio for `.gtd/` steering files — document symbols
-for a `qa`-mode file's open questions and a `review`-mode file's review
-chunks/hunks, code actions to check/uncheck a hunk or a whole chunk,
-go-to-definition (`textDocument/definition`) from a `review`-mode hunk pointer
-line into the file it points at (at its 1-based `#line`, or the top of the file
-for a bare `./path`; the `./`-relative path resolves against the repo's git
-toplevel), and diagnostics publishing the same parser findings `gtd validate`
-reports (see `src/OpenQuestions.ts` / `src/ReviewDoc.ts` and
+for a `qa`-mode file's open questions and, for a `review`-mode file, one symbol
+per chunk that still has an unchecked hunk (the outline lists only the packages
+left to review, with no hunk children), code actions to check/uncheck a hunk or
+a whole chunk, go-to-definition (`textDocument/definition`) from a `review`-mode
+hunk pointer line into the file it points at (at its 1-based `#line`, or the top
+of the file for a bare `./path`; the `./`-relative path resolves against the
+repo's git toplevel), and diagnostics publishing the same parser findings
+`gtd validate` reports (see `src/OpenQuestions.ts` / `src/ReviewDoc.ts` and
 [STATES.md §12](../STATES.md#12-steering-file-validation-gtd-validate)).
 
 **Config-driven** (see

--- a/docs/design/state-file-association.md
+++ b/docs/design/state-file-association.md
@@ -84,11 +84,13 @@ same `file:`/`mode:` annotations (it is the LSP-heavy flow), including
   (vars-layer context; the LSP process's env supplies `GTD_VAR_` overrides like
   any invocation), and build a map of absolute rendered paths → mode. Document
   features dispatch on that map: `qa` files get question symbols + parser-error
-  diagnostics; `review` files get chunk/hunk symbols + check/uncheck code
-  actions + diagnostics. Conflicting modes for one path: first declaring state
-  wins, log a warning. **Fallback:** when NO config resolves (or a `.gtd` file
-  isn't mapped), keep today's basename dispatch (`TODO.md` → qa, `REVIEW.md` →
-  review) so the server still works standalone.
+  diagnostics; `review` files get one headline symbol per chunk that still has
+  an unchecked hunk (an outline of the packages left to review — no hunk
+  children) + check/uncheck code actions + diagnostics. Conflicting modes for
+  one path: first declaring state wins, log a warning. **Fallback:** when NO
+  config resolves (or a `.gtd` file isn't mapped), keep today's basename
+  dispatch (`TODO.md` → qa, `REVIEW.md` → review) so the server still works
+  standalone.
 - **The jump command returns:** `gtd.openSteeringFile` — resolve the CURRENT
   state exactly like the CLI (config + git HEAD via the existing Edge helpers;
   this re-adds the git/config wiring the v2 server had), render its `file:`, and

--- a/src/Lsp.test.ts
+++ b/src/Lsp.test.ts
@@ -81,15 +81,28 @@ describe("questionDiagnostics", () => {
 })
 
 describe("reviewSymbols", () => {
-  it("maps each chunk to a symbol with its checked/total count and one child per hunk", () => {
+  it("emits only headlines of chunks with an unchecked hunk, no hunk children", () => {
     const symbols = reviewSymbols(reviewDoc)
     expect(symbols.map((s) => s.name)).toEqual(["Add calculator (1/2)", "Wire it up (0/1)"])
-    expect(symbols[0]?.children?.map((c) => c.name)).toEqual([
-      "[ ] ./src/calc.ts#1",
-      "[x] ./src/calc.ts#5 — subtract",
-    ])
+    expect(symbols[0]?.children).toBeUndefined()
     expect(symbols[0]?.selectionRange.start.line).toBe(3)
-    expect(symbols[0]?.children?.[0]?.selectionRange.start.line).toBe(5)
+  })
+
+  it("omits a fully-checked chunk's headline", () => {
+    const doc = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## All done",
+      "",
+      "- [x] ./src/calc.ts#1",
+      "",
+      "## Still open",
+      "",
+      "- [ ] ./src/index.ts#10",
+      "",
+    ].join("\n")
+    expect(reviewSymbols(doc).map((s) => s.name)).toEqual(["Still open (0/1)"])
   })
 })
 

--- a/src/Lsp.ts
+++ b/src/Lsp.ts
@@ -80,7 +80,7 @@ import {
 } from "vscode-languageserver/node"
 import { TextDocument } from "vscode-languageserver-textdocument"
 import { parseOpenQuestions, type OpenQuestion } from "./OpenQuestions.js"
-import { parseReviewDoc, type ReviewFile, FILE_POINTER_RE } from "./ReviewDoc.js"
+import { parseReviewDoc, FILE_POINTER_RE } from "./ReviewDoc.js"
 import { ConfigService } from "./Config.js"
 import { Cwd } from "./Cwd.js"
 import { EnvVars } from "./EnvVars.js"
@@ -141,34 +141,25 @@ export const questionDiagnostics = (content: string): Diagnostic[] => {
   }))
 }
 
-const hunkLabel = (file: ReviewFile): string => {
-  const box = file.checked ? "[x]" : "[ ]"
-  const location = file.line !== undefined ? `${file.path}#${file.line}` : file.path
-  return file.note ? `${box} ${location} — ${file.note}` : `${box} ${location}`
-}
-
-/** Document symbols for `.gtd/REVIEW.md`'s chunks (the user-facing "work packages") and their hunks. */
+/** Document symbols for `.gtd/REVIEW.md`: only the headlines of chunks (the user-facing "work packages") that still carry at least one unchecked hunk — the outline is the list of packages left to review, nothing else. */
 export const reviewSymbols = (content: string): DocumentSymbol[] => {
   const { changesets } = parseReviewDoc(content)
   const lines = content.split(/\r?\n/)
-  return changesets.map((chunk, i) => {
-    const start = chunk.headingLine
-    const end = Math.max(start, (changesets[i + 1]?.headingLine ?? lines.length) - 1)
-    const checkedCount = chunk.files.filter((file) => file.checked).length
-    const children: DocumentSymbol[] = chunk.files.map((file) => ({
-      name: hunkLabel(file),
-      kind: SymbolKind.Boolean,
-      range: lineRange(lines, file.sourceLine),
-      selectionRange: lineRange(lines, file.sourceLine),
-    }))
-    return {
-      name: `${chunk.title} (${checkedCount}/${chunk.files.length})`,
-      kind: SymbolKind.Package,
-      range: spanRange(lines, start, end),
-      selectionRange: lineRange(lines, start),
-      children,
-    }
-  })
+  return changesets
+    .map((chunk, i) => {
+      const start = chunk.headingLine
+      const end = Math.max(start, (changesets[i + 1]?.headingLine ?? lines.length) - 1)
+      const checkedCount = chunk.files.filter((file) => file.checked).length
+      return {
+        name: `${chunk.title} (${checkedCount}/${chunk.files.length})`,
+        kind: SymbolKind.Package,
+        range: spanRange(lines, start, end),
+        selectionRange: lineRange(lines, start),
+        unchecked: checkedCount < chunk.files.length,
+      }
+    })
+    .filter((symbol) => symbol.unchecked)
+    .map(({ unchecked: _unchecked, ...symbol }) => symbol)
 }
 
 /** Diagnostics for `.gtd/REVIEW.md` — the same findings `gtd validate` reports for a `review`-mode file, published live over LSP instead. Whole-document range: `ReviewDoc.errors` carries no per-line position. */


### PR DESCRIPTION
## What

`gtd lsp`'s document symbols for a `review`-mode file now list **only the headline of each chunk that still has an unchecked hunk** — an outline of the packages left to review. Previously every chunk was emitted, each with one child symbol per hunk.

## Changes

- `reviewSymbols` (`src/Lsp.ts`): filter to chunks with an unchecked hunk; drop the per-hunk `SymbolKind.Boolean` children. Removed the now-dead `hunkLabel` helper and `ReviewFile` import.
- The `(checked/total)` headline count, check/uncheck code actions, and hunk go-to-definition are unchanged.
- Unit tests (`src/Lsp.test.ts`): replaced the "one child per hunk" test with no-children/filter-by-unchecked coverage plus a fully-checked-chunk-omitted case.
- Docs: README, `docs/cli.md`, `docs/design/state-file-association.md`.

## Testing

`npm run build` + full vitest suite: 622 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)