### PR TITLE
feat!: restore the built-in default workflow; gtd init seeds vars/modes only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,14 +30,15 @@ entirely at the edge in `src/ReviewWindow.ts` and oblivious to the pure engine
 ### Changing the Workflow
 
 There is no engine-side wiring left to trace through when a workflow's shape
-changes — a workflow (the bundled template or custom) is DATA, not code. gtd
-ships NO default: a repo scaffolds one with `gtd init` (no argument), which
-writes the single bundled template inline into `.gtdrc.json`; a state command
-with no `workflow:` configured fails (`Config.ts`'s `toOperations` throws
-`NO_WORKFLOW_MESSAGE`). gtd ships ONE bundled template, `unified.yaml` — a
-single machine with two file-keyed entry points (`.gtd/TODO.md` → the simple
-flow, `.gtd/REQUIREMENTS.md` → the advanced flow) converging on a shared
-review-and-squash tail. To change what it does, edit
+changes — a workflow (the bundled default or a custom one) is DATA, not code.
+gtd ships ONE bundled template, `unified.yaml`, as its BUILT-IN DEFAULT: a state
+command with no `workflow:` configured falls back to it (`Config.ts`'s
+`toOperations` returns `defaultWorkflowDefinition`/`defaultWorkflowVars` from
+`templates.ts`), so gtd works out of the box with no config. `gtd init` seeds
+only `vars.testCommand` + a `modes:` formatting suggestion, never the workflow.
+The unified template is a single machine with two file-keyed entry points
+(`.gtd/TODO.md` → the simple flow, `.gtd/REQUIREMENTS.md` → the advanced flow)
+converging on a shared review-and-squash tail. To change what it does, edit
 `src/workflows/unified.yaml` (states, `actor`, exactly one content kind, `on`
 edges, `retry`, `model`, `file`/`mode`, `reviewWindow`/`reviewBase`) —
 `src/workflows/templates.ts` compiles/renders it through the same
@@ -130,29 +131,32 @@ a project plugs its own into a mode's `format:`).
   oblivious; `program.ts` calls it, it calls `GitService`/`Edge.ts`.
 - **`src/program.ts`** — CLI dispatch (`init`/`step`/`next`/`status`/`validate`/
   `mermaid`; `lsp` and `init` dispatched BEFORE the config-reading path so they
-  run with no workflow configured). `runInitCommand` writes
-  `renderInitScaffold(name)` to `.gtdrc.json` (uncommitted) — the base config
-  plus externalized `gtd-prompts/` files and a seeded top-level `modes:`
-  Prettier suggestion (`MODES_SUGGESTION`) — guarded by `configPresentAt` (no
-  clobber) + `assertInitLocation`. Unlike the state commands, init derives no
-  git state, so `assertInitLocation` permits a repo root OR any directory
-  OUTSIDE a repository (to scaffold a shared parent-dir config a nested repo
-  finds by walking up), refusing only a repository SUBDIRECTORY (config below
-  the root is never found by the upward walk); it returns `inRepo` so init
-  tailors its "commit before starting" guidance. Calls `Edge.ts` for everything
-  IO-shaped; calls `PatternMachine.ts`'s pure `step`/`matchesPattern`/
-  `parsePattern` directly where no IO is needed (e.g. `gtd status`'s per-change
-  pattern report).
+  need not touch the config). `runInitCommand` writes `renderInitScaffold()` to
+  `.gtdrc.json` (uncommitted) — a MINIMAL config seeding `vars.testCommand` and
+  a top-level `modes:` Prettier suggestion (`MODES_SUGGESTION`), NO `workflow:`
+  key (the machine is built in) — guarded by `configPresentAt` (no clobber) +
+  `assertInitLocation`. Unlike the state commands, init derives no git state, so
+  `assertInitLocation` permits a repo root OR any directory OUTSIDE a repository
+  (to seed a shared parent-dir config a nested repo finds by walking up),
+  refusing only a repository SUBDIRECTORY (config below the root is never found
+  by the upward walk); it returns `inRepo` so init tailors its "commit before
+  starting" guidance. Calls `Edge.ts` for everything IO-shaped; calls
+  `PatternMachine.ts`'s pure `step`/`matchesPattern`/`parsePattern` directly
+  where no IO is needed (e.g. `gtd status`'s per-change pattern report).
 - **`src/workflows/unified.yaml` + `templates.ts`** — the single bundled
-  workflow template `gtd init` scaffolds, plus `templates.ts`
-  (`renderInitScaffold` for the `.gtdrc.json` write — which seeds the top-level
-  `modes:` Prettier suggestion, `MODES_SUGGESTION`; `renderInitConfig` is the
-  hermetic base form reused by the `Given the workflow` test fixture and stays
-  modes-free — and `compileTemplate` for tests/mermaid) — compiled through the
-  exact same `compileWorkflowConfig` path, no privileged code path. Every
-  content string in the template MUST be inline (no `./`-relative file
-  references): it ships inside the single-file `dist/gtd.bundle.mjs` build, so
-  it can't reach out to sibling files on disk at runtime.
+  workflow template gtd runs as its BUILT-IN DEFAULT (`Config.ts` falls back to
+  it when no `workflow:` is configured), plus `templates.ts`:
+  `defaultWorkflowDefinition`/`defaultWorkflowVars` (the compiled default
+  `Config.ts` and the in-memory test layer fall back to); `renderInitScaffold`
+  (the minimal `vars`+`modes` `.gtdrc.json` write — seeding `MODES_SUGGESTION`,
+  no workflow); `renderInitConfig` (materializes the full default into a
+  `workflow:` config — the eject/customize starting point and the hermetic,
+  modes-free `Given the workflow` test fixture); and `compileTemplate`
+  (tests/mermaid). All compiled through the exact same `compileWorkflowConfig`
+  path, no privileged code path. Every content string in the template MUST be
+  inline (no `./`-relative file references): it ships inside the single-file
+  `dist/gtd.bundle.mjs` build, so it can't reach out to sibling files on disk at
+  runtime.
 
 ### The Configurable Machine (`workflow:` and `vars:` in .gtdrc)
 
@@ -160,16 +164,17 @@ a project plugs its own into a mode's `format:`).
 cwd→home), decodes it against `src/ConfigSchema.ts` (two keys: `workflow` and
 `vars`, both `Schema.Unknown` — the shape is validated structurally by the
 compiler, not by `effect/schema`), and compiles the `workflow:` value through
