### PR TITLE
feat(loop): condensed, color-coded driver output

### DIFF
--- a/.gtdrc.json
+++ b/.gtdrc.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/pmelab/gtd/main/schema.json",
   "vars": {
-    "testCommand": "npm test"
+    "testCommand": "npm test",
+    "todoFile": "TODO.md",
+    "requirementsFile": "REQUIREMENTS.md",
+    "reviewFile": "REVIEW.md"
   },
   "modes": {
     "qa": {

--- a/.gtdrc.json
+++ b/.gtdrc.json
@@ -3,8 +3,7 @@
   "vars": {
     "testCommand": "npm test",
     "todoFile": "TODO.md",
-    "requirementsFile": "REQUIREMENTS.md",
-    "reviewFile": "REVIEW.md"
+    "requirementsFile": "REQUIREMENTS.md"
   },
   "modes": {
     "qa": {

--- a/README.md
+++ b/README.md
@@ -181,7 +181,11 @@ code), waits for you to save and exit, then captures your edit itself and keeps
 driving — or halts if you left nothing changed — so you never run
 `gtd step human` by hand. Pass `--no-edit` (or set `GTD_NO_EDIT`) to fall back
 to halting and printing the gate instead, if you'd rather edit and re-launch it
-yourself. See [Driving the loop](docs/loop.md).
+yourself. Bare `gtd` prints one line per event — colored and emoji on a real
+terminal, plain ASCII under `NO_COLOR` or when piped — and redirects the noisier
+agent/check/step subprocess output to a per-repo/per-worktree log file.
+`gtd log` opens that logfile in your editor. See
+[Driving the loop](docs/loop.md).
 
 Before wiring gtd into a repo, note the
 [repository requirements](docs/cli.md#repository-requirements) — most

--- a/bin/gtd
+++ b/bin/gtd
@@ -10,6 +10,10 @@ set -euo pipefail
 #   - `edit [path]` -> handled entirely here in bash, never forwarded to the
 #     bundle: opens `${VISUAL:-$EDITOR}` on `path`, or (no `path` given) on the
 #     resolved rest's `.file` (or `.` when absent).
+#   - `log` -> handled entirely here in bash, never forwarded to the bundle:
+#     opens `${VISUAL:-$EDITOR}` on the current repo/worktree's loop logfile
+#     (see `resolve_log_path`), refusing rather than opening an empty buffer
+#     when no loop has produced one yet.
 #   - no arguments, or exactly `loop` with no further arguments -> fall through
 #     into the loop body below (the loop protocol comment further down).
 #   - `loop` with additional arguments (other than a lone `--no-edit`) ->
@@ -51,6 +55,147 @@ launch_editor() {
   bash -c "$editor \"\$1\"" gtd-edit "$target"
 }
 
+# ── Rendering primitives (capability detection, palette/markers, emitters) ──
+# Additive: nothing below calls these yet. `FANCY=1` only when stdout (fd 1)
+# is a real terminal AND `NO_COLOR` is unset — any pipe/redirect/non-tty
+# stdout, or `NO_COLOR` set to any value, gives plain ASCII with no escape
+# codes, per the NO_COLOR convention (https://no-color.org).
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then FANCY=1; else FANCY=0; fi
+
+if [[ "$FANCY" == 1 ]]; then
+  C_RESET=$'\e[0m'; C_BOLD=$'\e[1m'; C_DIM=$'\e[2m'
+  C_CYAN=$'\e[36m'; C_GREEN=$'\e[32m'; C_YELLOW=$'\e[33m'; C_RED=$'\e[31m'
+  M_TRANS="➡️"; M_AGENT="🤖"; M_CHECK="🔧"; M_HUMAN="✍️"
+  M_FIX="🔁"; M_COMMIT="✅"; M_SETTLE="🎉"; M_ERROR="❌"
+else
+  C_RESET=""; C_BOLD=""; C_DIM=""
+  C_CYAN=""; C_GREEN=""; C_YELLOW=""; C_RED=""
+  M_TRANS="->"; M_AGENT="[agent]"; M_CHECK="[check]"; M_HUMAN="[you]"
+  M_FIX="[fix]"; M_COMMIT="[commit]"; M_SETTLE="[done]"; M_ERROR="[err]"
+fi
+
+# emit_transition <from> <to> <files> — a captured state-to-state move. The
+# "→" separator is literal (not FANCY-dependent) — the same separator the
+# engine's commit grammar itself uses, per the package spec.
+emit_transition() {
+  local from="$1" to="$2" files="$3"
+  if [[ -n "$files" ]]; then
+    printf '%s  %s%s → %s%s  (%s%s%s)\n' \
+      "$M_TRANS" "$C_BOLD$C_CYAN" "$from" "$to" "$C_RESET" \
+      "$C_DIM" "$files" "$C_RESET"
+  else
+    printf '%s  %s%s → %s%s\n' \
+      "$M_TRANS" "$C_BOLD$C_CYAN" "$from" "$to" "$C_RESET"
+  fi
+}
+
+# emit_action <marker> <label> — the heartbeat printed before a turn runs.
+emit_action() {
+  local marker="$1" label="$2"
+  printf '%s %s%s\n' "$marker" "$label" "$C_RESET"
+}
+
+# emit_commit <subject> <files> — a non-transition capture (a bare-subject
+# self-loop, or the squash's agent-authored final commit).
+emit_commit() {
+  local subject="$1" files="$2"
+  if [[ -n "$files" ]]; then
+    printf '%s %s%s%s  (%s%s%s)\n' "$M_COMMIT" "$C_GREEN" "$subject" "$C_RESET" \
+      "$C_DIM" "$files" "$C_RESET"
+  else
+    printf '%s %s%s%s\n' "$M_COMMIT" "$C_GREEN" "$subject" "$C_RESET"
+  fi
+}
+
+# emit_gate <state> <message> — the human-instruction line at a message rest.
+emit_gate() {
+  local message="$2"
+  printf '%s  %s%s%s\n' "$M_HUMAN" "$C_BOLD$C_YELLOW" "$message" "$C_RESET"
+}
+
+# emit_settled <state> — the terminal "nothing left to do" signal.
+emit_settled() {
+  printf '%s %ssettled — nothing left to do%s\n' "$M_SETTLE" "$C_GREEN" "$C_RESET"
+}
+
+# emit_error <message> — refusals/stalls/failures, to stderr; <message> may be
+# multi-line and is passed through verbatim.
+emit_error() {
+  local message="$1"
+  printf '%s %s%s%s\n' "$M_ERROR" "$C_RED" "$message" "$C_RESET" >&2
+}
+
+# emit_log_pointer — the "see the log" line printed right after every
+# emit_error call, to stderr: suppression must never hide a failure, so every
+# error points at where the redirected subprocess output actually went.
+emit_log_pointer() {
+  if [[ "$FANCY" == 1 ]]; then
+    printf '%s📄 see %s%s\n' "$C_DIM" "$GTD_LOOP_LOG" "$C_RESET" >&2
+  else
+    printf '%ssee %s%s\n' "$C_DIM" "$GTD_LOOP_LOG" "$C_RESET" >&2
+  fi
+}
+
+# ── Git-derivation helpers (parse_subject, report_commits) ──────────────────
+# Additive: nothing below calls these yet. Replaces today's
+# head_before/head_after string comparisons in a later change.
+
+# parse_subject <subject> — sets S_ACTOR / S_FROM / S_TO / S_KIND. Patterns are
+# held in variables (rather than inlined) so bash's [[ =~ ]] doesn't need the
+# literal parens/spaces quoted inline.
+parse_subject() {
+  local subject="$1"
+  local transition_re='^gtd\(([^)]+)\): (.+) → (.+)$'
+  local capture_re='^gtd\(([^)]+)\): (.+)$'
+  S_ACTOR="" S_FROM="" S_TO="" S_KIND=""
+  if [[ "$subject" =~ $transition_re ]]; then
+    S_KIND=transition
+    S_ACTOR="${BASH_REMATCH[1]}"
+    S_FROM="${BASH_REMATCH[2]}"
+    S_TO="${BASH_REMATCH[3]}"
+  elif [[ "$subject" =~ $capture_re ]]; then
+    S_KIND=capture
+    S_ACTOR="${BASH_REMATCH[1]}"
+    S_TO="${BASH_REMATCH[2]}"
+  else
+    S_KIND=squash
+    S_TO="$subject"
+  fi
+}
+
+# report_commits <head_before> — walks <head_before>..HEAD in order, emitting
+# a transition/commit line per new commit; returns non-zero (having emitted
+# nothing) when there were no new commits.
+report_commits() {
+  local head_before="$1" sha subject files reported=0
+  while IFS= read -r sha; do
+    [[ -z "$sha" ]] && continue
+    reported=1
+    subject="$(git log -1 --format=%s "$sha")"
+    files="$(git diff-tree --no-commit-id --name-only -r "$sha" | paste -sd, - | sed 's/,/, /g')"
+    parse_subject "$subject"
+    case "$S_KIND" in
+      transition) emit_transition "$S_FROM" "$S_TO" "$files" ;;
+      capture | squash) emit_commit "$subject" "$files" ;;
+    esac
+  done < <(git rev-list --reverse "$head_before"..HEAD)
+  [[ "$reported" == 1 ]]
+}
+
+# ── Log file (resolve_log_path, gtd log) ────────────────────────────────────
+
+# resolve_log_path — echoes the loop's logfile path: $GTD_LOOP_LOG verbatim if
+# set, else "$(git rev-parse --git-dir)/gtd-loop.log" (per-repository AND
+# per-worktree automatically, since a linked worktree's git-dir is its own
+# private .git/worktrees/<name>).
+resolve_log_path() {
+  if [[ -n "${GTD_LOOP_LOG:-}" ]]; then
+    echo "$GTD_LOOP_LOG"
+  else
+    echo "$(git rev-parse --git-dir)/gtd-loop.log"
+  fi
+}
+
 # --no-edit / GTD_NO_EDIT govern only the loop's automatic editor launching at
 # human gates (see handle_human_gate further down) — `gtd edit` itself never
 # reads either. `--no-edit` is recognised in exactly the two sanctioned
@@ -79,6 +224,21 @@ if [[ "${1:-}" == "edit" ]]; then
     file="$(jq -r '.file // empty' <<<"$peek_json")"
     launch_editor "${file:-.}"
   fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "log" ]]; then
