### PR TITLE
fix(review-window): scope the checkout window per worktree; add gtd abandon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,11 +126,16 @@ a project plugs its own into a mode's `format:`).
 - **`src/ReviewWindow.ts`** — the review checkout window edge (see STATES.md
   §11): `openReviewWindow`/`closeReviewWindow` (the `git reset --mixed`
   open/close bracketing every state subcommand, keyed on the resolved rest's
-  `reviewWindow: true` and on `refs/gtd/review-head` existence) and
-  `reviewBaseHash` (the `reviewBase`-state diff-base derivation). Pure engine is
+  `reviewWindow: true` and on `refs/worktree/gtd/review-head` existence) and
+  `reviewBaseHash` (the `reviewBase`-state diff-base derivation). The window's
+  refs live in git's PER-WORKTREE `refs/worktree/*` namespace so linked
+  worktrees sharing one `.git` never clobber each other (issue #118); the
+  pre-7.2 SHARED `refs/gtd/*` pair is read-only legacy (`openWindowRefs`),
+  closed only when HEAD is contained in the saved head. Pure engine is
   oblivious; `program.ts` calls it, it calls `GitService`/`Edge.ts`.
-- **`src/program.ts`** — CLI dispatch (`init`/`step`/`next`/`status`/`validate`;
-  `lsp`, `init`, and `visualize` dispatched BEFORE the config-reading path's
+- **`src/program.ts`** — CLI dispatch
+  (`init`/`step`/`review`/`fix`/`abandon`/`next`/`status`/`validate`; `lsp`,
+  `init`, and `visualize` dispatched BEFORE the config-reading path's
   git/repo-root/review-window bracket — `lsp`/`init` need no config at all,
   `visualize` reads the workflow but no git state). `runInitCommand` writes
   `renderInitScaffold()` to `.gtdrc.json` (uncommitted) — a MINIMAL config
@@ -144,7 +149,11 @@ a project plugs its own into a mode's `format:`).
   so init tailors its "commit before starting" guidance. Calls `Edge.ts` for
   everything IO-shaped; calls `PatternMachine.ts`'s pure
   `step`/`matchesPattern`/`parsePattern` directly where no IO is needed (e.g.
-  `gtd status`'s per-change pattern report).
+  `gtd status`'s per-change pattern report). `runAbandonCommand` is the human
+  counterpart to a squash: it mixed-resets to `computeProcessRun`'s
+  `startParentHash` (the window already closed by the shared bracket), keeping
+  every dropped commit's content as pending changes — a no-op success at the
+  initial state.
 - **`src/Visualize.ts` (+ `src/visualize.html`)** — the `gtd visualize` viewer:
   `buildVizModel` describes the active workflow as JSON (the flat compiled
   states with their edges/details, PLUS the sub-machine grouping via

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ over — a `workflow:` is the whole definition). See
 
 gtd is a small **pattern machine**: named states, each awaiting one actor and
 carrying one piece of content (a script, a prompt, a message, or a squash commit
-template), with an ordered set of change-patterns routing to the next state.
-Four commands drive it:
+template), with an ordered set of change-patterns routing to the next state. A
+handful of commands drive it:
 
 - **`gtd step <actor>`** — authenticate as `<actor>` and perform the one
   transition the pending changes match.
@@ -91,6 +91,9 @@ Four commands drive it:
 - **`gtd fix`** — start a brand new process that goes straight into repairing
   the current failing tests, then runs the shared review/squash tail (a no-op if
   the suite is already green).
+- **`gtd abandon`** — end the process underway without completing it: rewind to
+  the commit it started from, keeping everything it produced as uncommitted
+  changes (nothing is discarded).
 - **`gtd visualize`** — serve an interactive diagram of the active workflow on a
   local web server (the main flow, its sub-machines, and per-state details).
 

--- a/STATES.md
+++ b/STATES.md
@@ -295,6 +295,18 @@ the message filename appears only in user-authored patterns/templates.
 * <process start parent>
 ```
 
+**Abandoning instead of finishing.** A squash is the workflow's own way out of a
+process; **`gtd abandon`** is the human's. It targets the same boundary — the
+process's start parent — but with `git reset --mixed` and no commit: every turn
+commit is dropped and everything they carried (code, `.gtd/` steering files)
+stays in the working tree as uncommitted changes, so nothing is lost and the
+machine rests at the initial state again. Resting there already is a no-op
+success (a recovery command that fails when there is nothing to recover is a
+worse tool); a process whose first commit is the repository's root commit is the
+one refusal, since there is no earlier commit to rewind to. Like the squash,
+this lives entirely at the edge (`src/program.ts`) — the pure engine has no
+notion of abandoning.
+
 ## 9. Validation
 
 `validateDefinition` (run at config-load time, never at step time) rejects a
@@ -688,8 +700,20 @@ gutters, per-file diff, and discard-hunk already understand.
 begins, so an editor would otherwise show a clean tree. gtd temporarily rewinds
 HEAD and the index to the review base (`git reset --mixed <base>`) with the
 working tree untouched, so the entire `base..HEAD` diff re-appears as
-uncommitted changes. The real head is preserved under `refs/gtd/review-head`
-(the base under `refs/gtd/review-base`) so nothing is lost.
+uncommitted changes. The real head is preserved under
+`refs/worktree/gtd/review-head` (the base under `refs/worktree/gtd/review-base`)
+so nothing is lost.
+
+**One window per worktree.** Those two refs sit in git's **per-worktree**
+`refs/worktree/*` namespace, so N linked worktrees of one repository
+(`git worktree add`, sharing a single `.git`) each get their own independent
+window, and git drops the refs along with the worktree. gtd ≤ 7.1 used the
+SHARED `refs/gtd/*` namespace, where a window opened in one worktree made the
+next worktree's very first gtd invocation "close" it — mixed-resetting that
+worktree's branch onto the other's saved head. A window an older gtd left open
+across the upgrade is still finished from the legacy refs, but only when HEAD is
+contained in the saved head; otherwise the close refuses with the manual
+recovery, rather than resetting a branch onto a sibling worktree's work.
 
 **The base.** By default it is the process's diff base (`computeProcessRun`'s
 `diffBase` — see §7), so the window shows the whole current cycle — or, for a
@@ -711,15 +735,15 @@ window — it is opened and closed entirely at the edge (`src/ReviewWindow.ts`),
 bracketing every state subcommand (`step`/`next`/`status`):
 
 - **Close first, always.** Before anything reads or mutates state, gtd restores
-  the real head if a window is open (keyed solely on `refs/gtd/review-head`
-  existing). This is why the machine resolves the true rest, not the rewound
-  base — and why a reviewer's own edits, made while the window was open, land as
-  the resting state's ordinary pending changes and are captured by its `on`
-  patterns like any other diff (in the unified template, a code edit at
-  `await-review` is feedback — it routes through `review-deciding` into a
-  build + re-review round; ticking every box with no comment signs off into the
-  squash finale, while a deleted `.gtd/REVIEW.md` is refused by the sign-off
-  gate — see §10).
+  the real head if a window is open (keyed solely on
+  `refs/worktree/gtd/review-head` existing). This is why the machine resolves
+  the true rest, not the rewound base — and why a reviewer's own edits, made
+  while the window was open, land as the resting state's ordinary pending
+  changes and are captured by its `on` patterns like any other diff (in the
+  unified template, a code edit at `await-review` is feedback — it routes
+  through `review-deciding` into a build + re-review round; ticking every box
+  with no comment signs off into the squash finale, while a deleted
+  `.gtd/REVIEW.md` is refused by the sign-off gate — see §10).
 - **Re-arm last.** After the subcommand finishes — on success, on refusal, and
   after read-only commands too — gtd re-opens the window if the resolved rest
   declares `reviewWindow: true`. Every command participates, so the editor's

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,6 +25,11 @@ Commands:
                    state (fixEntry: true) that goes straight into repairing the
                    current failing tests. Requires a clean tree resting at the
                    workflow's initial state
+  abandon          End the process currently underway without completing it:
+                   close any open review checkout window, then rewind HEAD to
+                   the commit the process started from, keeping everything it
+                   produced as uncommitted changes. A no-op when no process is
+                   underway
   next             Print the resolved rest's rendered script/prompt/message
                    (no mutation)
   status           Print the resolved rest's state/actor and which declared
@@ -167,7 +172,8 @@ written):
 
 - the machine currently resting at the workflow's **initial state** (a plain
   non-gtd branch resolves there via the inert-subject rule — the normal case; a
-  process already underway refuses);
+  process already underway refuses — finish it, or
+  [`gtd abandon`](#gtd-abandon---json) it);
 - a **clean working tree**;
 - the active workflow declaring a **`reviewEntry: true`** state (otherwise:
   `gtd review: the active workflow declares no review entry state`);
@@ -213,7 +219,8 @@ Requires, in order (any failure is a plain refusal — exit non-zero, nothing
 written):
 
 - the machine currently resting at the workflow's **initial state** (a process
-  already underway refuses);
+  already underway refuses — finish it, or [`gtd abandon`](#gtd-abandon---json)
+  it);
 - a **clean working tree**;
 - the active workflow declaring a **`fixEntry: true`** state (otherwise:
   `gtd fix: the active workflow declares no fix entry state`).
@@ -231,6 +238,62 @@ committed: gtd(human): fix-check
 unified template the fix-entry state is `fix-check`: a red suite drops into the
 shared `fixing` loop and out through the review + squash tail; a green suite is
 a no-op back to `idle`.
+
+## `gtd abandon [--json]`
+
+Ends the process currently underway **without completing it** — the way out of a
+process nobody is going to finish, and the command `gtd review`/`gtd fix` name
+when they refuse ("finish it, or run `gtd abandon`, before starting a review").
+A workflow's own exit is its squash finale
+([STATES.md §8](../STATES.md#8-the-squash-lifecycle)); this is the human's, and
+it targets the same boundary:
+
+1. any open **review checkout window** is closed first (the bracket every state
+   subcommand runs — see
+   [STATES.md §11](../STATES.md#11-the-review-checkout-window)), so the rewind
+   starts from the real head, not the rewound base;
+2. HEAD is `git reset --mixed`ed to the commit the process started from (its
+   start parent — the same target a squash resets to).
+
+**Nothing is discarded.** Every turn commit the process wrote is dropped, and
+everything they carried — the code, the `.gtd/` steering files — stays in the
+working tree as uncommitted changes for you to keep, re-commit, or throw away
+with ordinary git:
+
+```
+abandoned the process resting at "await-review" — HEAD is back at 1a2b3c4
+("feat: add calculator"), resting at "idle".
+Everything the process produced is kept as uncommitted changes (`git status`);
+discard them with `git checkout -- . && git clean -fd .gtd` for a clean tree.
+```
+
+Takes no positional argument (extra arguments are a usage error). Resting at the
+workflow's initial state is a **no-op success**, not a refusal — a recovery
+command that fails when there is nothing to recover is a worse tool:
+
+```
+no gtd process is underway (resting at "idle") — nothing to abandon
+```
+
+The one refusal is a process whose first commit is the repository's own root
+commit: there is no earlier commit to rewind to, so its commits have to be
+removed by hand.
+
+`--json` emits `{state, abandoned, from, head}` — `state` is the initial state
+the machine returns to, `abandoned` whether anything was rewound, and (only when
+it was) `from` the state the abandoned process rested at plus `head` the full
+hash HEAD now points at:
+
+```json
+{
+  "state": "idle",
+  "abandoned": true,
+  "from": "await-review",
+  "head": "1a2b3c4…"
+}
+```
+
+The no-op reports `{"state": "idle", "abandoned": false}` and still exits 0.
 
 ## `gtd next [--json]`
 
@@ -495,3 +558,11 @@ the plain-text one.
   `--help`/`--version` (and the `help`/`version` subcommands), `lsp`, and
   `visualize` skip this guard entirely (`visualize` still reads the `.gtdrc`
   workflow, but needs no git state).
+- **Linked worktrees are independent.** N `git worktree` worktrees of one
+  repository (sharing a single `.git`) each run their own gtd process: state is
+  derived from that worktree's own HEAD, and the review checkout window's refs
+  live in git's per-worktree `refs/worktree/gtd/*` namespace, so a review
+  resting in one worktree neither blocks nor rewrites any other
+  ([STATES.md §11](../STATES.md#11-the-review-checkout-window)). This holds from
+  7.2 on; gtd ≤ 7.1 kept the window under the shared `refs/gtd/*` refs, where
+  the first worktree to open one clobbered every sibling's branch.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -449,9 +449,10 @@ The unified template enables `reviewWindow: true` on `await-review` and marks
 `review-deciding` `reviewBase: true`, so the first review covers the whole cycle
 but each subsequent feedback round's window narrows to `last-review..HEAD`. The
 pure engine never observes an open window — it is opened/closed entirely at the
-edge; the real head is preserved under `refs/gtd/review-head` (the base under
-`refs/gtd/review-base`) for the window's lifetime. See
-[STATES.md §11](../STATES.md) for the full lifecycle.
+edge; the real head is preserved under `refs/worktree/gtd/review-head` (the base
+under `refs/worktree/gtd/review-base`) for the window's lifetime — git's
+per-worktree ref namespace, so linked worktrees of one repository each get their
+own window. See [STATES.md §11](../STATES.md) for the full lifecycle.
 
 ### `reviewEntry:` — the review entry point (`gtd review <commitish>`)
 

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -34,6 +34,19 @@ capture for the human as its opening move (see below), so re-launching the loop
 is the only thing the human ever does — at a gate they edit and re-run, and the
 loop picks their change up.
 
+**A `"message"` rest is a real handoff, not a slow beat.** No driver signs off
+for the human: in the bundled workflow the loop runs the whole cycle unattended
+up to `await-review` and then STOPS there with the review checkout window open
+(the reviewable diff surfaced as uncommitted changes — see
+[STATES.md §11](../STATES.md#11-the-review-checkout-window)). Advancing takes a
+human edit to `.gtd/REVIEW.md`: ticking every box with **no** comment signs off
+into the squash finale, while any comment (a note, or a code edit of your own)
+is feedback that routes into another build + re-review round. Re-launching the
+loop after that edit picks the decision up. Until then the loop halts on every
+run — that is the contract, not a stall. A review nobody is going to finish is
+ended with [`gtd abandon`](cli.md#gtd-abandon---json), which drops the process's
+commits and keeps their content as uncommitted changes.
+
 ```bash
 gtd next --json   # ask who's up and what they should do
 ```

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -159,6 +159,42 @@ loudly at load time rather than silently misinterpreting.
 or agent harness, upgrading the `gtd` binary also means re-copying that skill
 from this release.
 
+## 7.2: the review checkout window is now per worktree
+
+The review checkout window's two refs moved from the SHARED `refs/gtd/*`
+namespace to git's PER-WORKTREE `refs/worktree/*` one:
+
+| before (≤ 7.1)         | from 7.2                        |
+| ---------------------- | ------------------------------- |
+| `refs/gtd/review-head` | `refs/worktree/gtd/review-head` |
+| `refs/gtd/review-base` | `refs/worktree/gtd/review-base` |
+
+Nothing in a `.gtdrc` or a workflow definition references those names, so **no
+config change is needed**. What changes is behaviour in a repository checked out
+as several linked worktrees (`git worktree add`, one `.git` shared between
+them): each worktree now has its own window, so a review resting in one no
+longer "closes" from another — which, on the shared refs, mixed-reset that other
+worktree's branch onto the reviewing worktree's saved head and left every
+sibling refusing with "a process is already underway".
+
+A window an OLDER gtd left open across the upgrade still closes from the legacy
+refs, so an in-flight review in a single-worktree repo needs no attention. In a
+multi-worktree repo gtd cannot tell which worktree a shared ref belongs to, so
+it closes only when HEAD is contained in the saved head and otherwise refuses
+with the exact recovery commands — run them in the worktree that owns the
+window:
+
+```bash
+git reset --mixed refs/gtd/review-head
+git update-ref -d refs/gtd/review-head
+git update-ref -d refs/gtd/review-base
+```
+
+7.2 also adds [`gtd abandon`](cli.md#gtd-abandon---json), the supported way out
+of a process that will never be finished (it closes the window, then rewinds
+HEAD to the process's start parent, keeping everything the process produced as
+uncommitted changes) — no hand-editing of refs required.
+
 ## Prior breaking change: the v1 → v2 label grammar (historical)
 
 v2 replaced v1's undifferentiated turn labels with six labels carrying the

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -22,7 +22,7 @@ export interface GitReaderOperations {
    */
   readonly diffRef: (ref: string, exclude?: ReadonlyArray<string>) => Effect.Effect<string, Error>
   readonly resolveRef: (ref: string) => Effect.Effect<string, Error>
-  /** `git rev-parse --verify --quiet <ref>` — the ref's hash if it resolves, `Option.none` if it doesn't exist (never fails). Used to detect an open review checkout window (`refs/gtd/review-head`). */
+  /** `git rev-parse --verify --quiet <ref>` — the ref's hash if it resolves, `Option.none` if it doesn't exist (never fails). Used to detect an open review checkout window (`refs/worktree/gtd/review-head`). */
   readonly readRefOption: (ref: string) => Effect.Effect<Option.Option<string>, Error>
   /** `git merge-base --is-ancestor <a> <b>` — true iff `a` is an ancestor of `b`. Never fails: a non-zero exit (or error) reports `false`. Guards the review window's close against a HEAD that has moved off the reviewed branch. */
   readonly isAncestor: (a: string, b: string) => Effect.Effect<boolean, Error>
@@ -117,7 +117,7 @@ export interface GitWriterOperations {
    * lands the squash commit.
    */
   readonly discardPending: () => Effect.Effect<void, Error>
-  /** `git update-ref <ref> <hash>` — point a repo-local ref (e.g. `refs/gtd/review-head`) at a commit. */
+  /** `git update-ref <ref> <hash>` — point a repo-local ref (e.g. the per-worktree `refs/worktree/gtd/review-head`) at a commit. */
   readonly updateRef: (ref: string, hash: string) => Effect.Effect<void, Error>
   /** `git update-ref -d <ref>` — idempotent: deleting a missing ref is a no-op. */
   readonly deleteRef: (ref: string) => Effect.Effect<void, Error>

--- a/src/ReviewWindow.test.ts
+++ b/src/ReviewWindow.test.ts
@@ -11,6 +11,8 @@ import { Cwd } from "./Cwd.js"
 import { computeProcessRun } from "./Edge.js"
 import {
   closeReviewWindow,
+  LEGACY_REVIEW_BASE_REF,
+  LEGACY_REVIEW_HEAD_REF,
   openReviewWindow,
   reviewBaseHash,
   REVIEW_BASE_REF,
@@ -38,8 +40,10 @@ const def: WorkflowDefinition = {
 
 let repoDir: string
 
-const gitExec = (...args: string[]): string =>
-  execSync(`git ${args.join(" ")}`, { cwd: repoDir, encoding: "utf8", stdio: "pipe" }).trim()
+const gitIn = (dir: string, ...args: string[]): string =>
+  execSync(`git ${args.join(" ")}`, { cwd: dir, encoding: "utf8", stdio: "pipe" }).trim()
+
+const gitExec = (...args: string[]): string => gitIn(repoDir, ...args)
 
 const commit = (message: string, files: Record<string, string> = {}): void => {
   for (const [path, content] of Object.entries(files)) {
@@ -53,16 +57,20 @@ const commit = (message: string, files: Record<string, string> = {}): void => {
 
 const headSubject = (): string => gitExec("log", "-1", "--format=%s")
 const status = (): string => gitExec("status", "--porcelain", "-uall")
-const refExists = (ref: string): boolean => {
+const refExistsIn = (dir: string, ref: string): boolean => {
   try {
-    gitExec("rev-parse", "--verify", "--quiet", ref)
+    gitIn(dir, "rev-parse", "--verify", "--quiet", ref)
     return true
   } catch {
     return false
   }
 }
+const refExists = (ref: string): boolean => refExistsIn(repoDir, ref)
 
-const run = <A>(eff: Effect.Effect<A, Error, GitService | ConfigService>): Promise<A> =>
+const runIn = <A>(
+  dir: string,
+  eff: Effect.Effect<A, Error, GitService | ConfigService>,
+): Promise<A> =>
   Effect.runPromise(
     eff.pipe(
       Effect.provide(GitService.Live),
@@ -71,20 +79,42 @@ const run = <A>(eff: Effect.Effect<A, Error, GitService | ConfigService>): Promi
           load: Effect.succeed({ workflow: def, workflowVars: {}, rcVars: {}, rawWorkflow: {} }),
         }),
       ),
-      Effect.provide(Cwd.layer(repoDir)),
+      Effect.provide(Cwd.layer(dir)),
       Effect.provide(NodeContext.layer),
     ),
   )
+
+const run = <A>(eff: Effect.Effect<A, Error, GitService | ConfigService>): Promise<A> =>
+  runIn(repoDir, eff)
+
+/**
+ * A LINKED worktree of `repoDir` (`git worktree add`) on its own branch, with
+ * one non-gtd commit of its own on top of the shared base — the sibling
+ * worktree of issue #118. Sharing one `.git`, it shares the ref store too, so
+ * only a per-worktree ref namespace keeps the two windows apart.
+ */
+let siblingDir: string | undefined
+
+const addSiblingWorktree = (base: string): string => {
+  siblingDir = `${repoDir}-sibling`
+  gitExec("worktree", "add", "-q", "-b", "sibling", siblingDir, base)
+  gitIn(siblingDir, "commit", "--allow-empty", "-m", '"feat: sibling work"')
+  return siblingDir
+}
 
 beforeEach(() => {
   repoDir = mkdtempSync(join(tmpdir(), "gtd-review-window-"))
   gitExec("init")
   gitExec("config", "user.email", '"t@t.com"')
   gitExec("config", "user.name", '"T"')
+  // Never depend on the developer's own signing setup for a throwaway repo.
+  gitExec("config", "commit.gpgsign", "false")
   commit("chore: initial commit", { "readme.txt": "hello" })
 })
 
 afterEach(() => {
+  if (siblingDir !== undefined) rmSync(siblingDir, { recursive: true, force: true })
+  siblingDir = undefined
   rmSync(repoDir, { recursive: true, force: true })
 })
 
@@ -151,5 +181,79 @@ describe("closeReviewWindow — safety", () => {
   it("is a no-op when no window is open", async () => {
     const closed = await run(closeReviewWindow)
     expect(closed.closed).toBe(false)
+  })
+})
+
+describe("linked worktrees — per-worktree window refs (issue #118)", () => {
+  it("keeps a sibling worktree out of another worktree's open window", async () => {
+    const base = gitExec("rev-parse", "HEAD")
+    commit("gtd(agent): building", { "src/calc.ts": "export const add = 1\n" })
+    commit("gtd(human): gate")
+    const sibling = addSiblingWorktree(base)
+    const siblingHead = gitIn(sibling, "rev-parse", "HEAD")
+
+    const opened = await run(openReviewWindow)
+    expect(opened.opened).toBe(true)
+    // The window's refs live in the per-worktree namespace, so the sibling
+    // sharing this `.git` cannot even see them…
+    expect(refExists(REVIEW_HEAD_REF)).toBe(true)
+    expect(refExistsIn(sibling, REVIEW_HEAD_REF)).toBe(false)
+
+    // …and its own gtd invocations close nothing: pre-7.2 this reset the
+    // sibling's branch onto THIS worktree's saved head.
+    const closed = await runIn(sibling, closeReviewWindow)
+    expect(closed.closed).toBe(false)
+    expect(gitIn(sibling, "rev-parse", "HEAD")).toBe(siblingHead)
+
+    // This worktree's window survived the sibling's invocation untouched.
+    expect(headSubject()).toBe("chore: initial commit")
+    expect(refExists(REVIEW_HEAD_REF)).toBe(true)
+    const restored = await run(closeReviewWindow)
+    expect(restored.closed).toBe(true)
+    expect(headSubject()).toBe("gtd(human): gate")
+  })
+})
+
+describe("closeReviewWindow — the legacy shared refs (gtd ≤ 7.1)", () => {
+  // A window an older gtd left open across the upgrade: HEAD rewound to the
+  // base, the real head parked under the SHARED refs.
+  const openLegacyWindow = (dir: string, base: string, head: string): void => {
+    gitIn(dir, "update-ref", LEGACY_REVIEW_BASE_REF, base)
+    gitIn(dir, "update-ref", LEGACY_REVIEW_HEAD_REF, head)
+    gitIn(dir, "reset", "--mixed", base)
+  }
+
+  it("finishes a window left behind by an older gtd in this worktree", async () => {
+    const base = gitExec("rev-parse", "HEAD")
+    commit("gtd(agent): building", { "src/calc.ts": "export const add = 1\n" })
+    commit("gtd(human): gate")
+    const realHead = gitExec("rev-parse", "HEAD")
+    openLegacyWindow(repoDir, base, realHead)
+
+    const closed = await run(closeReviewWindow)
+    expect(closed.closed).toBe(true)
+    expect(gitExec("rev-parse", "HEAD")).toBe(realHead)
+    expect(refExists(LEGACY_REVIEW_HEAD_REF)).toBe(false)
+    expect(refExists(LEGACY_REVIEW_BASE_REF)).toBe(false)
+    expect(status()).toBe("")
+  })
+
+  it("refuses a shared-ref window that belongs to another worktree, leaving the branch alone", async () => {
+    const base = gitExec("rev-parse", "HEAD")
+    commit("gtd(agent): building", { "src/calc.ts": "export const add = 1\n" })
+    commit("gtd(human): gate")
+    const realHead = gitExec("rev-parse", "HEAD")
+    const sibling = addSiblingWorktree(base)
+    const siblingHead = gitIn(sibling, "rev-parse", "HEAD")
+    openLegacyWindow(repoDir, base, realHead)
+
+    await expect(runIn(sibling, closeReviewWindow)).rejects.toThrow(
+      /does not belong to this worktree/,
+    )
+    // Nothing moved, nothing was deleted — the owning worktree can still
+    // recover with the commands the message spells out.
+    expect(gitIn(sibling, "rev-parse", "HEAD")).toBe(siblingHead)
+    expect(refExists(LEGACY_REVIEW_HEAD_REF)).toBe(true)
+    expect(refExists(LEGACY_REVIEW_BASE_REF)).toBe(true)
   })
 })

--- a/src/ReviewWindow.ts
+++ b/src/ReviewWindow.ts
@@ -29,25 +29,46 @@ import type { GitOperations } from "./Git.js"
  * every state subcommand:
  *
  * - `closeReviewWindow` runs BEFORE anything reads or mutates state, keyed
- *   solely on `refs/gtd/review-head` existing: `git reset --mixed
- *   refs/gtd/review-head` restores HEAD/index exactly, leaving only the
- *   reviewer's own edits dirty (captured by the resting state's own `on`
- *   patterns like any other pending change). The pure machine therefore never
- *   sees the window.
+ *   solely on `REVIEW_HEAD_REF` existing: `git reset --mixed <that ref>`
+ *   restores HEAD/index exactly, leaving only the reviewer's own edits dirty
+ *   (captured by the resting state's own `on` patterns like any other pending
+ *   change). The pure machine therefore never sees the window.
  * - `openReviewWindow` runs AFTER the subcommand finishes and self-guards on
  *   the resolved rest declaring `reviewWindow: true`: it saves HEAD to
- *   `refs/gtd/review-head` (the base to `refs/gtd/review-base`), then `git
- *   reset --mixed <base>`. It re-arms after read-only commands (`gtd next` /
- *   `gtd status`) and refused invocations too, so the editor's diff view stays
- *   consistent no matter which command the loop last ran.
+ *   `REVIEW_HEAD_REF` (the base to `REVIEW_BASE_REF`), then `git reset --mixed
+ *   <base>`. It re-arms after read-only commands (`gtd next` / `gtd status`)
+ *   and refused invocations too, so the editor's diff view stays consistent no
+ *   matter which command the loop last ran.
  *
  * Every open/close step is idempotent under re-entry, so a crash at any point
  * is recovered by the next invocation's close (the saved ref also keeps the
  * real head GC-reachable for the window's whole lifetime).
  */
 
-export const REVIEW_HEAD_REF = "refs/gtd/review-head"
-export const REVIEW_BASE_REF = "refs/gtd/review-base"
+/**
+ * The window's two state refs live in git's PER-WORKTREE `refs/worktree/*`
+ * namespace, so linked worktrees sharing one `.git` (`git worktree add`) each
+ * get their OWN window: a review resting in one worktree is invisible to — and
+ * un-clobberable by — every other one, and git drops the refs with the
+ * worktree.
+ *
+ * gtd ≤ 7.1 kept them in the SHARED `refs/gtd/*` namespace (the legacy names
+ * below), which made a second worktree's very first gtd invocation close the
+ * FIRST worktree's window: its `git reset --mixed` moved the second worktree's
+ * branch onto the other worktree's saved head, and every later invocation
+ * refused with "a process is already underway" (issue #118).
+ */
+export const REVIEW_HEAD_REF = "refs/worktree/gtd/review-head"
+export const REVIEW_BASE_REF = "refs/worktree/gtd/review-base"
+
+/**
+ * The pre-7.2 SHARED refs. gtd never writes them any more; `closeReviewWindow`
+ * only reads them to finish a window an older gtd left open across the upgrade
+ * — and only when HEAD is still contained in the saved head, since a shared ref
+ * may belong to a sibling worktree (see `openWindowRefs`).
+ */
+export const LEGACY_REVIEW_HEAD_REF = "refs/gtd/review-head"
+export const LEGACY_REVIEW_BASE_REF = "refs/gtd/review-base"
 
 // git's empty-tree object — `computeProcessRun`'s `startParentHash` when a
 // process covers the whole history with no earlier commit. There is no real
@@ -79,40 +100,100 @@ export const reviewBaseHash = (
     return base
   })
 
+/** The ref pair an open window is recorded under, plus whether it is the legacy shared pair. */
+interface WindowRefs {
+  readonly headRef: string
+  readonly baseRef: string
+  readonly headHash: string
+  readonly legacy: boolean
+}
+
+/** The manual-recovery incantation every close refusal ends with. */
+const manualRecovery = (refs: WindowRefs): string =>
+  `\`git reset --mixed ${refs.headRef} && git update-ref -d ${refs.headRef} && ` +
+  `git update-ref -d ${refs.baseRef}\``
+
+/**
+ * Which ref pair (if any) records an open window: this worktree's own
+ * `refs/worktree/gtd/*` pair first, falling back to the pre-7.2 shared
+ * `refs/gtd/*` pair so an upgrade mid-window still closes cleanly.
+ */
+const openWindowRefs = (git: GitOperations): Effect.Effect<Option.Option<WindowRefs>, Error> =>
+  Effect.gen(function* () {
+    const scoped = yield* git.readRefOption(REVIEW_HEAD_REF)
+    if (Option.isSome(scoped)) {
+      return Option.some({
+        headRef: REVIEW_HEAD_REF,
+        baseRef: REVIEW_BASE_REF,
+        headHash: scoped.value,
+        legacy: false,
+      })
+    }
+    const legacy = yield* git.readRefOption(LEGACY_REVIEW_HEAD_REF)
+    if (Option.isNone(legacy)) return Option.none()
+    return Option.some({
+      headRef: LEGACY_REVIEW_HEAD_REF,
+      baseRef: LEGACY_REVIEW_BASE_REF,
+      headHash: legacy.value,
+      legacy: true,
+    })
+  })
+
 /**
  * Restore the real head if a review checkout window is open; no-op otherwise.
- * Keyed on `refs/gtd/review-head` existence, NOT on any config or machine
- * state, so it always runs first and the machine never sees the window.
+ * Keyed on the saved-head ref's existence (see `openWindowRefs`), NOT on any
+ * config or machine state, so it always runs first and the machine never sees
+ * the window.
  *
  * Fails loudly — refs left in place — when HEAD is no longer on the reviewed
  * branch (the base is not an ancestor of HEAD, e.g. after a branch switch): a
  * mixed reset there would rewrite the wrong branch's tip. Manual commits on
  * top of the base pass the guard: the reset keeps their content in the working
  * tree, where the next turn's capture picks it up as review feedback.
+ *
+ * A window found under the LEGACY shared refs gets one extra guard: a shared
+ * ref may have been written by a sibling worktree, so the close only proceeds
+ * when HEAD is contained in the saved head — the shape a window this worktree
+ * opened itself has. Anything else refuses with the manual recovery rather
+ * than resetting this branch onto another worktree's work (issue #118).
  */
 export const closeReviewWindow: Effect.Effect<{ readonly closed: boolean }, Error, GitService> =
   Effect.gen(function* () {
     const git = yield* GitService
-    const savedHead = yield* git.readRefOption(REVIEW_HEAD_REF)
-    if (Option.isNone(savedHead)) return { closed: false }
+    const open = yield* openWindowRefs(git)
+    if (Option.isNone(open)) return { closed: false }
+    const refs = open.value
 
-    const base = yield* git.readRefOption(REVIEW_BASE_REF)
+    const base = yield* git.readRefOption(refs.baseRef)
     if (Option.isSome(base) && base.value !== EMPTY_TREE) {
       const onReviewedBranch = yield* git.isAncestor(base.value, "HEAD")
       if (!onReviewedBranch) {
         return yield* Effect.fail(
           new Error(
             "a gtd review checkout window is open but HEAD has moved off the reviewed branch — " +
-              "return to it, or restore manually with " +
-              "`git reset --mixed refs/gtd/review-head && git update-ref -d refs/gtd/review-head && git update-ref -d refs/gtd/review-base`",
+              `return to it, or restore manually with ${manualRecovery(refs)}`,
           ),
         )
       }
     }
 
-    yield* git.mixedResetTo(REVIEW_HEAD_REF)
-    yield* git.deleteRef(REVIEW_HEAD_REF)
-    yield* git.deleteRef(REVIEW_BASE_REF)
+    if (refs.legacy) {
+      const ownsWindow = yield* git.isAncestor("HEAD", refs.headHash)
+      if (!ownsWindow) {
+        return yield* Effect.fail(
+          new Error(
+            `a review checkout window is recorded under the shared ${LEGACY_REVIEW_HEAD_REF} ` +
+              "(written by gtd 7.1 or older) but it does not belong to this worktree — HEAD is " +
+              "not contained in it. gtd now scopes the window per worktree " +
+              `(${REVIEW_HEAD_REF}); in the worktree that owns it, run ${manualRecovery(refs)}`,
+          ),
+        )
+      }
+    }
+
+    yield* git.mixedResetTo(refs.headRef)
+    yield* git.deleteRef(refs.headRef)
+    yield* git.deleteRef(refs.baseRef)
     return { closed: true }
   })
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -83,6 +83,11 @@ Commands:
                    state (fixEntry: true) that goes straight into repairing the
                    current failing tests. Requires a clean tree resting at the
                    workflow's initial state
+  abandon          End the process currently underway without completing it:
+                   close any open review checkout window, then rewind HEAD to
+                   the commit the process started from, keeping everything it
+                   produced as uncommitted changes. A no-op when no process is
+                   underway
   next             Print the resolved rest's rendered script/prompt/message
                    (no mutation)
   status           Print the resolved rest's state/actor and which declared
@@ -535,7 +540,7 @@ const runReviewCommand = (
     if (rest.state !== initialStateOf(rest.def)) {
       return yield* Effect.fail(
         new Error(
-          `gtd review: a process is already underway (resting at "${rest.state}") — finish or abandon it before starting a review`,
+          `gtd review: a process is already underway (resting at "${rest.state}") — finish it, or run \`gtd abandon\`, before starting a review`,
         ),
       )
     }
@@ -608,7 +613,7 @@ const runFixCommand = (
     if (rest.state !== initialStateOf(rest.def)) {
       return yield* Effect.fail(
         new Error(
-          `gtd fix: a process is already underway (resting at "${rest.state}") — finish or abandon it before starting a fix`,
+          `gtd fix: a process is already underway (resting at "${rest.state}") — finish it, or run \`gtd abandon\`, before starting a fix`,
         ),
       )
     }
@@ -633,6 +638,82 @@ const runFixCommand = (
       write(JSON.stringify({ state: entryState, subject }) + "\n")
     } else {
       write(`committed: ${subject}\n`)
+    }
+  })
+
+// git's empty-tree object — `computeProcessRun`'s `startParentHash` when the
+// process covers the whole history, so there is no earlier commit to rewind to.
+const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+/**
+ * `gtd abandon`: end the process currently underway WITHOUT completing it,
+ * returning the machine to the workflow's initial state — the recovery path out
+ * of a process nobody is going to finish (the refusals of `gtd review`/`gtd fix`
+ * name it: "finish or abandon it before starting a review").
+ *
+ * NOTHING is discarded. The shared bracket in `makeProgram` has already closed
+ * any open review checkout window (so HEAD is the real head), and abandon then
+ * `git reset --mixed`es HEAD to the commit the process started from
+ * (`computeProcessRun`'s `startParentHash` — the same boundary a squash resets
+ * to). Every turn commit the process wrote is dropped, and everything they
+ * carried — the code, the `.gtd/` steering files — stays in the working tree as
+ * uncommitted changes for the human to keep, re-commit, or discard with
+ * ordinary git.
+ *
+ * Idempotent: resting at the initial state (a plain non-gtd branch, or a
+ * just-squashed cycle) is a no-op SUCCESS, not a refusal — a recovery command
+ * that fails when there is nothing to recover is a worse tool. The one refusal
+ * is a process whose first commit is the repository's own root commit: there is
+ * no earlier commit to rewind to.
+ */
+const runAbandonCommand = (
+  argv: readonly string[],
+  json: boolean,
+  write: (chunk: string) => void,
+): Effect.Effect<void, Error, ProgramRequirements> =>
+  Effect.gen(function* () {
+    yield* rejectExtraArgs("abandon", argv)
+
+    const git = yield* GitService
+    const rest = yield* resolveRest()
+    const initial = initialStateOf(rest.def)
+    if (rest.state === initial) {
+      if (json) {
+        write(JSON.stringify({ state: initial, abandoned: false }) + "\n")
+      } else {
+        write(`no gtd process is underway (resting at "${initial}") — nothing to abandon\n`)
+      }
+      return
+    }
+
+    const run = yield* computeProcessRun(git, rest.def)
+    if (run.startParentHash === EMPTY_TREE) {
+      return yield* Effect.fail(
+        new Error(
+          `gtd abandon: the process underway (resting at "${rest.state}") starts at the ` +
+            "repository's first commit — there is no earlier commit to rewind to",
+        ),
+      )
+    }
+
+    yield* git.mixedResetTo(run.startParentHash)
+    const subject = yield* git.lastCommitSubject()
+    if (json) {
+      write(
+        JSON.stringify({
+          state: initial,
+          abandoned: true,
+          from: rest.state,
+          head: run.startParentHash,
+        }) + "\n",
+      )
+    } else {
+      write(
+        `abandoned the process resting at "${rest.state}" — HEAD is back at ` +
+          `${run.startParentHash.slice(0, 7)} ("${subject}"), resting at "${initial}".\n` +
+          `Everything the process produced is kept as uncommitted changes (\`git status\`); ` +
+          `discard them with \`git checkout -- . && git clean -fd .gtd\` for a clean tree.\n`,
+      )
     }
   })
 
@@ -1290,7 +1371,15 @@ const runVisualizeCommand = (
     yield* Effect.never.pipe(Effect.ensuring(Effect.sync(() => server.close())))
   })
 
-const KNOWN_SUBCOMMANDS = ["step", "review", "fix", "next", "status", "validate"] as const
+const KNOWN_SUBCOMMANDS = [
+  "step",
+  "review",
+  "fix",
+  "abandon",
+  "next",
+  "status",
+  "validate",
+] as const
 type KnownSubcommand = (typeof KNOWN_SUBCOMMANDS)[number]
 
 /**
@@ -1411,6 +1500,8 @@ const dispatchKnownSubcommand = (
       return runReviewCommand(argv, json, write)
     case "fix":
       return runFixCommand(argv, json, write)
+    case "abandon":
+      return runAbandonCommand(argv, json, write)
     case "next":
       return runNextCommand(json, write)
     case "status":

--- a/tests/integration/features/abandon.feature
+++ b/tests/integration/features/abandon.feature
@@ -1,0 +1,108 @@
+@inmem
+Feature: gtd abandon — end the process underway without completing it
+
+  `gtd review`/`gtd fix` refuse while a process is underway ("finish it, or run
+  `gtd abandon`"), and a workflow only leaves a process through its own squash
+  finale. `gtd abandon` is the way out of one nobody is going to finish: it
+  closes any open review checkout window (the shared bracket every state
+  subcommand runs), then rewinds HEAD to the commit the process started from —
+  the same boundary a squash resets to.
+
+  Nothing is discarded: every turn commit is dropped, and everything they
+  carried (the code, the `.gtd/` steering files) stays in the working tree as
+  uncommitted changes. Resting at the initial state is a no-op SUCCESS — a
+  recovery command that fails when there is nothing to recover is a worse tool.
+
+  Background:
+    Given a test project
+    And the workflow
+
+  Scenario: abandons a cycle mid-flight — HEAD back at the process boundary, the work kept as pending changes
+    Given a file ".gtd/TODO.md" with:
+      """
+      Build a thing.
+      """
+    When I run gtd step human
+    Then it succeeds
+    And the last commit subject is "gtd(human): idle → start-check"
+    When I run gtd step check
+    Then it succeeds
+    And the last commit subject is "gtd(check): start-check → planning"
+    When I run gtd with args "abandon"
+    Then it succeeds
+    And stdout contains "abandoned the process resting at \"planning\""
+    # HEAD is back at the process boundary: the config commit before the cycle.
+    And the last commit subject is "chore: init gtd workflow"
+    # The plan the cycle committed is kept, now as a pending change.
+    And the git status contains ".gtd/TODO.md"
+    And ".gtd/TODO.md" contains "Build a thing."
+    When I run gtd status
+    Then it succeeds
+    And stdout contains "State: idle"
+
+  Scenario: a no-op success when no process is underway — nothing to abandon
+    Given I record the commit count
+    When I run gtd with args "abandon"
+    Then it succeeds
+    And stdout contains "nothing to abandon"
+    And the commit count is unchanged
+    And the last commit subject is "chore: init gtd workflow"
+
+  Scenario: abandons a gtd review process — the checkout window closes and the reviewed branch tip is restored
+    Given I mark the current commit as "base"
+    And a commit "feat: add calculator" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    When I run gtd with args "review base"
+    Then it succeeds
+    When I run gtd step check
+    Then it succeeds
+    And the last commit subject is "gtd(check): review-start-check → reviewing"
+    Given a file ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add calc.ts
+
+      - [ ] ./src/calc.ts#1 — new export
+      """
+    When I run gtd step agent
+    Then it succeeds
+    # await-review declares `reviewWindow: true`, so the window is open here.
+    And the git ref "refs/worktree/gtd/review-head" exists
+    When I run gtd with args "abandon"
+    Then it succeeds
+    # The window closed first, so the rewind starts from the REAL head — the
+    # reviewed branch tip is restored, not the review base.
+    And the git ref "refs/worktree/gtd/review-head" does not exist
+    And the git ref "refs/worktree/gtd/review-base" does not exist
+    And the last commit subject is "feat: add calculator"
+    # The reviewed changeset stays committed; only the review doc is pending.
+    And the git status contains ".gtd/REVIEW.md"
+    And the git status does not contain "src/calc.ts"
+
+  Scenario: --json reports the abandoned process and the state it returned to
+    Given a file ".gtd/TODO.md" with:
+      """
+      Build a thing.
+      """
+    When I run gtd step human
+    Then it succeeds
+    When I run gtd with args "abandon --json"
+    Then it succeeds
+    And stdout contains "\"abandoned\":true"
+    And stdout contains "\"from\":\"start-check\""
+    And stdout contains "\"state\":\"idle\""
+
+  Scenario: --json reports the no-op too, without an error envelope
+    When I run gtd with args "abandon --json"
+    Then it succeeds
+    And stdout contains "\"abandoned\":false"
+    And stdout does not contain "\"state\":\"error\""
+
+  Scenario: takes no argument
+    When I run gtd with args "abandon planning"
+    Then it fails
+    And stderr contains "gtd abandon: too many arguments"

--- a/tests/integration/features/command-surface.feature
+++ b/tests/integration/features/command-surface.feature
@@ -1,7 +1,7 @@
 @inmem
 Feature: Command surface — bare gtd, unknown subcommands, --help, --version
 
-  gtd v3 exposes `init`, `step <actor>`, `review <commitish>`,
+  gtd v3 exposes `init`, `step <actor>`, `review <commitish>`, `fix`, `abandon`,
   `next`, `status`, `validate`, `lsp`, `visualize`, `version`, and `help` as its
   subcommands. Bare `gtd` (no subcommand) is a usage error. `--help`/`help` and
   `--version`/`version` short-circuit before any repo-state work and exit 0
@@ -32,6 +32,8 @@ Feature: Command surface — bare gtd, unknown subcommands, --help, --version
     And stdout contains "init "
     And stdout contains "step <actor>"
     And stdout contains "review <commitish>"
+    And stdout contains "fix"
+    And stdout contains "abandon"
     And stdout contains "next"
     And stdout contains "visualize"
 

--- a/tests/integration/features/default-workflow.feature
+++ b/tests/integration/features/default-workflow.feature
@@ -96,7 +96,7 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
     Then it succeeds
     # await-review declares `reviewWindow: true` — resolve the true rest via
     # `gtd status` rather than raw HEAD.
-    And the git ref "refs/gtd/review-head" exists
+    And the git ref "refs/worktree/gtd/review-head" exists
     When I run gtd status
     Then it succeeds
     And stdout contains "State: await-review"
@@ -172,7 +172,7 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
       """
     When I run gtd step agent
     Then it succeeds
-    And the git ref "refs/gtd/review-head" exists
+    And the git ref "refs/worktree/gtd/review-head" exists
     When I run gtd status
     Then it succeeds
     And stdout contains "State: await-review"
@@ -330,7 +330,7 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
     And stderr contains "was deleted"
     # Nothing committed — the refusal re-arms the review window, so the cycle
     # stays at the gate for the reviewer to restore + tick.
-    And the git ref "refs/gtd/review-head" exists
+    And the git ref "refs/worktree/gtd/review-head" exists
 
   Scenario: stepping at await-review with a box still unticked and no comment is refused — finish reviewing first
     Given a test project
@@ -360,7 +360,7 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
     Then it fails
     And stderr contains "still unticked and no comment"
     # Nothing committed — the window re-arms, keeping the reviewer at the gate.
-    And the git ref "refs/gtd/review-head" exists
+    And the git ref "refs/worktree/gtd/review-head" exists
 
   Scenario: at await-review, gtd next surfaces the sign-off vs. feedback contract in its human-gate message
     Given a test project

--- a/tests/integration/features/review-entry.feature
+++ b/tests/integration/features/review-entry.feature
@@ -180,7 +180,7 @@ Feature: gtd review <commitish> — start a review process from an ordinary bran
       """
     When I run gtd next
     Then it succeeds
-    And the git ref "refs/gtd/review-head" exists
+    And the git ref "refs/worktree/gtd/review-head" exists
     # HEAD rests at "base" — the process's diff base — surfacing the whole
     # <commitish>..HEAD diff as ordinary uncommitted changes.
     And the last commit subject is "chore: init gtd workflow"

--- a/tests/integration/features/review-window.feature
+++ b/tests/integration/features/review-window.feature
@@ -6,11 +6,12 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
   base (the process start, unless a `reviewBase` state narrows it) with the
   working tree untouched, so the whole reviewable diff shows up as ordinary
   uncommitted changes in any editor's standard git integration. The real head
-  is preserved under `refs/gtd/review-head` (the base under
-  `refs/gtd/review-base`); every gtd invocation restores it BEFORE reading or
-  mutating state, so the pure machine never sees the window and the reviewer's
-  own edits are captured by the resting state's own `on` patterns like any
-  other pending change.
+  is preserved under `refs/worktree/gtd/review-head` (the base under
+  `refs/worktree/gtd/review-base`) — git's PER-WORKTREE ref namespace, so
+  linked worktrees sharing one `.git` each get their own window; every gtd
+  invocation restores it BEFORE reading or mutating state, so the pure machine
+  never sees the window and the reviewer's own edits are captured by the
+  resting state's own `on` patterns like any other pending change.
 
   The bundled unified workflow declares `reviewWindow: true` on
   `await-review`. Each scenario builds a cycle that rests there: the
@@ -42,8 +43,8 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
   Scenario: Resting at the gate opens the window — HEAD at the base, the diff dirty
     When I run gtd next
     Then it succeeds
-    And the git ref "refs/gtd/review-head" exists
-    And the git ref "refs/gtd/review-base" exists
+    And the git ref "refs/worktree/gtd/review-head" exists
+    And the git ref "refs/worktree/gtd/review-base" exists
     # HEAD rests at the review base: the cycle's process boundary.
     And the last commit subject is "chore: init gtd workflow"
     # The whole package diff is visible as uncommitted changes…
@@ -58,7 +59,7 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
     Then it succeeds
     # `gtd status` closed the window, resolved the true rest, then re-armed it:
     And stdout contains "State: await-review"
-    And the git ref "refs/gtd/review-head" exists
+    And the git ref "refs/worktree/gtd/review-head" exists
     And the last commit subject is "chore: init gtd workflow"
 
   Scenario: Deleting the review doc is refused — the window stays open, nothing commits
@@ -68,7 +69,7 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
     Then it fails
     And stderr contains "was deleted"
     # Nothing committed; the window re-arms so the reviewer can restore + tick.
-    And the git ref "refs/gtd/review-head" exists
+    And the git ref "refs/worktree/gtd/review-head" exists
     And the last commit subject is "chore: init gtd workflow"
 
   Scenario: Ticking every box with no comment signs off — the window closes and routes to review-deciding
@@ -87,7 +88,7 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
     # Every box ticked, no note, no code edit — a clean sign-off hands to the
     # deterministic check, which collapses the cycle from there.
     And the last commit subject is "gtd(human): await-review → review-deciding"
-    And the git ref "refs/gtd/review-head" does not exist
+    And the git ref "refs/worktree/gtd/review-head" does not exist
 
   Scenario: Reviewer code edits are feedback — the window closes and routes to review-deciding
     Given I run gtd next
@@ -101,11 +102,11 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
     # A code edit is a comment: it routes to the deterministic review check,
     # which turns it into a build + re-review round.
     And the last commit subject is "gtd(human): await-review → review-deciding"
-    And the git ref "refs/gtd/review-head" does not exist
+    And the git ref "refs/worktree/gtd/review-head" does not exist
 
   Scenario: Read-only commands re-arm the window on their way out
     Given I run gtd next
     When I run gtd status
     Then it succeeds
-    And the git ref "refs/gtd/review-head" exists
+    And the git ref "refs/worktree/gtd/review-head" exists
     And the last commit subject is "chore: init gtd workflow"

--- a/tests/integration/features/unified-advanced-flow.feature
+++ b/tests/integration/features/unified-advanced-flow.feature
@@ -274,7 +274,7 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
       """
     When I run gtd step agent
     Then it succeeds
-    And the git ref "refs/gtd/review-head" exists
+    And the git ref "refs/worktree/gtd/review-head" exists
     When I run gtd status
     Then it succeeds
     And stdout contains "State: await-review"


### PR DESCRIPTION
The review checkout window kept its state in the SHARED refs
`refs/gtd/review-head`/`refs/gtd/review-base`, so linked worktrees of one
repository (`git worktree add`, one `.git` between them) fought over a single
window: the first gtd invocation in worktree B saw A's saved head, "closed"
A's window by mixed-resetting B's branch onto A's commit, and every later
invocation there refused with "a process is already underway". Recovery meant
hand-editing refs — there was no supported way out of a stuck process.

Both refs move into git's per-worktree `refs/worktree/*` namespace, so each
worktree gets its own window and git drops the refs with the worktree. A window
an older gtd left open still closes from the legacy shared refs, but only when
HEAD is contained in the saved head; otherwise the close refuses with the exact
recovery commands rather than resetting a branch onto a sibling's work.

`gtd abandon` is the new way out of a process nobody will finish: it closes any
open window, then mixed-resets HEAD to the process's start parent — the same
boundary a squash targets — keeping everything the dropped commits carried as
uncommitted changes. Resting at the initial state is a no-op success; the sole
refusal is a process starting at the repository's root commit. `gtd review`/
`gtd fix` now name the command in their "already underway" refusals.

Fixes #118

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VMxCwSZ3eEKUwdV2e1nydo