### PR TITLE
fix(test): scrub inherited GTD_LOOP_* so the e2e suite is hermetic under the loop

### DIFF
--- a/tests/integration/features/gtd-log.feature
+++ b/tests/integration/features/gtd-log.feature
@@ -56,6 +56,22 @@ Feature: gtd log — opening the current loop's log file in the editor
     Then it succeeds
     And the fake editor was opened on ".git/gtd-loop.log"
 
+  Scenario: an inherited GTD_LOOP_LOG from an outer loop driver never leaks into a spawned gtd
+    # When the suite runs AS a gtd loop's own check, the driver has exported
+    # GTD_LOOP_LOG (the outer worktree's log path). A spawned gtd must resolve
+    # ITS OWN log, not inherit the driver's — else every log-path assertion
+    # breaks. The harness strips inherited GTD_LOOP_* at the spawn boundary.
+    Given a test project
+    And the loop driver leaked GTD_LOOP_LOG as "/somewhere/else/.git/gtd-loop.log"
+    And a file ".git/gtd-loop.log" with:
+      """
+      this repo's own loop log
+      """
+    And $EDITOR is a no-op script
+    When I run "log" via gtd
+    Then it succeeds
+    And the fake editor was opened on ".git/gtd-loop.log"
+
   Scenario: gtd log rejects an extra argument as a usage error, never opening the editor
     Given a test project
     And $EDITOR is a script that appends "should never be seen" to the opened file

--- a/tests/integration/support/hooks.ts
+++ b/tests/integration/support/hooks.ts
@@ -3,18 +3,30 @@ import { rmSync } from "node:fs"
 import type { GtdWorld } from "./world.js"
 import { InMemRepo } from "./inmem/Repo.js"
 
