### PR TITLE
fix(loop): key loop log to the cwd worktree, immune to inherited GIT_DIR

### DIFF
--- a/bin/gtd
+++ b/bin/gtd
@@ -184,15 +184,25 @@ report_commits() {
 
 # ── Log file (resolve_log_path, gtd log) ────────────────────────────────────
 
+# worktree_git_dir — the git dir of the working tree gtd is operating in,
+# derived purely from the cwd. GIT_DIR/GIT_WORK_TREE are scrubbed for this one
+# call so an inherited GIT_DIR (e.g. leaked from a parent git process, a hook,
+# or another worktree's shell) can never point our per-worktree state at a
+# DIFFERENT worktree — that would let two concurrently looping worktrees
+# collide on one log/memory file. A linked worktree's git-dir is its own
+# private .git/worktrees/<name>, so this is per-repository AND per-worktree.
+worktree_git_dir() {
+  env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR -u GIT_INDEX_FILE \
+    git rev-parse --git-dir
+}
+
 # resolve_log_path — echoes the loop's logfile path: $GTD_LOOP_LOG verbatim if
-# set, else "$(git rev-parse --git-dir)/gtd-loop.log" (per-repository AND
-# per-worktree automatically, since a linked worktree's git-dir is its own
-# private .git/worktrees/<name>).
+# set, else "$(worktree_git_dir)/gtd-loop.log".
 resolve_log_path() {
   if [[ -n "${GTD_LOOP_LOG:-}" ]]; then
     echo "$GTD_LOOP_LOG"
   else
-    echo "$(git rev-parse --git-dir)/gtd-loop.log"
+    echo "$(worktree_git_dir)/gtd-loop.log"
   fi
 }
 
@@ -385,7 +395,7 @@ prev_state=""
 prev_content=""
 # Where the last "prompt" turn's `memory` scope + session id are remembered
 # across iterations and across restarts. In the git dir, never the work tree.
-memory_marker="$(git rev-parse --git-dir 2>/dev/null || echo .git)/gtd-loop-memory"
+memory_marker="$(worktree_git_dir 2>/dev/null || echo .git)/gtd-loop-memory"
 
 # Truncated once here (not every iteration), so the file always reflects the
 # current run but survives after the loop exits for a later `gtd log`.

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -165,10 +165,14 @@ The driver — not the prompt text — owns ending the agent's turn
 prompt says explicitly not to run `gtd step agent` itself.
 
 `bin/gtd log` opens the current repo/worktree's loop logfile —
-`"$(git rev-parse --git-dir)/gtd-loop.log"` by default, or `$GTD_LOOP_LOG`
-verbatim when set — in `${VISUAL:-$EDITOR}`, the same editor resolution
-`bin/gtd edit` uses. It takes no arguments and errors out (rather than opening
-an empty buffer) if no loop has produced a log yet.
+`"$(worktree_git_dir)/gtd-loop.log"` by default, or `$GTD_LOOP_LOG` verbatim
+when set — in `${VISUAL:-$EDITOR}`, the same editor resolution `bin/gtd edit`
+uses. It takes no arguments and errors out (rather than opening an empty buffer)
+if no loop has produced a log yet. `worktree_git_dir` derives the git dir from
+the cwd with `GIT_DIR`/`GIT_WORK_TREE` scrubbed, so an inherited `GIT_DIR`
+(leaked from a parent git process, a hook, or another worktree's shell) can
+never key the log — or the loop's memory marker — to a different worktree; two
+worktrees looping at once each keep their own log.
 
 ## Rendered output and logging
 

--- a/tests/integration/features/gtd-log.feature
+++ b/tests/integration/features/gtd-log.feature
@@ -5,9 +5,12 @@ Feature: gtd log — opening the current loop's log file in the editor
   bash-level convenience command, dispatched before anything reaches the
   bundle: it opens `${VISUAL:-$EDITOR}` on the current repo/worktree's loop
   logfile, resolved the same way the loop itself resolves it —
-  `"$(git rev-parse --git-dir)/gtd-loop.log"`, or `$GTD_LOOP_LOG` verbatim when
-  set. It takes no arguments, and refuses rather than opening an empty buffer
-  when no loop has produced a log yet.
+  `"$(worktree_git_dir)/gtd-loop.log"`, or `$GTD_LOOP_LOG` verbatim when set.
+  `worktree_git_dir` derives the git dir from the cwd with GIT_DIR/GIT_WORK_TREE
+  scrubbed, so an inherited GIT_DIR can never key the log to a DIFFERENT
+  worktree (two concurrently looping worktrees must not collide on one log). It
+  takes no arguments, and refuses rather than opening an empty buffer when no
+  loop has produced a log yet.
 
   Scenario: gtd log refuses when no loop has produced a log yet
     Given a test project
@@ -40,6 +43,18 @@ Feature: gtd log — opening the current loop's log file in the editor
     When I run "log" via gtd
     Then it succeeds
     And the fake editor was opened on "notes/custom.log"
+
+  Scenario: gtd log keys the log to this worktree, ignoring an inherited GIT_DIR
+    Given a test project
+    And GIT_DIR points at a separate git dir
+    And a file ".git/gtd-loop.log" with:
+      """
+      this worktree's own loop log
+      """
+    And $EDITOR is a no-op script
+    When I run "log" via gtd
+    Then it succeeds
+    And the fake editor was opened on ".git/gtd-loop.log"
 
   Scenario: gtd log rejects an extra argument as a usage error, never opening the editor
     Given a test project

--- a/tests/integration/support/hooks.ts
+++ b/tests/integration/support/hooks.ts
@@ -3,6 +3,20 @@ import { rmSync } from "node:fs"
 import type { GtdWorld } from "./world.js"
 import { InMemRepo } from "./inmem/Repo.js"
 
+// Scrub every inherited GIT_* var from the test process's environment, once,
+// at support-load time. @live scenarios spawn git and the gtd bundle against a
+// fresh tmp repo, relying on cwd-based discovery; an ambient GIT_DIR/
+// GIT_WORK_TREE (present when the suite runs as the loop's own check, whose
+// environment carried one) would override that discovery and point `git init`
+// and every subsequent op at the OUTER worktree's git dir instead of the tmp
+// repo's own .git — the same cross-worktree leak `bin/gtd`'s worktree_git_dir
+// guards against. Mutating process.env here keeps every child spawn and
+// `{ ...process.env }` spread (world.ts, gtd-loop.steps.ts, project-setup.ts)
+// hermetic from one place. The vitest runner itself needs no GIT_* var.
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("GIT_")) delete process.env[key]
+}
+
 /**
  * Detect tier from scenario tags.
  * `@live` → live spawnSync path.

--- a/tests/integration/support/steps/gtd-loop.steps.ts
+++ b/tests/integration/support/steps/gtd-loop.steps.ts
@@ -1,5 +1,5 @@
 import { Given, Then, When } from "quickpickle"
-import { execFile as execFileCb } from "node:child_process"
+import { execFile as execFileCb, execFileSync } from "node:child_process"
 import { promisify } from "node:util"
 import { writeFileSync, mkdtempSync, chmodSync, readFileSync, existsSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -86,6 +86,7 @@ function gtdLoopEnv(world: GtdWorld): NodeJS.ProcessEnv {
     GTD_NO_EDIT: noEditValue(world),
     GTD_LOOP_AGENT_CMD: world.stubAgentPath ? `bash "${world.stubAgentPath}"` : undefined,
     GTD_LOOP_LOG: world.gtdLoopLogOverride,
+    GIT_DIR: world.gitDirOverride,
     NO_COLOR: world.noColorOverride,
   }
   for (const [key, value] of Object.entries(overrides)) {
@@ -111,6 +112,19 @@ Given("GTD_NO_EDIT is set to {string}", (world: GtdWorld, value: string) => {
 // the same relative path string.
 Given("GTD_LOOP_LOG is set to {string}", (world: GtdWorld, value: string) => {
   world.gtdLoopLogOverride = value
+})
+
+// Injects a stray `$GIT_DIR` pointing at a SEPARATE (valid, but unrelated) git
+// dir — modelling the leak that broke issue-#118-class per-worktree isolation:
+// an ambient GIT_DIR (from a parent git process, a hook, or another worktree's
+// shell) would divert bin/gtd's `git rev-parse --git-dir` away from the cwd
+// worktree. A real bare dir (not a bogus path) so a regressed bin/gtd fails as
+// a clean wrong-path, not a git fatal. Lives inside repoDir so the After hook's
+// repoDir cleanup removes it too.
+Given("GIT_DIR points at a separate git dir", (world: GtdWorld) => {
+  const separate = join(world.repoDir, "separate.git")
+  execFileSync("git", ["init", "--bare", "-q", separate], { encoding: "utf-8" })
+  world.gitDirOverride = separate
 })
 
 // Sets $NO_COLOR explicitly, for scenarios proving the plain-ASCII rendering

--- a/tests/integration/support/world.ts
+++ b/tests/integration/support/world.ts
@@ -50,6 +50,8 @@ export class GtdWorld extends QuickPickleWorld {
   gtdNoEditOverride: string | undefined = undefined
   /** Explicit `$GTD_LOOP_LOG` value a scenario wants exported (`gtd log`/loop logging scenarios, @live only). */
   gtdLoopLogOverride: string | undefined = undefined
