### PR TITLE
feat(cli): merge gtd-loop into bin/gtd as the single entry point

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,19 +223,19 @@ NEVER executes anything itself. The command lives INLINE in that state's own
 `script:` content (no BLESSED `testCommand` config key — see `docs/upgrading.md`
 — though the templates' script does read its own `vars.testCommand`,
 workflow-authored data like any other `it.vars` entry, not a name the engine
-special-cases). `gtd next` renders and prints the script; the DRIVER
-(`bin/gtd-loop`, or any loop harness) executes that rendered `content` verbatim
-via `bash` — gtd itself never runs a workflow script (the only place gtd spawns
-a subprocess at all is a steering-file mode's own `format:`/`validate:` command,
-see `src/SteeringMode.ts`). The driver then runs `gtd step <actor>` for that
-state's own actor to capture the outcome from whatever the script left in the
-tree (e.g. an `on` pattern matching `A .gtd/FEEDBACK.md` vs `C`). Mechanics
-belong in the script; which `on` pattern the resulting diff matches is the only
-thing that decides the outcome — there is no separate capture-rule layer to keep
-in sync. In e2e, simulate a check's outcome by writing the output file (e.g.
+special-cases). `gtd next` renders and prints the script; the DRIVER (`bin/gtd`,
+or any loop harness) executes that rendered `content` verbatim via `bash` — gtd
+itself never runs a workflow script (the only place gtd spawns a subprocess at
+all is a steering-file mode's own `format:`/`validate:` command, see
+`src/SteeringMode.ts`). The driver then runs `gtd step <actor>` for that state's
+own actor to capture the outcome from whatever the script left in the tree (e.g.
+an `on` pattern matching `A .gtd/FEEDBACK.md` vs `C`). Mechanics belong in the
+script; which `on` pattern the resulting diff matches is the only thing that
+decides the outcome — there is no separate capture-rule layer to keep in sync.
+In e2e, simulate a check's outcome by writing the output file (e.g.
 `Given a file "FEEDBACK.md" with:`) and running `gtd step check` — `@inmem`
-scenarios never execute scripts; only `@live` scenarios (the `bin/gtd-loop`
-driver in `gtd-loop.feature`) actually run them.
+scenarios never execute scripts; only `@live` scenarios (the `bin/gtd` driver in
+`gtd-loop.feature`) actually run them.
 
 ## CLI Design
 

--- a/README.md
+++ b/README.md
@@ -157,11 +157,11 @@ through two `vars` tiers — `plannerModel` (heavier planning and review) and
 place (a `vars:` edit or a `GTD_VAR_plannerModel` override) instead of per
 state.
 
-`gtd-loop`, installed alongside `gtd`, is a ready-to-run driver for the whole
-protocol — point it at a repo and it runs the loop until it's your turn. It is
-the only command you run: at a gate you edit files (answer a plan question, tick
-a review box, fix code) and re-launch it, and it captures your edit as its
-opening move before driving on — so you never run `gtd step human` by hand. See
+Bare `gtd` (or `gtd loop`) is a ready-to-run driver for the whole protocol —
+point it at a repo and it runs the loop until it's your turn. It is the only
+command you run: at a gate you edit files (answer a plan question, tick a review
+box, fix code) and re-launch it, and it captures your edit as its opening move
+before driving on — so you never run `gtd step human` by hand. See
 [Driving the loop](docs/loop.md).
 
 Before wiring gtd into a repo, note the
@@ -191,8 +191,8 @@ Both halves are enforced by `gtd validate` and the `gtd step` gate.
   sub-machines, and the bundled workflow template
 - [CLI reference](docs/cli.md) — every command, exit codes, JSON schemas,
   repository requirements
-- [Driving the loop](docs/loop.md) — the reference loop driver, `gtd-loop`,
-  custom agents
+- [Driving the loop](docs/loop.md) — the reference loop driver,
+  `gtd`/`gtd loop`, custom agents
 - [Configuration](docs/configuration.md) — `gtd init`, the `.gtdrc` `workflow:`
   schema, lookup
 - [Upgrading](docs/upgrading.md) — breaking changes and migration