-// Scrub every inherited GIT_* var from the test process's environment, once,
-// at support-load time. @live scenarios spawn git and the gtd bundle against a
-// fresh tmp repo, relying on cwd-based discovery; an ambient GIT_DIR/
-// GIT_WORK_TREE (present when the suite runs as the loop's own check, whose
-// environment carried one) would override that discovery and point `git init`
-// and every subsequent op at the OUTER worktree's git dir instead of the tmp
-// repo's own .git — the same cross-worktree leak `bin/gtd`'s worktree_git_dir
-// guards against. Mutating process.env here keeps every child spawn and
-// `{ ...process.env }` spread (world.ts, gtd-loop.steps.ts, project-setup.ts)
-// hermetic from one place. The vitest runner itself needs no GIT_* var.
+// Scrub every inherited GIT_* and GTD_LOOP_* var from the test process's
+// environment, once, at support-load time — so the suite runs identically
+// whether launched from a plain shell or AS A gtd LOOP'S OWN CHECK (the loop
+// driver runs `npm test` as a child, inheriting its runtime env).
+//
+// - GIT_*: @live scenarios spawn git and the gtd bundle against a fresh tmp
+//   repo, relying on cwd-based discovery; an ambient GIT_DIR/GIT_WORK_TREE
+//   would override that discovery and point `git init` and every subsequent op
+//   at the OUTER worktree's git dir instead of the tmp repo's own .git — the
+//   same cross-worktree leak `bin/gtd`'s worktree_git_dir guards against.
+// - GTD_LOOP_*: the loop driver exports GTD_LOOP_LOG (bin/gtd), the absolute
+//   path of the CURRENT worktree's loop log. `bin/gtd`'s resolve_log_path uses
+//   $GTD_LOOP_LOG verbatim when set — so a spawned `bin/gtd` inheriting it would
+//   report the driver's log path instead of resolving the tmp repo's own,
+//   breaking every gtd-log/gtd-loop log-path assertion. Scrubbing the whole
+//   GTD_LOOP_ prefix also drops any other leaked driver runtime state
+//   (GTD_LOOP_PROMPT/SESSION_ID/…); scenarios that WANT these set them
+//   explicitly via world overrides in gtd-loop.steps.ts.
+//
+// Mutating process.env here keeps every child spawn and `{ ...process.env }`
+// spread (world.ts, gtd-loop.steps.ts, project-setup.ts) hermetic from one
+// place. The vitest runner itself needs none of these vars.
 for (const key of Object.keys(process.env)) {
-  if (key.startsWith("GIT_")) delete process.env[key]
+  if (key.startsWith("GIT_") || key.startsWith("GTD_LOOP_")) delete process.env[key]
 }
 
 /**

--- a/tests/integration/support/steps/gtd-loop.steps.ts
+++ b/tests/integration/support/steps/gtd-loop.steps.ts
@@ -82,6 +82,18 @@ function gtdLoopEnv(world: GtdWorld): NodeJS.ProcessEnv {
   // provisioned one (via the shared "$EDITOR is a script..."/"...no-op
   // script" steps in edit.steps.ts), sets $EDITOR to the fake editor script.
   const env = editorEnv(world, { ...process.env })
+  // Simulate the loop driver having exported GTD_LOOP_LOG into the environment
+  // the suite inherits when it runs as the driver's own check (see the strip
+  // below and hooks.ts's global scrub).
+  if (world.leakedGtdLoopLog !== undefined) env["GTD_LOOP_LOG"] = world.leakedGtdLoopLog
+  // Hermetic: drop any inherited GTD_LOOP_* runtime state before applying the
+  // scenario's explicit overrides, so a spawned bin/gtd resolves its OWN log
+  // path rather than the driver's. Mirrors hooks.ts's process.env scrub at the
+  // spawn boundary; keeping it here exercises the guard in CI (where no loop
+  // driver set the var) via the leak-injection step above.
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("GTD_LOOP_")) delete env[key]
+  }
   const overrides: Record<string, string | undefined> = {
     GTD_NO_EDIT: noEditValue(world),
     GTD_LOOP_AGENT_CMD: world.stubAgentPath ? `bash "${world.stubAgentPath}"` : undefined,
@@ -112,6 +124,15 @@ Given("GTD_NO_EDIT is set to {string}", (world: GtdWorld, value: string) => {
 // the same relative path string.
 Given("GTD_LOOP_LOG is set to {string}", (world: GtdWorld, value: string) => {
   world.gtdLoopLogOverride = value
+})
+
+// Seeds a LEAKED $GTD_LOOP_LOG into the spawned env — modelling the loop driver
+// having exported its own log path (bin/gtd's `export GTD_LOOP_LOG`) into the
+// environment the suite inherits when it runs as that driver's check. Distinct
+// from "GTD_LOOP_LOG is set to" (an intentional per-scenario override): this
+// value must be STRIPPED, not honoured, so a spawned gtd resolves its own log.
+Given("the loop driver leaked GTD_LOOP_LOG as {string}", (world: GtdWorld, value: string) => {
+  world.leakedGtdLoopLog = value
 })
 
 // Injects a stray `$GIT_DIR` pointing at a SEPARATE (valid, but unrelated) git

--- a/tests/integration/support/steps/gtd-loop.steps.ts
+++ b/tests/integration/support/steps/gtd-loop.steps.ts
@@ -77,23 +77,25 @@ function applyHerdrEnv(env: NodeJS.ProcessEnv, world: GtdWorld): void {
   env["HERDR_PANE_ID"] = "test-pane"
 }
 
+// Drops any inherited GTD_LOOP_* runtime state from a spawn env so a spawned
+// bin/gtd resolves its OWN log path, not the loop driver's (which exports
+// GTD_LOOP_LOG when running the suite as its check). Mirrors hooks.ts's global
+// process.env scrub at the spawn boundary; `world.leakedGtdLoopLog` seeds a
+// simulated leak first so the regression scenario exercises the strip in CI
+// (where no real loop driver set the var).
+function scrubInheritedLoopEnv(env: NodeJS.ProcessEnv, world: GtdWorld): void {
+  if (world.leakedGtdLoopLog !== undefined) env["GTD_LOOP_LOG"] = world.leakedGtdLoopLog
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("GTD_LOOP_")) delete env[key]
+  }
+}
+
 function gtdLoopEnv(world: GtdWorld): NodeJS.ProcessEnv {
   // editorEnv strips any ambient $EDITOR/$VISUAL and, when a scenario
   // provisioned one (via the shared "$EDITOR is a script..."/"...no-op
   // script" steps in edit.steps.ts), sets $EDITOR to the fake editor script.
   const env = editorEnv(world, { ...process.env })
-  // Simulate the loop driver having exported GTD_LOOP_LOG into the environment
-  // the suite inherits when it runs as the driver's own check (see the strip
-  // below and hooks.ts's global scrub).
-  if (world.leakedGtdLoopLog !== undefined) env["GTD_LOOP_LOG"] = world.leakedGtdLoopLog
-  // Hermetic: drop any inherited GTD_LOOP_* runtime state before applying the
-  // scenario's explicit overrides, so a spawned bin/gtd resolves its OWN log
-  // path rather than the driver's. Mirrors hooks.ts's process.env scrub at the
-  // spawn boundary; keeping it here exercises the guard in CI (where no loop
-  // driver set the var) via the leak-injection step above.
-  for (const key of Object.keys(env)) {
-    if (key.startsWith("GTD_LOOP_")) delete env[key]
-  }
+  scrubInheritedLoopEnv(env, world)
   const overrides: Record<string, string | undefined> = {
     GTD_NO_EDIT: noEditValue(world),
     GTD_LOOP_AGENT_CMD: world.stubAgentPath ? `bash "${world.stubAgentPath}"` : undefined,

--- a/tests/integration/support/world.ts
+++ b/tests/integration/support/world.ts
@@ -52,6 +52,8 @@ export class GtdWorld extends QuickPickleWorld {
   gtdLoopLogOverride: string | undefined = undefined
   /** A stray `$GIT_DIR` value a scenario wants injected into the spawned bin/gtd's env — proving per-worktree state (log, memory marker) stays keyed to the cwd worktree, never the inherited GIT_DIR (@live only). */
   gitDirOverride: string | undefined = undefined
