### PR TITLE
fix(herdr): pass pane id before options so lifecycle reports actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Both halves are enforced by `gtd validate` and the `gtd step` gate.
 
 Herdr integration: a workflow state can declare an optional `label:` — a
 human-readable display name surfaced in `gtd next --json`/`gtd status`. The
-reference `bin/gtd-loop` driver uses it to report its lifecycle
+reference `bin/gtd` driver uses it to report its lifecycle
 (working/blocked/idle) to a [Herdr](https://herdr.dev) pane sidebar via the
 `herdr` CLI when running under Herdr (`HERDR_ENV=1`, a pane ID, and `herdr` on
 `$PATH`); outside Herdr this is a complete no-op. See

--- a/bin/gtd
+++ b/bin/gtd
@@ -67,20 +67,38 @@ fi
 # `--resume`/`--session-id`. An adapter that ignores them keeps working.
 herdr_ok() { [ "${HERDR_ENV:-}" = 1 ] && [ -n "${HERDR_PANE_ID:-}" ] && command -v herdr >/dev/null 2>&1; }
 
+# Run a `herdr` invocation best-effort. Normally output is discarded and a
+# failure is swallowed (`|| true`) so a missing/incompatible herdr never blocks
+# the loop. Set GTD_HERDR_DEBUG=1 to instead surface every call and its exit
+# code on stderr — the escape hatch that makes a silent CLI-signature mismatch
+# (e.g. an arg herdr rejects) visible again.
+herdr_run() {
+  if [ "${GTD_HERDR_DEBUG:-}" = 1 ]; then
+    printf 'gtd/herdr: %s\n' "$*" >&2
+    herdr "$@" >&2
+    printf 'gtd/herdr: exit=%s\n' "$?" >&2
+  else
+    herdr "$@" >/dev/null 2>&1 || true
+  fi
+}
+
+# NOTE: herdr requires the positional <PANE_ID> BEFORE the options for
+# `pane` subcommands — passing it last makes herdr reject the first option as
+# `unknown option` (exit 2). Keep the pane id first here.
 herdr_report() {  # $1=state (working|blocked|idle)  $2=message
   herdr_ok || return 0
-  herdr pane report-agent --source herdr:gtd --agent gtd \
-    --state "$1" --message "$2" "$HERDR_PANE_ID" >/dev/null 2>&1 || true
+  herdr_run pane report-agent "$HERDR_PANE_ID" \
+    --source herdr:gtd --agent gtd --state "$1" --message "$2"
 }
 
 herdr_notify() {  # $1=title  $2=body
   herdr_ok || return 0
-  herdr notification show "$1" --body "$2" --sound request >/dev/null 2>&1 || true
+  herdr_run notification show "$1" --body "$2" --sound request
 }
 
 herdr_release() {  # hand the pane back to Herdr's normal detection
   herdr_ok || return 0
-  herdr pane release-agent --source herdr:gtd --agent gtd "$HERDR_PANE_ID" >/dev/null 2>&1 || true
+  herdr_run pane release-agent "$HERDR_PANE_ID" --source herdr:gtd --agent gtd
 }
 
 trap 'code=$?; if [ "$code" -ne 0 ]; then

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -183,18 +183,21 @@ GTD_LOOP_AGENT_CMD='my-agent-cli --prompt "$GTD_LOOP_PROMPT"' gtd
 
 ## Herdr integration (optional)
 
-`bin/gtd-loop` optionally reports its lifecycle to [Herdr](https://herdr.dev) (a
+`bin/gtd` optionally reports its lifecycle to [Herdr](https://herdr.dev) (a
 terminal multiplexer for coding agents) via a `herdr` CLI binary, entirely at
 the driver's edge — gtd core never talks to Herdr. Every call is best-effort
 (guarded, output discarded, `|| true`), so a missing/failing `herdr` binary
-never blocks, slows, or fails the loop.
+never blocks, slows, or fails the loop. Because that guard also hides a herdr
+CLI-signature mismatch, set `GTD_HERDR_DEBUG=1` to surface every `herdr` call
+and its exit code on stderr instead.
 
 The reporting is a no-op unless all three guard conditions hold: `HERDR_ENV=1`,
-a non-empty `$HERDR_PANE_ID`, and `herdr` on `$PATH`. When they do, `gtd-loop`
-makes three kinds of calls:
+a non-empty `$HERDR_PANE_ID`, and `herdr` on `$PATH`. When they do, `gtd` makes
+three kinds of calls (note the positional `<PANE_ID>` comes BEFORE the options —
+herdr's `pane` subcommands reject a trailing pane id):
 
-- `herdr pane report-agent --source herdr:gtd --agent gtd --state <state> --message <label> "$HERDR_PANE_ID"`
-- `herdr pane release-agent --source herdr:gtd --agent gtd "$HERDR_PANE_ID"`
+- `herdr pane report-agent "$HERDR_PANE_ID" --source herdr:gtd --agent gtd --state <state> --message <label>`
+- `herdr pane release-agent "$HERDR_PANE_ID" --source herdr:gtd --agent gtd`
 - `herdr notification show <title> --body <label> --sound request`
 
 mapped onto the loop's states like this:

--- a/skills/loop/SKILL.md
+++ b/skills/loop/SKILL.md
@@ -155,12 +155,13 @@ indefinitely.
 ## Herdr reporting (optional, driver-side)
 
 A Herdr-aware driver MAY additionally report its lifecycle to a Herdr pane —
-`herdr pane report-agent --state working|blocked|idle` at the top of each
-iteration/gate/settle, and `herdr notification show` at a human gate or on
-abnormal exit (see `bin/gtd-loop` and `docs/loop.md`'s "Herdr integration"
-section for the exact mapping). This is purely additive: it never changes the
-dispatch contract above (`kind` → message/script/prompt), never gates a step,
-and is a complete no-op outside Herdr.
+`herdr pane report-agent "$HERDR_PANE_ID" --state working|blocked|idle` at the
+top of each iteration/gate/settle (the pane id is positional and comes before
+the options), and `herdr notification show` at a human gate or on abnormal exit
+(see `bin/gtd` and `docs/loop.md`'s "Herdr integration" section for the exact
+mapping). This is purely additive: it never changes the dispatch contract above
+(`kind` → message/script/prompt), never gates a step, and is a complete no-op
+outside Herdr.
 
 ## Notes
 

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -454,9 +454,9 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And stdout contains "--- Settled (checking: check passed, nothing to do) ---"
     And the fake herdr log contains, in order:
       """
-      pane report-agent --source herdr:gtd --agent gtd --state working --message working test-pane
-      pane report-agent --source herdr:gtd --agent gtd --state idle --message checking test-pane
-      pane release-agent --source herdr:gtd --agent gtd test-pane
+      pane report-agent test-pane --source herdr:gtd --agent gtd --state working --message working
+      pane report-agent test-pane --source herdr:gtd --agent gtd --state idle --message checking
+      pane release-agent test-pane --source herdr:gtd --agent gtd
       """
 
   Scenario: Reports blocked and notifies Herdr when halting at a human gate
@@ -512,7 +512,7 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And stdout contains "--- Your turn (idle) ---"
     And the fake herdr log contains, in order:
       """
-      pane report-agent --source herdr:gtd --agent gtd --state blocked --message idle test-pane
+      pane report-agent test-pane --source herdr:gtd --agent gtd --state blocked --message idle
       notification show gtd needs you
       """
 
@@ -544,8 +544,8 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And stdout contains "--- Settled (watching: check passed, nothing to do) ---"
     And the fake herdr log contains, in order:
       """
-      pane report-agent --source herdr:gtd --agent gtd --state idle --message watching test-pane
-      pane release-agent --source herdr:gtd --agent gtd test-pane
+      pane report-agent test-pane --source herdr:gtd --agent gtd --state idle --message watching
+      pane release-agent test-pane --source herdr:gtd --agent gtd
       """
 
   Scenario: Reports blocked and notifies Herdr via the exit trap when the loop stops on failure
@@ -585,6 +585,6 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And stderr contains "no progress at 'working'"
     And the fake herdr log contains, in order:
       """
-      pane report-agent --source herdr:gtd --agent gtd --state blocked --message working: exited 1 test-pane
+      pane report-agent test-pane --source herdr:gtd --agent gtd --state blocked --message working: exited 1
       notification show gtd stopped
       """

--- a/tests/integration/support/steps/gtd-loop.steps.ts
+++ b/tests/integration/support/steps/gtd-loop.steps.ts
@@ -29,13 +29,26 @@ Given("a stub agent script that responds to prompts with:", (world: GtdWorld, sc
 // mere presence on world is what `gtdLoopEnv` uses to decide whether to
 // provision the Herdr environment at all. The stub logs every invocation's
 // arguments as one space-joined line (however bash's `"$@"` renders them) to
-// a log file, then exits 0, so scenarios can assert on the exact sequence of
-// calls gtd made without a real Herdr install.
+// a log file, so scenarios can assert on the exact sequence of calls gtd made
+// without a real Herdr install.
+//
+// The stub also emulates the one bit of real herdr arg-parsing gtd got wrong
+// once (the positional <PANE_ID> must precede the options on a `pane`
+// subcommand — a trailing pane id makes real herdr reject the first option as
+// `unknown option`, exit 2): a `pane <subcmd>` whose first argument after the
+// subcommand starts with `-` exits 2, so re-introducing the old pane-id-last
+// order fails these scenarios instead of silently no-op'ing.
 Given("a fake herdr binary", (world: GtdWorld) => {
   const dir = mkdtempSync(join(tmpdir(), "gtd-loop-herdr-"))
   const logPath = join(dir, "herdr.log")
   const herdrPath = join(dir, "herdr")
-  writeFileSync(herdrPath, `#!/usr/bin/env bash\necho "$@" >> "${logPath}"\nexit 0\n`)
+  writeFileSync(
+    herdrPath,
+    `#!/usr/bin/env bash\n` +
+      `echo "$@" >> "${logPath}"\n` +
+      `if [ "$1" = pane ] && [ "\${3:0:1}" = - ]; then exit 2; fi\n` +
+      `exit 0\n`,
+  )
   chmodSync(herdrPath, 0o755)
   world.fakeHerdrDir = dir
   world.fakeHerdrLogPath = logPath


### PR DESCRIPTION
## Problem

The Herdr integration in `bin/gtd` never worked against herdr 0.7.x. herdr's `pane` subcommands require the positional `<PANE_ID>` **before** the options, but the driver passed `$HERDR_PANE_ID` **last**:

```
herdr pane report-agent --source herdr:gtd --agent gtd --state working --message LABEL "$HERDR_PANE_ID"
```

herdr rejects this with `unknown option: herdr:gtd` (exit 2). The best-effort guards (`>/dev/null 2>&1 || true`) swallowed the failure, so `report-agent`/`release-agent` silently no-op'd on every call — the pane never showed gtd's working/blocked/idle lifecycle.

Verified live against herdr 0.7.5: pane-id-first exits 0 and updates the pane; pane-id-last exits 2. Confirmed the full working→blocked→idle→release lifecycle renders correctly once reordered.

## Fix

- Reorder the pane id to the front in `herdr_report` / `herdr_release`.
- Add a `GTD_HERDR_DEBUG=1` escape hatch that surfaces each `herdr` call + its exit code on stderr, so a future CLI-signature mismatch can't hide behind the guards again.
- Strengthen the e2e fake-`herdr` stub to reject a `pane` subcommand whose first arg is an option (exit 2) — reproducing herdr's real rule so a regression to the old order fails the suite. Update the log assertions to the corrected order.
- Fix stale `bin/gtd-loop` references and the wrong-order examples in `README.md`, `docs/loop.md`, `skills/loop/SKILL.md`.

## Not fixed (herdr-side config)

`notification show` returns `{"reason":"disabled","shown":false}` — notifications are disabled in the herdr config, not a gtd bug. The human-gate alert won't pop until they're enabled in herdr itself.

## Test

All 13 `gtd-loop.feature` scenarios pass (4 Herdr ones exercise the corrected order + stricter stub); typecheck, lint, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)