+  /** A stray `$GIT_DIR` value a scenario wants injected into the spawned bin/gtd's env — proving per-worktree state (log, memory marker) stays keyed to the cwd worktree, never the inherited GIT_DIR (@live only). */
+  gitDirOverride: string | undefined = undefined
   /** Explicit `$NO_COLOR` value a scenario wants exported (loop rendering scenarios, @live only). */
   noColorOverride: string | undefined = undefined
 


### PR DESCRIPTION
## Problem

The e2e suite failed 8 tests (in `gtd-log.feature` / `gtd-loop.feature`) whenever it ran **as the loop's own check** — all asserting on `.git/gtd-loop.log` but getting the *outer* worktree's git-dir, e.g. `…/.git/worktrees/<name>/gtd-loop.log`. Green under a bare `vitest` run, red under the loop.

Root cause: an ambient `GIT_DIR` in the check's environment. `git rev-parse --git-dir` honours it, so:

- **Product:** `bin/gtd`'s loop-log path and memory marker detached from the cwd worktree and could point at a *different* worktree — breaking the per-worktree, no-collision guarantee two concurrently-looping worktrees rely on.
- **Tests:** each tmp repo's `git init` reinitialised the outer worktree's git-dir instead of creating its own `.git`, so assertions mismatched (and, worse, git ops could target the outer worktree).

## Fix

- **`bin/gtd`** — new `worktree_git_dir` helper resolves the git dir from the cwd with `GIT_DIR`/`GIT_WORK_TREE`/`GIT_COMMON_DIR`/`GIT_INDEX_FILE` scrubbed; used for both the log path and the memory marker. gtd is cwd-driven everywhere else, so the per-worktree state now is too — immune to a stray inherited `GIT_DIR`.
- **Test hermeticity** — scrub every `GIT_*` var from the test process env once at support load (`hooks.ts`), so every child spawn / `{ ...process.env }` spread stays keyed to the tmp repo's own `.git`.
- **Regression scenario** — `gtd log keys the log to this worktree, ignoring an inherited GIT_DIR` proves the log stays cwd-local even when `GIT_DIR` points at a separate git dir.
- Docs (`docs/loop.md`) and the feature's header updated.

## Verification

`format:check`, `typecheck`, `lint`, `test:unit`, full `test:e2e` all green — including a run with an ambient `GIT_DIR` exported (the exact condition that produced the original failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)