### PR TITLE
feat(loop): auto-open editor at human gates, add gtd edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ handful of commands drive it:
   pending changes, and which action leads where. The panel and diagram highlight
   refresh live (~every 3s) while the page is open, so advancing the process
   elsewhere shows up without a manual refresh.
+- **`gtd edit [path]`** — open `<path>` (or, with no argument, the current
+  resting state's steering file, or the repo dir) in `${VISUAL:-$EDITOR}`,
+  blocking until it exits.
 
 `gtd version` (or `gtd --version`/`-v`) prints the installed version and exits;
 `gtd help` (or `gtd --help`/`-h`) prints the command list. Both short-circuit
@@ -169,10 +172,13 @@ state.
 
 Bare `gtd` (or `gtd loop`) is a ready-to-run driver for the whole protocol —
 point it at a repo and it runs the loop until it's your turn. It is the only
-command you run: at a gate you edit files (answer a plan question, tick a review
-box, fix code) and re-launch it, and it captures your edit as its opening move
-before driving on — so you never run `gtd step human` by hand. See
-[Driving the loop](docs/loop.md).
+command you run: at a human gate it now opens `${VISUAL:-$EDITOR}` on the gate's
+file for you automatically (answer a plan question, tick a review box, fix
+code), waits for you to save and exit, then captures your edit itself and keeps
+driving — or halts if you left nothing changed — so you never run
+`gtd step human` by hand. Pass `--no-edit` (or set `GTD_NO_EDIT`) to fall back
+to halting and printing the gate instead, if you'd rather edit and re-launch it
+yourself. See [Driving the loop](docs/loop.md).
 
 Before wiring gtd into a repo, note the
 [repository requirements](docs/cli.md#repository-requirements) — most

--- a/bin/gtd
+++ b/bin/gtd
@@ -3,9 +3,17 @@ set -euo pipefail
 
 # This file is the single published `bin` entry: `bin/gtd`. Before anything
 # else, it dispatches on $1:
+#   - `--no-edit` (bare, or immediately after `loop`) -> stripped here and
+#     disables the loop's automatic editor launching for this run (see
+#     `edit_disabled`/`GTD_NO_EDIT` below); dispatch then continues on the
+#     remaining arguments as if it had never been given.
+#   - `edit [path]` -> handled entirely here in bash, never forwarded to the
+#     bundle: opens `${VISUAL:-$EDITOR}` on `path`, or (no `path` given) on the
+#     resolved rest's `.file` (or `.` when absent).
 #   - no arguments, or exactly `loop` with no further arguments -> fall through
 #     into the loop body below (the loop protocol comment further down).
-#   - `loop` with additional arguments -> usage error, exit 2.
+#   - `loop` with additional arguments (other than a lone `--no-edit`) ->
+#     usage error, exit 2.
 #   - anything else -> hand off to the bundle via `run_gtd`, forwarding all
 #     arguments unchanged (e.g. `bin/gtd status`, `bin/gtd step human`).
 # `run_gtd` is the ONE place that knows how to invoke "the bundle": by default
@@ -25,6 +33,55 @@ run_gtd() {
   fi
 }
 
+# Shared editor-launch helper — used by both the `edit` subcommand below and
+# the loop's human-gate flow further down. Resolves the editor git-style
+# ($VISUAL, then $EDITOR — no fallback to `vi`), then launches it blocking in
+# the foreground with the target path passed as a positional parameter
+# (never string-spliced into the command), so a multi-word command
+# (`code --wait`) and a path with special characters both work. A launch
+# failure (bad/missing editor binary) is a plain non-zero return, propagating
+# under `set -e`; the editor's own exit code is otherwise ignored entirely —
+# the outcome is judged from tree state afterward, not from this function.
+launch_editor() {
+  local target="$1" editor="${VISUAL:-${EDITOR:-}}"
+  if [[ -z "$editor" ]]; then
+    echo "gtd: no editor configured — set \$EDITOR (or \$VISUAL)" >&2
+    return 1
+  fi
+  bash -c "$editor \"\$1\"" gtd-edit "$target"
+}
+
+# --no-edit / GTD_NO_EDIT govern only the loop's automatic editor launching at
+# human gates (see handle_human_gate further down) — `gtd edit` itself never
+# reads either. `--no-edit` is recognised in exactly the two sanctioned
+# positions (bare, or right after `loop`) and stripped before anything below
+# looks at "$@", so the bundle's own unknown-option guard never sees it.
+edit_disabled=0
+[[ -n "${GTD_NO_EDIT:-}" ]] && edit_disabled=1
+if [[ "${1:-}" == "--no-edit" && $# -eq 1 ]]; then
+  edit_disabled=1
+  shift
+elif [[ "${1:-}" == "loop" && "${2:-}" == "--no-edit" && $# -eq 2 ]]; then
+  edit_disabled=1
+  set -- loop
+fi
+
+if [[ "${1:-}" == "edit" ]]; then
+  shift
+  if [[ $# -gt 0 ]]; then
+    launch_editor "$1"
+  else
+    if ! peek_json="$(run_gtd next --json 2>&1)"; then
+      echo "gtd edit: could not determine the next step:" >&2
+      echo "$peek_json" >&2
+      exit 1
+    fi
+    file="$(jq -r '.file // empty' <<<"$peek_json")"
+    launch_editor "${file:-.}"
+  fi
+  exit 0
+fi
+
 if [[ $# -gt 0 && "$1" != "loop" ]]; then
   run_gtd "$@"
   exit $?
@@ -33,12 +90,16 @@ if [[ "${1:-}" == "loop" && $# -gt 1 ]]; then
   echo "gtd: 'loop' takes no arguments" >&2
   exit 2
 fi
-# otherwise ($# -eq 0, or exactly "loop" with no further args): fall through
-# into the existing loop body below, unchanged in behavior.
+# otherwise ($# -eq 0, or exactly "loop" with no further args, --no-edit
+# already stripped above): fall through into the existing loop body below,
+# unchanged in behavior.
 
 # Drives the v3 pattern-machine loop (see docs/loop.md): each iteration asks
 # `gtd next --json` who's up and what they should do, dispatching on `kind`:
-#   - "message" (a human rest)  -> halt, tell the user what gtd is waiting on.
+#   - "message" (a human rest)  -> see handle_human_gate above: with editing on
+#     (the default) open the editor at the gate and step human, driving on a
+#     captured commit; with editing off (--no-edit/GTD_NO_EDIT), halt and tell
+#     the user what gtd is waiting on, unchanged from before this feature.
 #   - "script"  (a check rest) -> execute `content` (the emitted wrapper
 #     script) verbatim via bash — exit code deliberately ignored, the outcome
 #     lives in the tree — then `gtd step <actor>` to capture it; zero new
@@ -81,6 +142,57 @@ herdr_notify() {  # $1=title  $2=body
 herdr_release() {  # hand the pane back to Herdr's normal detection
   herdr_ok || return 0
   herdr pane release-agent --source herdr:gtd --agent gtd "$HERDR_PANE_ID" >/dev/null 2>&1 || true
+}
+
+# Shared human-gate handler for a "message" (human) rest — used both by the
+# opening move (when editing is on) and by every "message" rest the main loop
+# encounters. $1 is the rest's `next --json` blob.
+#
+# Editing OFF ($edit_disabled): today's behavior, unchanged — print the gate
+# and exit 0 without touching an editor.
+#
+# Editing ON (the default): open the editor on the rest's `.file` (or `.` when
+# absent), wait for it to exit, then run `gtd step human`:
+#   - a NEW commit was authored -> return normally so the caller keeps driving.
+#   - ZERO commits were authored -> halt, exit 0 (closing the editor without a
+#     capturable change means "done for now" — and keeps a gate with no `C`
+#     pattern, e.g. idle, from being reopened forever).
+#   - the step REFUSES (non-zero exit: malformed steering file, unfinished
+#     review) -> surface it verbatim and halt, exit non-zero — the same
+#     wording an opening-move refusal already used before this function
+#     existed.
+handle_human_gate() {
+  local json="$1" file label state step_out head_before head_after
+  label="$(jq -r '.label // .state' <<<"$json")"
+  state="$(jq -r .state <<<"$json")"
+
+  if [[ "$edit_disabled" == 1 ]]; then
+    herdr_report blocked "$label"
+    herdr_notify "gtd needs you — $(basename "$PWD")" "$label"
+    echo "--- Your turn ($state) ---"
+    run_gtd next
+    exit 0
+  fi
+
+  file="$(jq -r '.file // empty' <<<"$json")"
+  herdr_report working "$label"
+  launch_editor "${file:-.}"
+
+  head_before="$(git rev-parse HEAD 2>/dev/null || echo none)"
+  if ! step_out="$(run_gtd step human 2>&1)"; then
+    echo "gtd-loop: could not capture your changes at the human gate:" >&2
+    echo "$step_out" >&2
+    echo "Fix the reported issue and re-run gtd-loop." >&2
+    exit 1
+  fi
+  head_after="$(git rev-parse HEAD 2>/dev/null || echo none)"
+  if [[ "$head_before" == "$head_after" ]]; then
+    herdr_report idle "$label"
+    herdr_release
+    echo "--- Done for now ($state: nothing captured) ---"
+    exit 0
+  fi
+  # else: a new commit was captured — return normally, caller keeps driving.
 }
 
 trap 'code=$?; if [ "$code" -ne 0 ]; then
@@ -136,6 +248,12 @@ run_agent_turn() {
 # a harmless no-op; a genuine refusal there (a malformed steering file, or an
 # edit no `on` pattern accepts) is surfaced and stops the loop rather than being
 # driven past.
+#
+# Editing ON: route through the exact same gate logic the main loop uses below
+# (open the editor there first, THEN step) instead of blindly stepping human
+# and moving on. Editing OFF: unchanged from before this function existed —
+# step silently, refusal surfaced and halts, a clean/committed gate just falls
+# into the loop below.
 if ! peek_json="$(run_gtd next --json 2>&1)"; then
   echo "gtd-loop: could not determine the next step:" >&2
   echo "$peek_json" >&2
@@ -143,11 +261,15 @@ if ! peek_json="$(run_gtd next --json 2>&1)"; then
   exit 1
 fi
 if [[ "$(jq -r .kind <<<"$peek_json")" == "message" ]]; then
-  if ! step_out="$(run_gtd step human 2>&1)"; then
-    echo "gtd-loop: could not capture your changes at the human gate:" >&2
-    echo "$step_out" >&2
-    echo "Fix the reported issue and re-run gtd-loop." >&2
-    exit 1
+  if [[ "$edit_disabled" == 1 ]]; then
+    if ! step_out="$(run_gtd step human 2>&1)"; then
+      echo "gtd-loop: could not capture your changes at the human gate:" >&2
+      echo "$step_out" >&2
+      echo "Fix the reported issue and re-run gtd-loop." >&2
+      exit 1
+    fi
+  else
+    handle_human_gate "$peek_json"
   fi
 fi
 
@@ -168,17 +290,14 @@ while true; do
   label="$(jq -r '.label // .state' <<<"$next_json")"
   GTD_LAST_LABEL="$label"
 
-  if [[ "$kind" != "message" ]]; then
-    herdr_report working "$label"
+  if [[ "$kind" == "message" ]]; then
+    # handle_human_gate exits 0/non-zero itself on a halt/refusal; it only
+    # returns here when a new commit was captured, so we keep driving.
+    handle_human_gate "$next_json"
+    continue
   fi
 
-  if [[ "$kind" == "message" ]]; then
-    herdr_report blocked "$label"
-    herdr_notify "gtd needs you — $(basename "$PWD")" "$label"
-    echo "--- Your turn ($state) ---"
-    run_gtd next
-    exit 0
-  fi
+  herdr_report working "$label"
 
   if [[ "$kind" == "script" ]]; then
     head_before="$(git rev-parse HEAD 2>/dev/null || echo none)"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,6 +45,10 @@ Commands:
                    commits that would be lost
   next             Print the resolved rest's rendered script/prompt/message
                    (no mutation)
+  edit [path]      Open <path> (repo-relative) in $VISUAL/$EDITOR, blocking
+                   until the editor exits. With no argument, opens the
+                   resolved rest's declared file (or the repo root if it
+                   declares none). Never reads --no-edit/GTD_NO_EDIT
   status           Print the resolved rest's state/actor and which declared
                    pattern (if any) each pending change matches (no mutation)
   validate         Format and validate the steering file the resolved rest
@@ -63,6 +67,8 @@ Options:
   --no-open        (gtd visualize only) do not open the browser
   --cost=<n>       (gtd step only) record the invocation's token cost
   --model=<name>   (gtd step only, with --cost) tag that cost's model
+  --no-edit        (bare gtd or gtd loop only) disable the loop's automatic
+                   editor launching at human gates
   --version, -v    Print version and exit
   --help, -h       Print this help and exit
 ```
@@ -79,12 +85,32 @@ history relative to cwd, so it refuses with a clear error if invoked from a
 subdirectory.
 
 `--json`, `--cost=<n>`, and `--model=<name>` (the latter two only for
-`gtd step`) are the only long options. Any other `--` option (including a typo
-like `--jsn`) is rejected with a usage error rather than silently ignored, so a
-mistyped flag can never degrade a JSON caller to plain-text mode. A bare
-`--cost`/`--model` with no value, a non-numeric or negative `--cost`, an empty
-`--model`, `--model` without `--cost`, or either flag on any command other than
-`gtd step` are all usage errors.
+`gtd step`) are the only long options the compiled bundle recognizes. Any other
+`--` option (including a typo like `--jsn`) is rejected with a usage error
+rather than silently ignored, so a mistyped flag can never degrade a JSON caller
+to plain-text mode. A bare `--cost`/`--model` with no value, a non-numeric or
+negative `--cost`, an empty `--model`, `--model` without `--cost`, or either
+flag on any command other than `gtd step` are all usage errors.
+
+`--no-edit` is a separate, bash-level flag handled entirely by `bin/gtd` itself,
+stripped before anything reaches the bundle — see [`--no-edit`](#--no-edit)
+below.
+
+## `--no-edit`
+
+A flag on the loop driver only — bare `gtd --no-edit` or `gtd loop --no-edit`
+(the two are equivalent, since bare `gtd` and `gtd loop` are themselves
+equivalent). Recognized in exactly those two positions; any other
+placement/combination (e.g. `gtd step --no-edit`, or combined with any other
+argument) is a usage error. The `GTD_NO_EDIT` environment variable (any
+non-empty value) does the same thing.
+
+Disables the loop's default behavior of launching an editor at human gates,
+restoring the previous halt-and-print-and-exit behavior with no editor involved.
+It governs only the loop's own automatic launching — `gtd edit` invoked directly
+never reads it (see [`gtd edit`](#gtd-edit-path) above). See
+[Driving the loop](loop.md) and `skills/loop/SKILL.md` for the full gate-flow
+description.
 
 ## `gtd init`
 
@@ -407,6 +433,40 @@ which are JSON-only. `--json` emits
   human-readable `describe`) alongside the rendered text. **Omitted entirely**
   when the state has no `on` (a commit state); a per-edge `describe` is likewise
   omitted when that edge declares none.
+
+## `gtd edit [path]`
+
+Handled entirely in `bin/gtd`'s own bash — unlike every other subcommand, it is
+**never forwarded** to the compiled bundle (`dist/gtd.bundle.mjs`).
+
+With `<path>` given (repo-relative), opens it in `${VISUAL:-$EDITOR}` (git's own
+precedence — `$VISUAL` first, then `$EDITOR`; no fallback to `vi`), blocking in
+the foreground until the editor exits. It creates nothing if `<path>` doesn't
+exist — the path is handed straight to the editor command verbatim. The editor's
+own exit code is ignored entirely; success is judged from tree state afterward,
+not from this command.
+
+With no argument, it peeks with `gtd next --json` to find the resolved rest's
+declared `.file`, and opens that (repo-relative), or the repo directory (`.`)
+when the resolved state declares no `file:`. If `gtd next --json` itself fails
+(e.g. not in a repo), it prints an error and exits non-zero without attempting
+to open an editor:
+
+```
+gtd edit: could not determine the next step:
+<gtd next --json's own error output>
+```
+
+`gtd edit` **never** reads `--no-edit`/`GTD_NO_EDIT` — those two govern only the
+loop's own automatic editor launching at human gates (see
+[Driving the loop](loop.md) and `skills/loop/SKILL.md`), not this command.
+Invoked directly, `gtd edit` always launches, unconditionally.
+
+If neither `$VISUAL` nor `$EDITOR` is set, no editor is launched:
+
+```
+gtd: no editor configured — set $EDITOR (or $VISUAL)
+```
 
 ## Running `script` rests (no `gtd` subcommand)
 

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -41,16 +41,35 @@ loop picks their change up.
 
 **A `"message"` rest is a real handoff, not a slow beat.** No driver signs off
 for the human: in the bundled workflow the loop runs the whole cycle unattended
-up to `await-review` and then STOPS there with the review checkout window open
+up to `await-review` and then rests there with the review checkout window open
 (the reviewable diff surfaced as uncommitted changes — see
 [STATES.md §11](../STATES.md#11-the-review-checkout-window)). Advancing takes a
 human edit to `.gtd/REVIEW.md`: ticking every box with **no** comment signs off
 into the squash finale, while any comment (a note, or a code edit of your own)
-is feedback that routes into another build + re-review round. Re-launching the
-loop after that edit picks the decision up. Until then the loop halts on every
-run — that is the contract, not a stall. A review nobody is going to finish is
-ended with [`gtd abandon`](cli.md#gtd-abandon---json), which drops the process's
-commits and keeps their content as uncommitted changes.
+is feedback that routes into another build + re-review round. That gate is the
+contract, not a stall — nothing advances until the edit is captured, whether the
+capture happens within the same run or a later one. A review nobody is going to
+finish is ended with [`gtd abandon`](cli.md#gtd-abandon---json), which drops the
+process's commits and keeps their content as uncommitted changes.
+
+**Editing is on by default.** Reaching a `"message"` rest, `bin/gtd` opens
+`${VISUAL:-$EDITOR}` on the rest's declared `.file` (or the repo root `.` when
+the state declares none), blocking until the editor exits, then runs
+`gtd step human` to capture whatever changed:
+
+- a new commit was captured → the loop keeps driving on its own; re-launching is
+  never necessary;
+- zero commits were captured (a clean tree once the editor closed) → the loop
+  halts, exit 0 — "done for now";
+- the step refuses (a malformed steering file, or an edit matching no declared
+  pattern) → the refusal is surfaced verbatim and the loop halts non-zero,
+  exactly as a manual `gtd step human` refusal would.
+
+Set `GTD_NO_EDIT` (any non-empty value), or pass `--no-edit` — see
+[`cli.md`'s `--no-edit`](cli.md#--no-edit) for its exact syntax and positioning
+— to disable this and restore the original halt-and-print behavior: the loop
+prints the gate via `gtd next` and exits 0 without touching an editor, leaving
+the human to edit and re-launch the loop themselves.
 
 ```bash
 gtd next --json   # ask who's up and what they should do
@@ -73,16 +92,18 @@ when the machine rests at a `"message"` gate — so `gtd` is the only command a
 human runs. `bin/gtd` is the packaged entry point: invoked bare, or with `loop`
 as its first argument, it runs this exact script; any other first argument (e.g.
 `next`, `step`, `status`) hands off to `node dist/gtd.bundle.mjs` instead. The
-loop body it runs adds four things on top of the reference script above: it
-stops with a diagnostic if the same `"prompt"` state/content repeat with no
-progress (see `skills/loop/SKILL.md`'s "Stall detection"); it lets
-`GTD_LOOP_AGENT_CMD` swap in any coding agent CLI in place of the default
-`claude -p`, receiving the prompt via `$GTD_LOOP_PROMPT`; it exports the
-resolved state's optional `model` hint as `$GTD_LOOP_MODEL`, appending
-`--model "$GTD_LOOP_MODEL"` to the default `claude -p` invocation whenever it's
-non-empty; and it acts on the optional `memory` scope hint (see "Agent memory
-scope" below) — continuing one agent session across consecutive same-scope turns
-and starting fresh when the scope changes.
+loop body it runs adds five things on top of the reference script above: it
+opens an editor at every `"message"` gate instead of just printing it (see
+"Editing is on by default" above; `--no-edit`/`GTD_NO_EDIT` fall back to the
+reference script's plain print-and-exit); it stops with a diagnostic if the same
+`"prompt"` state/content repeat with no progress (see `skills/loop/SKILL.md`'s
+"Stall detection"); it lets `GTD_LOOP_AGENT_CMD` swap in any coding agent CLI in
+place of the default `claude -p`, receiving the prompt via `$GTD_LOOP_PROMPT`;
+it exports the resolved state's optional `model` hint as `$GTD_LOOP_MODEL`,
+appending `--model "$GTD_LOOP_MODEL"` to the default `claude -p` invocation
+whenever it's non-empty; and it acts on the optional `memory` scope hint (see
+"Agent memory scope" below) — continuing one agent session across consecutive
+same-scope turns and starting fresh when the scope changes.
 
 `bin/gtd` resolves both its bundle hand-off and the loop's own internal `gtd`
 calls against `dist/gtd.bundle.mjs` next to its own location. Set `GTD_BIN` — a

--- a/skills/loop/SKILL.md
+++ b/skills/loop/SKILL.md
@@ -33,17 +33,19 @@ by hand first. So:
 
 1. Peek once with `gtd next --json` (it never mutates anything).
 2. **Only if** that peek reports `"kind":"message"` (the machine rests at a
-   human gate), run `gtd step human` to commit whatever the human left pending,
-   then continue into the loop below from the resulting state. A clean gate is a
-   harmless no-op; a human edit is captured as their turn (e.g. accepting a plan
-   with no edit advances past `plan-review`).
+   human gate), act on it exactly as "Halting on a human gate" below describes
+   for a `"message"` rest — by default that opens an editor on the gate's file
+   (or the repo root) and blocks until it exits, then steps; under
+   `--no-edit`/`GTD_NO_EDIT` it steps immediately with no editor instead. Only
+   when the resulting `gtd step human` captures a new commit do you continue
+   into the loop below from the resulting state (e.g. accepting a plan with no
+   edit still advances past `plan-review`, since that state's accept is itself a
+   clean-tree pattern); a clean tree with nothing to capture, or a refusal,
+   halts right there per "Halting on a human gate".
 3. If the peek reports any other `kind`, do **not** step human — the machine is
    mid-cycle at an agent/check rest (a restart after a crash, say), where
    `gtd step human` would refuse out-of-turn. Just enter the loop and resume
    driving.
-
-If that `gtd step human` refuses (a malformed steering file, or an edit no `on`
-pattern accepts), surface the message and stop rather than driving past it.
 
 ## The loop
 
@@ -57,7 +59,8 @@ Repeat this cycle until it halts:
    interprets this string itself. There is also an optional `"memory"` — the
    agent-memory scope; see "Agent memory scope" below for how to act on it.
    **`kind` is the dispatch key**:
-   - `"message"` (a human rest): halt — see "Halting on a human gate" below.
+   - `"message"` (a human rest): act on the gate — see "Halting on a human gate"
+     below.
    - `"script"` (a check rest): `content` is an executable wrapper shell script.
      Execute it verbatim (e.g. `bash -c "$content"`), ignoring its exit code —
      the outcome lives in the tree, not the exit status — then run
@@ -138,10 +141,40 @@ by hand — but as the `--json` driver, you own the gate.)
 
 ## Halting on a human gate
 
-When `gtd next --json` reports `"kind":"message"`, stop driving the loop. Tell
-the user plainly what gtd is waiting on: the reported `state`, and (if you want
-the human-readable phrasing) run `gtd next` without `--json` to get the same
-message rendered for a person. Do not attempt to act on the human's behalf.
+When `gtd next --json` reports `"kind":"message"` (the machine rests at a human
+gate) — whether at the opening peek above or on any later loop iteration — what
+happens next depends on whether editing is enabled.
+
+By default (editing ON), open `${VISUAL:-$EDITOR}` on the gate's `.file` field
+(or the repo root `.` when the state declares no `file:`), blocking until the
+editor exits, then run `gtd step human` to capture whatever the human left in
+the tree:
+
+- A **new commit** captured (including a clean-tree accept a state declares via
+  its own `C` pattern, e.g. accepting a plan with no edit) means the editor
+  session was the human's turn: keep driving — go back into the loop from the
+  resulting state.
+- **Zero commits** captured (the tree was clean when the editor closed) means
+  there was nothing to do: halt (exit 0) — done for now. This is the same
+  halt-and-stop outcome as before, just reached after an editor session instead
+  of before one.
+- A **refusal** (non-zero exit from `gtd step human` — e.g. a malformed steering
+  file, or an edit matching no declared `on` pattern) surfaces the refusal
+  message verbatim and halts with non-zero exit, same as any other step refusal.
+
+Pass `--no-edit` (as a bare flag, or immediately after `loop`) or set
+`GTD_NO_EDIT` to any non-empty value to disable the editor for the run: gtd
+reverts to the previous behavior instead — print the gate's message plainly (the
+reported `state`, and, if you want the human-readable phrasing, run `gtd next`
+without `--json` for the same message rendered for a person) and halt
+immediately (exit 0) without touching an editor or stepping. The human then
+edits and re-runs the loop by hand, exactly as before this feature existed. Do
+not attempt to act on the human's behalf either way.
+
+None of this touches the `kind`-dispatch contract (`"message"` / `"script"` /
+`"prompt"`), stall detection, or the `gtd validate` self-validation gate after a
+producing agent turn — editor-at-gate only changes what happens at a `"message"`
+rest.
 
 ## Stall detection
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -84,6 +84,10 @@ Commands:
                    an agent through gtd next/gtd step calls until the
                    workflow returns to its initial state again. A bare gtd
                    invocation and gtd loop both launch it identically
+  edit [path]      Open \${VISUAL:-$EDITOR} on <path>, or — with no path — on
+                   the resolved rest's declared file (or the repo directory
+                   if it declares none). Handled entirely by bin/gtd, not
+                   this bundle
   init             Scaffold a minimal .gtdrc.json for this repo, seeding the
                    default variables you are most likely to change (the test
                    command) and a Prettier formatting suggestion. gtd runs its

--- a/tests/integration/features/edit.feature
+++ b/tests/integration/features/edit.feature
@@ -1,0 +1,71 @@
+@live
+Feature: gtd edit — opening a target path in the human's editor
+
+  `bin/gtd edit [path]` (see bin/gtd's own dispatch comment) opens
+  `${VISUAL:-$EDITOR}` on `path` when given, or — with no argument — on the
+  file the machine currently rests at (`gtd next --json`'s `.file`), falling
+  back to the repo directory (`.`) when the resting state declares no `file:`.
+  With neither `$EDITOR` nor `$VISUAL` configured, it refuses rather than
+  silently doing nothing. Real subprocess execution against a fake,
+  non-interactive editor script standing in for a real `$EDITOR`, so this
+  feature runs `@live`.
+
+  Scenario: gtd edit <path> opens the given path in the editor
+    Given a test project
+    And $EDITOR is a script that appends "hello from the fake editor" to the opened file
+    When I run gtd edit "NOTE.md"
+    Then it succeeds
+    And the fake editor was opened on "NOTE.md"
+    And "NOTE.md" contains "hello from the fake editor"
+
+  Scenario: gtd edit with no argument opens the resting state's declared file
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            file: NOTE.md
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": done
+          done:
+            commit: "chore: done"
+      """
+    And $EDITOR is a script that appends "sketch written by the fake editor" to the opened file
+    When I run gtd edit with no argument
+    Then it succeeds
+    And the fake editor was opened on "NOTE.md"
+    And "NOTE.md" contains "sketch written by the fake editor"
+
+  Scenario: gtd edit with no argument opens the repo directory when the resting state declares no file
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": done
+          done:
+            commit: "chore: done"
+      """
+    And $EDITOR is a no-op script
+    When I run gtd edit with no argument
+    Then it succeeds
+    And the fake editor was opened on "."
+
+  Scenario: gtd edit refuses when neither $EDITOR nor $VISUAL is configured
+    Given a test project
+    And $EDITOR is a script that appends "should never be seen" to the opened file
+    And $EDITOR is unset
+    When I run gtd edit "NOTE.md"
+    Then it fails
+    And stderr contains "$EDITOR"
+    And the fake editor was not invoked
+    And "NOTE.md" does not exist

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -395,6 +395,261 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     Then it succeeds
     And stdout contains "State: idle"
 
+  # The scenarios below prove bin/gtd's editor-at-gate behaviour (see
+  # handle_human_gate and the --no-edit/GTD_NO_EDIT dispatch at the top of
+  # bin/gtd): with editing on (the default) a human gate opens the fake
+  # editor before stepping human, so an edit matching the gate's `on` pattern
+  # lets the loop keep driving, while a no-op editor halts exactly like
+  # today's edit-disabled behaviour. `reviewing` is a second, mid-cycle human
+  # gate (distinct from the opening `idle` gate) so these scenarios prove the
+  # MAIN LOOP's gate handling, not just the opening move's. `idle` here is a
+  # silent check-actor no-op (not a message gate) so that, once the cycle
+  # reaches `done` and falls back to the workflow's initial state, the loop
+  # settles quietly instead of re-opening the editor a second time.
+
+  Scenario: With editing on, an edit matching the gate's pattern lets the loop drive past a human gate
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: check
+            initial: true
+            script: "true"
+            on:
+              "A .gtd/FEEDBACK.md": idle
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Build the package described below: write src/calc.ts exporting add(a, b)."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: |
+              if [ -f src/calc.ts ] && grep -q add src/calc.ts; then rm -f .gtd/FEEDBACK.md; else mkdir -p .gtd && echo "missing add" > .gtd/FEEDBACK.md; fi
+            on:
+              "A .gtd/FEEDBACK.md": working
+              "M .gtd/FEEDBACK.md": working
+              "C": reviewing
+          reviewing:
+            actor: human
+            file: .gtd/REVIEW.md
+            message: "sign off on the build"
+            on:
+              "A .gtd/REVIEW.md": done
+          done:
+            commit: "chore: build reviewed"
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Build the package described below"*)
+          mkdir -p src
+          cat > src/calc.ts <<'CALC'
+      export const add = (a, b) => a + b
+      CALC
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    And $EDITOR is a script that appends "Looks good." to the opened file
+    When I run bare gtd
+    Then it succeeds
+    And the fake editor was opened on ".gtd/REVIEW.md"
+    And the git log contains "chore: build reviewed"
+    And stdout contains "--- Settled (idle: check passed, nothing to do) ---"
+
+  Scenario: With editing on, a no-op editor halts the loop at the gate instead of looping forever
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: check
+            initial: true
+            script: "true"
+            on:
+              "A .gtd/FEEDBACK.md": idle
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Build the package described below: write src/calc.ts exporting add(a, b)."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: |
+              if [ -f src/calc.ts ] && grep -q add src/calc.ts; then rm -f .gtd/FEEDBACK.md; else mkdir -p .gtd && echo "missing add" > .gtd/FEEDBACK.md; fi
+            on:
+              "A .gtd/FEEDBACK.md": working
+              "M .gtd/FEEDBACK.md": working
+              "C": reviewing
+          reviewing:
+            actor: human
+            file: .gtd/REVIEW.md
+            message: "sign off on the build"
+            on:
+              "A .gtd/REVIEW.md": done
+          done:
+            commit: "chore: build reviewed"
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Build the package described below"*)
+          mkdir -p src
+          cat > src/calc.ts <<'CALC'
+      export const add = (a, b) => a + b
+      CALC
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    And $EDITOR is a no-op script
+    When I run bare gtd
+    Then it succeeds
+    And the fake editor was opened on ".gtd/REVIEW.md"
+    And stdout contains "--- Done for now (reviewing: nothing captured) ---"
+    And ".gtd/REVIEW.md" does not exist
+
+  Scenario: --no-edit restores the halt-at-gate behaviour, never launching the editor
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: check
+            initial: true
+            script: "true"
+            on:
+              "A .gtd/FEEDBACK.md": idle
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Build the package described below: write src/calc.ts exporting add(a, b)."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: |
+              if [ -f src/calc.ts ] && grep -q add src/calc.ts; then rm -f .gtd/FEEDBACK.md; else mkdir -p .gtd && echo "missing add" > .gtd/FEEDBACK.md; fi
+            on:
+              "A .gtd/FEEDBACK.md": working
+              "M .gtd/FEEDBACK.md": working
+              "C": reviewing
+          reviewing:
+            actor: human
+            file: .gtd/REVIEW.md
+            message: "sign off on the build"
+            on:
+              "A .gtd/REVIEW.md": done
+          done:
+            commit: "chore: build reviewed"
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Build the package described below"*)
+          mkdir -p src
+          cat > src/calc.ts <<'CALC'
+      export const add = (a, b) => a + b
+      CALC
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    And $EDITOR is a script that appends "should never be seen" to the opened file
+    When I run gtd loop --no-edit
+    Then it succeeds
+    And stdout contains "--- Your turn (reviewing) ---"
+    And the fake editor was not invoked
+
+  Scenario: GTD_NO_EDIT set to a non-empty value behaves identically to --no-edit
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: check
+            initial: true
+            script: "true"
+            on:
+              "A .gtd/FEEDBACK.md": idle
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Build the package described below: write src/calc.ts exporting add(a, b)."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: |
+              if [ -f src/calc.ts ] && grep -q add src/calc.ts; then rm -f .gtd/FEEDBACK.md; else mkdir -p .gtd && echo "missing add" > .gtd/FEEDBACK.md; fi
+            on:
+              "A .gtd/FEEDBACK.md": working
+              "M .gtd/FEEDBACK.md": working
+              "C": reviewing
+          reviewing:
+            actor: human
+            file: .gtd/REVIEW.md
+            message: "sign off on the build"
+            on:
+              "A .gtd/REVIEW.md": done
+          done:
+            commit: "chore: build reviewed"
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Build the package described below"*)
+          mkdir -p src
+          cat > src/calc.ts <<'CALC'
+      export const add = (a, b) => a + b
+      CALC
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    And $EDITOR is a script that appends "should never be seen" to the opened file
+    And GTD_NO_EDIT is set to "1"
+    When I run bare gtd
+    Then it succeeds
+    And stdout contains "--- Your turn (reviewing) ---"
+    And the fake editor was not invoked
+
   # The scenarios below prove bin/gtd's Herdr pane reporting (see its
   # `herdr_ok`/`herdr_report`/`herdr_notify`/`herdr_release` helpers): it shells
   # out to a `herdr` CLI only when HERDR_ENV=1, HERDR_PANE_ID is set, and

--- a/tests/integration/support/steps/edit.steps.ts
+++ b/tests/integration/support/steps/edit.steps.ts
@@ -1,0 +1,152 @@
+import { Given, Then, When } from "quickpickle"
+import { execFile as execFileCb } from "node:child_process"
+import { promisify } from "node:util"
+import { writeFileSync, mkdtempSync, chmodSync, existsSync, readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import assert from "node:assert"
+import type { GtdWorld } from "../world.js"
+
+const execFile = promisify(execFileCb)
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "../../../..")
+const GTD_BIN_PATH = join(PROJECT_ROOT, "bin/gtd")
+
+// Bash single-quotes a string for safe embedding inside a generated shell
+// script (the fake editor bodies below never interpolate untrusted input
+// otherwise).
+function shQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+// Builds a fake `$EDITOR` script at a fresh temp path: every invocation first
+// appends the target path it was opened on (bash's `$1`) as one line to a log
+// file, so scenarios can assert both WHETHER the editor ran and WHAT it was
+// opened on; `body` is then appended verbatim to perform (or skip) the actual
+// edit.
+function writeFakeEditor(world: GtdWorld, body: string): void {
+  const dir = mkdtempSync(join(tmpdir(), "gtd-edit-fake-"))
+  const logPath = join(dir, "invocations.log")
+  const scriptPath = join(dir, "editor.sh")
+  writeFileSync(
+    scriptPath,
+    `#!/usr/bin/env bash\nset -euo pipefail\necho "$1" >> ${shQuote(logPath)}\n${body}\n`,
+  )
+  chmodSync(scriptPath, 0o755)
+  world.fakeEditorPath = scriptPath
+  world.fakeEditorLogPath = logPath
+}
+
+// Shows the actual edit the fake editor performs directly in the scenario
+// text: it appends `text` as a line to whatever file it was opened on
+// (creating the file if the editor was opened on a path that doesn't exist
+// yet — exactly like a real editor saving a new file).
+Given(
+  "$EDITOR is a script that appends {string} to the opened file",
+  (world: GtdWorld, text: string) => {
+    writeFakeEditor(world, `mkdir -p "$(dirname -- "$1")"\nprintf '%s\\n' ${shQuote(text)} >> "$1"`)
+  },
+)
+
+// The "closed the editor without changing anything" case: it still records
+// that it ran (for the invocation-log assertions below), but never touches
+// the target path.
+Given("$EDITOR is a no-op script", (world: GtdWorld) => {
+  writeFakeEditor(world, ": # no-op — closes without editing anything")
+})
+
+// No editor configured at all — clears any fake editor a prior step in this
+// scenario may have set, so `$EDITOR`/`$VISUAL` are both absent from the
+// spawned process's environment (see `editorEnv` below, which strips them by
+// default). The invocation log path (if one was already allocated) is left in
+// place so "the fake editor was not invoked" can still assert its absence.
+Given("$EDITOR is unset", (world: GtdWorld) => {
+  world.fakeEditorPath = undefined
+})
+
+/**
+ * The environment a subprocess spawn of `bin/gtd` should see for the
+ * fake-editor mechanism: `$EDITOR`/`$VISUAL` are always stripped first (an
+ * ambient real editor must never leak into a test subprocess with no tty),
+ * then `$EDITOR` is set to the fake editor script when one is provisioned.
+ * Shared by this file's own `gtd edit` invocations and by
+ * `gtd-loop.steps.ts`'s loop invocations.
+ */
+export function editorEnv(world: GtdWorld, base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env = { ...base }
+  delete env["EDITOR"]
+  delete env["VISUAL"]
+  if (world.fakeEditorPath) {
+    env["EDITOR"] = world.fakeEditorPath
+  }
+  return env
+}
+
+// Normalizes an execFile rejection (a non-zero exit) into the world's result
+// shape: its `code` is the numeric exit code, with stdout/stderr captured so
+// far — defaulting to 1/empty when the failure carries no such fields.
+function failedResult(err: unknown): GtdWorld["lastResult"] {
+  const e = err as { code?: unknown; stdout?: string; stderr?: string }
+  return {
+    exitCode: typeof e.code === "number" ? e.code : 1,
+    stdout: e.stdout ?? "",
+    stderr: e.stderr ?? "",
+  }
+}
+
+async function runGtdEdit(world: GtdWorld, args: string[]): Promise<void> {
+  try {
+    const { stdout, stderr } = await execFile("bash", [GTD_BIN_PATH, "edit", ...args], {
+      cwd: world.repoDir,
+      env: editorEnv(world, process.env),
+      encoding: "utf-8",
+      timeout: 30_000,
+    })
+    world.lastResult = { exitCode: 0, stdout, stderr }
+  } catch (err: unknown) {
+    world.lastResult = failedResult(err)
+  }
+}
+
+When("I run gtd edit {string}", async (world: GtdWorld, path: string) => {
+  await runGtdEdit(world, [path])
+})
+
+When("I run gtd edit with no argument", async (world: GtdWorld) => {
+  await runGtdEdit(world, [])
+})
+
+// Asserts the LAST path the fake editor was opened on — the final line of its
+// invocation log.
+Then("the fake editor was opened on {string}", (world: GtdWorld, path: string) => {
+  assert.ok(
+    world.fakeEditorLogPath,
+    'no fake editor was provisioned for this scenario — add a "$EDITOR is a script..." step',
+  )
+  assert.ok(
+    existsSync(world.fakeEditorLogPath!),
+    `Expected the fake editor to have been invoked (opened on "${path}"), but it never ran.`,
+  )
+  const lines = readFileSync(world.fakeEditorLogPath!, "utf-8").trim().split("\n")
+  const last = lines[lines.length - 1]
+  assert.strictEqual(
+    last,
+    path,
+    `Expected the fake editor to have been opened on "${path}". Invocation log:\n${lines.join("\n")}`,
+  )
+})
+
+// The concrete, file-backed proof that no editor process ran at all: the log
+// path was allocated (by an earlier "$EDITOR is a script..."/"...no-op
+// script" step) but the script itself never executed, so the log file was
+// never created.
+Then("the fake editor was not invoked", (world: GtdWorld) => {
+  if (world.fakeEditorLogPath === undefined) return
+  const invoked = existsSync(world.fakeEditorLogPath)
+  assert.ok(
+    !invoked,
+    invoked
+      ? `Expected the fake editor NOT to have been invoked, but its invocation log exists:\n${readFileSync(world.fakeEditorLogPath, "utf-8")}`
+      : "",
+  )
+})

--- a/tests/integration/support/steps/gtd-loop.steps.ts
+++ b/tests/integration/support/steps/gtd-loop.steps.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import assert from "node:assert"
 import type { GtdWorld } from "../world.js"
+import { editorEnv } from "./edit.steps.js"
 
 const execFile = promisify(execFileCb)
 
@@ -41,22 +42,47 @@ Given("a fake herdr binary", (world: GtdWorld) => {
   world.fakeHerdrLogPath = logPath
 })
 
+// Resolves $GTD_NO_EDIT for a loop subprocess. An explicit override wins (a
+// scenario asserting on the env var's own effect); otherwise, when no fake
+// editor was provisioned, "1" keeps every OTHER scenario on the pre-existing
+// halt-at-gate behavior it asserts on — without it, a real ambient editor
+// would launch against a tty-less subprocess and hang until the spawn timeout.
+function noEditValue(world: GtdWorld): string | undefined {
+  if (world.gtdNoEditOverride !== undefined) return world.gtdNoEditOverride
+  if (!world.fakeEditorPath) return "1"
+  return undefined
+}
+
+// Adds the fake-herdr wiring: the stub binary must be discoverable on PATH for
+// bin/gtd's `herdr_ok` to fire its Herdr-reporting calls (alongside HERDR_ENV +
+// a non-empty HERDR_PANE_ID). bin/gtd self-locates its bundle, so no `gtd` PATH
+// shim is needed.
+function applyHerdrEnv(env: NodeJS.ProcessEnv, world: GtdWorld): void {
+  if (!world.fakeHerdrDir) return
+  env["PATH"] = `${world.fakeHerdrDir}:${process.env["PATH"]}`
+  env["HERDR_ENV"] = "1"
+  env["HERDR_PANE_ID"] = "test-pane"
+}
+
 function gtdLoopEnv(world: GtdWorld): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = { ...process.env }
-  // bin/gtd self-locates its bundle, so no `gtd` PATH shim is needed; the
-  // fake herdr binary, however, must be discoverable on PATH for herdr_ok.
-  if (world.fakeHerdrDir) {
-    env["PATH"] = `${world.fakeHerdrDir}:${process.env["PATH"]}`
-  }
-  if (world.stubAgentPath) {
-    env["GTD_LOOP_AGENT_CMD"] = `bash "${world.stubAgentPath}"`
-  }
-  if (world.fakeHerdrDir) {
-    env["HERDR_ENV"] = "1"
-    env["HERDR_PANE_ID"] = "test-pane"
-  }
+  // editorEnv strips any ambient $EDITOR/$VISUAL and, when a scenario
+  // provisioned one (via the shared "$EDITOR is a script..."/"...no-op
+  // script" steps in edit.steps.ts), sets $EDITOR to the fake editor script.
+  const env = editorEnv(world, { ...process.env })
+  const noEdit = noEditValue(world)
+  if (noEdit !== undefined) env["GTD_NO_EDIT"] = noEdit
+  if (world.stubAgentPath) env["GTD_LOOP_AGENT_CMD"] = `bash "${world.stubAgentPath}"`
+  applyHerdrEnv(env, world)
   return env
 }
+
+// Sets $GTD_NO_EDIT explicitly (a non-empty value disables the loop's
+// automatic editor launching, identically to passing --no-edit) — for
+// scenarios asserting on the env-var form of that switch specifically,
+// distinct from the --no-edit flag itself.
+Given("GTD_NO_EDIT is set to {string}", (world: GtdWorld, value: string) => {
+  world.gtdNoEditOverride = value
+})
 
 function toFailedResult(err: unknown): { exitCode: number; stdout: string; stderr: string } {
   const e = err as { code?: unknown; stdout?: string; stderr?: string }

--- a/tests/integration/support/world.ts
+++ b/tests/integration/support/world.ts
@@ -42,6 +42,12 @@ export class GtdWorld extends QuickPickleWorld {
   fakeHerdrDir: string | undefined = undefined
   /** Path to the fake herdr binary's invocation log, when provisioned. */
   fakeHerdrLogPath: string | undefined = undefined
+  /** Path to a fake `$EDITOR` script standing in for a real editor (`gtd edit`/loop-gate scenarios, @live only). Absent means no editor is configured. */
+  fakeEditorPath: string | undefined = undefined
+  /** Path to the fake editor's invocation log (one line per call — the target path it opened), when provisioned. */
+  fakeEditorLogPath: string | undefined = undefined
+  /** Explicit `$GTD_NO_EDIT` value a scenario wants exported, overriding the tier's usual default (`gtd-loop` scenarios only). */
+  gtdNoEditOverride: string | undefined = undefined
 
   /** Environment variables the in-memory tier's `EnvVars` layer exposes (`it.vars`'s highest-precedence `GTD_VAR_` layer) — never mutates the real `process.env`. Set by `Given an environment variable "..." set to "..."`. */
   envVars: Record<string, string> = {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
             "./tests/integration/support/hooks.ts",
             "./tests/integration/support/steps/common.steps.ts",
             "./tests/integration/support/steps/config.steps.ts",
+            "./tests/integration/support/steps/edit.steps.ts",
             "./tests/integration/support/steps/formatting.steps.ts",
             "./tests/integration/support/steps/gtd-loop.steps.ts",
             "./tests/integration/support/steps/lsp.steps.ts",


### PR DESCRIPTION
## Summary

Editing files at a human gate and re-launching the loop by hand was the only manual step left in the protocol. This turns `gtd` into a true single-command loop.

- `bin/gtd` now opens `${VISUAL:-$EDITOR}` on the gate's file (or the repo dir) at a human gate, waits for it to exit, then captures the result and keeps driving.
  - A clean tree after the editor closes halts (nothing to capture); a refusal surfaces verbatim.
- Adds `gtd edit [path]`, handled entirely in `bin/gtd`'s bash (never forwarded to the bundle) so it works with no path via the same `next --json` peek the gate handler uses.
- `--no-edit`/`GTD_NO_EDIT` restores the old halt-and-print behavior for anyone who prefers to edit and re-launch manually — recognized only in the two sanctioned positions (bare, or right after `loop`) so it can't silently swallow other arguments.

## Test plan

- New `tests/integration/features/edit.feature` covers `gtd edit`.
- Extended `gtd-loop.feature` for the auto-open gate behavior.
- README, `docs/cli.md`, `docs/loop.md`, and `skills/loop/SKILL.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)