--- a/bin/gtd
+++ b/bin/gtd
@@ -1,6 +1,41 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# This file is the single published `bin` entry: `bin/gtd`. Before anything
+# else, it dispatches on $1:
+#   - no arguments, or exactly `loop` with no further arguments -> fall through
+#     into the loop body below (the loop protocol comment further down).
+#   - `loop` with additional arguments -> usage error, exit 2.
+#   - anything else -> hand off to the bundle via `run_gtd`, forwarding all
+#     arguments unchanged (e.g. `bin/gtd status`, `bin/gtd step human`).
+# `run_gtd` is the ONE place that knows how to invoke "the bundle": by default
+# it resolves `dist/gtd.bundle.mjs` relative to this script's own location
+# (not cwd), but `GTD_BIN` (a dev/test override for the whole invocation
+# command, e.g. `GTD_BIN="node $PWD/dev/run.mjs"`) takes precedence when set.
+# Every call the loop body makes below goes through `run_gtd` too, so the loop
+# always drives the exact same build/source it was launched from — no
+# dependence on a `gtd` binary being on PATH.
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+run_gtd() {
+  if [[ -n "${GTD_BIN:-}" ]]; then
+    eval "$GTD_BIN" '"$@"'
+  else
+    node "$SCRIPT_DIR/../dist/gtd.bundle.mjs" "$@"
+  fi
+}
+
+if [[ $# -gt 0 && "$1" != "loop" ]]; then
+  run_gtd "$@"
+  exit $?
+fi
+if [[ "${1:-}" == "loop" && $# -gt 1 ]]; then
+  echo "gtd: 'loop' takes no arguments" >&2
+  exit 2
+fi
+# otherwise ($# -eq 0, or exactly "loop" with no further args): fall through
+# into the existing loop body below, unchanged in behavior.
+
 # Drives the v3 pattern-machine loop (see docs/loop.md): each iteration asks
 # `gtd next --json` who's up and what they should do, dispatching on `kind`:
 #   - "message" (a human rest)  -> halt, tell the user what gtd is waiting on.
@@ -78,14 +113,14 @@ run_agent_turn() {
 # a harmless no-op; a genuine refusal there (a malformed steering file, or an
 # edit no `on` pattern accepts) is surfaced and stops the loop rather than being
 # driven past.
-if ! peek_json="$(gtd next --json 2>&1)"; then
+if ! peek_json="$(run_gtd next --json 2>&1)"; then
   echo "gtd-loop: could not determine the next step:" >&2
   echo "$peek_json" >&2
   echo "Run \`gtd status\` to inspect the repo." >&2
   exit 1
 fi
 if [[ "$(jq -r .kind <<<"$peek_json")" == "message" ]]; then
-  if ! step_out="$(gtd step human 2>&1)"; then
+  if ! step_out="$(run_gtd step human 2>&1)"; then
     echo "gtd-loop: could not capture your changes at the human gate:" >&2
     echo "$step_out" >&2
     echo "Fix the reported issue and re-run gtd-loop." >&2
@@ -94,7 +129,7 @@ if [[ "$(jq -r .kind <<<"$peek_json")" == "message" ]]; then
 fi
 
 while true; do
-  if ! next_json="$(gtd next --json 2>&1)"; then
+  if ! next_json="$(run_gtd next --json 2>&1)"; then
     echo "gtd-loop: could not determine the next step:" >&2
     echo "$next_json" >&2
     echo "Run \`gtd status\` to inspect the repo." >&2
@@ -110,7 +145,7 @@ while true; do
 
   if [[ "$kind" == "message" ]]; then
     echo "--- Your turn ($state) ---"
-    gtd next
+    run_gtd next
     exit 0
   fi
 
@@ -121,7 +156,7 @@ while true; do
     # the tree, and `gtd step` captures whatever it left there via the state's
     # own `on` patterns.
     bash -c "$content" || true
-    gtd step "$actor" >/dev/null
+    run_gtd step "$actor" >/dev/null
     head_after="$(git rev-parse HEAD 2>/dev/null || echo none)"
     if [[ "$head_before" == "$head_after" ]]; then
       echo "--- Settled ($state: check passed, nothing to do) ---"
@@ -137,7 +172,7 @@ while true; do
   # progress; stop rather than spin on it.
   if [[ "$state" == "$prev_state" && "$content" == "$prev_content" ]]; then
     echo "gtd-loop: no progress at '$state' — the agent's last turn changed nothing. Stopping to avoid spinning." >&2
-    gtd next >&2
+    run_gtd next >&2
     exit 1
   fi
   prev_state="$state"
@@ -180,7 +215,7 @@ while true; do
   run_agent_turn "$content" "$resume"
 
   fix_attempt=0
-  while ! validate_out="$(gtd validate 2>&1)"; do
+  while ! validate_out="$(run_gtd validate 2>&1)"; do
     fix_attempt=$((fix_attempt + 1))
     if ((fix_attempt > 3)); then
       echo "gtd-loop: '$state' still fails \`gtd validate\` after 3 fix attempts:" >&2
@@ -195,5 +230,5 @@ while true; do
     run_agent_turn "$content"$'\n\n'"Your last turn does not pass \`gtd validate\`. Fix these format violations, then finish:"$'\n'"$validate_out" "$fix_resume"
   done
 
-  gtd step "$actor" >/dev/null
+  run_gtd step "$actor" >/dev/null
 done

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,12 +4,19 @@
 Usage: gtd [command] [options]
 
 Commands:
-  init             Scaffold a minimal .gtdrc.json for this repo, seeding a
-                   testCommand var (npm test) and a ready-to-edit Prettier
-                   formatting suggestion under modes:. Writes no workflow — gtd
-                   runs the bundled unified workflow as its built-in default.
-                   Takes no argument. Refuses if a gtd config already exists.
-                   Leaves the file uncommitted for you to review and commit
+  (no command), loop
+                   Launch the loop driver (bin/gtd), which repeatedly drives
+                   an agent through gtd next/gtd step calls until the
+                   workflow returns to its initial state again. A bare gtd
+                   invocation and gtd loop both launch it identically
+  init             Scaffold a minimal .gtdrc.json for this repo, seeding the
+                   default variables you are most likely to change (the test
+                   command) and a Prettier formatting suggestion. gtd runs its
+                   built-in workflow by default, so no workflow is written —
+                   add a workflow: key only to customize the machine itself.
+                   Takes no argument. Run once per repo; refuses if a gtd
+                   config already exists. Leaves the file uncommitted for you
+                   to review and commit
   step <actor>     Authenticate as <actor>, match the resolved rest's
                    declared patterns against the pending changes, and commit
                    (or squash) the one resulting transition. Pass
@@ -38,7 +45,9 @@ Commands:
                    declares, with its mode's commands (its file:/mode:);
                    exits non-zero with the findings when it is invalid
   lsp              Start the LSP server for .gtd/ steering files (stdio)
-  visualize        Serve an interactive diagram of the active workflow locally
+  visualize        Serve an interactive diagram of the active workflow on a
+                   local web server (--port <n>, --no-open; --json prints the
+                   model and exits)
   version          Print version and exit
   help             Print this help and exit
 
@@ -55,9 +64,11 @@ Options:
 `--version` (`-v`) / `gtd version` and `--help` (`-h`) / `gtd help`
 short-circuit before any git or repository-state work — they run outside a repo
 and in any repo state (the bare subcommands are exact equivalents of their flag
-forms). Bare `gtd` (no subcommand) is a usage error: it prints the help text and
-exits 1 without touching the repository. Every other command must be run from
-the **repository root** — gtd derives the workflow, pending changes, and process
+forms). Bare `gtd` (no subcommand) and `gtd loop` both launch the loop driver
+(`bin/gtd`) immediately — neither is a usage error. Any other, truly unknown
+subcommand remains a usage error: it prints the help text and exits 1 without
+touching the repository. Every other (recognized) command must be run from the
+**repository root** — gtd derives the workflow, pending changes, and process
 history relative to cwd, so it refuses with a clear error if invoked from a
 subdirectory.
 
@@ -354,7 +365,7 @@ which are JSON-only. `--json` emits
 
 There is no `gtd` subcommand that executes a workflow script — gtd never runs a
 workflow script itself. When `gtd next` resolves to a `script`-content rest, the
-**driver** (`bin/gtd-loop`, or any loop harness) executes the emitted `content`
+**driver** (`bin/gtd`, or any loop harness) executes the emitted `content`
 verbatim via `bash -c` — foreground, inherited stdio, exit code deliberately
 ignored (a check script encodes its outcome in the tree, e.g. writing a findings
 file, never in its exit status) — then runs `gtd step <actor>` for that state's
@@ -446,7 +457,7 @@ agent or human:
 - **The producing agent self-validates.** Plain `gtd next` appends a "run
   `gtd validate` and fix all violations" instruction to a `prompt` rest that
   declares `file:`+`mode:`; `gtd next --json` withholds it and the driving loop
-  runs `gtd validate` after the turn instead (see `bin/gtd-loop` /
+  runs `gtd validate` after the turn instead (see `bin/gtd` /
   [STATES.md §12](../STATES.md#12-steering-file-validation-gtd-validate)).
 - **`gtd step` enforces the same gate.** Capturing a turn out of a state that
   declares `file:`+`mode:` formats that file in place and validates it first

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -52,9 +52,10 @@ gtd next --json   # ask who's up and what they should do
 ```
 
 See [`skills/loop/SKILL.md`](../skills/loop/SKILL.md) for the agent-facing
-instructions that follow the same pinned contract. `gtd-loop`, installed
-alongside `gtd` (see below), is the packaged, ready-to-run implementation of
-that same script for anyone who doesn't want to drive the loop by hand.
+instructions that follow the same pinned contract. `gtd` itself (bare, or with
+`loop` as its first argument — see below) is the packaged, ready-to-run
+implementation of that same script for anyone who doesn't want to drive the loop
+by hand.
 
 ## The reference loop driver
 
@@ -63,17 +64,29 @@ A minimal bash implementation of the pinned protocol, driving an agent CLI (e.g.
 reference for what a loop driver must do; keep any other implementation
 (including `skills/loop/SKILL.md`) consistent with it rather than editing both
 independently. Both open with the same move — capture the human's pending edit
-when the machine rests at a `"message"` gate — so `gtd-loop` is the only command
-a human runs. `bin/gtd-loop` is this exact script, packaged as the `gtd-loop`
-binary, with four additions: it stops with a diagnostic if the same `"prompt"`
-state/content repeat with no progress (see `skills/loop/SKILL.md`'s "Stall
-detection"); it lets `GTD_LOOP_AGENT_CMD` swap in any coding agent CLI in place
-of the default `claude -p`, receiving the prompt via `$GTD_LOOP_PROMPT`; it
-exports the resolved state's optional `model` hint as `$GTD_LOOP_MODEL`,
-appending `--model "$GTD_LOOP_MODEL"` to the default `claude -p` invocation
-whenever it's non-empty; and it acts on the optional `memory` scope hint (see
-"Agent memory scope" below) — continuing one agent session across consecutive
-same-scope turns and starting fresh when the scope changes.
+when the machine rests at a `"message"` gate — so `gtd` is the only command a
+human runs. `bin/gtd` is the packaged entry point: invoked bare, or with `loop`
+as its first argument, it runs this exact script; any other first argument (e.g.
+`next`, `step`, `status`) hands off to `node dist/gtd.bundle.mjs` instead. The
+loop body it runs adds four things on top of the reference script above: it
+stops with a diagnostic if the same `"prompt"` state/content repeat with no
+progress (see `skills/loop/SKILL.md`'s "Stall detection"); it lets
+`GTD_LOOP_AGENT_CMD` swap in any coding agent CLI in place of the default
+`claude -p`, receiving the prompt via `$GTD_LOOP_PROMPT`; it exports the
+resolved state's optional `model` hint as `$GTD_LOOP_MODEL`, appending
+`--model "$GTD_LOOP_MODEL"` to the default `claude -p` invocation whenever it's
+non-empty; and it acts on the optional `memory` scope hint (see "Agent memory
+scope" below) — continuing one agent session across consecutive same-scope turns
+and starting fresh when the scope changes.
+
+`bin/gtd` resolves both its bundle hand-off and the loop's own internal `gtd`
+calls against `dist/gtd.bundle.mjs` next to its own location. Set `GTD_BIN` — a
+full command, not just a path — to point both at source instead, e.g. for
+development or testing:
+
+```bash
+GTD_BIN="node $PWD/dev/run.mjs" bin/gtd
+```
 
 ```bash
 #!/usr/bin/env bash
@@ -139,9 +152,9 @@ turn, or either side has no `memory` — start fresh.
 This is what makes a loop retain memory while a phase boundary clears it: a loop
 that keeps re-entering one state emits the same label every lap, so the agent
 accumulates context across the loop; the move to the next phase's
-differently-labelled state resets it. `bin/gtd-loop` implements this by mapping
-the signal onto claude's session flags — `--session-id` to pin a fresh session
-when the scope changes, `--resume` to continue it while the scope holds — and
+differently-labelled state resets it. `bin/gtd` implements this by mapping the
+signal onto claude's session flags — `--session-id` to pin a fresh session when
+the scope changes, `--resume` to continue it while the scope holds — and
 persists the current scope + session id in the git dir (never the working tree,
 so `gtd status` and the pending diff never see them) so retention survives even
 across the restarts a human gate forces mid-loop. See `skills/loop/SKILL.md`'s
@@ -149,7 +162,7 @@ across the restarts a human gate forces mid-loop. See `skills/loop/SKILL.md`'s
 
 ## Using a different agent
 
-`gtd-loop` defaults to
+`gtd` (bare, or `gtd loop`) defaults to
 `claude -p "$GTD_LOOP_PROMPT" --dangerously-skip-permissions`, but the agent
 invocation is swappable: set `GTD_LOOP_AGENT_CMD` to any shell command, and it
 runs with the prompt available as `$GTD_LOOP_PROMPT` in its environment, along
@@ -160,5 +173,5 @@ session). An adapter that ignores any of these keeps working unchanged. For
 example, to drive a different agent CLI:
 
 ```bash
-GTD_LOOP_AGENT_CMD='my-agent-cli --prompt "$GTD_LOOP_PROMPT"' gtd-loop
+GTD_LOOP_AGENT_CMD='my-agent-cli --prompt "$GTD_LOOP_PROMPT"' gtd
 ```

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -159,6 +159,47 @@ loudly at load time rather than silently misinterpreting.
 or agent harness, upgrading the `gtd` binary also means re-copying that skill
 from this release.
 
+## 7.4: `gtd-loop` is gone — bare `gtd` and `gtd loop` run it directly
+
+`gtd-loop`, the standalone loop-driver binary installed alongside `gtd`, no
+longer exists. Its body now lives in `bin/gtd` itself, which is a bash entry
+script that dispatches on its first argument:
+
+| behavior                                               | before (≤ 7.3)                                 | from 7.4                                        |
+| ------------------------------------------------------ | ---------------------------------------------- | ----------------------------------------------- |
+| `gtd-loop`                                             | separate installed binary                      | removed                                         |
+| bare `gtd` (no subcommand)                             | usage error, prints help, exits 1              | runs the loop driver immediately                |
+| `gtd loop`                                             | not a recognized subcommand                    | runs the loop driver immediately                |
+| any other subcommand (`step`, `status`, `validate`, …) | handled by `node dist/gtd.bundle.mjs` directly | same, now reached via `bin/gtd`'s hand-off/exec |
+
+**Bare `gtd` is a behavior flip, not merely an addition** — the same kind of
+change as the v1 → v2 label grammar below: previously it printed the help text
+and exited 1 without touching the repository; from 7.4 it launches the loop
+driver immediately, identically to `gtd loop`. A script that relied on bare
+`gtd` failing fast (e.g. to detect a missing subcommand) now gets a running loop
+instead of an error.
+
+Because `bin/gtd` is a bash script for every invocation now, **running `gtd` at
+all — including any subcommand — requires bash**. Before 7.4, only the loop
+driver (`gtd-loop`) needed bash; a subcommand could be invoked directly via the
+bundle (e.g. `node node_modules/.bin/gtd`) with no bash in between. This is
+intentional and accepted, not an oversight: gtd's loop, its `script`-content
+checks, and a steering-file mode's own `format:`/`validate:` commands already
+run via `bash -c` (see
+[Configuration](configuration.md#modes--pluggable-steering-file-modes)) — gtd
+already assumes a unix/bash agent environment everywhere else, so the entry
+point catching up removes an inconsistency rather than introducing a new
+dependency.
+
+**Migration:**
+
+- Anyone invoking `gtd-loop` directly — in scripts, CI, or docs — should invoke
+  `gtd` or `gtd loop` instead.
+- Anyone relying on `node node_modules/.bin/gtd` resolving straight to the
+  bundle should note `gtd` is now a bash script that execs the bundle for
+  subcommands, so behavior for actual subcommands (`gtd step`, `gtd status`,
+  etc.) is unchanged — only the underlying file changed.
+
 ## 7.2: the review checkout window is now per worktree
 
 The review checkout window's two refs moved from the SHARED `refs/gtd/*`

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "private": false,
   "description": "Git-aware CLI that emits the next prompt for an autonomous coding agent based on the current repository state",
   "bin": {
-    "gtd": "dist/gtd.bundle.mjs",
-    "gtd-loop": "bin/gtd-loop"
+    "gtd": "bin/gtd"
   },
   "files": [
     "dist/",

--- a/skills/loop/SKILL.md
+++ b/skills/loop/SKILL.md
@@ -9,9 +9,10 @@ description: >-
 # gtd loop
 
 Drive `gtd` (v3 — the pattern machine) to completion by alternating
-`gtd next --json` with whatever it says to do next. Never call bare `gtd` — it
-has no default command and it is a usage error. Only `gtd next --json` and
-`gtd step <actor>` are used here.
+`gtd next --json` with whatever it says to do next. Don't call bare `gtd` or
+`gtd loop` from in here — that starts a NEW loop process, recursively, on top of
+the one you're already driving. Only `gtd next --json` and `gtd step <actor>`
+are used here.
 
 ## Requirements
 
@@ -162,4 +163,5 @@ indefinitely.
   `.gtd/FEEDBACK.md`); the fix round follows as your next `"prompt"` beat.
 - `gtd next --json` never mutates the working tree; it is safe to call as often
   as needed to inspect state.
-- Never run bare `gtd` — it is a usage error.
+- Don't run bare `gtd` or `gtd loop` from inside the loop — that starts a NEW
+  loop process; only `gtd next --json` and `gtd step <actor>` belong here.

--- a/src/program.ts
+++ b/src/program.ts
@@ -60,6 +60,11 @@ const GTD_VERSION: string = (_require("../package.json") as { version: string })
 const HELP_TEXT = `Usage: gtd [command] [options]
 
 Commands:
+  (no command), loop
+                   Launch the loop driver (bin/gtd), which repeatedly drives
+                   an agent through gtd next/gtd step calls until the
+                   workflow returns to its initial state again. A bare gtd
+                   invocation and gtd loop both launch it identically
   init             Scaffold a minimal .gtdrc.json for this repo, seeding the
                    default variables you are most likely to change (the test
                    command) and a Prettier formatting suggestion. gtd runs its

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -1,13 +1,18 @@
 @live
-Feature: gtd-loop — the packaged reference loop driver (v3)
+Feature: gtd loop — the packaged reference loop driver (v3)
 
-  `bin/gtd-loop` is the installable implementation of the loop protocol
-  documented in docs/loop.md. These scenarios spawn it as a real subprocess
-  (never the real `claude` CLI — a stub agent script stands in, wired through
+  `bin/gtd` is the single installable entry point: bare `gtd` (no arguments)
+  and `gtd loop` (no further arguments) both run the installable
+  implementation of the loop protocol documented in docs/loop.md, while any
+  other first argument (e.g. `gtd status`) hands off to the real bundle
+  unchanged. These scenarios spawn `bin/gtd` as a real subprocess (never the
+  real `claude` CLI — a stub agent script stands in, wired through
   `GTD_LOOP_AGENT_CMD`) against a minimal custom `.gtdrc` `workflow:` to prove
   its dispatch: an agent prompt turn chained through a script (check) turn,
-  settling when a script rest makes no progress, and stalling when an
-  agent's turn doesn't either.
+  settling when a script rest makes no progress, stalling when an agent's
+  turn doesn't either, `gtd loop` behaving identically to bare `gtd`, a
+  `gtd loop` with an extra argument being rejected as a usage error, and a
+  real subcommand being forwarded to the bundle untouched.
 
   Scenario: Chains an agent turn through a check turn and halts back at idle
     Given a test project
@@ -56,13 +61,13 @@ Feature: gtd-loop — the packaged reference loop driver (v3)
           ;;
       esac
       """
-    When I run gtd-loop
+    When I run bare gtd
     Then it succeeds
     And stdout contains "--- Your turn (idle) ---"
     And the git log contains "chore: calculator done"
     And "src/calc.ts" exists
 
-  Scenario: Captures the human's pending edit at the opening gate, so the human only runs gtd-loop
+  Scenario: Captures the human's pending edit at the opening gate, so the human only runs gtd
     # The machine rests at the initial human gate `idle` (no gtd commit — the
     # test project's "chore: initial commit" resolves to the initial state) with
     # an uncommitted NOTE.md sketch. The human never runs `gtd step human`: the
@@ -116,7 +121,7 @@ Feature: gtd-loop — the packaged reference loop driver (v3)
           ;;
       esac
       """
-    When I run gtd-loop
+    When I run bare gtd
     Then it succeeds
     And "src/calc.ts" exists
     And the git log contains "chore: calculator done"
@@ -143,7 +148,7 @@ Feature: gtd-loop — the packaged reference loop driver (v3)
       """
       note
       """
-    When I run gtd-loop
+    When I run bare gtd
     Then it succeeds
     And stdout contains "--- Settled (watching: check passed, nothing to do) ---"
 
@@ -217,7 +222,7 @@ Feature: gtd-loop — the packaged reference loop driver (v3)
           ;;
       esac
       """
-    When I run gtd-loop
+    When I run bare gtd
     Then it succeeds
     And stdout contains "AGENT MEMORY=work RESUME=0"
     And stdout contains "AGENT MEMORY=fix RESUME=0"
@@ -280,7 +285,7 @@ Feature: gtd-loop — the packaged reference loop driver (v3)
           ;;
       esac
       """
-    When I run gtd-loop
+    When I run bare gtd
     Then it succeeds
     And stdout contains "AGENT: first draft"
     And stdout contains "AGENT: fixing the plan"
@@ -317,6 +322,74 @@ Feature: gtd-loop — the packaged reference loop driver (v3)
       """
       : # does nothing — the build prompt is never acted on
       """
-    When I run gtd-loop
+    When I run bare gtd
     Then it fails
     And stderr contains "no progress at 'working'"
+
+  Scenario: gtd loop with no further arguments behaves identically to bare gtd
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Build the package described below: write src/calc.ts exporting add(a, b)."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: |
+              if [ -f src/calc.ts ] && grep -q add src/calc.ts; then rm -f .gtd/FEEDBACK.md; else mkdir -p .gtd && echo "missing add" > .gtd/FEEDBACK.md; fi
+            on:
+              "A .gtd/FEEDBACK.md": working
+              "M .gtd/FEEDBACK.md": working
+              "C": done
+          done:
+            commit: "chore: calculator done"
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Build the package described below"*)
+          mkdir -p src
+          cat > src/calc.ts <<'CALC'
+      export const add = (a, b) => a + b
+      CALC
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    When I run gtd loop
+    Then it succeeds
+    And stdout contains "--- Your turn (idle) ---"
+    And the git log contains "chore: calculator done"
+    And "src/calc.ts" exists
+
+  Scenario: gtd loop rejects an extra argument as a usage error without running node
+    Given a test project
+    And I record the commit count
+    When I run gtd loop extra
+    Then the exit code is 2
+    And stderr contains "gtd: 'loop' takes no arguments"
+    And the commit count is unchanged
+
+  Scenario: any other first argument hands off to the bundle, forwarding it untouched
+    Given a test project
+    And the workflow
+    When I run "status" via gtd
+    Then it succeeds
+    And stdout contains "State: idle"

--- a/tests/integration/support/steps/gtd-loop.steps.ts
+++ b/tests/integration/support/steps/gtd-loop.steps.ts
@@ -9,11 +9,10 @@ import type { GtdWorld } from "../world.js"
 const execFile = promisify(execFileCb)
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "../../../..")
-const GTD_BIN = join(PROJECT_ROOT, "dist/gtd.bundle.mjs")
-const GTD_LOOP_BIN = join(PROJECT_ROOT, "bin/gtd-loop")
+const GTD_BIN_PATH = join(PROJECT_ROOT, "bin/gtd")
 
 // The stub stands in for a real coding agent CLI: it reads $GTD_LOOP_PROMPT
-// (set by gtd-loop per turn) and reacts however the docstring says to, so the
+// (set by the loop per turn) and reacts however the docstring says to, so the
 // scenario text shows exactly what the "agent" does for each prompt it sees.
 Given("a stub agent script that responds to prompts with:", (world: GtdWorld, script: string) => {
   const dir = mkdtempSync(join(tmpdir(), "gtd-loop-stub-"))
@@ -23,22 +22,8 @@ Given("a stub agent script that responds to prompts with:", (world: GtdWorld, sc
   world.stubAgentPath = scriptPath
 })
 
-// A `gtd` shim on PATH — bin/gtd-loop calls bare `gtd`, exactly as it would
-// once installed, rather than the absolute dist path the @live tier's own
-// runGtdLive uses for `gtd` directly.
-function writeGtdShim(): string {
-  const shimDir = mkdtempSync(join(tmpdir(), "gtd-loop-path-"))
-  const gtdShim = join(shimDir, "gtd")
-  writeFileSync(gtdShim, `#!/usr/bin/env bash\nexec node "${GTD_BIN}" "$@"\n`)
-  chmodSync(gtdShim, 0o755)
-  return shimDir
-}
-
 function gtdLoopEnv(world: GtdWorld): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {
-    ...process.env,
-    PATH: `${writeGtdShim()}:${process.env["PATH"]}`,
-  }
+  const env: NodeJS.ProcessEnv = { ...process.env }
   if (world.stubAgentPath) {
     env["GTD_LOOP_AGENT_CMD"] = `bash "${world.stubAgentPath}"`
   }
@@ -51,12 +36,14 @@ function toFailedResult(err: unknown): { exitCode: number; stdout: string; stder
   return { exitCode, stdout: e.stdout ?? "", stderr: e.stderr ?? "" }
 }
 
-// Spawns the real bin/gtd-loop against the real built gtd.bundle.mjs, exactly
-// like the @live tier's runGtdLive does for `gtd` itself — gtd-loop is its own
-// process, so it can't go through the in-process/inmem tier.
-When("I run gtd-loop", async (world: GtdWorld) => {
+// Spawns the real bin/gtd against the real built dist/gtd.bundle.mjs, exactly
+// like the @live tier's runGtdLive does for `gtd` itself — bin/gtd is its own
+// process, so it can't go through the in-process/inmem tier. bin/gtd
+// self-locates the bundle relative to its own script path, so no PATH shim
+// is needed to reach it.
+async function runBinGtd(world: GtdWorld, args: string[]): Promise<void> {
   try {
-    const { stdout, stderr } = await execFile("bash", [GTD_LOOP_BIN], {
+    const { stdout, stderr } = await execFile("bash", [GTD_BIN_PATH, ...args], {
       cwd: world.repoDir,
       env: gtdLoopEnv(world),
       encoding: "utf-8",
@@ -66,4 +53,27 @@ When("I run gtd-loop", async (world: GtdWorld) => {
   } catch (err: unknown) {
     world.lastResult = toFailedResult(err)
   }
+}
+
+// Bare `gtd`, no arguments — the loop body's default entry point.
+When("I run bare gtd", async (world: GtdWorld) => {
+  await runBinGtd(world, [])
+})
+
+// `gtd loop` with no further arguments — must dispatch to the exact same
+// loop body as bare `gtd`.
+When("I run gtd loop", async (world: GtdWorld) => {
+  await runBinGtd(world, ["loop"])
+})
+
+// `gtd loop` plus an extra argument — a usage error, rejected before node
+// ever runs.
+When("I run gtd loop {word}", async (world: GtdWorld, extraArg: string) => {
+  await runBinGtd(world, ["loop", extraArg])
+})
+
+// Any other first argument hands off to the bundle unchanged, forwarding all
+// arguments — e.g. "status" via gtd, or "step human" via gtd.
+When("I run {string} via gtd", async (world: GtdWorld, args: string) => {
+  await runBinGtd(world, args.split(" "))
 })


### PR DESCRIPTION
## Summary

Replace the separate `gtd-loop` binary with `bin/gtd`, a bash entry script that dispatches on its first argument:

- no argument or a bare `loop` → runs the loop driver body (unchanged from `gtd-loop`)
- any other argument → execs `dist/gtd.bundle.mjs` unchanged

`package.json` now publishes only one bin (`"gtd": "bin/gtd"`), so installing the package no longer creates two separate commands to keep straight.

## Behavior change

Bare `gtd` flips from a usage error to launching the loop immediately, matching `gtd loop` — deliberate, since a bundled single-file build can't shell out to a sibling `gtd-loop` script anyway.

## Docs & tests

- README, `docs/cli.md`, `docs/loop.md`, `docs/upgrading.md`, the loop skill, and AGENTS.md updated to reference `bin/gtd` throughout
- `docs/upgrading.md` gains a 7.4 migration entry for anyone invoking `gtd-loop` directly or relying on `gtd` resolving straight to the bundle
- Tests move off the PATH-shim trick — `bin/gtd` now self-locates the bundle relative to its own script path via `run_gtd`/`$GTD_BIN` — and gain scenarios for `gtd loop`'s no-args/extra-arg cases and for a real subcommand forwarding through untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)