-`compileWorkflowConfig`. There is NO default fallback: an absent `workflow:`
-throws `NO_WORKFLOW_MESSAGE` (pointing at `gtd init`). The load is exposed as a
-DEFERRED effect — `ConfigService` provides `{ load: Effect<ConfigOperations> }`,
-not the ops directly — because the layer is provided to the whole program and
-built eagerly (`main.ts`), so if it loaded/failed at build time the "no
-workflow" error would break `gtd init`/`gtd lsp` too; consumers do
-`yield* (yield* ConfigService).load` (Edge/program/ReviewWindow/Lsp). The
-top-level `vars:` value compiles through the same `compileVarsMap` (see
-`Config.ts`'s `compileRcVars`). There is no module-global registry (no v2-style
-`activeWorkflow()`/`setActiveWorkflow`):
+`compileWorkflowConfig`. An absent `workflow:` falls back to the BUILT-IN
+DEFAULT (`defaultWorkflowDefinition`/`defaultWorkflowVars` from `templates.ts`,
+with the top-level `modes:` merged over via `mergeModes`) — never an error. The
+load is exposed as a DEFERRED effect — `ConfigService` provides
+`{ load: Effect<ConfigOperations> }`, not the ops directly — because the layer
+is provided to the whole program and built eagerly (`main.ts`), so if it
+loaded/failed at build time a CUSTOM-workflow validation error would break
+`gtd init`/`gtd lsp` too; consumers do `yield* (yield* ConfigService).load`
+(Edge/program/ReviewWindow/Lsp). The top-level `vars:` value compiles through
+the same `compileVarsMap` (see `Config.ts`'s `compileRcVars`). There is no
+module-global registry (no v2-style `activeWorkflow()`/`setActiveWorkflow`):
 `ConfigOperations { workflow, workflowVars, rcVars }` flows through the
 `ConfigService` Context tag like any other Effect dependency, read fresh each
 invocation — nothing to reset between tests. `src/Edge.ts`'s `resolveVars`

--- a/README.md
+++ b/README.md
@@ -49,28 +49,28 @@ Or run without installing:
 npx @pmelab/gtd
 ```
 
-Then scaffold the workflow for the repo — run once:
+That's it — gtd ships the **unified** workflow as its **built-in default**, so a
+state command works out of the box with no configuration at all.
+
+Optionally, seed the settings a project usually tunes — run once:
 
 ```bash
 gtd init
 ```
 
-This writes a `.gtdrc.json` for the bundled unified workflow, with each agent
-state's prompt saved as an editable Markdown file under `gtd-prompts/` and
-referenced from the config (review and commit both). Edit a prompt by editing
-its `gtd-prompts/*.md` file — no config edit needed. File references resolve
-relative to **the `.gtdrc` that declares them**, so a config and its
-`gtd-prompts/` can even live in a parent directory shared across repos while gtd
-runs from each repo root — run `gtd init` from that parent directory (it need
-not be a git repo) to scaffold it there (see
-[Configuration](docs/configuration.md#content-values-inline-or-a-file-reference)).
-It also seeds a top-level `modes:` block suggesting **Prettier** as the
-steering-file formatter (`npx prettier --write` for the built-in `qa`/`review`
-modes — format only, so gtd still validates); edit or drop it freely (swap in
-dprint, a script, or delete the key). `gtd init` takes no argument. gtd ships
-**no** default workflow: a state command run before `gtd init` fails, pointing
-you back here. See [Configuration](docs/configuration.md#gtd-init) for the
-template.
+This writes a minimal `.gtdrc.json` seeding the one variable most projects
+change — the test command (`vars.testCommand`, defaulting to `npm test`) — plus
+a top-level `modes:` block suggesting **Prettier** as the steering-file
+formatter (`npx prettier --write` for the built-in `qa`/`review` modes — format
+only, so gtd still validates); edit or drop either freely (point `testCommand`
+at your suite, swap Prettier for dprint or a script, delete a key). It writes
+**no** `workflow:` key — the machine is built in — so review and commit the file
+before your first `gtd step`. `gtd init` takes no argument and refuses to
+clobber an existing config; it may also run in a plain parent directory (not a
+git repo) to seed a shared config a nested repo picks up. To customize the
+machine itself, add a `workflow:` key (there is no default fallback to merge
+over — a `workflow:` is the whole definition). See
+[Configuration](docs/configuration.md#gtd-init) for the details.
 
 ## How it works
 

--- a/STATES.md
+++ b/STATES.md
@@ -330,15 +330,16 @@ anything touches the repository. See
 
 ## 10. The bundled workflow template
 
-gtd ships **no** default workflow — a repo scaffolds one with `gtd init` (no
-argument, see [Configuration](docs/configuration.md#gtd-init)), which writes the
-single bundled template (`src/workflows/unified.yaml`) into `.gtdrc.json` — each
-agent state's `prompt:` extracted to an editable `gtd-prompts/<state>.md` file
-the config references via `./`
-([auto-inlined at load](docs/configuration.md#content-values-inline-or-a-file-reference)),
-with human `message:`/check `script:`/the `done` `commit:` bodies left inline.
-It compiles through the exact same compiler a custom `workflow:` key goes
-through — no privileged code path.
+gtd ships the single bundled template (`src/workflows/unified.yaml`) as its
+**built-in default workflow**: when no `workflow:` key is configured anywhere in
+the cwd→home config chain, `src/Config.ts` runs this template directly, so a
+state command works with no configuration at all. `gtd init` (no argument, see
+[Configuration](docs/configuration.md#gtd-init)) seeds only the settings a
+project tunes — `vars.testCommand` and a `modes:` formatting suggestion — never
+the workflow itself. To customize the machine, a repo declares its own
+`workflow:` key (materialize the default as a starting point); it compiles
+through the exact same compiler the built-in default goes through — no
+privileged code path.
 
 The **unified** template is one machine with **four entry points behind a
 green-baseline gate, into one shared tail**. EVERY entry first runs the test

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,12 +4,12 @@
 Usage: gtd [command] [options]
 
 Commands:
-  init             Scaffold a .gtdrc.json for this repo with the bundled
-                   unified workflow; its agent prompts are written as editable
-                   Markdown under gtd-prompts/ and referenced from the config.
-                   Takes no argument. Run once per repo; refuses if a gtd
-                   config already exists. Leaves the files uncommitted for you
-                   to review and commit
+  init             Scaffold a minimal .gtdrc.json for this repo, seeding a
+                   testCommand var (npm test) and a ready-to-edit Prettier
+                   formatting suggestion under modes:. Writes no workflow — gtd
+                   runs the bundled unified workflow as its built-in default.
+                   Takes no argument. Refuses if a gtd config already exists.
+                   Leaves the file uncommitted for you to review and commit
   step <actor>     Authenticate as <actor>, match the resolved rest's
                    declared patterns against the pending changes, and commit
                    (or squash) the one resulting transition. Pass
@@ -65,15 +65,17 @@ mistyped flag can never degrade a JSON caller to plain-text mode. A bare
 
 ## `gtd init`
 
-Scaffolds a `.gtdrc.json` at the repository root with the bundled **unified**
-workflow template inline under a `workflow:` key, plus a `$schema` link. It
-takes **no argument** — passing one is a usage error
-(`gtd init: too many arguments — init takes no argument`). gtd ships **no**
-default workflow, so this is the one-time setup step for a repo; a state command
-run before it fails with `gtd: no workflow configured — run \`gtd init\` to
-create .gtdrc.json`.
+Scaffolds a **minimal** `.gtdrc.json` at the repository root, plus a `$schema`
+link. It writes **no** `workflow:` key — gtd runs the bundled **unified**
+workflow as its built-in default, so a state command works out of the box with
+no config and no init at all. What `gtd init` seeds is the two things most
+projects tune: a `vars: { "testCommand": "npm test" }` entry (the var the
+bundled workflow's check script reads) and a ready-to-edit `modes:` block
+suggesting a Prettier `format:` for each built-in steering-file mode
+(`qa`/`review`). It takes **no argument** — passing one is a usage error
+(`gtd init: too many arguments — init takes no argument`).
 
-The unified template has four entry points — each behind a green-baseline gate
+The bundled default has four entry points — each behind a green-baseline gate
 that runs the suite before starting — into one shared review/squash tail (see
 [STATES.md §10](../STATES.md#10-the-bundled-workflow-templates)): creating
 `.gtd/TODO.md` starts the simple flow (planning → building → checking), creating
@@ -81,15 +83,16 @@ that runs the suite before starting — into one shared review/squash tail (see
 per-package parallel build, agentic spec-review), `gtd review <commitish>`
 enters review directly, and `gtd fix` goes straight into repairing failing
 tests. A red baseline halts at a `*-start-blocked` gate rather than starting new
-work.
+work. To CUSTOMIZE that machine, add your own `workflow:` key (a full definition
+— there is no `extends`/merge); see
+[Configuration](configuration.md#the-workflow-key).
 
 The file is written **uncommitted**; review and commit it before your first
 `gtd step` (an uncommitted `.gtdrc.json` is a pending change the initial state
 would otherwise capture). `gtd init` refuses if the repo root already has its
-own gtd config (a global/ancestor config, e.g. `~/.gtdrc`, does not count),
-requires the repository root, and — with `gtd lsp` — is one of the two commands
-that run with no workflow configured. `--json` prints
-`{"written":".gtdrc.json","workflow":"unified","prompts":[…]}`. See
+own gtd config (a global/ancestor config, e.g. `~/.gtdrc`, does not count) and
+requires the repository root (or a directory outside any repo). `--json` prints
+`{"written":".gtdrc.json","inRepo":true}`. See
 [Configuration](configuration.md#gtd-init).
 
 ## `gtd step <actor> [--cost=<n>] [--model=<name>]`
@@ -460,11 +463,11 @@ naming the state instead — bind it to an editor keybinding for a "jump to the
 active steering file" command.
 
 Dispatched before the repository-root guard and the config-reading path — the
-server needs no git/workflow state of its own (like `gtd init`, it runs with no
-workflow configured). Rejects `--json` (exit 1,
-`gtd lsp does not accept --json`) and extra positional arguments — it's a
-long-running server, not a state command. Runs until the client disconnects (the
-LSP `exit` notification), then exits cleanly.
+server needs no git/workflow state of its own (like `gtd init`, it needs no
+config to run). Rejects `--json` (exit 1, `gtd lsp does not accept --json`) and
+extra positional arguments — it's a long-running server, not a state command.
+Runs until the client disconnects (the LSP `exit` notification), then exits
+cleanly.
 
 ## Error envelope
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,12 +1,15 @@
 # Configuration
 
-gtd reads a required `.gtdrc` config file via
-[cosmiconfig](https://github.com/cosmiconfig/cosmiconfig). gtd ships **no**
-default workflow: scaffold one for the repo with [`gtd init`](#gtd-init) (once),
-which writes a `.gtdrc.json` for a bundled workflow template (with its agent
-prompts as editable Markdown under `gtd-prompts/`). A state command run with no
-`workflow:` configured fails, pointing you at `gtd init`. Supported filenames
-(searched in this order):
+gtd reads an optional `.gtdrc` config file via
+[cosmiconfig](https://github.com/cosmiconfig/cosmiconfig). gtd ships the bundled
+**unified** workflow as its **built-in default**: with no `workflow:` configured
+anywhere in the cwd→home config chain, that default is used automatically, so a
+state command works out of the box with no config at all.
+[`gtd init`](#gtd-init) is optional — it seeds a minimal `.gtdrc.json` with the
+two things most projects tune (a `testCommand` var and a Prettier formatting
+suggestion), not the workflow. To CUSTOMIZE the machine itself, add your own
+[`workflow:`](#the-workflow-key) key. Supported filenames (searched in this
+order):
 
 - `.gtdrc`
 - `.gtdrc.json`
@@ -19,10 +22,11 @@ prompts as editable Markdown under `gtd-prompts/`). A state command run with no
 
 v3's `.gtdrc` has exactly three blessed top-level keys:
 
-- **`workflow`** (object, **required**) — the whole machine definition (its
-  states, plus its own `vars:` defaults and `modes:`), compiled by
-  `src/PatternConfig.ts`. Absent = a hard error pointing at
-  [`gtd init`](#gtd-init); there is no bundled default. See
+- **`workflow`** (object, optional) — the whole machine definition (its states,
+  plus its own `vars:` defaults and `modes:`), compiled by
+  `src/PatternConfig.ts`. Absent = gtd's built-in default (the bundled unified
+  workflow) is used. Declare it to fully REPLACE that default with your own
+  machine (there is no `extends`/merge). See
   ["The `workflow:` key" below](#the-workflow-key) for its schema.
 - **`vars`** (object, optional) — a flat `name -> scalar` map, one layer of the
   merged `it.vars` every template sees — see ["Variables"](#variables) below.
@@ -52,11 +56,12 @@ interprets.
 > verify a change compiles. This section is the exhaustive schema reference
 > behind it.
 
-The `workflow:` key is the **only** definition source — there is no `extends`,
-no merge-over-a-built-in. The bundled template `gtd init` scaffolds is itself a
-YAML asset (`src/workflows/unified.yaml`) compiled through the exact same
-compiler (`compileWorkflowConfig`); `gtd init` just writes it, inline, under
-this key. Its shape:
+A declared `workflow:` key fully REPLACES gtd's built-in default — there is no
+`extends`, no merge-over-a-built-in. The built-in default is itself a YAML asset
+(`src/workflows/unified.yaml`) compiled through the exact same compiler
+(`compileWorkflowConfig`) your own `workflow:` value goes through — no
+privileged code path — so you can materialize it into config form as a starting
+point to edit (`renderInitConfig` in `src/workflows/templates.ts`). Its shape:
 
 ```yaml
 workflow:
@@ -107,8 +112,8 @@ root, discovers the parent `.gtdrc` by walking up the directory chain (see
 level's `./`-relative references against that level's own directory. When
 workflows are layered across levels, every reference resolves against the file
 that wrote it, so a parent's `./gtd-prompts/x.md` and a child's never collide.
-You can scaffold such a shared config by running [`gtd init`](#gtd-init) from
-that parent directory — it need not be a git repository.
+(This is a capability of a `.gtdrc` you write yourself — `gtd init` seeds only
+`vars:`/`modes:`, not a `workflow:` with file references.)
 
 ```yaml
 workflow:
@@ -380,16 +385,17 @@ So for a state declaring `mode: qa`:
 | both                             | its `format:` | its `validate:`             |
 
 That is what makes the built-in modes extensible rather than all-or-nothing —
-and the top-level key means a project can plug its formatter into the workflow
-it scaffolded (`gtd init`) without re-declaring a `modes:` block on the workflow
-itself. **`gtd init` seeds exactly this block by default** (the Prettier
-suggestion below), so a fresh repo already formats its steering files — edit or
-drop it to taste. It sits alongside the `workflow:` key in your `.gtdrc.json`:
+and the top-level key means a project can plug its formatter into the built-in
+default workflow (or its own) without re-declaring a `modes:` block on the
+workflow itself. **`gtd init` seeds exactly this block by default** (the
+Prettier suggestion below), so a fresh repo already formats its steering files —
+edit or drop it to taste. It is what a scaffolded `.gtdrc.json` contains
+(`gtd init` writes no `workflow:` key — the built-in default is used):
 
 ```jsonc
-// .gtdrc.json — the workflow from `gtd init`, plus your own markdown formatter
+// .gtdrc.json — as scaffolded by `gtd init`: a testCommand var and the markdown formatter
 {
-  "workflow": { "...": "..." },
+  "vars": { "testCommand": "npm test" },
   "modes": {
     "qa": { "format": "npx prettier --write <%= it.file %>" },
     "review": { "format": "npx prettier --write <%= it.file %>" },
@@ -702,24 +708,21 @@ can still override with its own `.gtdrc`.
 
 ## `gtd init`
 
-gtd ships **no** default workflow, so a repo must scaffold one before any state
-command works:
+gtd ships the bundled unified workflow as its **built-in default**, so a state
+command works out of the box with **no** config and no init at all. `gtd init`
+is therefore optional — it just seeds the two things most projects tune:
 
 ```bash
 gtd init      # takes no argument
 ```
 
-`gtd init` writes a `.gtdrc.json` at the repository root with the bundled
-unified template's workflow under a `workflow:` key, plus a `$schema` link (so
-editors pick up completion/validation). It takes **no argument** — passing one
-is a usage error (`gtd init: too many arguments — init takes no argument`). Each
-**agent state's prompt** is written as a standalone Markdown file under
-`gtd-prompts/<state>.md` and the config references it via a
-`./gtd-prompts/<state>.md`
-[file reference](#content-values-inline-or-a-file-reference) — gtd inlines it at
-load time, so a prompt is editable Markdown and editing it changes the workflow
-with no config edit. Human `message:` blocks and check `script:` bodies stay
-inline in the config (they are workflow mechanics, not prompts).
+`gtd init` writes a **minimal** `.gtdrc.json` at the repository root — a
+`$schema` link (so editors pick up completion/validation), a
+`vars: { "testCommand": "npm test" }` entry (the var the built-in workflow's
+check script reads), and a ready-to-edit `modes:` formatting suggestion (below).
+It writes **no** `workflow:` key — the built-in default is used until you
+declare your own. It takes **no argument** — passing one is a usage error
+(`gtd init: too many arguments — init takes no argument`).
 
 `gtd init` writes only config — it derives no git state — so it need not run in
 a git repository. It runs at a **repository root** or in a directory **outside
@@ -731,9 +734,9 @@ only to write into a repository **subdirectory**, where the upward config walk
 would never find the file. Either way, it will not overwrite an existing config
 at that directory (remove it first to re-scaffold).
 
-It also seeds a top-level [`modes:`](#modes--pluggable-steering-file-modes)
-block as a ready-to-edit suggestion — a Prettier `format:` for each built-in
-steering-file mode the template uses:
+The [`modes:`](#modes--pluggable-steering-file-modes) block it seeds is a
+ready-to-edit suggestion — a Prettier `format:` for each built-in steering-file
+mode the default workflow uses:
 
 ```jsonc
 "modes": {
@@ -748,8 +751,8 @@ this is the one default it suggests: a fresh repo auto-formats its steering
 files out of the box, and you edit or drop the block freely (swap Prettier for
 dprint, point at a script, or delete the key).
 
-The one bundled template has three entry points into a shared review/squash tail
-(all walked through in
+The built-in default workflow has three entry points into a shared review/squash
+tail (all walked through in
 [STATES.md §10](../STATES.md#10-the-bundled-workflow-templates)):
 
 - **the simple flow** — creating `.gtd/TODO.md` starts idle → planning ⇄
@@ -763,20 +766,15 @@ The one bundled template has three entry points into a shared review/squash tail
   review a foreign branch.
 
 Both file-created flows converge on `reviewing` → `await-review`, and a full
-sign-off squashes the whole cycle into one commit.
+sign-off squashes the whole cycle into one commit. To CUSTOMIZE any of this, add
+a [`workflow:`](#the-workflow-key) key that fully replaces the default.
 
-The files are written **uncommitted** — review them, then commit `.gtdrc.json`
-and `gtd-prompts/` before your first `gtd step` (an uncommitted file is a
-pending change the initial state's `* **` edge would otherwise capture).
-`gtd init` refuses if the repo root already has its OWN gtd config (remove it
-first to re-init; a global/ancestor config such as `~/.gtdrc` does not count),
-requires the repository root, and is one of the two commands (with `gtd lsp`)
-that run with no workflow configured. A state command run before `gtd init`
-fails with:
-
-```
-gtd: no workflow configured — run `gtd init` to create .gtdrc.json
-```
+The file is written **uncommitted** — review it, then commit `.gtdrc.json`
+before your first `gtd step` (an uncommitted file is a pending change the
+initial state's `* **` edge would otherwise capture). `gtd init` refuses if the
+repo root already has its OWN gtd config (remove it first to re-init; a
+global/ancestor config such as `~/.gtdrc` does not count) and requires the
+repository root (or a directory outside any repo).
 
 ## A complete example
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,7 +31,8 @@ registry to keep in sync: a workflow's content strings are either inline in its
 YAML/`.gtdrc` or a `./`-relative file reference auto-inlined at config load
 (`src/PatternConfig.ts`) — see
 [Configuration](configuration.md#content-values-inline-or-a-file-reference). The
-bundled workflow template (`src/workflows/unified.yaml`) `gtd init` scaffolds is
+bundled workflow template (`src/workflows/unified.yaml`) gtd runs as its
+built-in default (and materializes into config form via `renderInitConfig`) is
 imported as raw text via tsdown's `.yaml`-as-text loader (`tsdown.config.ts`)
 and compiled through the same path a `.gtdrc` `workflow:` key goes through
 (`src/workflows/templates.ts`) — no privileged code path.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -122,28 +122,24 @@ upgrading.
 
 ## How to adopt
 
-`workflow:` is now **required** — gtd ships no default workflow, so after
-upgrading each repo must scaffold one **once**:
+`workflow:` is **optional** — gtd ships the bundled **unified** workflow as its
+built-in default, so after upgrading a repo works with **no** config and no init
+at all. The default forks on which steering file you create: `.gtd/TODO.md`
+starts the **simple flow** (a `planning` ⇄ `plan-review` plan-iteration loop,
+direct `building`, a `checking`/`fixing` loop), while `.gtd/REQUIREMENTS.md`
+starts the **advanced flow** (two-phase grilling ⇄ grilling-answer /
+architecting ⇄ architecting-answer / decompose / picking / per-package build
+with an agentic spec-review gate). Both converge on the same `reviewing` →
+`await-review` tail, and a full sign-off squashes the whole cycle into one
+commit (see [STATES.md §10](../STATES.md#10-the-bundled-workflow-templates)).
+
+`gtd init` is now optional and no longer writes a workflow — it seeds only a
+minimal `.gtdrc.json` (a `testCommand` var and a Prettier formatting
+suggestion). Run it if you want to tune those; otherwise nothing is required:
 
 ```bash
-gtd init      # takes no argument
+gtd init      # optional — seeds testCommand + a formatting suggestion
 ```
-
-`gtd init` (no argument) writes a `.gtdrc.json` for the single bundled
-**unified** template (its agent prompts extracted to editable `gtd-prompts/*.md`
-files the config references). The template forks on which steering file you
-create: `.gtd/TODO.md` starts the **simple flow** (a `planning` ⇄ `plan-review`
-plan-iteration loop, direct `building`, a `checking`/`fixing` loop), while
-`.gtd/REQUIREMENTS.md` starts the **advanced flow** (two-phase grilling ⇄
-grilling-answer / architecting ⇄ architecting-answer / decompose / picking /
-per-package build with an agentic spec-review gate). Both converge on the same
-`reviewing` → `await-review` tail, and a full sign-off squashes the whole cycle
-into one commit (see
-[STATES.md §10](../STATES.md#10-the-bundled-workflow-templates)). Review and
-commit the generated `.gtdrc.json` (and its `gtd-prompts/` directory), then
-continue from a settled `idle` boundary. **Note:** a repo relying on earlier
-gtd's auto-created `.gtdrc.json` `$schema` stub (which carried no `workflow:`)
-will now fail until you `gtd init` — the stub alone is no longer enough.
 
 A repo that customized v2's `workflow:` key (actors, gates, guard vocabulary,
 ladders) needs to rewrite it from scratch in the v3 schema — see

--- a/skills/authoring/SKILL.md
+++ b/skills/authoring/SKILL.md
@@ -23,21 +23,26 @@ what the user wants. This skill is the authoring contract;
 `skills/loop/SKILL.md` is the separate contract for _driving_ a workflow once it
 exists.
 
-## Golden rule: start from a bundled template, edit incrementally
+## Golden rule: start from the built-in default, edit incrementally
 
-Do **not** write a workflow from a blank page. gtd ships one known-good
-template. Scaffold it and edit it:
+Do **not** write a workflow from a blank page. gtd ships one known-good workflow
+— the unified template (two file-keyed entry points, simple / advanced, into one
+shared review + squash-finale tail) — and RUNS it as its built-in default when
+no `workflow:` key is configured. To customize it, declare a `workflow:` key
+that fully REPLACES the default (there is no `extends`/merge), so start from the
+default's own source and edit it:
 
 ```bash
-gtd init      # the unified template: two file-keyed entry points (simple /
-              # advanced) into one shared review + squash-finale tail
+# The built-in default's source, heavily commented — copy from it, don't start blank:
+src/workflows/unified.yaml
 ```
 
-`gtd init` writes the template inline under the `workflow:` key of a new
-`.gtdrc.json` (it refuses if a config already exists). If a `.gtdrc` is already
-present, read its `workflow:` and edit in place instead. When in doubt about a
-construct, read the bundled source for a working example:
-`src/workflows/unified.yaml` (heavily commented).
+If a `.gtdrc` already declares a `workflow:`, read it and edit in place instead.
+Otherwise, materialize the built-in default into config form (`renderInitConfig`
+in `src/workflows/templates.ts`) as your starting point, or hand-copy the states
+you want to change from `src/workflows/unified.yaml`. `gtd init` does **not**
+write a workflow — it only seeds a minimal `.gtdrc.json` (a `testCommand` var
+and a formatting suggestion), so it is not the way to scaffold one to edit.
 
 Make one small change, **verify it compiles** (see "Verify" below), then make
 the next. A workflow that fails to compile breaks every `gtd` state command in
@@ -48,7 +53,7 @@ the repo, so never leave it broken between edits.
 Exactly these top-level keys (any other key is a hard error):
 
 ```yaml
-workflow: # REQUIRED — the whole machine (states + its own vars/modes)
+workflow: # optional — the whole machine (states + its own vars/modes)
   vars: { ... } # optional — the workflow's own it.vars defaults
   modes: { ... } # optional — steering-file modes a state's mode: may name
   states: { ... } # the named states
@@ -57,9 +62,11 @@ modes: { ... } # optional — project layer over workflow.modes
 $schema: "..." # optional — point at the shipped schema.json for editor autocomplete
 ```
 
-There is **no default workflow** and no `extends`/merge — `workflow:` is the
-sole definition source. Config can be `.gtdrc`, `.gtdrc.json`, `.gtdrc.yaml`,
-`.gtdrc.yml`, `gtd.config.json`, or `gtd.config.yaml`.
+gtd ships a **built-in default** workflow (the unified template), used when no
+`workflow:` key is configured. A declared `workflow:` fully REPLACES it — there
+is **no** `extends`/merge, so `workflow:` is the sole definition source when
+present. Config can be `.gtdrc`, `.gtdrc.json`, `.gtdrc.yaml`, `.gtdrc.yml`,
+`gtd.config.json`, or `gtd.config.yaml`.
 
 ## Anatomy of a state
 

--- a/src/Config.test.ts
+++ b/src/Config.test.ts
@@ -4,8 +4,9 @@ import { tmpdir } from "node:os"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { Effect, Exit, Layer } from "effect"
 import { NodeContext } from "@effect/platform-node"
-import { ConfigService, NO_WORKFLOW_MESSAGE } from "./Config.js"
+import { ConfigService } from "./Config.js"
 import { Cwd } from "./Cwd.js"
+import { compileTemplate } from "./workflows/templates.js"
 
 // ConfigService.Live only loads/validates the config — it never writes.
 // NodeContext.layer satisfies FileSystem + CommandExecutor.
@@ -47,24 +48,39 @@ const minimalWorkflowYaml = (idleMessage: string) =>
   ].join("\n")
 
 describe("ConfigService", () => {
-  it("with no config anywhere: fails with the `gtd init` hint (there is no default)", async () => {
-    const exit = await runExit(Effect.flatMap(ConfigService, (c) => c.load))
+  it("with no config anywhere: falls back to the built-in default workflow", async () => {
+    const cfg = await getConfig()
 
-    expect(Exit.isFailure(exit)).toBe(true)
-    if (Exit.isFailure(exit)) {
-      expect(String(exit.cause)).toContain(NO_WORKFLOW_MESSAGE)
-    }
+    // The built-in default is gtd's bundled unified template — same compiled
+    // shape and its own `vars:` defaults.
+    const { definition, vars } = compileTemplate()
+    expect(cfg.workflow).toEqual(definition)
+    expect(cfg.workflowVars).toEqual(vars)
+    expect(cfg.rcVars).toEqual({})
   })
 
-  it("a config with a top-level `vars:` but no `workflow:` still fails with the init hint", async () => {
-    writeFileSync(join(projectDir, ".gtdrc.yaml"), `vars:\n  testCommand: "npm test"\n`)
+  it("a config with a top-level `vars:` but no `workflow:` uses the built-in default", async () => {
+    writeFileSync(join(projectDir, ".gtdrc.yaml"), `vars:\n  testCommand: "custom-test"\n`)
 
-    const exit = await runExit(Effect.flatMap(ConfigService, (c) => c.load))
+    const cfg = await getConfig()
 
-    expect(Exit.isFailure(exit)).toBe(true)
-    if (Exit.isFailure(exit)) {
-      expect(String(exit.cause)).toContain(NO_WORKFLOW_MESSAGE)
-    }
+    // No `workflow:` -> built-in default; the top-level `vars:` still loads as
+    // the `rcVars` layer that overrides the workflow's own defaults.
+    expect(cfg.workflow).toEqual(compileTemplate().definition)
+    expect(cfg.rcVars).toEqual({ testCommand: "custom-test" })
+  })
+
+  it("layers a top-level `modes:` key over the built-in default's modes", async () => {
+    writeFileSync(
+      join(projectDir, ".gtdrc.yaml"),
+      [`modes:`, `  qa:`, `    format: "adr-fmt <%= it.file %>"`, ``].join("\n"),
+    )
+
+    const cfg = await getConfig()
+
+    // No `workflow:` -> built-in default, with the rc `modes:` merged in.
+    expect(cfg.workflow.states).toEqual(compileTemplate().definition.states)
+    expect(cfg.workflow.modes?.qa).toEqual({ format: "adr-fmt <%= it.file %>" })
   })
 
   it("reads a custom `workflow:` from a single .gtdrc.yaml in cwd", async () => {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -8,16 +8,18 @@ import {
   compileVarsMap,
   compileWorkflowConfig,
   inlineWorkflowFileRefs,
+  mergeModes,
 } from "./PatternConfig.js"
 import { type ModeDef, type WorkflowDefinition } from "./PatternMachine.js"
+import { defaultWorkflowDefinition, defaultWorkflowVars } from "./workflows/templates.js"
 import { Cwd } from "./Cwd.js"
 import { ArrayFormatter, ParseError } from "effect/ParseResult"
 import { ConfigSchema, type DecodedConfig } from "./ConfigSchema.js"
 
 export interface ConfigOperations {
-  /** The active workflow definition — the `.gtdrc` `workflow:` key compiled through `compileWorkflowConfig`. gtd ships no default: a repo scaffolds one with `gtd init`, and config with no `workflow:` key fails (see `toOperations`). */
+  /** The active workflow definition — the `.gtdrc` `workflow:` key compiled through `compileWorkflowConfig`, or gtd's built-in bundled default when no `workflow:` key is configured (see `toOperations`). */
   readonly workflow: WorkflowDefinition
-  /** The active workflow's own declared `vars:` defaults (layer 1 of the merged `it.vars` — see `src/Edge.ts`'s `resolveVars`). */
+  /** The active workflow's own declared `vars:` defaults (layer 1 of the merged `it.vars` — see `src/Edge.ts`'s `resolveVars`). `defaultWorkflowVars` for the built-in default. */
   readonly workflowVars: Record<string, string>
   /** The top-level `.gtdrc` `vars:` key (layer 2), already cwd→home deep-merged like any other config key. `{}` when absent. */
   readonly rcVars: Record<string, string>
@@ -236,29 +238,31 @@ const compileRcVars = (raw: unknown): Record<string, string> => {
 }
 
 /**
- * The error every config-reading command fails with when no `workflow:` key is
- * configured anywhere in the cwd→home chain. gtd ships no default workflow, so
- * there is nothing to fall back to — the user must scaffold one with
- * `gtd init`. Exported so the CLI layer and tests can assert on it verbatim.
- */
-export const NO_WORKFLOW_MESSAGE =
-  "gtd: no workflow configured — run `gtd init` to create .gtdrc.json"
-
-/**
- * Compile the decoded config's `workflow:` key plus its top-level
- * `vars:`/`modes:` keys into `ConfigOperations`. Its `./`/`../` content file
- * references were already inlined per declaring file by `loadMerged`, so the
- * compiler is invoked with `inlineFileRefs: false` and `root` is passed only as
- * an (unused) `configDir` placeholder. Throws `NO_WORKFLOW_MESSAGE` when no
- * `workflow:` key is present (there is no bundled default to fall back to — see
- * `gtd init`), or (via `compileWorkflowConfig`/`compileRcVars`) on any invalid
- * workflow/vars.
+ * Compile the decoded config's `workflow:` key (or gtd's built-in bundled
+ * default, when absent) plus its top-level `vars:`/`modes:` keys into
+ * `ConfigOperations`. A custom `workflow:`'s `./`/`../` content file references
+ * were already inlined per declaring file by `loadMerged`, so the compiler is
+ * invoked with `inlineFileRefs: false` and `root` is passed only as an (unused)
+ * `configDir` placeholder.
+ *
+ * When no `workflow:` key is configured anywhere in the cwd→home chain, the
+ * built-in default (`defaultWorkflowDefinition`, pre-compiled and validated
+ * once at module load) is used. Layering the top-level `modes:` over it can
+ * only ADD mode names (never invalidate a `mode:` reference), so it needs no
+ * re-validation. Throws (via `compileWorkflowConfig`/`compileRcVars`) only on
+ * an invalid CUSTOM workflow/vars; the built-in default never throws here.
  */
 const toOperations = (decoded: DecodedConfig, root: string): ConfigOperations => {
   const rcVars = compileRcVars(decoded.vars)
   const rcModes = compileRcModes(decoded.modes)
   if (decoded.workflow === undefined) {
-    throw new Error(NO_WORKFLOW_MESSAGE)
+    const modes = mergeModes(defaultWorkflowDefinition.modes, rcModes)
+    return {
+      workflow:
+        modes !== undefined ? { ...defaultWorkflowDefinition, modes } : defaultWorkflowDefinition,
+      workflowVars: defaultWorkflowVars,
+      rcVars,
+    }
   }
   const { definition, vars: workflowVars } = compileWorkflowConfig(
     decoded.workflow,
@@ -281,10 +285,11 @@ const formatSchemaError = (e: ParseError): string => {
  * The service interface. Config loading is exposed as a DEFERRED effect
  * (`load`) rather than an already-loaded `ConfigOperations` value: the layer
  * is provided to the whole program (see `main.ts`), which builds it eagerly,
- * so if it loaded (and validated a workflow) at BUILD time, the "no workflow
- * configured" failure would break `gtd init` and `gtd lsp` too — the two
- * commands that must run with no workflow configured yet. Deferring to `load`
- * means the failure surfaces only when a command actually reads the config.
+ * so if it loaded (and validated a CUSTOM workflow) at BUILD time, a
+ * config-validation failure would break `gtd init` and `gtd lsp` too — the two
+ * commands that must run without touching the config. Deferring to `load` means
+ * any such failure surfaces only when a command actually reads the config. (An
+ * absent `workflow:` no longer fails at all — the built-in default is used.)
  */
 interface ConfigServiceOperations {
   readonly load: Effect.Effect<ConfigOperations, Error>

--- a/src/PatternConfig.ts
+++ b/src/PatternConfig.ts
@@ -212,7 +212,7 @@ export const compileModesMap = (
  * formatting to `qa` without touching its validation. Both arguments may be
  * `undefined` (an absent key); the result is `undefined` only when both are.
  */
-const mergeModes = (
+export const mergeModes = (
   base: Readonly<Record<string, ModeDef>> | undefined,
   override: Readonly<Record<string, ModeDef>> | undefined,
 ): Record<string, ModeDef> | undefined => {

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -364,9 +364,10 @@ describe("gtd review <commitish> — subcommand guards", () => {
 
   it("the happy path writes one empty entry commit with a Gtd-Review-Base trailer, resting at the unified template's review-entry state (review-start-check)", async () => {
     const repo = seededRepo()
-    // gtd ships no default workflow: scaffold the unified template (whose
-    // `review-start-check` state declares `reviewEntry: true`) and commit it,
-    // exactly as `gtd init` + a commit would.
+    // Pin the bundled unified template (whose `review-start-check` state
+    // declares `reviewEntry: true`) explicitly and commit it — this is the same
+    // machine gtd runs as its built-in default, materialized via
+    // `renderInitConfig` (see src/workflows/templates.ts).
     repo.writeFile(".gtdrc.json", renderInitConfig())
     repo.commitAllWithPrefix("chore: init gtd workflow")
     const base = repo.commitHistory().at(-1)!.hash
@@ -508,8 +509,8 @@ describe("JSON error envelope", () => {
 
 describe("cliErrorLine", () => {
   it("does not double a message that already carries a gtd prefix", () => {
-    expect(cliErrorLine(new Error("gtd: no workflow configured — run `gtd init`"))).toBe(
-      "gtd: no workflow configured — run `gtd init`",
+    expect(cliErrorLine(new Error("gtd: unknown option '--jsn' — see `gtd --help`"))).toBe(
+      "gtd: unknown option '--jsn' — see `gtd --help`",
     )
     expect(cliErrorLine(new Error("gtd init: too many arguments"))).toBe(
       "gtd init: too many arguments",

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,9 +1,9 @@
 import { createRequire } from "node:module"
-import { dirname, join } from "node:path"
+import { join } from "node:path"
 import { FileSystem } from "@effect/platform"
 import { Effect, Either } from "effect"
 import { configPresentAt, ConfigService } from "./Config.js"
-import { PROMPTS_DIR, renderInitScaffold } from "./workflows/templates.js"
+import { renderInitScaffold } from "./workflows/templates.js"
 import { Cwd } from "./Cwd.js"
 import { EnvVars } from "./EnvVars.js"
 import { WorktreeReader } from "./WorktreeReader.js"
@@ -60,11 +60,13 @@ const GTD_VERSION: string = (_require("../package.json") as { version: string })
 const HELP_TEXT = `Usage: gtd [command] [options]
 
 Commands:
-  init             Scaffold a .gtdrc.json for this repo with the bundled
-                   unified workflow; its agent prompts are written as editable
-                   Markdown under gtd-prompts/ and referenced from the config.
+  init             Scaffold a minimal .gtdrc.json for this repo, seeding the
+                   default variables you are most likely to change (the test
+                   command) and a Prettier formatting suggestion. gtd runs its
+                   built-in workflow by default, so no workflow is written —
+                   add a workflow: key only to customize the machine itself.
                    Takes no argument. Run once per repo; refuses if a gtd
-                   config already exists. Leaves the files uncommitted for you
+                   config already exists. Leaves the file uncommitted for you
                    to review and commit
   step <actor>     Authenticate as <actor>, match the resolved rest's
                    declared patterns against the pending changes, and commit
@@ -120,7 +122,7 @@ export const isEnveloped = (error: unknown): boolean =>
  * The stderr line for a CLI error (see `main.ts`): a `gtd: ` prefix UNLESS the
  * message already carries one. Most gtd errors are authored with a
  * `gtd:`/`gtd <cmd>:` prefix of their own (e.g. `gtd init: …`,
- * `gtd: no workflow configured …`), so a blind prepend produced a doubled
+ * `gtd: unknown option …`), so a blind prepend produced a doubled
  * `gtd: gtd: …`.
  */
 export const cliErrorLine = (error: unknown): string => {
@@ -247,20 +249,19 @@ const runLspCommand = (argv: readonly string[], json: boolean): Effect.Effect<vo
   })
 
 /**
- * `gtd init`: scaffold a `.gtdrc.json` carrying the bundled unified workflow
- * template inline. Takes NO argument — gtd ships a single template and no
- * longer offers a choice. Dispatched like `lsp` — BEFORE the
- * closeReviewWindow/dispatch/openReviewWindow block — because it is the ONE
- * command that must run with no workflow configured yet: it needs no
- * `ConfigService` (which would throw the "no workflow" error pre-init) and no
- * review window. It still runs the repo-root guard (it writes `.gtdrc.json` at
- * the root) and refuses to clobber an existing config. It also writes each
- * agent state's prompt as a standalone `gtd-prompts/<state>.md` file the config
- * references via `./` (see `renderInitScaffold`), so prompts are editable
- * Markdown rather than JSON-escaped strings. Everything is left UNCOMMITTED, so
- * the message warns to commit it all before the first `gtd step` (an
- * uncommitted config/prompt is a pending change the initial state's `* **` edge
- * would otherwise capture).
+ * `gtd init`: scaffold a MINIMAL `.gtdrc.json` seeding the default variables a
+ * fresh project is most likely to change — the test command (`vars.testCommand`)
+ * and a ready-to-edit Prettier formatting suggestion (`modes:`). It writes NO
+ * `workflow:` key: gtd ships the unified workflow as its built-in default and
+ * runs it whenever none is configured (see `src/Config.ts`), so there is
+ * nothing to scaffold there — a project customizes the machine itself only by
+ * adding a `workflow:` key. Takes NO argument. Dispatched like `lsp` — BEFORE
+ * the closeReviewWindow/dispatch/openReviewWindow block — because it needs no
+ * `ConfigService` and no review window. It still runs the repo-root guard (it
+ * writes `.gtdrc.json` at the root) and refuses to clobber an existing config.
+ * The file is left UNCOMMITTED, so the message warns to commit it before the
+ * first `gtd step` (an uncommitted config counts as a pending change the
+ * initial state's `* **` edge would otherwise capture).
  */
 const runInitCommand = (
   argv: readonly string[],
@@ -288,30 +289,17 @@ const runInitCommand = (
     yield* fs
       .writeFileString(join(root, ".gtdrc.json"), scaffold.config)
       .pipe(Effect.mapError(toError))
-    for (const prompt of scaffold.prompts) {
-      const full = join(root, prompt.path)
-      yield* fs.makeDirectory(dirname(full), { recursive: true }).pipe(Effect.mapError(toError))
-      yield* fs.writeFileString(full, prompt.content).pipe(Effect.mapError(toError))
-    }
     if (json) {
-      write(
-        JSON.stringify({
-          written: ".gtdrc.json",
-          workflow: "unified",
-          prompts: scaffold.prompts.map((p) => p.path),
-          inRepo,
-        }) + "\n",
-      )
+      write(JSON.stringify({ written: ".gtdrc.json", inRepo }) + "\n")
     } else {
-      const promptCount = scaffold.prompts.length
       const wrote =
-        `Wrote .gtdrc.json with the bundled unified workflow, and its ${promptCount} agent ` +
-        `prompt${promptCount === 1 ? "" : "s"} as editable Markdown under ${PROMPTS_DIR}/ ` +
-        `(referenced from the config).\n\n`
+        `Wrote .gtdrc.json seeding the default variables (the test command) and a\n` +
+        `Prettier formatting suggestion. gtd runs its built-in workflow by default — add\n` +
+        `a workflow: key only if you want to customize the machine itself.\n\n`
       const nextSteps = inRepo
-        ? `Review and commit them before starting: an uncommitted .gtdrc.json (or prompt\n` +
-          `file) counts as a pending change, so the initial state would capture it on the\n` +
-          `first step. Once committed, run \`gtd step human\` to begin.\n`
+        ? `Review and commit it before starting: an uncommitted .gtdrc.json counts as a\n` +
+          `pending change, so the initial state would capture it on the first step. Once\n` +
+          `committed, run \`gtd step human\` to begin.\n`
         : `This directory is not a git repository, so there is nothing to commit here. The\n` +
           `config applies to any gtd repository nested below it — gtd discovers it by\n` +
           `walking up from the repository root. Run \`gtd step human\` from such a repo to\n` +
@@ -1390,7 +1378,7 @@ export interface RunOptions {
  * `status` / `validate` / `mermaid` (see `src/Edge.ts` and
  * `docs/design/pattern-machine-plan.md` §3),
  * plus `lsp` and `init` — both dispatched before the config-reading
- * path since they must work with no workflow configured yet. Bare `gtd` or an
+ * path since neither needs to touch the config. Bare `gtd` or an
  * unknown subcommand is a usage error. Shared setup (argv parsing, the
  * repo-root guard) lives here; each subcommand's own logic is a named
  * `run*Command` function above.

--- a/src/workflows/templates.test.ts
+++ b/src/workflows/templates.test.ts
@@ -2,20 +2,14 @@ import { describe, expect, it } from "vitest"
 import { validateDefinition } from "../PatternMachine.js"
 import {
   compileTemplate,
+  defaultWorkflowDefinition,
+  defaultWorkflowVars,
+  INIT_VARS,
   MODES_SUGGESTION,
-  PROMPTS_DIR,
   renderInitConfig,
   renderInitScaffold,
   SCHEMA_URL,
 } from "./templates.js"
-
-/** Shape of a scaffolded config's `workflow.states` after prompt extraction. */
-type ScaffoldStates = Record<
-  string,
-  { prompt?: string; message?: string; script?: string; commit?: string }
->
-const scaffoldStates = (config: string): ScaffoldStates =>
-  (JSON.parse(config) as { workflow: { states: ScaffoldStates } }).workflow.states
 
 describe("the bundled unified workflow template", () => {
   it("compiles with no validation findings and exactly one initial state", () => {
@@ -60,72 +54,56 @@ describe("the bundled unified workflow template", () => {
     )
   })
 
-  it("renders a valid .gtdrc.json with the $schema key first", () => {
+  it("exposes the compiled default as the built-in fallback (definition + its own vars)", () => {
+    // `src/Config.ts` and the in-memory test layer fall back to these when no
+    // `workflow:` is configured — so they must be the same compiled shape the
+    // template produces, with the template's own `vars:` defaults intact.
+    expect(validateDefinition(defaultWorkflowDefinition)).toEqual([])
+    expect(defaultWorkflowDefinition).toEqual(compileTemplate().definition)
+    expect(defaultWorkflowVars).toEqual(compileTemplate().vars)
+    expect(defaultWorkflowVars.testCommand).toBe("npm test")
+  })
+
+  it("renders the full workflow config with the $schema key first (renderInitConfig)", () => {
+    // renderInitConfig materializes the built-in default into a `workflow:`
+    // config — the way to eject/customize the machine, and the hermetic
+    // `Given the workflow` test fixture (modes-free).
     const rendered = renderInitConfig()
-    const parsed = JSON.parse(rendered) as { $schema: string; workflow: unknown }
+    const parsed = JSON.parse(rendered) as { $schema: string; workflow: unknown; modes?: unknown }
     expect(parsed.$schema).toBe(SCHEMA_URL)
     expect(parsed.workflow).toBeTypeOf("object")
+    expect(parsed.modes).toBeUndefined()
     expect(rendered.endsWith("\n")).toBe(true)
   })
 
-  describe("renderInitScaffold", () => {
-    it("extracts every agent prompt to a gtd-prompts/<state>.md file and references it from the config", () => {
-      const { config, prompts } = renderInitScaffold()
-      const states = scaffoldStates(config)
-      const inlineStates = scaffoldStates(renderInitConfig())
-      const promptStates = Object.entries(inlineStates)
-        .filter(([, s]) => typeof s.prompt === "string")
-        .map(([stateName]) => stateName)
-
-      expect(promptStates.length).toBeGreaterThan(0)
-      expect(prompts.map((p) => p.path).sort()).toEqual(
-        promptStates.map((s) => `${PROMPTS_DIR}/${s}.md`).sort(),
-      )
-      for (const stateName of promptStates) {
-        const path = `${PROMPTS_DIR}/${stateName}.md`
-        expect(states[stateName]!.prompt).toBe(`./${path}`)
-        const file = prompts.find((p) => p.path === path)
-        expect(file?.content).toBe(inlineStates[stateName]!.prompt)
-      }
-    })
-
-    it("leaves human messages, check scripts, and commit templates inline in the config", () => {
-      const states = scaffoldStates(renderInitScaffold().config)
-      for (const state of Object.values(states)) {
-        expect(state.message?.startsWith("./")).not.toBe(true)
-        expect(state.script?.startsWith("./")).not.toBe(true)
-        expect(state.commit?.startsWith("./")).not.toBe(true)
-      }
-      const inline = scaffoldStates(renderInitConfig())
-      for (const [stateName, s] of Object.entries(inline)) {
-        if (s.message !== undefined) expect(states[stateName]!.message).toBe(s.message)
-        if (s.script !== undefined) expect(states[stateName]!.script).toBe(s.script)
-        if (s.commit !== undefined) expect(states[stateName]!.commit).toBe(s.commit)
-      }
-    })
-
-    it("keeps the $schema key first and ends with a newline", () => {
+  describe("renderInitScaffold — the minimal config `gtd init` writes", () => {
+    it("seeds only the default vars and the Prettier modes suggestion, no workflow", () => {
       const { config } = renderInitScaffold()
-      const parsed = JSON.parse(config) as { $schema: string }
+      const parsed = JSON.parse(config) as {
+        $schema: string
+        vars: unknown
+        modes: unknown
+        workflow?: unknown
+      }
       expect(parsed.$schema).toBe(SCHEMA_URL)
+      expect(parsed.vars).toEqual(INIT_VARS)
+      expect(parsed.modes).toEqual(MODES_SUGGESTION)
+      // The workflow is built in — init never writes it.
+      expect(parsed.workflow).toBeUndefined()
       expect(config.endsWith("\n")).toBe(true)
     })
 
-    it("seeds the top-level `modes:` Prettier suggestion for qa/review (format only)", () => {
+    it("seeds testCommand as the one variable a fresh project usually changes", () => {
       const { config } = renderInitScaffold()
-      const parsed = JSON.parse(config) as { modes?: unknown }
-      expect(parsed.modes).toEqual(MODES_SUGGESTION)
+      const parsed = JSON.parse(config) as { vars: { testCommand?: string } }
+      expect(parsed.vars.testCommand).toBe("npm test")
+    })
+
+    it("seeds a format-only Prettier suggestion for qa/review (gtd still validates)", () => {
       expect(MODES_SUGGESTION.qa.format).toContain("prettier")
       expect(MODES_SUGGESTION.review.format).toContain("prettier")
       expect(MODES_SUGGESTION.qa).not.toHaveProperty("validate")
       expect(MODES_SUGGESTION.review).not.toHaveProperty("validate")
-    })
-
-    it("does NOT seed `modes:` in the hermetic base config (renderInitConfig)", () => {
-      // renderInitConfig doubles as the `Given the workflow` test fixture; it
-      // must stay modes-free so gate scenarios never shell out to Prettier.
-      const parsed = JSON.parse(renderInitConfig()) as { modes?: unknown }
-      expect(parsed.modes).toBeUndefined()
     })
   })
 })

--- a/src/workflows/templates.ts
+++ b/src/workflows/templates.ts
@@ -1,27 +1,31 @@
 import { parse as parseYaml } from "yaml"
 import { compileWorkflowConfig, type CompiledWorkflowConfig } from "../PatternConfig.js"
+import type { WorkflowDefinition } from "../PatternMachine.js"
 import unifiedYaml from "./unified.yaml"
 
 /**
  * The `$schema` URL editors resolve for `.gtdrc.json` completion/validation —
- * written as the first key of every `gtd init` config (see `renderInitConfig`).
+ * written as the first key of every `gtd init` config (see `renderInitScaffold`).
  */
 export const SCHEMA_URL = "https://raw.githubusercontent.com/pmelab/gtd/main/schema.json"
 
 /**
- * The repo-root-relative directory `gtd init` writes each agent state's prompt
- * into as a standalone, editable Markdown file (see `renderInitScaffold`). The
- * scaffolded `.gtdrc.json` references these via `./gtd-prompts/<state>.md`
- * content-value file references, which `compileWorkflowConfig` inlines at load
- * time (`resolveContent` in `src/PatternConfig.ts`) — so editing a prompt file
- * changes the workflow with no config edit.
+ * The default `vars:` `gtd init` seeds into the scaffolded `.gtdrc.json` — the
+ * one variable a fresh project almost always changes. It mirrors the bundled
+ * workflow's OWN `testCommand` default (`npm test`), surfaced at the top level
+ * as a ready-to-edit override (the top-level `vars:` layer wins over the
+ * workflow's own — see `src/Edge.ts`'s `resolveVars`). Everything else the
+ * workflow needs already ships inside the built-in default, so there is nothing
+ * else to seed.
  */
-export const PROMPTS_DIR = "gtd-prompts"
+export const INIT_VARS = {
+  testCommand: "npm test",
+} as const
 
 /**
- * The top-level `modes:` block `gtd init` SEEDS into the scaffolded
+ * The top-level `modes:` block `gtd init` seeds into the scaffolded
  * `.gtdrc.json` as a ready-to-edit suggestion: a `format:` command for each
- * built-in steering-file mode the bundled template uses (`qa` for the plan /
+ * built-in steering-file mode the bundled default uses (`qa` for the plan /
  * open-questions files, `review` for REVIEW.md), so a fresh project's steering
  * files are auto-formatted with Prettier before gtd validates them. Only
  * `format:` is declared — gtd's built-in `qa`/`review` validators still do the
@@ -29,11 +33,6 @@ export const PROMPTS_DIR = "gtd-prompts"
  * docs/configuration.md `modes:`). gtd ships no formatter, so this is the one
  * place a default is suggested; a project edits or drops it freely (swap
  * Prettier for dprint, point at a script, delete the key).
- *
- * Seeded only by `renderInitScaffold` (the real `gtd init` write path), NOT by
- * `renderInitConfig`: the latter is reused as a hermetic test fixture (the
- * `Given the workflow` step) that must not depend on Prettier being installed
- * or spawn a subprocess at every steering-file gate.
  */
 export const MODES_SUGGESTION = {
   qa: { format: "npx prettier --write <%= it.file %>" },
@@ -41,94 +40,77 @@ export const MODES_SUGGESTION = {
 } as const
 
 /**
- * The single bundled workflow template `gtd init` scaffolds — the raw YAML text
- * of `unified.yaml`, imported as a string (tsdown's `.yaml` text loader / the
- * vitest `rawMd` transform — see tsdown.config.ts / tests/vitest.rawMd.ts), so
- * this module never touches the filesystem: it works identically in the dev
- * checkout, under `vitest`, and inside the single-file `dist/gtd.bundle.mjs`
- * build. gtd ships NO default workflow and no longer offers a choice of
- * templates — `gtd init` takes no argument.
+ * The single bundled workflow template — the raw YAML text of `unified.yaml`,
+ * imported as a string (tsdown's `.yaml` text loader / the vitest `rawMd`
+ * transform — see tsdown.config.ts / tests/vitest.rawMd.ts), so this module
+ * never touches the filesystem: it works identically in the dev checkout,
+ * under `vitest`, and inside the single-file `dist/gtd.bundle.mjs` build. gtd
+ * ships this as its BUILT-IN DEFAULT — a repo with no `workflow:` configured
+ * runs it directly (see `src/Config.ts`'s `toOperations`), so `gtd init` no
+ * longer writes the workflow into the config at all.
  */
 const UNIFIED_WORKFLOW = unifiedYaml
 
 /**
- * Render the fully-inline BASE `.gtdrc.json` for the bundled template: a
- * `$schema` link (so editors pick up completion/validation) plus the template's
- * whole workflow object nested under a `workflow:` key — exactly the shape a
- * hand-authored `.gtdrc` `workflow:` value takes (`{ vars, states }`). The
- * template's multi-line prompts/scripts become `\n`-escaped JSON strings; the
- * config loader parses them back identically to the YAML source.
- *
- * This is NOT the exact file `gtd init` writes — the real write path
- * (`renderInitScaffold`) additionally externalizes agent prompts and seeds the
- * top-level `modes:` Prettier suggestion (`MODES_SUGGESTION`). This base form is
- * kept modes-free so it doubles as a hermetic test fixture (the
- * `Given the workflow` step) whose steering-file gates never shell out to
- * Prettier.
+ * The bundled default, compiled once through the exact same
+ * `compileWorkflowConfig` a user's `.gtdrc` `workflow:` key goes through — no
+ * privileged code path. `src/Config.ts` (and the in-memory test layer) fall
+ * back to this whenever no `workflow:` key is configured; `compileTemplate`
+ * exposes it fresh for Mermaid rendering and tests. `configDir` is `"."` and
+ * never consulted: no template content value starts with `./`/`../`.
+ */
+const DEFAULT_WORKFLOW: CompiledWorkflowConfig = compileWorkflowConfig(
+  parseYaml(UNIFIED_WORKFLOW),
+  ".",
+)
+
+/** The compiled built-in default workflow definition — the fallback when no `workflow:` is configured. */
+export const defaultWorkflowDefinition: WorkflowDefinition = DEFAULT_WORKFLOW.definition
+
+/** The built-in default workflow's own declared `vars:` defaults (layer 1 of the merged `it.vars`). */
+export const defaultWorkflowVars: Record<string, string> = DEFAULT_WORKFLOW.vars
+
+/**
+ * Render the full built-in workflow as a `.gtdrc.json` `workflow:` value — the
+ * template's whole workflow object nested under a `workflow:` key, exactly the
+ * shape a hand-authored `.gtdrc` `workflow:` value takes (`{ vars, states }`),
+ * plus a `$schema` link. This is NOT what `gtd init` writes (init seeds only
+ * vars/modes — the workflow itself is built in); it is kept as the way to
+ * MATERIALIZE the default for editing, and as the hermetic `Given the workflow`
+ * test fixture (modes-free, so its steering-file gates never shell out to
+ * Prettier).
  */
 export const renderInitConfig = (): string => {
   const workflow = parseYaml(UNIFIED_WORKFLOW) as unknown
   return JSON.stringify({ $schema: SCHEMA_URL, workflow }, null, 2) + "\n"
 }
 
-/** One agent prompt `gtd init` writes out as a standalone Markdown file. */
-export interface ScaffoldPromptFile {
-  /** Repo-root-relative path, e.g. `gtd-prompts/planning.md`. */
-  readonly path: string
-  /** The prompt body, verbatim from the bundled template's inline `prompt:`. */
-  readonly content: string
-}
-
-/** The files `gtd init` writes: the `.gtdrc.json` text plus one Markdown file per agent prompt. */
+/** The single file `gtd init` writes: the `.gtdrc.json` contents. */
 export interface InitScaffold {
-  /** The `.gtdrc.json` contents, with each agent state's `prompt:` rewritten to a `./gtd-prompts/<state>.md` file reference and a top-level `modes:` Prettier suggestion seeded (see `MODES_SUGGESTION`). */
+  /** The `.gtdrc.json` contents — a `$schema` link plus the seeded default `vars:` and `modes:`; NO `workflow:` (the default is built in). */
   readonly config: string
-  /** The extracted prompt files, one per agent (`prompt:`) state, in declaration order. */
-  readonly prompts: readonly ScaffoldPromptFile[]
 }
 
 /**
- * Render everything `gtd init` writes. Like `renderInitConfig`, but each agent
- * state's inline `prompt:` is EXTRACTED into a standalone
- * `gtd-prompts/<state>.md` file and the config value is rewritten to a
- * `./gtd-prompts/<state>.md` file reference — `compileWorkflowConfig` inlines
- * it back at load time (`resolveContent`), so the workflow behaves identically
- * to the fully-inline `renderInitConfig` form while the prompts stay editable
- * as ordinary Markdown. Only `prompt:` content is externalized: human
- * `message:` blocks, check `script:` bodies, and the `done` `commit:` template
- * remain inline in the config (they are workflow mechanics, not prompts). The
- * bundled YAML template itself stays fully inline (it ships inside the
- * single-file bundle); this function is the only place the split happens, at
- * scaffold time.
- *
- * It also seeds a top-level `modes:` block (`MODES_SUGGESTION`) — a ready-to-
- * edit Prettier `format:` for the built-in `qa`/`review` steering-file modes —
- * so a fresh project auto-formats its steering files out of the box. This lives
- * here rather than in `renderInitConfig` so the latter stays a hermetic test
- * fixture (see `MODES_SUGGESTION`).
+ * Render what `gtd init` writes: a minimal `.gtdrc.json` seeding the default
+ * variables (`vars.testCommand`) and a ready-to-edit Prettier formatting
+ * suggestion (`modes:`). It carries NO `workflow:` key — gtd ships the unified
+ * workflow as its built-in default and runs it whenever none is configured
+ * (see `src/Config.ts`). A project that wants to customize the machine itself
+ * adds a `workflow:` key (materialize the default with `renderInitConfig` as a
+ * starting point); everyday tuning is just editing the seeded `vars:`/`modes:`.
  */
 export const renderInitScaffold = (): InitScaffold => {
-  const workflow = parseYaml(UNIFIED_WORKFLOW) as {
-    states?: Record<string, Record<string, unknown>>
-  }
-  const prompts: ScaffoldPromptFile[] = []
-  for (const [stateName, state] of Object.entries(workflow.states ?? {})) {
-    if (typeof state.prompt === "string") {
-      const path = `${PROMPTS_DIR}/${stateName}.md`
-      prompts.push({ path, content: state.prompt })
-      state.prompt = `./${path}`
-    }
-  }
   const config =
-    JSON.stringify({ $schema: SCHEMA_URL, modes: MODES_SUGGESTION, workflow }, null, 2) + "\n"
-  return { config, prompts }
+    JSON.stringify({ $schema: SCHEMA_URL, vars: INIT_VARS, modes: MODES_SUGGESTION }, null, 2) +
+    "\n"
+  return { config }
 }
 
 /**
  * Compile the bundled template through the same `compileWorkflowConfig` a
- * user's `.gtdrc` `workflow:` key goes through. Used only where a compiled
- * `WorkflowDefinition` is needed directly (Mermaid rendering, tests) — the
- * `gtd init` write path uses `renderInitScaffold` and never compiles.
+ * user's `.gtdrc` `workflow:` key goes through. Used where a freshly-compiled
+ * `WorkflowDefinition` is needed directly (Mermaid rendering, tests).
  * `configDir` is `"."` and never consulted: no template content value starts
  * with `./`/`../`.
  */

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -1,18 +1,19 @@
-# The unified gtd workflow template — written verbatim into `.gtdrc.json`
-# (nested under a `workflow:` key) by `gtd init` (no argument). gtd ships no
-# default workflow: a repo picks this bundled template with `gtd init`, and a
-# state command run with no workflow configured fails (see src/Config.ts).
-# See STATES.md §10 for the full walkthrough.
+# The unified gtd workflow template — gtd's BUILT-IN DEFAULT workflow. When no
+# `workflow:` key is configured anywhere in the cwd→home config chain,
+# src/Config.ts runs this template directly, so a state command works with no
+# configuration at all. `gtd init` seeds only the settings a project tunes
+# (vars.testCommand + a modes: formatting suggestion), never the workflow
+# itself. See STATES.md §10 for the full walkthrough.
 #
 # Compiled through the exact same `compileWorkflowConfig` a user's `.gtdrc`
 # `workflow:` key goes through — no privileged code path
 # (src/workflows/templates.ts does the compiling). Every content string below
 # is INLINE (no `./`-relative file references): the bundled template ships
 # inside a single-file build (`dist/gtd.bundle.mjs`), so its content must
-# already be resolved at BUILD time. `gtd init` DERIVES the scaffolded
-# `.gtdrc.json` from this inline source (`renderInitScaffold`): each agent
-# state's `prompt:` is written out as an editable `gtd-prompts/<state>.md`
-# file; human `message:`/check `script:`/the `done` `commit:` body stay inline.
+# already be resolved at BUILD time. `renderInitConfig` (src/workflows/
+# templates.ts) can MATERIALIZE this inline source into a `.gtdrc.json`
+# `workflow:` value — the way to eject/customize the machine, and the hermetic
+# test fixture — but `gtd init` itself no longer writes the workflow.
 #
 # ── Four entry points behind a green-baseline gate, one shared tail ─────────
 #

--- a/tests/integration/features/init.feature
+++ b/tests/integration/features/init.feature
@@ -1,88 +1,40 @@
 @live
-Feature: gtd init — scaffold a .gtdrc.json from the bundled unified workflow
+Feature: gtd init — seed a minimal .gtdrc.json (default vars + formatting)
 
-  `gtd init` (see src/program.ts) writes a `.gtdrc.json` carrying the bundled
-  unified workflow template inline. It takes NO argument — gtd ships a single
-  template and no default, so a state command run with no workflow configured
-  fails with a pointer back to `gtd init`. The written file is left UNCOMMITTED
-  (the user reviews and commits it), and init refuses to clobber an existing
-  config. Runs @live so the real config-detection (cosmiconfig over the real
-  filesystem) is exercised.
+  `gtd init` (see src/program.ts) writes a MINIMAL `.gtdrc.json` seeding the
+  default variables a fresh project usually changes (the test command) and a
+  Prettier formatting suggestion (`modes:`). It writes NO `workflow:` key — gtd
+  ships the unified workflow as its built-in default and runs it whenever none
+  is configured, so a state command works out of the box with no init at all. A
+  project customizes the machine itself only by adding a `workflow:` key. The
+  written file is left UNCOMMITTED (the user reviews and commits it), and init
+  refuses to clobber an existing config. Runs @live so the real config-detection
+  (cosmiconfig over the real filesystem) is exercised.
 
-  Scenario: gtd init writes an uncommitted .gtdrc.json with the unified workflow inline
+  Scenario: gtd init writes an uncommitted minimal .gtdrc.json with default vars and modes
     Given a test project
     When I run gtd with args "init"
     Then it succeeds
     And stdout contains "Wrote .gtdrc.json"
-    And stdout contains "gtd-prompts/"
+    And stdout contains "built-in workflow"
     And stdout contains "commit"
     And ".gtdrc.json" exists
     And ".gtdrc.json" contains "\"$schema\""
-    And ".gtdrc.json" contains "\"workflow\""
-    And ".gtdrc.json" contains "review-deciding"
-    # Both entry points and the advanced machinery live in the one template.
-    And ".gtdrc.json" contains "adv-grilling"
-    And ".gtdrc.json" contains "decompose"
-    And ".gtdrc.json" contains "spec-review"
-    And ".gtdrc.json" contains "squashing"
+    # Seeds the test command as a ready-to-edit top-level var.
+    And ".gtdrc.json" contains "\"vars\""
+    And ".gtdrc.json" contains "\"testCommand\""
+    And ".gtdrc.json" contains "npm test"
     # A ready-to-edit top-level `modes:` block seeds a Prettier formatter for the
     # built-in qa/review steering-file modes (format only — gtd still validates).
     And ".gtdrc.json" contains "\"modes\""
     And ".gtdrc.json" contains "npx prettier --write"
+    # No workflow is written — the machine is built in.
+    And ".gtdrc.json" does not contain "\"workflow\""
+    And ".gtdrc.json" does not contain "review-deciding"
+    # No prompt files are extracted — the prompts live in the built-in workflow.
+    And "gtd-prompts/planning.md" does not exist
     # Left uncommitted — HEAD is still the project's own initial commit.
     And the last commit subject is "chore: initial commit"
-
-  # Each agent state's prompt is extracted to gtd-prompts/<state>.md and the
-  # config references it via a ./ file reference; human messages and check
-  # scripts stay inline in the config.
-  Scenario: gtd init extracts agent prompts to gtd-prompts/ and references them
-    Given a test project
-    When I run gtd with args "init"
-    Then it succeeds
-    And "gtd-prompts/planning.md" exists
-    And "gtd-prompts/planning.md" contains "autonomous coding agent"
-    And "gtd-prompts/building.md" exists
-    And "gtd-prompts/fixing.md" exists
-    And "gtd-prompts/reviewing.md" exists
-    And "gtd-prompts/architecting.md" exists
-    And "gtd-prompts/decompose.md" exists
-    And "gtd-prompts/spec-review.md" exists
-    And "gtd-prompts/squashing.md" exists
-    And ".gtdrc.json" contains "./gtd-prompts/planning.md"
-    # idle is a human message, checking is a script — both stay inline.
-    And "gtd-prompts/idle.md" does not exist
-    And "gtd-prompts/checking.md" does not exist
-    And ".gtdrc.json" contains "No active gtd cycle"
-
-  # The extracted files are LIVE: gtd inlines them at load time, so editing a
-  # prompt file changes the workflow with no config edit.
-  Scenario: the workflow resolves an edited prompt file at runtime
-    Given a test project
-    When I run gtd with args "init"
-    Then it succeeds
-    Given "gtd-prompts/planning.md" is modified to:
-      """
-      SENTINEL edited planning prompt body
-      """
-    # A passing test command so the green-baseline gate (start-check) proceeds
-    # to planning — the state whose edited prompt this scenario checks.
-    And a file "package.json" with:
-      """
-      { "scripts": { "test": "exit 0" } }
-      """
-    And the working tree is committed
-    And a file ".gtd/TODO.md" with:
-      """
-      build a small widget
-      """
-    When I run gtd step human
-    Then it succeeds
-    And the last commit subject is "gtd(human): idle → start-check"
-    When I run gtd step check
-    Then it succeeds
-    And the last commit subject is "gtd(check): start-check → planning"
-    When I run gtd next
-    Then stdout contains "SENTINEL edited planning prompt body"
 
   Scenario: gtd init rejects a workflow argument
     Given a test project
@@ -107,14 +59,16 @@ Feature: gtd init — scaffold a .gtdrc.json from the bundled unified workflow
     Then it succeeds
     And stdout contains "Wrote .gtdrc.json"
     And ".gtdrc.json" exists
-    And ".gtdrc.json" contains "\"workflow\""
+    And ".gtdrc.json" contains "\"testCommand\""
 
-  Scenario: a state command with no workflow configured fails with the init hint
+  # gtd ships a built-in default workflow, so a state command works with no
+  # config at all — no init required.
+  Scenario: a state command with no config runs on the built-in default workflow
     Given a test project
     When I run gtd status
-    Then it fails
-    And stderr contains "no workflow configured"
-    And stderr contains "gtd init"
+    Then it succeeds
+    And stdout contains "State: idle"
+    And stdout contains "Awaits: human"
 
   # init writes only config — it derives no git state, so it may scaffold a
   # SHARED config in a plain parent directory that is not a repo. A nested repo
@@ -126,8 +80,7 @@ Feature: gtd init — scaffold a .gtdrc.json from the bundled unified workflow
     And stdout contains "Wrote .gtdrc.json"
     And stdout contains "not a git repository"
     And ".gtdrc.json" exists
-    And ".gtdrc.json" contains "\"workflow\""
-    And "gtd-prompts/building.md" exists
+    And ".gtdrc.json" contains "\"testCommand\""
 
   # But a repository SUBDIRECTORY is refused: gtd discovers config by walking UP
   # from the repo root, so a config written below the root would never be found.

--- a/tests/integration/features/smoke.feature
+++ b/tests/integration/features/smoke.feature
@@ -4,8 +4,8 @@ Feature: v3 pattern-machine smoke — simple workflow hops, gtd next --json, cus
   Minimal smoke coverage for the v3 CLI (`gtd step <actor>` / `gtd next` /
   `gtd status`, see src/Edge.ts and
   docs/design/pattern-machine-plan.md). Proves the rewritten edge/CLI wiring
-  end to end: a couple of `simple`-workflow hops (scaffolded by `gtd init
-  simple`), the `gtd next --json` contract, and a custom `.gtdrc` `workflow:`
+  end to end: a couple of simple-flow hops on the built-in default workflow, the
+  `gtd next --json` contract, and a custom `.gtdrc` `workflow:`
   squashing through a `commit:` state. Comprehensive coverage (every
   simple-workflow state, retry/escalation, the full check/fix/review cycle,
   both refusal shapes) has its own dedicated feature files — see

--- a/tests/integration/support/inmem/layers.ts
+++ b/tests/integration/support/inmem/layers.ts
@@ -14,16 +14,17 @@ import {
   type GitWriterOperations,
   type GitOperations,
 } from "../../../../src/Git.js"
-import {
-  ConfigService,
-  NO_WORKFLOW_MESSAGE,
-  type ConfigOperations,
-} from "../../../../src/Config.js"
+import { ConfigService, type ConfigOperations } from "../../../../src/Config.js"
 import {
   compileModesMap,
   compileVarsMap,
   compileWorkflowConfig,
+  mergeModes,
 } from "../../../../src/PatternConfig.js"
+import {
+  defaultWorkflowDefinition,
+  defaultWorkflowVars,
+} from "../../../../src/workflows/templates.js"
 import { InMemRepo } from "./Repo.js"
 import { Cwd } from "../../../../src/Cwd.js"
 import { EnvVars } from "../../../../src/EnvVars.js"
@@ -411,21 +412,27 @@ const compileRcModes = (raw: unknown) => {
 
 /**
  * Mirrors the real `ConfigService.Live`'s `toOperations`: an absent
- * `workflow:` key THROWS `NO_WORKFLOW_MESSAGE` (gtd ships no default — a repo
- * scaffolds one with `gtd init`); a present one is compiled through the SAME
- * `compileWorkflowConfig` the real service uses — no bespoke in-memory
- * workflow interpretation. Likewise the top-level `vars:` key goes through the
- * same `compileRcVars` the real service uses. `configDir` is `"/repo"` (this
- * harness's fixed in-memory root, matching `topLevel`/`realPath` above) so a
- * scenario's custom workflow could reference `./`-relative content if it ever
- * needed to (none currently do; every @inmem custom-workflow scenario writes
- * inline content).
+ * `workflow:` key falls back to gtd's built-in bundled default
+ * (`defaultWorkflowDefinition`, with the top-level `modes:` layered over it);
+ * a present one is compiled through the SAME `compileWorkflowConfig` the real
+ * service uses — no bespoke in-memory workflow interpretation. Likewise the
+ * top-level `vars:` key goes through the same `compileRcVars` the real service
+ * uses. `configDir` is `"/repo"` (this harness's fixed in-memory root, matching
+ * `topLevel`/`realPath` above) so a scenario's custom workflow could reference
+ * `./`-relative content if it ever needed to (none currently do; every @inmem
+ * custom-workflow scenario writes inline content).
  */
 const makeConfigOps = (raw: Record<string, unknown>): ConfigOperations => {
   const rcVars = compileRcVars(raw["vars"])
   const rcModes = compileRcModes(raw["modes"])
   if (raw["workflow"] === undefined) {
-    throw new Error(NO_WORKFLOW_MESSAGE)
+    const modes = mergeModes(defaultWorkflowDefinition.modes, rcModes)
+    return {
+      workflow:
+        modes !== undefined ? { ...defaultWorkflowDefinition, modes } : defaultWorkflowDefinition,
+      workflowVars: defaultWorkflowVars,
+      rcVars,
+    }
   }
   const { definition, vars: workflowVars } = compileWorkflowConfig(
     raw["workflow"],
@@ -439,8 +446,8 @@ const makeInMemoryConfigService = (repo: InMemRepo): Layer.Layer<ConfigService> 
   const worktree = (repo as unknown as { worktree: Map<string, string> })["worktree"]
 
   // Deferred exactly like the real `ConfigService.Live`: `load` (re)reads the
-  // worktree config on each access and throws `NO_WORKFLOW_MESSAGE` when no
-  // `workflow:` is present, so building the layer never fails and
+  // worktree config on each access and falls back to the built-in default when
+  // no `workflow:` is present, so building the layer never fails and
   // config-independent commands (`init`) run with no config in the worktree.
   const load = Effect.try({
     try: (): ConfigOperations => {

--- a/tests/integration/support/steps/common.steps.ts
+++ b/tests/integration/support/steps/common.steps.ts
@@ -299,6 +299,14 @@ Then("{string} contains {string}", (world: GtdWorld, path: string, text: string)
   assert.ok(content.includes(text), `Expected "${path}" to contain "${text}". Got:\n${content}`)
 })
 
+Then("{string} does not contain {string}", (world: GtdWorld, path: string, text: string) => {
+  const content = world.readRepoFile(path)
+  assert.ok(
+    !content.includes(text),
+    `Expected "${path}" NOT to contain "${text}". Got:\n${content}`,
+  )
+})
+
 // Full-history assertion for journey scenarios: the exact commit subject
 // sequence, oldest → newest, one subject per docstring line.
 Then("the commit subjects from oldest to newest are:", (world: GtdWorld, doc: string) => {

--- a/tests/integration/support/steps/config.steps.ts
+++ b/tests/integration/support/steps/config.steps.ts
@@ -78,12 +78,14 @@ Given(
   },
 )
 
-// Scaffolds the bundled unified workflow template into `.gtdrc.json` and
-// commits it — exactly what `gtd init` writes (via the same `renderInitConfig`),
-// minus the "leave it uncommitted" part: committing keeps the working tree
-// clean so the machine starts at the template's initial state. gtd ships one
-// template and no default fallback, so a scenario exercising its shape sets it
-// up explicitly here.
+// Materializes the bundled unified workflow into `.gtdrc.json` (via
+// `renderInitConfig`) and commits it. The workflow is gtd's BUILT-IN default,
+// so a scenario need not configure it — but pinning it explicitly (and
+// committing to keep the tree clean, resting at the template's initial state)
+// keeps a scenario's assertions stable against the exact shape it was written
+// for. `renderInitConfig` is modes-free, so the steering-file gates stay
+// hermetic (no shelling out to Prettier). This is NOT what `gtd init` writes
+// (init seeds only vars/modes — see init.feature).
 const scaffoldUnifiedWorkflow = (world: GtdWorld): void => {
   const content = renderInitConfig()
   if (world.tier === "inmem") {


### PR DESCRIPTION
## What & why

gtd ships the bundled **unified** workflow as its **built-in default** again. When no `workflow:` key is configured anywhere in the cwd→home config chain, the default is used automatically — a state command works out of the box with **no config and no `gtd init`**. The `no workflow configured` error is removed.

`gtd init` is now a lightweight seeder: it writes a **minimal** `.gtdrc.json` with only the settings a project tunes — `vars.testCommand` and a Prettier `modes:` formatting suggestion. It no longer writes the workflow inline or extracts `gtd-prompts/`. Customizing the machine itself is done by adding a `workflow:` key (no `extends`/merge — it fully replaces the default).

This reverts the design of #`v6.0.0` (`feat!: replace bundled default workflow with gtd init <workflow>`) while keeping `gtd init` around as a vars/modes seeder.

## Changes

- **`templates.ts`** — export the compiled default (`defaultWorkflowDefinition`/`defaultWorkflowVars`); `renderInitScaffold` writes the minimal vars/modes config; `renderInitConfig` kept as the full-workflow materializer / hermetic test fixture.
- **`Config.ts`** + in-memory test layer — fall back to the built-in default (merging top-level `modes:`) instead of throwing `NO_WORKFLOW_MESSAGE`.
- **`PatternConfig.ts`** — export `mergeModes`.
- **`program.ts`** — `gtd init` minimal write; help text and messages reframed.
- **Tests** — `templates.test.ts`, `Config.test.ts`, `init.feature` rewritten; new generic `"{string}" does not contain "{string}"` step; `smoke.feature`/`config.steps` prose updated.
- **Docs** — README, AGENTS.md, STATES.md, `unified.yaml` header, `docs/{cli,configuration,upgrading,development}.md`, `skills/authoring/SKILL.md`.

## Breaking change

`.gtdrc` `workflow:` is optional again and `gtd init` no longer scaffolds a workflow. A repo that adopted `gtd init`'s inline workflow + `gtd-prompts/` keeps working (an explicit `workflow:` still wins); a repo that relied on `gtd init` to produce a workflow now gets the built-in default instead.

## Verification

`npm test` passes end-to-end: format, typecheck, lint, 486 unit tests, 183 e2e tests (including the real-binary `@live` `init.feature`), and the health gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)