+  /** A leaked `$GTD_LOOP_LOG` (as the loop driver exports when running the suite as its own check) to seed into the spawned env BEFORE the hermetic GTD_LOOP_* strip — proving the strip neutralises it so the spawned gtd resolves its own log, not the driver's (@live only). */
+  leakedGtdLoopLog: string | undefined = undefined
   /** Explicit `$NO_COLOR` value a scenario wants exported (loop rendering scenarios, @live only). */
   noColorOverride: string | undefined = undefined
 


### PR DESCRIPTION
## The real root cause (PR #130 was incomplete)

`.gtd/FEEDBACK.md` kept showing the same 8–11 log-path failures even after #130 merged. #130 hardened `GIT_DIR` (`worktree_git_dir` + `GIT_*` scrub) — but `GIT_DIR` was never the trigger.

The actual leak is **`GTD_LOOP_LOG`**. The loop driver `export`s it (`bin/gtd`) as the absolute path of the current worktree's loop log, then runs `npm test` as its baseline check. The e2e suite spawns `bin/gtd` with `{ ...process.env }`, so every spawned gtd **inherited** that `GTD_LOOP_LOG` — and `resolve_log_path` uses `$GTD_LOOP_LOG` verbatim when set, short-circuiting before `worktree_git_dir` is ever reached. So the log-path assertions saw the driver's worktree log path instead of each tmp repo's own `.git/gtd-loop.log`.

This reproduces **only** when the suite runs as a loop's check (a plain `npm test` / `vitest` shell has no `GTD_LOOP_LOG`, so it's green) — which is exactly why it was invisible outside the loop. (Confirmed by instrumenting `bin/gtd`: all tmp-repo `worktree_git_dir` calls resolve to `.git`; the failing `gtd log` calls never reached it because `GTD_LOOP_LOG` was set.) It also explains the `#20` "no editor configured" oddity: the driver's real log file exists, so `gtd log` skipped the "no loop log yet" branch.

## Fix

- **`hooks.ts`** — extend the load-time `process.env` scrub to drop `GTD_LOOP_*` alongside `GIT_*`, so the suite runs identically whether launched from a shell or from inside a loop.
- **`gtdLoopEnv` (`gtd-loop.steps.ts`)** — strip `GTD_LOOP_*` at the spawn boundary before applying each scenario's explicit overrides (defense-in-depth, and makes the guard exercisable in CI where no driver set the var).
- **Regression scenario** (`gtd-log.feature`) — seeds a leaked `GTD_LOOP_LOG` and asserts the spawned gtd still resolves its own `.git/gtd-loop.log`.

No product change: `bin/gtd` correctly honors `GTD_LOOP_LOG` (that's the documented override) and correctly exports it per-worktree; the bug was purely the test harness not being hermetic against the driver's runtime env.

## Verification

Reproduced the failure by exporting `GTD_LOOP_LOG` and running the suite; with the fix, `typecheck`, `lint`, `format`, `test:unit`, and the **full `test:e2e` all pass with `GTD_LOOP_LOG` exported** — the exact condition that produced the loop-only failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)