### PR TITLE
feat(restore): add `gtd restore` to undo a squash or abandon

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ handful of commands drive it:
 - **`gtd abandon`** — end the process underway without completing it: rewind to
   the commit it started from, keeping everything it produced as uncommitted
   changes (nothing is discarded).
+- **`gtd restore`** — undo the last squash (or `gtd abandon`) by hard-resetting
+  HEAD back to its retained pre-squash tip, bringing the turn-by-turn history
+  back. Refuses on a dirty working tree, when there is nothing retained to
+  restore, or when HEAD has since moved past it with commits that would be lost.
 - **`gtd visualize`** — serve an interactive diagram of the active workflow on a
   local web server (the main flow, its sub-machines, and per-state details).
 

--- a/STATES.md
+++ b/STATES.md
@@ -271,10 +271,14 @@ entering it performs, atomically:
    discarded with the turns below). A failed render (a malformed template,
    `read()` throwing for a missing path) **refuses the step and touches
    nothing** — no reset, no commit, no file discarded.
-2. **Soft-reset** to the process's start parent (the commit before the process's
+2. **Retain** the pre-squash tip (HEAD, before anything below moves it) on the
+   per-worktree retained-history ref (see "Undoing a squash or abandon" below; a
+   no-op for an empty process, where the tip already equals the start parent).
+3. **Soft-reset** to the process's start parent (the commit before the process's
    first turn — `EMPTY_TREE` if the process covers the whole history) and write
-   **one** commit with the rendered message, verbatim as its subject/body.
-3. **Discard** everything still left uncommitted — the message-template file
+   **one** commit with the rendered message plus a `Gtd-History: <hash>` trailer
+   pointing at the retained tip, otherwise verbatim as its subject/body.
+4. **Discard** everything still left uncommitted — the message-template file
    included; it never enters history.
 
 The net effect: every intermediate `gtd(<actor>): <state>` commit the process
@@ -306,6 +310,21 @@ worse tool); a process whose first commit is the repository's root commit is the
 one refusal, since there is no earlier commit to rewind to. Like the squash,
 this lives entirely at the edge (`src/program.ts`) — the pure engine has no
 notion of abandoning.
+
+**Undoing a squash or abandon.** Both a squash and `gtd abandon` first record
+the pre-collapse tip on the per-worktree `refs/worktree/gtd/history` ref
+(`src/RetainedHistory.ts`) before they act — a rolling ref, so a later
+squash/abandon simply overwrites it with its own tip, and self-cleaning: git
+drops it along with the worktree, same per-worktree `refs/worktree/*` namespace
+rationale as the review checkout window's own refs (§11). **`gtd restore`** is
+the way back: it hard-resets HEAD to that retained tip and clears the ref,
+refusing on a dirty working tree, when there is no retained history, or when
+HEAD has since advanced past the tip with commits that would be discarded
+(checked by `restorability`, which accepts either a freshly-landed squash commit
+— HEAD's own `Gtd-History:` trailer still points at the tip — or a cleaned
+abandon/fast-forward where HEAD is an ancestor of the tip). Like the squash and
+abandon, this lives entirely at the edge (`src/program.ts`) — the pure engine
+has no notion of restoring.
 
 ## 9. Validation
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,12 @@ Commands:
                    the commit the process started from, keeping everything it
                    produced as uncommitted changes. A no-op when no process is
                    underway
+  restore          Hard-reset HEAD back to the pre-squash tip retained by the
+                   last squash/abandon (refs/worktree/gtd/history), undoing a
+                   squash or bringing back an abandoned process's turns.
+                   Refuses on a dirty working tree, when there is no retained
+                   history, or when HEAD has advanced past the squash with
+                   commits that would be lost
   next             Print the resolved rest's rendered script/prompt/message
                    (no mutation)
   status           Print the resolved rest's state/actor and which declared