+  shift
+  if [[ $# -gt 0 ]]; then
+    echo "gtd log: takes no arguments" >&2
+    exit 2
+  fi
+  log_path="$(resolve_log_path)"
+  if [[ ! -f "$log_path" ]]; then
+    echo "gtd log: no loop log yet at $log_path" >&2
+    exit 1
+  fi
+  launch_editor "$log_path"
   exit 0
 fi
 
@@ -166,8 +326,8 @@ herdr_release() {  # hand the pane back to Herdr's normal detection
 # opening move (when editing is on) and by every "message" rest the main loop
 # encounters. $1 is the rest's `next --json` blob.
 #
-# Editing OFF ($edit_disabled): today's behavior, unchanged — print the gate
-# and exit 0 without touching an editor.
+# Editing OFF ($edit_disabled): today's behavior, unchanged — render the gate
+# via emit_gate and exit 0 without touching an editor.
 #
 # Editing ON (the default): open the editor on the rest's `.file` (or `.` when
 # absent), wait for it to exit, then run `gtd step human`:
@@ -187,7 +347,7 @@ handle_human_gate() {
   if [[ "$edit_disabled" == 1 ]]; then
     herdr_report blocked "$label"
     herdr_notify "gtd needs you — $(basename "$PWD")" "$label"
-    echo "--- Your turn ($state) ---"
+    emit_gate "$state" "$label"
     run_gtd next
     exit 0
   fi
@@ -198,19 +358,22 @@ handle_human_gate() {
 
   head_before="$(git rev-parse HEAD 2>/dev/null || echo none)"
   if ! step_out="$(run_gtd step human 2>&1)"; then
-    echo "gtd-loop: could not capture your changes at the human gate:" >&2
-    echo "$step_out" >&2
-    echo "Fix the reported issue and re-run gtd-loop." >&2
+    emit_error "could not capture your changes at the human gate:
+$step_out
+Fix the reported issue and re-run gtd-loop."
+    emit_log_pointer
     exit 1
   fi
   head_after="$(git rev-parse HEAD 2>/dev/null || echo none)"
   if [[ "$head_before" == "$head_after" ]]; then
     herdr_report idle "$label"
     herdr_release
-    echo "--- Done for now ($state: nothing captured) ---"
+    emit_action "$M_HUMAN" "done for now (nothing captured)"
     exit 0
   fi
-  # else: a new commit was captured — return normally, caller keeps driving.
+  # A new commit was captured — render it, then return normally so the
+  # caller keeps driving.
+  report_commits "$head_before"
 }
 
 trap 'code=$?; if [ "$code" -ne 0 ]; then
@@ -223,6 +386,17 @@ prev_content=""
 # Where the last "prompt" turn's `memory` scope + session id are remembered
 # across iterations and across restarts. In the git dir, never the work tree.
 memory_marker="$(git rev-parse --git-dir 2>/dev/null || echo .git)/gtd-loop-memory"
+
+# Truncated once here (not every iteration), so the file always reflects the
+# current run but survives after the loop exits for a later `gtd log`.
+log_path="$(resolve_log_path)"
+: >"$log_path"
+export GTD_LOOP_LOG="$log_path"
+if [[ "$FANCY" == 1 ]]; then
+  printf '%s📄 log: %s  (tail -f to follow)%s\n' "$C_DIM" "$log_path" "$C_RESET"
+else
+  printf '%slog: %s  (tail -f to follow)%s\n' "$C_DIM" "$log_path" "$C_RESET"
+fi
 
 # Swappable agent adapter: GTD_LOOP_AGENT_CMD lets any coding agent CLI stand
 # in for the default, receiving the prompt via $GTD_LOOP_PROMPT, the state's
@@ -249,7 +423,8 @@ run_agent_turn() {
     cmd="$cmd"' --dangerously-skip-permissions'
   fi
   GTD_LOOP_PROMPT="$prompt" GTD_LOOP_MODEL="$model" GTD_LOOP_MEMORY="$memory" \
-    GTD_LOOP_SESSION_ID="$session_id" GTD_LOOP_MEMORY_RESUME="$do_resume" bash -c "$cmd"
+    GTD_LOOP_SESSION_ID="$session_id" GTD_LOOP_MEMORY_RESUME="$do_resume" bash -c "$cmd" \
+    >>"${GTD_LOOP_LOG:-/dev/null}" 2>&1
 }
 
 # Opening move: capture the human's pending edit so gtd-loop is the ONLY command
@@ -273,17 +448,19 @@ run_agent_turn() {
 # step silently, refusal surfaced and halts, a clean/committed gate just falls
 # into the loop below.
 if ! peek_json="$(run_gtd next --json 2>&1)"; then
-  echo "gtd-loop: could not determine the next step:" >&2
-  echo "$peek_json" >&2
-  echo "Run \`gtd status\` to inspect the repo." >&2
+  emit_error "could not determine the next step:
+$peek_json
+Run \`gtd status\` to inspect the repo."
+  emit_log_pointer
   exit 1
 fi
 if [[ "$(jq -r .kind <<<"$peek_json")" == "message" ]]; then
   if [[ "$edit_disabled" == 1 ]]; then
     if ! step_out="$(run_gtd step human 2>&1)"; then
-      echo "gtd-loop: could not capture your changes at the human gate:" >&2
-      echo "$step_out" >&2
-      echo "Fix the reported issue and re-run gtd-loop." >&2
+      emit_error "could not capture your changes at the human gate:
+$step_out
+Fix the reported issue and re-run gtd-loop."
+      emit_log_pointer
       exit 1
     fi
   else
@@ -318,18 +495,24 @@ while true; do
   herdr_report working "$label"
 
   if [[ "$kind" == "script" ]]; then
+    emit_action "$M_CHECK" "$label"
     head_before="$(git rev-parse HEAD 2>/dev/null || echo none)"
     # Execute the emitted wrapper verbatim; its exit code is deliberately
     # ignored (`|| true` under `set -e`) — the script encodes its outcome in
     # the tree, and `gtd step` captures whatever it left there via the state's
-    # own `on` patterns.
-    bash -c "$content" || true
-    run_gtd step "$actor" >/dev/null
-    head_after="$(git rev-parse HEAD 2>/dev/null || echo none)"
-    if [[ "$head_before" == "$head_after" ]]; then
+    # own `on` patterns. Its own output goes to the log, not the terminal.
+    bash -c "$content" >>"$GTD_LOOP_LOG" 2>&1 || true
+    if ! step_out="$(run_gtd step "$actor" 2>&1)"; then
+      printf '%s\n' "$step_out" >>"$GTD_LOOP_LOG"
+      emit_error "$step_out"
+      emit_log_pointer
+      exit 1
+    fi
+    printf '%s\n' "$step_out" >>"$GTD_LOOP_LOG"
+    if ! report_commits "$head_before"; then
       herdr_report idle "$label"
       herdr_release
-      echo "--- Settled ($state: check passed, nothing to do) ---"
+      emit_settled "$state"
       exit 0
     fi
     prev_state=""
@@ -341,8 +524,10 @@ while true; do
   # agent-owned state and content repeating means the last dispatch made no
   # progress; stop rather than spin on it.
   if [[ "$state" == "$prev_state" && "$content" == "$prev_content" ]]; then
-    echo "gtd-loop: no progress at '$state' — the agent's last turn changed nothing. Stopping to avoid spinning." >&2
-    run_gtd next >&2
+    next_out="$(run_gtd next 2>&1)" || true
+    emit_error "no progress at '$state' — the agent's last turn changed nothing. Stopping to avoid spinning.
+$next_out"
+    emit_log_pointer
     exit 1
   fi
   prev_state="$state"
@@ -382,23 +567,37 @@ while true; do
   # cap) before stepping — the plain-`gtd next` self-validation instruction's
   # driver-side equivalent, so the next rest is only ever handed a well-formed
   # file. gtd itself never validates at step time — this is the loop's job.
+  emit_action "$M_AGENT" "$label"
+  head_before="$(git rev-parse HEAD 2>/dev/null || echo none)"
   run_agent_turn "$content" "$resume"
 
   fix_attempt=0
   while ! validate_out="$(run_gtd validate 2>&1)"; do
     fix_attempt=$((fix_attempt + 1))
     if ((fix_attempt > 3)); then
-      echo "gtd-loop: '$state' still fails \`gtd validate\` after 3 fix attempts:" >&2
-      echo "$validate_out" >&2
-      echo "Stopping rather than stepping with a malformed steering file." >&2
+      emit_error "'$state' still fails \`gtd validate\` after 3 fix attempts:
+$validate_out
+Stopping rather than stepping with a malformed steering file."
+      emit_log_pointer
       exit 1
     fi
     # Resume the same session when there is one (the agent just wrote the file);
     # otherwise a fresh invocation still gets the findings via the prompt.
     fix_resume=0
     [[ -n "$session_id" ]] && fix_resume=1
+    emit_action "$M_FIX" "attempt $fix_attempt"
     run_agent_turn "$content"$'\n\n'"Your last turn does not pass \`gtd validate\`. Fix these format violations, then finish:"$'\n'"$validate_out" "$fix_resume"
   done
 
-  run_gtd step "$actor" >/dev/null
+  if ! step_out="$(run_gtd step "$actor" 2>&1)"; then
+    printf '%s\n' "$step_out" >>"$GTD_LOOP_LOG"
+    emit_error "$step_out"
+    emit_log_pointer
+    exit 1
+  fi
+  printf '%s\n' "$step_out" >>"$GTD_LOOP_LOG"
+  # A no-op step (nothing matched a declared pattern on a clean tree) reports
+  # zero commits here — report_commits returns non-zero, and that's fine: the
+  # NEXT iteration's stall check is what catches unchanged state/content.
+  report_commits "$head_before" || true
 done

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -137,7 +137,7 @@ while true; do
   content="$(jq -r .content <<<"$next_json")"
 
   if [[ "$kind" == "message" ]]; then
-    echo "--- Your turn ($state) ---"
+    echo "your turn ($state)"    # bin/gtd renders this via emit_gate instead
     gtd next
     exit 0
   fi
@@ -148,7 +148,7 @@ while true; do
     gtd step "$actor" >/dev/null # capture whatever it left in the tree
     head_after="$(git rev-parse HEAD 2>/dev/null || echo none)"
     if [[ "$head_before" == "$head_after" ]]; then
-      echo "--- Settled ($state: check passed, nothing to do) ---"
+      echo "settled ($state: check passed, nothing to do)"   # bin/gtd renders this via emit_settled instead
       exit 0
     fi
     continue
@@ -163,6 +163,29 @@ done
 The driver — not the prompt text — owns ending the agent's turn
 (`gtd step "$actor"` right after the agent acts): every default-workflow agent
 prompt says explicitly not to run `gtd step agent` itself.
+
+`bin/gtd log` opens the current repo/worktree's loop logfile —
+`"$(git rev-parse --git-dir)/gtd-loop.log"` by default, or `$GTD_LOOP_LOG`
+verbatim when set — in `${VISUAL:-$EDITOR}`, the same editor resolution
+`bin/gtd edit` uses. It takes no arguments and errors out (rather than opening
+an empty buffer) if no loop has produced a log yet.
+
+## Rendered output and logging
+
+`bin/gtd` detects its output capability once at startup (`FANCY`, true when
+stdout is a real terminal AND `NO_COLOR` is unset): on a real terminal it prints
+one colored/emoji line per event, and under `NO_COLOR` or a piped/redirected
+stdout it prints the same events as plain ASCII with no escape codes, per the
+[NO_COLOR convention](https://no-color.org). Normal events (a state transition,
+a captured commit, an agent/check turn starting, settling at idle) render to
+stdout; refusals, stalls, and validate-cap halts render to stderr, each followed
+by a `📄 see <log>` pointer (plain: `see <log>`).
+
+The three previously terminal-visible subprocess streams — the agent turn's own
+output, the check script's own output, and `gtd step`'s own output — are no
+longer printed directly: they're appended to the per-repo/per-worktree log file
+(truncated once at the start of the run) instead, and surfaced with
+`bin/gtd log` above.
 
 ## Agent memory scope
 

--- a/tests/integration/features/gtd-log.feature
+++ b/tests/integration/features/gtd-log.feature
@@ -1,0 +1,50 @@
+@live
+Feature: gtd log — opening the current loop's log file in the editor
+
+  `bin/gtd log` (see bin/gtd's own dispatch comment, alongside `gtd edit`) is a
+  bash-level convenience command, dispatched before anything reaches the
+  bundle: it opens `${VISUAL:-$EDITOR}` on the current repo/worktree's loop
+  logfile, resolved the same way the loop itself resolves it —
+  `"$(git rev-parse --git-dir)/gtd-loop.log"`, or `$GTD_LOOP_LOG` verbatim when
+  set. It takes no arguments, and refuses rather than opening an empty buffer
+  when no loop has produced a log yet.
+
+  Scenario: gtd log refuses when no loop has produced a log yet
+    Given a test project
+    When I run "log" via gtd
+    Then it fails
+    And the exit code is 1
+    And stderr contains "no loop log yet at"
+
+  Scenario: gtd log opens the current run's log file in the editor
+    Given a test project
+    And a file ".git/gtd-loop.log" with:
+      """
+      📄 log: .git/gtd-loop.log
+      🤖 a previous run's agent turn output
+      """
+    And $EDITOR is a script that appends "reviewed the log" to the opened file
+    When I run "log" via gtd
+    Then it succeeds
+    And the fake editor was opened on ".git/gtd-loop.log"
+    And ".git/gtd-loop.log" contains "reviewed the log"
+
+  Scenario: gtd log respects GTD_LOOP_LOG when set
+    Given a test project
+    And GTD_LOOP_LOG is set to "notes/custom.log"
+    And a file "notes/custom.log" with:
+      """
+      a previous run's log, at a custom path
+      """
+    And $EDITOR is a no-op script
+    When I run "log" via gtd
+    Then it succeeds
+    And the fake editor was opened on "notes/custom.log"
+
+  Scenario: gtd log rejects an extra argument as a usage error, never opening the editor
+    Given a test project
+    And $EDITOR is a script that appends "should never be seen" to the opened file
+    When I run "log extra" via gtd
+    Then the exit code is 2
+    And stderr contains "gtd log: takes no arguments"
+    And the fake editor was not invoked

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -63,7 +63,7 @@ Feature: gtd loop — the packaged reference loop driver (v3)
       """
     When I run bare gtd
     Then it succeeds
-    And stdout contains "--- Your turn (idle) ---"
+    And stdout contains "[you]  idle"
     And the git log contains "chore: calculator done"
     And "src/calc.ts" exists
 
@@ -150,7 +150,7 @@ Feature: gtd loop — the packaged reference loop driver (v3)
       """
     When I run bare gtd
     Then it succeeds
-    And stdout contains "--- Settled (watching: check passed, nothing to do) ---"
+    And stdout contains "[done] settled — nothing left to do"
 
   Scenario: Carries the memory scope across a loop and clears it at a phase boundary
     # Two agent phases: `working` (scope "work") then a fixing loop (scope
@@ -224,10 +224,10 @@ Feature: gtd loop — the packaged reference loop driver (v3)
       """
     When I run bare gtd
     Then it succeeds
-    And stdout contains "AGENT MEMORY=work RESUME=0"
-    And stdout contains "AGENT MEMORY=fix RESUME=0"
-    And stdout contains "AGENT MEMORY=fix RESUME=1"
-    And stdout contains "--- Your turn (idle) ---"
+    And the log file contains "AGENT MEMORY=work RESUME=0"
+    And the log file contains "AGENT MEMORY=fix RESUME=0"
+    And the log file contains "AGENT MEMORY=fix RESUME=1"
+    And stdout contains "[you]  idle"
 
   Scenario: Runs the self-validation gate after a producing agent turn and re-prompts until the steering file is well-formed
     # `planning` declares file:/mode: (.gtd/PLAN.md as `qa`), so its output has
@@ -287,9 +287,160 @@ Feature: gtd loop — the packaged reference loop driver (v3)
       """
     When I run bare gtd
     Then it succeeds
-    And stdout contains "AGENT: first draft"
-    And stdout contains "AGENT: fixing the plan"
+    And the log file contains "AGENT: first draft"
+    And the log file contains "AGENT: fixing the plan"
+    And stdout contains "[fix] attempt 1"
     And the git log contains "chore: planned"
+
+  Scenario: Renders a transition line and a bare self-loop capture line, logging what gtd step committed
+    # `working -> checking` differs (a real transition), while `checking`'s own
+    # "A .gtd/FEEDBACK.md": checking pattern targets itself (a self-loop, the
+    # bare `gtd(check): checking` capture form) before the second check attempt
+    # finally settles into `done`.
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Build the package described below: write src/calc.ts exporting add(a, b)."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: |
+              mkdir -p .gtd
+              c=".git/testcount"
+              n=$(cat "$c" 2>/dev/null || echo 0)
+              n=$((n + 1))
+              echo "$n" > "$c"
+              if [ "$n" -lt 2 ]; then echo "retry" > .gtd/FEEDBACK.md; else rm -f .gtd/FEEDBACK.md; fi
+            on:
+              "A .gtd/FEEDBACK.md": checking
+              "M .gtd/FEEDBACK.md": checking
+              "D .gtd/FEEDBACK.md": done
+              "C": done
+          done:
+            commit: "chore: calculator done"
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Build the package described below"*)
+          mkdir -p src
+          cat > src/calc.ts <<'CALC'
+      export const add = (a, b) => a + b
+      CALC
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    When I run bare gtd
+    Then it succeeds
+    And stdout contains "working → checking"
+    And stdout contains "gtd(check): checking"
+    And the log file contains "committed: gtd(agent): working → checking"
+    And the log file contains "committed: gtd(check): checking"
+    And "src/calc.ts" exists
+    And the git log contains "chore: calculator done"
+
+  Scenario: Redirects the check script's own output to the log file instead of the terminal
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": watching
+          watching:
+            actor: check
+            script: |
+              echo "CHECK: verifying the tree"
+              true
+            on:
+              "A .gtd/FEEDBACK.md": idle
+      """
+    And a commit "gtd(check): watching" that adds "NOTE.md" with:
+      """
+      note
+      """
+    When I run bare gtd
+    Then it succeeds
+    And stdout does not contain "CHECK: verifying the tree"
+    And the log file contains "CHECK: verifying the tree"
+
+  Scenario: Renders plain ASCII markers with no ANSI escape codes under NO_COLOR
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Build the package described below: write src/calc.ts exporting add(a, b)."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: |
+              if [ -f src/calc.ts ] && grep -q add src/calc.ts; then rm -f .gtd/FEEDBACK.md; else mkdir -p .gtd && echo "missing add" > .gtd/FEEDBACK.md; fi
+            on:
+              "A .gtd/FEEDBACK.md": working
+              "M .gtd/FEEDBACK.md": working
+              "C": done
+          done:
+            commit: "chore: calculator done"
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Build the package described below"*)
+          mkdir -p src
+          cat > src/calc.ts <<'CALC'
+      export const add = (a, b) => a + b
+      CALC
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    And NO_COLOR is set to "1"
+    When I run bare gtd
+    Then it succeeds
+    And stdout contains "[agent]"
+    And stdout contains "[you]"
+    And stdout has no ANSI escape codes
+    And stderr has no ANSI escape codes
 
   Scenario: Stops instead of spinning when the agent's turn makes no progress
     Given a test project
@@ -325,7 +476,54 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     When I run bare gtd
     Then it fails
     And stderr contains "no progress at 'working'"
+    And stderr contains "see .git/gtd-loop.log"
 
+  Scenario: Stops instead of stepping when a steering file still fails gtd validate after 3 fix attempts
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": planning
+          planning:
+            actor: agent
+            file: .gtd/PLAN.md
+            mode: qa
+            prompt: "Write .gtd/PLAN.md with the plan."
+            on:
+              "* **": done
+          done:
+            commit: "chore: planned"
+      """
+    And a commit "gtd(agent): planning" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      mkdir -p .gtd
+      cat > .gtd/PLAN.md <<'PLAN'
+      Plan: build the calculator.
+
+      ## Open Questions
+
+      ###
+
+      Forgot to write the question.
+      PLAN
+      """
+    When I run bare gtd
+    Then it fails
+    And stdout contains "[fix] attempt 3"
+    And stderr contains "'planning' still fails"
+    And stderr contains "after 3 fix attempts"
+    And stderr contains "Stopping rather than stepping with a malformed steering file."
+    And stderr contains "see .git/gtd-loop.log"
 
   Scenario: gtd loop with no further arguments behaves identically to bare gtd
     Given a test project
@@ -376,7 +574,7 @@ Feature: gtd loop — the packaged reference loop driver (v3)
       """
     When I run gtd loop
     Then it succeeds
-    And stdout contains "--- Your turn (idle) ---"
+    And stdout contains "[you]  idle"
     And the git log contains "chore: calculator done"
     And "src/calc.ts" exists
 
@@ -466,7 +664,7 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     Then it succeeds
     And the fake editor was opened on ".gtd/REVIEW.md"
     And the git log contains "chore: build reviewed"
-    And stdout contains "--- Settled (idle: check passed, nothing to do) ---"
+    And stdout contains "[done] settled — nothing left to do"
 
   Scenario: With editing on, a no-op editor halts the loop at the gate instead of looping forever
     Given a test project
@@ -526,7 +724,7 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     When I run bare gtd
     Then it succeeds
     And the fake editor was opened on ".gtd/REVIEW.md"
-    And stdout contains "--- Done for now (reviewing: nothing captured) ---"
+    And stdout contains "[you] done for now (nothing captured)"
     And ".gtd/REVIEW.md" does not exist
 
   Scenario: --no-edit restores the halt-at-gate behaviour, never launching the editor
@@ -586,7 +784,7 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And $EDITOR is a script that appends "should never be seen" to the opened file
     When I run gtd loop --no-edit
     Then it succeeds
-    And stdout contains "--- Your turn (reviewing) ---"
+    And stdout contains "[you]  reviewing"
     And the fake editor was not invoked
 
   Scenario: GTD_NO_EDIT set to a non-empty value behaves identically to --no-edit
@@ -647,7 +845,7 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And GTD_NO_EDIT is set to "1"
     When I run bare gtd
     Then it succeeds
-    And stdout contains "--- Your turn (reviewing) ---"
+    And stdout contains "[you]  reviewing"
     And the fake editor was not invoked
 
   # The scenarios below prove bin/gtd's Herdr pane reporting (see its
@@ -706,7 +904,7 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And a fake herdr binary
     When I run bare gtd
     Then it succeeds
-    And stdout contains "--- Settled (checking: check passed, nothing to do) ---"
+    And stdout contains "[done] settled — nothing left to do"
     And the fake herdr log contains, in order:
       """
       pane report-agent test-pane --source herdr:gtd --agent gtd --state working --message working
@@ -764,7 +962,7 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And a fake herdr binary
     When I run bare gtd
     Then it succeeds
-    And stdout contains "--- Your turn (idle) ---"
+    And stdout contains "[you]  idle"
     And the fake herdr log contains, in order:
       """
       pane report-agent test-pane --source herdr:gtd --agent gtd --state blocked --message idle
@@ -796,7 +994,7 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And a fake herdr binary
     When I run bare gtd
     Then it succeeds
-    And stdout contains "--- Settled (watching: check passed, nothing to do) ---"
+    And stdout contains "[done] settled — nothing left to do"
     And the fake herdr log contains, in order:
       """
       pane report-agent test-pane --source herdr:gtd --agent gtd --state idle --message watching

--- a/tests/integration/support/steps/gtd-loop.steps.ts
+++ b/tests/integration/support/steps/gtd-loop.steps.ts
@@ -1,7 +1,7 @@
 import { Given, Then, When } from "quickpickle"
 import { execFile as execFileCb } from "node:child_process"
 import { promisify } from "node:util"
-import { writeFileSync, mkdtempSync, chmodSync, readFileSync } from "node:fs"
+import { writeFileSync, mkdtempSync, chmodSync, readFileSync, existsSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import assert from "node:assert"
@@ -82,9 +82,15 @@ function gtdLoopEnv(world: GtdWorld): NodeJS.ProcessEnv {
   // provisioned one (via the shared "$EDITOR is a script..."/"...no-op
   // script" steps in edit.steps.ts), sets $EDITOR to the fake editor script.
   const env = editorEnv(world, { ...process.env })
-  const noEdit = noEditValue(world)
-  if (noEdit !== undefined) env["GTD_NO_EDIT"] = noEdit
-  if (world.stubAgentPath) env["GTD_LOOP_AGENT_CMD"] = `bash "${world.stubAgentPath}"`
+  const overrides: Record<string, string | undefined> = {
+    GTD_NO_EDIT: noEditValue(world),
+    GTD_LOOP_AGENT_CMD: world.stubAgentPath ? `bash "${world.stubAgentPath}"` : undefined,
+    GTD_LOOP_LOG: world.gtdLoopLogOverride,
+    NO_COLOR: world.noColorOverride,
+  }
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value !== undefined) env[key] = value
+  }
   applyHerdrEnv(env, world)
   return env
 }
@@ -95,6 +101,25 @@ function gtdLoopEnv(world: GtdWorld): NodeJS.ProcessEnv {
 // distinct from the --no-edit flag itself.
 Given("GTD_NO_EDIT is set to {string}", (world: GtdWorld, value: string) => {
   world.gtdNoEditOverride = value
+})
+
+// Sets $GTD_LOOP_LOG explicitly — the single-explicit-path override
+// `resolve_log_path` uses verbatim instead of deriving
+// "$(git rev-parse --git-dir)/gtd-loop.log". `value` is resolved relative to
+// the repo root by the subprocess itself (its cwd), exactly like the plain
+// "a file ..." step resolves paths, so scenarios can seed/assert on it with
+// the same relative path string.
+Given("GTD_LOOP_LOG is set to {string}", (world: GtdWorld, value: string) => {
+  world.gtdLoopLogOverride = value
+})
+
+// Sets $NO_COLOR explicitly, for scenarios proving the plain-ASCII rendering
+// path specifically — the spawned subprocess already has no tty (execFile
+// pipes stdout/stderr), so FANCY is always 0 regardless, but this makes a
+// scenario's intent to exercise that path explicit and documents the
+// NO_COLOR convention (https://no-color.org) alongside the piped-stdout case.
+Given("NO_COLOR is set to {string}", (world: GtdWorld, value: string) => {
+  world.noColorOverride = value
 })
 
 function toFailedResult(err: unknown): { exitCode: number; stdout: string; stderr: string } {
@@ -168,4 +193,42 @@ Then("the fake herdr log contains, in order:", (world: GtdWorld, block: string) 
     )
     cursor = idx + line.length
   }
+})
+
+// Resolves the loop's log file path the same way bin/gtd's resolve_log_path
+// does: $GTD_LOOP_LOG verbatim when a scenario overrode it, else the default
+// ".git/gtd-loop.log" (every gtd-loop.feature scenario runs against a plain,
+// non-worktree test project, so its git-dir is always ".git").
+function loopLogPath(world: GtdWorld): string {
+  return world.gtdLoopLogOverride ?? ".git/gtd-loop.log"
+}
+
+// Asserts on the loop's log file — where the agent turn, the check script,
+// and `gtd step`'s own output now land instead of the terminal.
+Then("the log file contains {string}", (world: GtdWorld, text: string) => {
+  const path = join(world.repoDir, loopLogPath(world))
+  const content = existsSync(path) ? readFileSync(path, "utf-8") : ""
+  assert.ok(
+    content.includes(text),
+    `Expected the log file ("${loopLogPath(world)}") to contain "${text}". Got:\n${content}`,
+  )
+})
+
+// The plain-ASCII rendering proof: no ANSI escape sequence (ESC "[") anywhere.
+// Built from a char code rather than a regex literal to avoid embedding a
+// literal control character in source.
+const ANSI_ESCAPE = String.fromCharCode(0x1b) + "["
+
+Then("stdout has no ANSI escape codes", (world: GtdWorld) => {
+  assert.ok(
+    !world.lastResult.stdout.includes(ANSI_ESCAPE),
+    `Expected stdout to contain no ANSI escape codes. Got:\n${JSON.stringify(world.lastResult.stdout)}`,
+  )
+})
+
+Then("stderr has no ANSI escape codes", (world: GtdWorld) => {
+  assert.ok(
+    !world.lastResult.stderr.includes(ANSI_ESCAPE),
+    `Expected stderr to contain no ANSI escape codes. Got:\n${JSON.stringify(world.lastResult.stderr)}`,
+  )
 })

--- a/tests/integration/support/world.ts
+++ b/tests/integration/support/world.ts
@@ -48,6 +48,10 @@ export class GtdWorld extends QuickPickleWorld {
   fakeEditorLogPath: string | undefined = undefined
   /** Explicit `$GTD_NO_EDIT` value a scenario wants exported, overriding the tier's usual default (`gtd-loop` scenarios only). */
   gtdNoEditOverride: string | undefined = undefined
+  /** Explicit `$GTD_LOOP_LOG` value a scenario wants exported (`gtd log`/loop logging scenarios, @live only). */
+  gtdLoopLogOverride: string | undefined = undefined
+  /** Explicit `$NO_COLOR` value a scenario wants exported (loop rendering scenarios, @live only). */
+  noColorOverride: string | undefined = undefined
 
   /** Environment variables the in-memory tier's `EnvVars` layer exposes (`it.vars`'s highest-precedence `GTD_VAR_` layer) — never mutates the real `process.env`. Set by `Given an environment variable "..." set to "..."`. */
   envVars: Record<string, string> = {}


### PR DESCRIPTION
## Summary

- Rework the bash loop's output stream (driver only, no core changes): state transitions, matched files, actions taken, commits, and human gate messages print condensed with colors and emojis; script and agent outputs are suppressed.
- New `gtd-log.feature` plus expanded `gtd-loop` e2e scenarios cover the output format.
- Moves the `todoFile`/`requirementsFile` steering files to the repo root in `.gtdrc.json`; `reviewFile` stays at the default `.gtd/REVIEW.md` because a root-level review file makes sign-off unreachable and loops the review cycle forever (#128).

## Test plan

- `npm test` (format, typecheck, lint, unit, e2e) — ran green as this branch's gtd cycle's check gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)