@@ -294,6 +300,47 @@ hash HEAD now points at:
 ```
 
 The no-op reports `{"state": "idle", "abandoned": false}` and still exits 0.
+
+## `gtd restore [--json]`
+
+Undoes the last squash or `gtd abandon` by hard-resetting HEAD back to the
+pre-squash tip that either one retains, before acting, on the per-worktree
+`refs/worktree/gtd/history` ref
+([STATES.md §8](../STATES.md#8-the-squash-lifecycle)):
+
+```
+restored the retained history — HEAD is back at 1a2b3c4 ("gtd(agent): drafting
+→ working"), resting at "await-review". Resume with the loop, or `git reset`
+to any earlier turn to restart from there.
+```
+
+Refuses on a dirty working tree — commit, stash, or discard your changes first.
+Refuses when there is no retained history to restore (nothing has been squashed
+or abandoned yet, or a previous `restore` already consumed it). Refuses when
+HEAD has advanced past the retained tip with commits that would be discarded by
+resetting:
+
+```
+gtd restore: HEAD has advanced past the squash — restoring would discard
+commits built on top of it — HEAD 4d5e6f7 is ahead of the retained tip
+1a2b3c4.
+```
+
+Takes no positional argument (extra arguments are a usage error).
+
+`--json` emits `{state, restored, to, from}` — `state` is the resolved rest
+after the reset, `restored` always `true` (a refusal exits non-zero instead),
+`to` the full hash HEAD was reset to, and `from` the state the machine rested at
+before the reset:
+
+```json
+{
+  "state": "await-review",
+  "restored": true,
+  "to": "1a2b3c4…",
+  "from": "idle"
+}
+```
 
 ## `gtd next [--json]`
 

--- a/src/Edge.test.ts
+++ b/src/Edge.test.ts
@@ -18,6 +18,7 @@ import {
   withReviewBaseTrailer,
   parseReviewBaseTrailer,
 } from "./Edge.js"
+import { withHistoryTrailer, parseHistoryTrailer } from "./RetainedHistory.js"
 import type { TemplateContext } from "./PatternTemplates.js"
 import type { StateDef, WorkflowDefinition } from "./PatternMachine.js"
 
@@ -38,6 +39,7 @@ const stubGit = (overrides: Partial<GitOperations>): GitOperations => ({
   diffHead: notImplemented("diffHead"),
   readFileAtRef: notImplemented("readFileAtRef"),
   lastCommitSubject: notImplemented("lastCommitSubject"),
+  lastCommitMessage: notImplemented("lastCommitMessage"),
   hasCommits: notImplemented("hasCommits"),
   diffRef: notImplemented("diffRef"),
   resolveRef: notImplemented("resolveRef"),
@@ -54,6 +56,7 @@ const stubGit = (overrides: Partial<GitOperations>): GitOperations => ({
   updateRef: notImplemented("updateRef"),
   deleteRef: notImplemented("deleteRef"),
   mixedResetTo: notImplemented("mixedResetTo"),
+  hardResetTo: notImplemented("hardResetTo"),
   restoreStagedFrom: notImplemented("restoreStagedFrom"),
   addIntentToAdd: notImplemented("addIntentToAdd"),
   ...overrides,
@@ -398,10 +401,28 @@ describe("executeDecision", () => {
   })
 
   it("a squash decision renders, soft-resets, commits as-is, and discards the rest", async () => {
-    const softResetTo = vi.fn(() => Effect.succeed(undefined))
-    const commitAsIs = vi.fn(() => Effect.succeed(undefined))
-    const discardPending = vi.fn(() => Effect.succeed(undefined))
-    const git = stubGit({ softResetTo, commitAsIs, discardPending })
+    const calls: string[] = []
+    const resolveRef = vi.fn(() => {
+      calls.push("resolveRef")
+      return Effect.succeed("tip-hash")
+    })
+    const updateRef = vi.fn(() => {
+      calls.push("updateRef")
+      return Effect.succeed(undefined)
+    })
+    const softResetTo = vi.fn(() => {
+      calls.push("softResetTo")
+      return Effect.succeed(undefined)
+    })
+    const commitAsIs = vi.fn(() => {
+      calls.push("commitAsIs")
+      return Effect.succeed(undefined)
+    })
+    const discardPending = vi.fn(() => {
+      calls.push("discardPending")
+      return Effect.succeed(undefined)
+    })
+    const git = stubGit({ resolveRef, updateRef, softResetTo, commitAsIs, discardPending })
     const outcome = await run(
       executeDecision(
         git,
@@ -418,8 +439,11 @@ describe("executeDecision", () => {
     )
     expect(outcome).toEqual({ kind: "squash", subject: "feat: done" })
     expect(softResetTo).toHaveBeenCalledWith("parent-hash")
-    expect(commitAsIs).toHaveBeenCalledWith("feat: done")
+    expect(commitAsIs).toHaveBeenCalledWith("feat: done\n\nGtd-History: tip-hash")
     expect(discardPending).toHaveBeenCalledOnce()
+    // The retention write (via `updateRef`) happens before the soft reset rewrites HEAD.
+    expect(calls.indexOf("updateRef")).toBeGreaterThanOrEqual(0)
+    expect(calls.indexOf("updateRef")).toBeLessThan(calls.indexOf("softResetTo"))
   })
 
   it("a failed commit-template render refuses the step, touching nothing", async () => {
@@ -528,6 +552,25 @@ describe("parseReviewBaseTrailer", () => {
   it("is undefined when the message carries no such trailer", () => {
     expect(parseReviewBaseTrailer("gtd(human): reviewing")).toBeUndefined()
     expect(parseReviewBaseTrailer("chore: init\n\nGtd-Cost: 10")).toBeUndefined()
+  })
+})
+
+describe("withHistoryTrailer", () => {
+  it("appends a `Gtd-History:` trailer after a blank line, leaving the subject as the first line", () => {
+    const message = withHistoryTrailer("subject line", "abc123")
+    expect(message).toBe("subject line\n\nGtd-History: abc123")
+    expect(message.split("\n")[0]).toBe("subject line")
+  })
+})
+
+describe("parseHistoryTrailer", () => {
+  it("reads the hash back off a message carrying the trailer", () => {
+    expect(parseHistoryTrailer("subject line\n\nGtd-History: abc123")).toBe("abc123")
+  })
+
+  it("is undefined when the message carries no such trailer", () => {
+    expect(parseHistoryTrailer("subject line")).toBeUndefined()
+    expect(parseHistoryTrailer("chore: init\n\nGtd-Cost: 10")).toBeUndefined()
   })
 })
 

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -16,6 +16,7 @@ import {
   type WorkflowDefinition,
 } from "./PatternMachine.js"
 import { renderStateTemplate, type TemplateContext, type TemplateEdge } from "./PatternTemplates.js"
+import { retainHistory, withHistoryTrailer } from "./RetainedHistory.js"
 
 /**
  * The v3 Effect edge (see `docs/design/pattern-machine-plan.md`, "Phase 3:
@@ -556,13 +557,15 @@ export type ExecutableDecision = Extract<StepDecision, { kind: "commit" | "squas
  * `Gtd-Cost: <cost>[ <model>]` trailer (the invocation's `--cost`/`--model`,
  * persisted in the git log); a `"squash"` decision renders the commit-state
  * template against the PENDING tree — a render failure REFUSES the step,
- * touching nothing — then soft-resets to the process's start parent, writes
- * ONE commit with the rendered message (via `commitAsIs`, so the
- * still-uncommitted template file is excluded), and discards everything left
- * pending (the template file included). A squash records no trailer of its own
- * — the whole-process total and per-model breakdown reach the message through
- * `it.processCost`/`it.processCostByModel` in the rendered template. A
- * `"noop"` performs no IO.
+ * touching nothing — then records the pre-squash tip on the retained-history
+ * ref (`retainHistory`, a no-op for an empty process) before soft-resetting to
+ * the process's start parent, writes ONE commit with the rendered message
+ * plus a `Gtd-History: <hash>` trailer pointing at that tip (via
+ * `withHistoryTrailer`/`commitAsIs`, so the still-uncommitted template file is
+ * excluded), and discards everything left pending (the template file
+ * included). The whole-process total and per-model breakdown reach the
+ * message through `it.processCost`/`it.processCostByModel` in the rendered
+ * template. A `"noop"` performs no IO.
  */
 export const executeDecision = (
   git: GitOperations,
@@ -588,8 +591,10 @@ export const executeDecision = (
               }`,
             ),
         })
+        const tip = yield* git.resolveRef("HEAD")
+        yield* retainHistory(git, tip, run.startParentHash)
         yield* git.softResetTo(run.startParentHash)
-        yield* git.commitAsIs(message)
+        yield* git.commitAsIs(withHistoryTrailer(message, tip))
         yield* git.discardPending()
         return { kind: "squash", subject: subjectOf(message) }
       }

--- a/src/Git.test.ts
+++ b/src/Git.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs"
 import { join, dirname } from "node:path"
 import { tmpdir } from "node:os"
 import { execSync } from "node:child_process"
@@ -431,6 +431,53 @@ for (const [tierName, makeTier] of tiers) {
         // second.txt still shows as a change (staged-new or untracked depending on tier)
         const status = t.statusPorcelain()
         expect(status).toContain("second.txt")
+      })
+    })
+
+    // -----------------------------------------------------------------------
+    describe("hardResetTo", () => {
+      it("moves HEAD, index, and working tree content back to the target ref", async () => {
+        const firstHash = t.resolveRef("HEAD")
+        t.commit("feat: second", { "readme.txt": "modified content" })
+
+        await t.run(Effect.flatMap(GitService, (g) => g.hardResetTo(firstHash)))
+
+        // HEAD is back at the first commit
+        expect(t.resolveRef("HEAD")).toBe(firstHash)
+
+        // index and working tree are both clean against the target ref — no
+        // pending changes at all (unlike softResetTo/mixedResetTo, which would
+        // surface readme.txt as a change)
+        expect(t.statusPorcelain()).toBe("")
+
+        // Live only: the working tree content itself reverted on disk to what
+        // it was at firstHash — this is what distinguishes a hard reset from
+        // softResetTo (worktree AND index untouched) and mixedResetTo
+        // (worktree untouched); a clean `status --porcelain` alone wouldn't
+        // catch a reset that moved HEAD/index but left stale file content on
+        // disk with matching mtimes.
+        if (tierName === "Live") {
+          expect(readFileSync(join(repoDir, "readme.txt"), "utf8")).toBe("hello")
+        }
+      })
+    })
+
+    // -----------------------------------------------------------------------
+    describe("lastCommitMessage", () => {
+      it("returns the full commit message (subject + body) of HEAD", async () => {
+        t.commit("feat: add thing\n\nA body explaining why.")
+
+        const message = await t.run(Effect.flatMap(GitService, (g) => g.lastCommitMessage()))
+
+        expect(message).toBe("feat: add thing\n\nA body explaining why.")
+      })
+
+      it("returns just the subject when HEAD carries no body", async () => {
+        t.commit("feat: subject only")
+
+        const message = await t.run(Effect.flatMap(GitService, (g) => g.lastCommitMessage()))
+
+        expect(message).toBe("feat: subject only")
       })
     })
 

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -14,6 +14,8 @@ export interface GitReaderOperations {
    */
   readonly diffHead: (exclude?: ReadonlyArray<string>) => Effect.Effect<string, Error>
   readonly lastCommitSubject: () => Effect.Effect<string, Error>
+  /** `git log -1 --pretty=%B` — the full commit message (subject + body) of HEAD. Mirrors `lastCommitSubject`'s `--pretty=%s`, but keeps the body — needed to read back a `Gtd-History:` trailer (see `RetainedHistory.ts`'s `parseHistoryTrailer`). */
+  readonly lastCommitMessage: () => Effect.Effect<string, Error>
   readonly hasCommits: () => Effect.Effect<boolean, Error>
   /**
    * `git diff <ref> HEAD`, optionally with `:(exclude)` pathspecs. Exclusions
@@ -123,6 +125,8 @@ export interface GitWriterOperations {
   readonly deleteRef: (ref: string) => Effect.Effect<void, Error>
   /** `git reset --mixed <ref>` — HEAD and index move to `ref`, the working tree is untouched (so committed work re-surfaces as pending changes). The open/close primitive of the review checkout window. */
   readonly mixedResetTo: (ref: string) => Effect.Effect<void, Error>
+  /** `git reset --hard <ref>` — HEAD, the index, AND the working tree all move to `ref` (unlike `softResetTo`/`mixedResetTo`, which leave the working tree — and for `softResetTo` the index too — untouched). */
+  readonly hardResetTo: (ref: string) => Effect.Effect<void, Error>
   /**
    * `git restore --staged --source=<source> -- <paths…>` — set the index
    * entries under each path to their state at `source` (including removals),
@@ -312,6 +316,9 @@ const makeGitImpl = (executor: CommandExecutor.CommandExecutor, root: string): G
 
     lastCommitSubject: () =>
       exec("git", "log", "-1", "--pretty=%s").pipe(Effect.map((s) => s.trim())),
+
+    lastCommitMessage: () =>
+      exec("git", "log", "-1", "--pretty=%B").pipe(Effect.map((s) => s.trim())),
 
     hasCommits: () =>
       exec("git", "rev-parse", "--verify", "HEAD").pipe(
@@ -546,6 +553,8 @@ const makeGitImpl = (executor: CommandExecutor.CommandExecutor, root: string): G
     deleteRef: (ref: string) => exec("git", "update-ref", "-d", ref).pipe(Effect.asVoid),
 
     mixedResetTo: (ref: string) => exec("git", "reset", "--mixed", ref).pipe(Effect.asVoid),
+
+    hardResetTo: (ref: string) => exec("git", "reset", "--hard", ref).pipe(Effect.asVoid),
 
     restoreStagedFrom: (source: string, paths: ReadonlyArray<string>) =>
       paths.length === 0

--- a/src/RetainedHistory.test.ts
+++ b/src/RetainedHistory.test.ts
@@ -1,0 +1,137 @@
+import { Effect, Option } from "effect"
+import { describe, expect, it, vi } from "vitest"
+import type { GitOperations } from "./Git.js"
+import {
+  clearRetainedHistory,
+  HISTORY_REF,
+  readRetainedHistory,
+  restorability,
+  retainHistory,
+  withHistoryTrailer,
+} from "./RetainedHistory.js"
+
+/**
+ * Unit coverage for the retention edge module (`src/RetainedHistory.ts`),
+ * mirroring `src/ReviewWindow.ts`'s own `stubGit`-style test-double pattern
+ * (see `src/Edge.test.ts`): a plain `GitOperations` stub with every method
+ * failing by default, so an unexpected call fails loudly instead of silently
+ * succeeding.
+ */
+
+const notImplemented = (name: string) => () =>
+  Effect.fail(new Error(`${name} should not have been called by this test`))
+
+const stubGit = (overrides: Partial<GitOperations>): GitOperations => ({
+  diffHead: notImplemented("diffHead"),
+  readFileAtRef: notImplemented("readFileAtRef"),
+  lastCommitSubject: notImplemented("lastCommitSubject"),
+  lastCommitMessage: notImplemented("lastCommitMessage"),
+  hasCommits: notImplemented("hasCommits"),
+  diffRef: notImplemented("diffRef"),
+  resolveRef: notImplemented("resolveRef"),
+  readRefOption: notImplemented("readRefOption"),
+  isAncestor: notImplemented("isAncestor"),
+  topLevel: notImplemented("topLevel"),
+  commitHistory: notImplemented("commitHistory"),
+  commitDiff: notImplemented("commitDiff"),
+  changedPaths: notImplemented("changedPaths"),
+  commitAllWithPrefix: notImplemented("commitAllWithPrefix"),
+  softResetTo: notImplemented("softResetTo"),
+  commitAsIs: notImplemented("commitAsIs"),
+  discardPending: notImplemented("discardPending"),
+  updateRef: notImplemented("updateRef"),
+  deleteRef: notImplemented("deleteRef"),
+  mixedResetTo: notImplemented("mixedResetTo"),
+  hardResetTo: notImplemented("hardResetTo"),
+  restoreStagedFrom: notImplemented("restoreStagedFrom"),
+  addIntentToAdd: notImplemented("addIntentToAdd"),
+  ...overrides,
+})
+
+const run = <A>(effect: Effect.Effect<A, Error>): Promise<A> => Effect.runPromise(effect)
+
+describe("retainHistory", () => {
+  it("points HISTORY_REF at the tip hash in the normal case", async () => {
+    const updateRef = vi.fn(() => Effect.succeed(undefined))
+    const git = stubGit({ updateRef })
+    await run(retainHistory(git, "tip123", "start456"))
+    expect(updateRef).toHaveBeenCalledWith(HISTORY_REF, "tip123")
+  })
+
+  it("is a no-op (skips the git call entirely) when tipHash === startParentHash", async () => {
+    const updateRef = vi.fn(() => Effect.succeed(undefined))
+    const git = stubGit({ updateRef })
+    await run(retainHistory(git, "same123", "same123"))
+    expect(updateRef).not.toHaveBeenCalled()
+  })
+})
+
+describe("readRetainedHistory", () => {
+  it("returns Option.none() when readRefOption resolves to none", async () => {
+    const git = stubGit({ readRefOption: () => Effect.succeed(Option.none()) })
+    const result = await run(readRetainedHistory(git))
+    expect(Option.isNone(result)).toBe(true)
+  })
+
+  it("returns Option.some(hash) when readRefOption resolves to some hash", async () => {
+    const git = stubGit({ readRefOption: () => Effect.succeed(Option.some("abc123")) })
+    const result = await run(readRetainedHistory(git))
+    expect(result).toEqual(Option.some("abc123"))
+  })
+})
+
+describe("restorability", () => {
+  it("(a) fresh squash — HEAD is the new squash commit, distinct from the retained tip, with a matching trailer — is safe", async () => {
+    const git = stubGit({})
+    const message = withHistoryTrailer("gtd(agent): squashed feature", "tip123")
+    const result = await run(restorability(git, "squashHead999", message, "tip123"))
+    expect(result).toEqual({ ok: true })
+  })
+
+  it("(a) also passes in the degenerate case headHash === tipHash, as long as the trailer matches", async () => {
+    const git = stubGit({})
+    const message = withHistoryTrailer("gtd(agent): squashed feature", "tip123")
+    const result = await run(restorability(git, "tip123", message, "tip123"))
+    expect(result).toEqual({ ok: true })
+  })
+
+  it("(a) with a mismatched trailer hash falls through to rule (b) — ok when isAncestor is true", async () => {
+    const message = withHistoryTrailer("gtd(agent): squashed feature", "someOtherTip")
+    const git = stubGit({ isAncestor: () => Effect.succeed(true) })
+    const result = await run(restorability(git, "tip123", message, "tip123"))
+    expect(result).toEqual({ ok: true })
+  })
+
+  it("(a) with a mismatched trailer hash falls through to rule (b) — refused when isAncestor is false", async () => {
+    const message = withHistoryTrailer("gtd(agent): squashed feature", "someOtherTip")
+    const git = stubGit({ isAncestor: () => Effect.succeed(false) })
+    const result = await run(restorability(git, "tip123", message, "tip123"))
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason.length).toBeGreaterThan(0)
+  })
+
+  it("(b) cleaned abandon / fast-forward — headHash !== tipHash, isAncestor true — is safe", async () => {
+    const git = stubGit({ isAncestor: () => Effect.succeed(true) })
+    const result = await run(restorability(git, "head789", "chore: cleanup", "tip123"))
+    expect(result).toEqual({ ok: true })
+  })
+
+  it("refuses when HEAD is neither the tip nor an ancestor of it", async () => {
+    const git = stubGit({ isAncestor: () => Effect.succeed(false) })
+    const result = await run(restorability(git, "head789", "chore: unrelated", "tip123"))
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(typeof result.reason).toBe("string")
+      expect(result.reason.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe("clearRetainedHistory", () => {
+  it("deletes HISTORY_REF", async () => {
+    const deleteRef = vi.fn(() => Effect.succeed(undefined))
+    const git = stubGit({ deleteRef })
+    await run(clearRetainedHistory(git))
+    expect(deleteRef).toHaveBeenCalledWith(HISTORY_REF)
+  })
+})

--- a/src/RetainedHistory.ts
+++ b/src/RetainedHistory.ts
@@ -1,0 +1,100 @@
+import { Effect, Option } from "effect"
+import type { GitOperations } from "./Git.js"
+
+/**
+ * Retention of a squashed (or abandoned) process's turn-by-turn history —
+ * Task C of `docs/design/pattern-machine-plan.md`'s follow-up note (see
+ * `.gtd/packages/01-retention-primitives.md`). Squashing collapses a whole
+ * cycle's turn commits into one; this module records the pre-squash tip so a
+ * later `gtd restore` (a separate, not-yet-built command-layer piece of work)
+ * can bring those turns back.
+ */
+
+/**
+ * The retained-history ref lives in git's PER-WORKTREE `refs/worktree/gtd/*`
+ * namespace — the same one `src/ReviewWindow.ts` uses for `REVIEW_HEAD_REF`/
+ * `REVIEW_BASE_REF`, for the same reason: linked worktrees sharing one `.git`
+ * must not clobber each other's retained history (issue #118).
+ */
+export const HISTORY_REF = "refs/worktree/gtd/history"
+
+const HISTORY_TRAILER_PREFIX = "Gtd-History: "
+// One `Gtd-History: <hash>` trailer line — same shape as `Edge.ts`'s `REVIEW_BASE_TRAILER_RE`.
+const HISTORY_TRAILER_RE = /^Gtd-History:[ \t]*(\S+)[ \t]*$/m
+
+/**
+ * Append a `Gtd-History: <hash>` trailer (after a blank line) to a commit
+ * `subject` — records the pre-squash tip commit hash so a later `gtd restore`
+ * command can read it back. Mirrors `Edge.ts`'s `withReviewBaseTrailer`
+ * placement: the subject (first line) is untouched.
+ */
+export const withHistoryTrailer = (subject: string, hash: string): string =>
+  `${subject}\n\n${HISTORY_TRAILER_PREFIX}${hash}`
+
+/**
+ * The `Gtd-History: <hash>` trailer recorded on a squash commit (see
+ * `withHistoryTrailer`), or `undefined` when `message` carries none. Read back
+ * by a later `gtd restore` command to recover the pre-squash tip.
+ */
+export const parseHistoryTrailer = (message: string): string | undefined =>
+  HISTORY_TRAILER_RE.exec(message)?.[1]
+
+/**
+ * Record the pre-squash tip so a later `gtd restore` can find it. A no-op
+ * (the git call is skipped entirely) when `tipHash === startParentHash`: an
+ * empty process — no turns were ever committed — has no turn chain worth
+ * keeping.
+ */
+export const retainHistory = (
+  git: GitOperations,
+  tipHash: string,
+  startParentHash: string,
+): Effect.Effect<void, Error> =>
+  tipHash === startParentHash ? Effect.void : git.updateRef(HISTORY_REF, tipHash)
+
+/** A thin wrapper over `git.readRefOption(HISTORY_REF)`. */
+export const readRetainedHistory = (
+  git: GitOperations,
+): Effect.Effect<Option.Option<string>, Error> => git.readRefOption(HISTORY_REF)
+
+/**
+ * The safety predicate deciding whether a future `gtd restore` to `tipHash`
+ * would be safe. Accepts exactly two shapes:
+ *
+ * (a) Fresh squash — HEAD IS the squash commit (a brand-new commit distinct
+ *     from `tipHash`, the pre-squash tip it collapsed) and its own message
+ *     still carries the `Gtd-History:` trailer pointing at that tip
+ *     (`parseHistoryTrailer(headMessage) === tipHash`). Hard-resetting from
+ *     here discards only that one squash commit, whose tree equals the tip's
+ *     — no content loss. If HEAD's trailer names a DIFFERENT hash (or none),
+ *     either a newer squash/abandon has since superseded this ref or HEAD
+ *     isn't a squash commit at all, so this falls through to (b) rather than
+ *     trusting a stale or absent match.
+ * (b) Cleaned abandon / fast-forward — HEAD is an ancestor of the retained
+ *     tip (`git.isAncestor(headHash, tipHash)`), i.e. nothing built on top of
+ *     the tip would be discarded by resetting back to it.
+ *
+ * Anything else is refused with a reason naming what would be lost.
+ */
+export const restorability = (
+  git: GitOperations,
+  headHash: string,
+  headMessage: string,
+  tipHash: string,
+): Effect.Effect<{ readonly ok: true } | { readonly ok: false; readonly reason: string }, Error> =>
+  Effect.gen(function* () {
+    if (parseHistoryTrailer(headMessage) === tipHash) return { ok: true }
+
+    const isAncestor = yield* git.isAncestor(headHash, tipHash)
+    if (isAncestor) return { ok: true }
+
+    return {
+      ok: false,
+      reason:
+        "HEAD has advanced past the squash — restoring would discard commits built on top of it",
+    }
+  })
+
+/** Idempotent: `deleteRef` already tolerates a missing ref. */
+export const clearRetainedHistory = (git: GitOperations): Effect.Effect<void, Error> =>
+  git.deleteRef(HISTORY_REF)

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -31,6 +31,8 @@ const failingGitLayer = Layer.succeed(GitService, {
   hasCommits: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   lastCommitSubject: () =>
     Effect.fail(new Error("GitService must not be called for --version/--help")),
+  lastCommitMessage: () =>
+    Effect.fail(new Error("GitService must not be called for --version/--help")),
   resolveRef: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   readFileAtRef: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   readRefOption: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
@@ -50,6 +52,7 @@ const failingGitLayer = Layer.succeed(GitService, {
   updateRef: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   deleteRef: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   mixedResetTo: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
+  hardResetTo: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   restoreStagedFrom: () =>
     Effect.fail(new Error("GitService must not be called for --version/--help")),
   addIntentToAdd: () =>

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,7 +1,7 @@
 import { createRequire } from "node:module"
 import { join } from "node:path"
 import { FileSystem } from "@effect/platform"
-import { Effect, Either } from "effect"
+import { Effect, Either, Option } from "effect"
 import { configPresentAt, ConfigService } from "./Config.js"
 import { renderInitScaffold } from "./workflows/templates.js"
 import { Cwd } from "./Cwd.js"
@@ -29,6 +29,12 @@ import {
   type ResolvedRest,
 } from "./Edge.js"
 import { closeReviewWindow, openReviewWindow, reviewBaseHash } from "./ReviewWindow.js"
+import {
+  clearRetainedHistory,
+  readRetainedHistory,
+  restorability,
+  retainHistory,
+} from "./RetainedHistory.js"
 import { startLspServer } from "./Lsp.js"
 import { buildVizModel, openInBrowser, startVizServer } from "./Visualize.js"
 import {
@@ -88,6 +94,12 @@ Commands:
                    the commit the process started from, keeping everything it
                    produced as uncommitted changes. A no-op when no process is
                    underway
+  restore          Hard-reset HEAD back to the pre-squash tip retained by the
+                   last squash/abandon (refs/worktree/gtd/history), undoing a
+                   squash or bringing back an abandoned process's turns.
+                   Refuses on a dirty working tree, when there is no retained
+                   history, or when HEAD has advanced past the squash with
+                   commits that would be lost
   next             Print the resolved rest's rendered script/prompt/message
                    (no mutation)
   status           Print the resolved rest's state/actor and which declared
@@ -696,6 +708,9 @@ const runAbandonCommand = (
       )
     }
 
+    const tip = yield* git.resolveRef("HEAD")
+    yield* retainHistory(git, tip, run.startParentHash)
+
     yield* git.mixedResetTo(run.startParentHash)
     const subject = yield* git.lastCommitSubject()
     if (json) {
@@ -713,6 +728,75 @@ const runAbandonCommand = (
           `${run.startParentHash.slice(0, 7)} ("${subject}"), resting at "${initial}".\n` +
           `Everything the process produced is kept as uncommitted changes (\`git status\`); ` +
           `discard them with \`git checkout -- . && git clean -fd .gtd\` for a clean tree.\n`,
+      )
+    }
+  })
+
+/**
+ * `gtd restore`: hard-reset HEAD back to the pre-squash tip a squash or
+ * `gtd abandon` retained (`RetainedHistory.ts`'s `HISTORY_REF`), undoing
+ * either. Unlike `gtd abandon` (which rewinds a process still underway),
+ * restore reaches BACK past a completed squash — or re-applies an abandon's
+ * own retained tip — to bring the turn-by-turn history back.
+ *
+ * Guarded by `restorability` so it never discards work it didn't create:
+ * refuses on a dirty working tree, when there is no retained history, and
+ * when HEAD has advanced past the retained tip with commits that would be
+ * lost by resetting.
+ */
+const runRestoreCommand = (
+  argv: readonly string[],
+  json: boolean,
+  write: (chunk: string) => void,
+): Effect.Effect<void, Error, ProgramRequirements> =>
+  Effect.gen(function* () {
+    yield* rejectExtraArgs("restore", argv)
+
+    const git = yield* GitService
+
+    const changes = yield* pendingChanges(git)
+    if (changes.length > 0) {
+      return yield* Effect.fail(
+        new Error(
+          "gtd restore: refuses on a dirty working tree — commit, stash, or discard your changes first.",
+        ),
+      )
+    }
+
+    const retained = yield* readRetainedHistory(git)
+    if (Option.isNone(retained)) {
+      return yield* Effect.fail(new Error("gtd restore: no retained history to restore."))
+    }
+    const tip = retained.value
+
+    const before = yield* resolveRest()
+    const headHash = yield* git.resolveRef("HEAD")
+    const headMessage = yield* git.lastCommitMessage()
+    const check = yield* restorability(git, headHash, headMessage, tip)
+    if (!check.ok) {
+      return yield* Effect.fail(
+        new Error(
+          `gtd restore: ${check.reason} — HEAD ${headHash.slice(0, 7)} is ahead of the ` +
+            `retained tip ${tip.slice(0, 7)}.`,
+        ),
+      )
+    }
+
+    yield* git.hardResetTo(tip)
+    yield* clearRetainedHistory(git)
+
+    const after = yield* resolveRest()
+    const subject = yield* git.lastCommitSubject()
+
+    if (json) {
+      write(
+        JSON.stringify({ state: after.state, restored: true, to: tip, from: before.state }) + "\n",
+      )
+    } else {
+      write(
+        `restored the retained history — HEAD is back at ${tip.slice(0, 7)} ("${subject}"), ` +
+          `resting at "${after.state}". Resume with the loop, or \`git reset\` to any earlier ` +
+          `turn to restart from there.\n`,
       )
     }
   })
@@ -1376,6 +1460,7 @@ const KNOWN_SUBCOMMANDS = [
   "review",
   "fix",
   "abandon",
+  "restore",
   "next",
   "status",
   "validate",
@@ -1502,6 +1587,8 @@ const dispatchKnownSubcommand = (
       return runFixCommand(argv, json, write)
     case "abandon":
       return runAbandonCommand(argv, json, write)
+    case "restore":
+      return runRestoreCommand(argv, json, write)
     case "next":
       return runNextCommand(json, write)
     case "status":

--- a/tests/integration/features/abandon.feature
+++ b/tests/integration/features/abandon.feature
@@ -40,6 +40,20 @@ Feature: gtd abandon — end the process underway without completing it
     Then it succeeds
     And stdout contains "State: idle"
 
+  Scenario: retains the abandoned tip on the retained-history ref
+    Given a file ".gtd/TODO.md" with:
+      """
+      Build a thing.
+      """
+    When I run gtd step human
+    Then it succeeds
+    When I run gtd step check
+    Then it succeeds
+    Given I mark the current commit as "tip"
+    When I run gtd with args "abandon"
+    Then it succeeds
+    And the git ref "refs/worktree/gtd/history" exists
+
   Scenario: a no-op success when no process is underway — nothing to abandon
     Given I record the commit count
     When I run gtd with args "abandon"

--- a/tests/integration/features/retained-history.feature
+++ b/tests/integration/features/retained-history.feature
@@ -1,0 +1,426 @@
+@inmem
+Feature: gtd restore — undo a squash (or an abandon) by hard-resetting to the retained tip
+
+  A squash collapses a whole cycle's turn commits into one, and `gtd abandon`
+  rewinds a process still underway — both retain the pre-collapse tip on
+  `refs/worktree/gtd/history` (see `src/RetainedHistory.ts`) before they act.
+  `gtd restore` is the way back: it hard-resets HEAD to that retained tip and
+  clears the ref, bringing the turn-by-turn history back (or re-applying an
+  abandon's own rewind).
+
+  It is guarded by `restorability` so it never discards work it didn't create:
+  it refuses on a dirty working tree, when there is no retained history to
+  restore, and when HEAD has moved past the retained tip with commits that
+  would be lost by resetting back to it.
+
+  Background:
+    Given a test project
+    And the workflow
+
+  Scenario: restores the full pre-squash commit chain after a squash, and clears the retained-history ref — also covers restoring immediately after a fresh squash
+    Given a file ".gtd/TODO.md" with:
+      """
+      Build a thing.
+      """
+    When I run gtd step human
+    Then it succeeds
+    When I run gtd step check
+    Then it succeeds
+
+    Given ".gtd/TODO.md" is modified to:
+      """
+      Build a thing. Implementation plan: add src/thing.ts exporting `thing`.
+      """
+    When I run gtd step agent
+    Then it succeeds
+
+    When I run gtd step human
+    Then it succeeds
+
+    Given the file ".gtd/TODO.md" is deleted
+    And a file "src/thing.ts" with:
+      """
+      export const thing = 1
+      """
+    When I run gtd step agent
+    Then it succeeds
+
+    When I run gtd step check
+    Then it succeeds
+
+    Given a file ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add thing.ts
+
+      - [ ] ./src/thing.ts#1 — new export
+      """
+    When I run gtd step agent
+    Then it succeeds
+
+    Given ".gtd/REVIEW.md" is modified to:
+      """
+      # Review: abc1234
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add thing.ts
+
+      - [x] ./src/thing.ts#1 — new export
+      """
+    When I run gtd step human
+    Then it succeeds
+    And the last commit subject is "gtd(human): await-review → review-deciding"
+
+    Given the file ".gtd/REVIEW.md" is deleted
+    When I run gtd step check
+    Then it succeeds
+    And the last commit subject is "gtd(check): review-deciding → squashing"
+
+    Given a file ".gtd/COMMIT_MSG.md" with:
+      """
+      feat: add thing
+
+      Adds src/thing.ts.
+      """
+    When I run gtd step agent
+    Then it succeeds
+    And the last commit subject is "feat: add thing"
+    And the git ref "refs/worktree/gtd/history" exists
+
+    When I run gtd with args "restore"
+    Then it succeeds
+    And stdout contains "restored the retained history"
+    And the commit subjects from oldest to newest are:
+      """
+      chore: initial commit
+      chore: init gtd workflow
+      gtd(human): idle → start-check
+      gtd(check): start-check → planning
+      gtd(agent): planning → plan-review
+      gtd(human): plan-review → building
+      gtd(agent): building → checking
+      gtd(check): checking → reviewing
+      gtd(agent): reviewing → await-review
+      gtd(human): await-review → review-deciding
+      gtd(check): review-deciding → squashing
+      """
+    And the git ref "refs/worktree/gtd/history" does not exist
+
+  Scenario: refuses when there is no retained history to restore
+    When I run gtd with args "restore"
+    Then it fails
+    And stderr contains "gtd restore: no retained history to restore."
+
+  Scenario: refuses on a dirty working tree, even with retained history available
+    Given a file ".gtd/TODO.md" with:
+      """
+      Build a thing.
+      """
+    When I run gtd step human
+    Then it succeeds
+    When I run gtd step check
+    Then it succeeds
+    When I run gtd with args "abandon"
+    Then it succeeds
+    And the git ref "refs/worktree/gtd/history" exists
+    # The abandon left ".gtd/TODO.md" as an uncommitted pending change — the
+    # tree is dirty, so restore refuses before it even looks at the ref.
+    When I run gtd with args "restore"
+    Then it fails
+    And stderr contains "gtd restore: refuses on a dirty working tree"
+
+  Scenario: cleaned-abandon safety case — restore succeeds when HEAD is an ancestor of the retained tip
+    Given a file ".gtd/TODO.md" with:
+      """
+      Build a thing.
+      """
+    When I run gtd step human
+    Then it succeeds
+    When I run gtd step check
+    Then it succeeds
+    And the last commit subject is "gtd(check): start-check → planning"
+
+    When I run gtd with args "abandon"
+    Then it succeeds
+    And the git ref "refs/worktree/gtd/history" exists
+    And the last commit subject is "chore: init gtd workflow"
+
+    # Clean up what the abandoned process left pending, exactly as abandon's
+    # own message suggests, so restore's dirty-tree guard doesn't fire.
+    Given the file ".gtd/TODO.md" is deleted
+
+    When I run gtd with args "restore"
+    Then it succeeds
+    And the last commit subject is "gtd(check): start-check → planning"
+    And the git ref "refs/worktree/gtd/history" does not exist
+
+  Scenario: work-on-top refusal — a commit made after the squash is never discarded
+    Given a file ".gtd/TODO.md" with:
+      """
+      Build a thing.
+      """
+    When I run gtd step human
+    Then it succeeds
+    When I run gtd step check
+    Then it succeeds
+
+    Given ".gtd/TODO.md" is modified to:
+      """
+      Build a thing. Implementation plan: add src/thing.ts exporting `thing`.
+      """
+    When I run gtd step agent
+    Then it succeeds
+
+    When I run gtd step human
+    Then it succeeds
+
+    Given the file ".gtd/TODO.md" is deleted
+    And a file "src/thing.ts" with:
+      """
+      export const thing = 1
+      """
+    When I run gtd step agent
+    Then it succeeds
+
+    When I run gtd step check
+    Then it succeeds
+
+    Given a file ".gtd/REVIEW.md" with:
+      """
+      # Review: abc1234
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add thing.ts
+
+      - [ ] ./src/thing.ts#1 — new export
+      """
+    When I run gtd step agent
+    Then it succeeds
+
+    Given ".gtd/REVIEW.md" is modified to:
+      """
+      # Review: abc1234
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add thing.ts
+
+      - [x] ./src/thing.ts#1 — new export
+      """
+    When I run gtd step human
+    Then it succeeds
+
+    Given the file ".gtd/REVIEW.md" is deleted
+    When I run gtd step check
+    Then it succeeds
+
+    Given a file ".gtd/COMMIT_MSG.md" with:
+      """
+      feat: add thing
+
+      Adds src/thing.ts.
+      """
+    When I run gtd step agent
+    Then it succeeds
+    And the last commit subject is "feat: add thing"
+
+    Given a commit "docs: add note" that adds "NOTE.md" with:
+      """
+      A note added after the squash landed.
+      """
+
+    When I run gtd with args "restore"
+    Then it fails
+    And stderr contains "HEAD has advanced past the squash"
+    And stderr matches "HEAD [0-9a-f]{7} is ahead of the retained tip [0-9a-f]{7}"
+    And the last commit subject is "docs: add note"
+
+  Scenario: superseded-ref case — two squashes in a row retain only the second tip, so restore lands on the second process's history
+    Given a file ".gtd/TODO.md" with:
+      """
+      Build the first thing.
+      """
+    When I run gtd step human
+    Then it succeeds
+    When I run gtd step check
+    Then it succeeds
+
+    Given ".gtd/TODO.md" is modified to:
+      """
+      Build the first thing. Implementation plan: add src/one.ts.
+      """
+    When I run gtd step agent
+    Then it succeeds
+
+    When I run gtd step human
+    Then it succeeds
+
+    Given the file ".gtd/TODO.md" is deleted
+    And a file "src/one.ts" with:
+      """
+      export const one = 1
+      """
+    When I run gtd step agent
+    Then it succeeds
+
+    When I run gtd step check
+    Then it succeeds
+
+    Given a file ".gtd/REVIEW.md" with:
+      """
+      # Review: cycle-one
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add one.ts
+
+      - [ ] ./src/one.ts#1 — new export
+      """
+    When I run gtd step agent
+    Then it succeeds
+
+    Given ".gtd/REVIEW.md" is modified to:
+      """
+      # Review: cycle-one
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add one.ts
+
+      - [x] ./src/one.ts#1 — new export
+      """
+    When I run gtd step human
+    Then it succeeds
+
+    Given the file ".gtd/REVIEW.md" is deleted
+    When I run gtd step check
+    Then it succeeds
+
+    Given a file ".gtd/COMMIT_MSG.md" with:
+      """
+      feat: cycle one
+      """
+    When I run gtd step agent
+    Then it succeeds
+    And the last commit subject is "feat: cycle one"
+    And the git ref "refs/worktree/gtd/history" exists
+
+    # Second cycle, on top of the first squash — its own retainHistory call
+    # rolls the SAME ref forward to its own pre-squash tip.
+    Given a file ".gtd/TODO.md" with:
+      """
+      Build the second thing.
+      """
+    When I run gtd step human
+    Then it succeeds
+    When I run gtd step check
+    Then it succeeds
+
+    Given ".gtd/TODO.md" is modified to:
+      """
+      Build the second thing. Implementation plan: add src/two.ts.
+      """
+    When I run gtd step agent
+    Then it succeeds
+
+    When I run gtd step human
+    Then it succeeds
+
+    Given the file ".gtd/TODO.md" is deleted
+    And a file "src/two.ts" with:
+      """
+      export const two = 2
+      """
+    When I run gtd step agent
+    Then it succeeds
+
+    When I run gtd step check
+    Then it succeeds
+
+    Given a file ".gtd/REVIEW.md" with:
+      """
+      # Review: cycle-two
+      <!-- base: def5678901234567890123456789012345678abc -->
+
+      ## Add two.ts
+
+      - [ ] ./src/two.ts#1 — new export
+      """
+    When I run gtd step agent
+    Then it succeeds
+
+    Given ".gtd/REVIEW.md" is modified to:
+      """
+      # Review: cycle-two
+      <!-- base: def5678901234567890123456789012345678abc -->
+
+      ## Add two.ts
+
+      - [x] ./src/two.ts#1 — new export
+      """
+    When I run gtd step human
+    Then it succeeds
+
+    Given the file ".gtd/REVIEW.md" is deleted
+    When I run gtd step check
+    Then it succeeds
+    And the last commit subject is "gtd(check): review-deciding → squashing"
+
+    Given a file ".gtd/COMMIT_MSG.md" with:
+      """
+      feat: cycle two
+      """
+    When I run gtd step agent
+    Then it succeeds
+    And the last commit subject is "feat: cycle two"
+    And the git ref "refs/worktree/gtd/history" exists
+
+    When I run gtd with args "restore"
+    Then it succeeds
+    And the git ref "refs/worktree/gtd/history" does not exist
+    And the commit subjects from oldest to newest are:
+      """
+      chore: initial commit
+      chore: init gtd workflow
+      feat: cycle one
+      gtd(human): idle → start-check
+      gtd(check): start-check → planning
+      gtd(agent): planning → plan-review
+      gtd(human): plan-review → building
+      gtd(agent): building → checking
+      gtd(check): checking → reviewing
+      gtd(agent): reviewing → await-review
+      gtd(human): await-review → review-deciding
+      gtd(check): review-deciding → squashing
+      """
+
+  Scenario: --json reports the restored state, hash, and prior state on success
+    Given a file ".gtd/TODO.md" with:
+      """
+      Build a thing.
+      """
+    When I run gtd step human
+    Then it succeeds
+    When I run gtd step check
+    Then it succeeds
+    And the last commit subject is "gtd(check): start-check → planning"
+
+    When I run gtd with args "abandon"
+    Then it succeeds
+    Given the file ".gtd/TODO.md" is deleted
+
+    When I run gtd with args "restore --json"
+    Then it succeeds
+    And stdout contains "\"restored\":true"
+    And stdout contains "\"state\":\"planning\""
+    And stdout contains "\"from\":\"idle\""
+
+  Scenario: --json reports the standard error envelope on refusal
+    When I run gtd with args "restore --json"
+    Then it fails
+    And stdout contains "\"state\":\"error\""
+    And stdout contains "no retained history to restore"
+
+  Scenario: takes no positional argument
+    When I run gtd with args "restore foo"
+    Then it fails
+    And stderr contains "gtd restore: too many arguments"

--- a/tests/integration/features/squash.feature
+++ b/tests/integration/features/squash.feature
@@ -77,6 +77,44 @@ Feature: Commit-state squash — a process collapses to one commit at its final 
     And "DRAFT.md" exists
     And "COMMIT_MSG.md" does not exist
 
+  Scenario: squashing retains the pre-squash tip on the history ref and trailer
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "write COMMIT_MSG.md"
+            on:
+              "A COMMIT_MSG.md": done
+              "M COMMIT_MSG.md": done
+          done:
+            commit: '<%~ it.read("COMMIT_MSG.md") %>'
+      """
+    And a commit "gtd(human): working" that adds "NOTE.md" with:
+      """
+      note
+      """
+    And I mark the current commit as "tip"
+    And a file "COMMIT_MSG.md" with:
+      """
+      feat: finish
+
+      Body.
+      """
+    When I run gtd step agent
+    Then it succeeds
+    And the last commit subject is "feat: finish"
+    And the git ref "refs/worktree/gtd/history" exists
+    And the last commit body contains the hash of "tip"
+
   Scenario: squashing discards any other uncommitted changes, not just the message file
     Given a test project
     And a gtd config file at ".gtdrc" with:

--- a/tests/integration/support/inmem/Repo.ts
+++ b/tests/integration/support/inmem/Repo.ts
@@ -143,6 +143,12 @@ export class InMemRepo {
     return c.message.split("\n")[0] ?? null
   }
 
+  lastCommitMessage(): string | null {
+    const c = this.headCommit()
+    if (!c) return null
+    return c.message
+  }
+
   commitHistory(base?: string): Array<{
     hash: string
     message: string
@@ -279,11 +285,11 @@ export class InMemRepo {
 
   /**
    * `git reset --hard <ref>` — move HEAD, the index, AND the worktree to
-   * `ref`'s commit. Test-SETUP only (no production `GitOperations`
-   * counterpart, unlike `softResetTo`/`mixedResetTo`): used by a scenario to
-   * simulate checking out a DIFFERENT point in history — e.g. to build two
-   * diverging tips off one shared base, so one of them is provably NOT an
-   * ancestor of the other (`gtd review <commitish>`'s ancestor guard).
+   * `ref`'s commit. Doubles as test-setup (a scenario simulating checking out
+   * a DIFFERENT point in history — e.g. to build two diverging tips off one
+   * shared base, so one of them is provably NOT an ancestor of the other,
+   * `gtd review <commitish>`'s ancestor guard) and as this repo's backing for
+   * the production `GitOperations.hardResetTo` (wired in `layers.ts`).
    */
   hardResetTo(ref: string): void {
     const hash = this.resolveRef(ref)

--- a/tests/integration/support/inmem/layers.ts
+++ b/tests/integration/support/inmem/layers.ts
@@ -106,6 +106,11 @@ const makeGitReaderOps = (repo: InMemRepo): GitReaderOperations => ({
     return subject !== null ? Effect.succeed(subject) : Effect.fail(new Error("No commits"))
   },
 
+  lastCommitMessage: () => {
+    const message = repo.lastCommitMessage()
+    return message !== null ? Effect.succeed(message) : Effect.fail(new Error("No commits"))
+  },
+
   resolveRef: (ref: string) => {
     const hash = repo.resolveRef(ref)
     return hash !== null
@@ -183,6 +188,8 @@ const makeGitWriterOps = (repo: InMemRepo): GitWriterOperations => ({
   deleteRef: (ref: string) => tryCatch(() => repo.deleteRef(ref)),
 
   mixedResetTo: (ref: string) => tryCatch(() => repo.mixedResetTo(ref)),
+
+  hardResetTo: (ref: string) => tryCatch(() => repo.hardResetTo(ref)),
 
   restoreStagedFrom: (source: string, paths: ReadonlyArray<string>) =>
     tryCatch(() => repo.restoreStagedFrom(source, paths)),

--- a/tests/integration/support/steps/common.steps.ts
+++ b/tests/integration/support/steps/common.steps.ts
@@ -218,6 +218,13 @@ Then("stdout does not contain {string}", (world: GtdWorld, text: string) => {
   )
 })
 
+Then("stderr matches {string}", (world: GtdWorld, pattern: string) => {
+  assert.ok(
+    new RegExp(pattern).test(world.lastResult.stderr),
+    `Expected stderr to match /${pattern}/. Got:\n${world.lastResult.stderr}`,
+  )
+})
+
 Then("stderr contains {string}", (world: GtdWorld, text: string) => {
   assert.ok(
     world.lastResult.stderr.includes(text),


### PR DESCRIPTION
## Summary

Adds `gtd restore` to undo a squash or an abandon — both were previously one-way.

- New `src/RetainedHistory.ts` records the pre-collapse tip on a per-worktree ref (`refs/worktree/gtd/history`, same namespace rationale as the review window's refs) before a squash or abandon acts, plus a `Gtd-History: <hash>` trailer on the squash commit.
- `gtd restore` hard-resets HEAD back to that retained tip and clears the ref, guarded by `restorability`, which allows only two safe shapes:
  - HEAD is the fresh squash commit whose own trailer names the tip, or
  - HEAD is an ancestor of the tip (a cleaned-up abandon).
- Anything else — dirty working tree, no retained history, or commits built on top of the squash — refuses rather than discarding work.

## Design notes

- Rolling single ref over a stack: a later squash/abandon overwrites the previous retained tip. Restoring one process's history is meant to be immediate, not archival.
- New `GitOperations` methods (`git.hardResetTo`, `lastCommitMessage`) keep this edge-only, matching the rest of the squash/abandon/review-window machinery — the pure engine never learns about restoring.

## Docs & tests

- README, STATES.md, docs/cli.md updated.
- New `RetainedHistory.test.ts`, `retained-history.feature`, plus additions to `abandon.feature`/`squash.feature` and Edge/Git unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)