### PR TITLE
fix(unified): exclude reviewFile from review sign-off check (#128)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,54 @@
+# Issue #128 — review sign-off unreachable when `reviewFile` lives outside `.gtd/`
+
+Full issue: `gh issue view 128`.
+
+## Symptom
+
+With `reviewFile` configured **outside `.gtd/`** (e.g.
+`vars.reviewFile: "REVIEW.md"` at the repo root), review sign-off is
+unreachable. Every clean sign-off attempt (tick all boxes, no comment, no code
+edit) is misclassified as feedback, so the process loops forever:
+
+```
+reviewing → await-review → review-deciding → feedback-collecting
+→ feedback-building → checking → reviewing → …
+```
+
+## Root cause
+
+`review-deciding`'s script in `src/workflows/unified.yaml` detects human
+hand-edits with a hardcoded path assumption:
+
+```bash
+codeFiles=$(git diff-tree --no-commit-id --name-only -r HEAD | grep -v '^\.gtd/')
+```
+
+The steering paths are var-configurable. With `reviewFile` at the repo root, the
+human's checkbox-tick commit (touching only `REVIEW.md`) survives the filter,
+`codeFiles` is non-empty, and the script takes the feedback branch instead of
+the sign-off branch.
+
+## Suggested fix
+
+Exclude the state's own steering file explicitly instead of (or in addition to)
+the `.gtd/` prefix:
+
+```bash
+codeFiles=$(git diff-tree --no-commit-id --name-only -r HEAD \
+  | grep -v '^\.gtd/' | grep -vxF "$reviewFile")
+```
+
+It is the only `grep -v '^\.gtd/'` site in the template. Consider also excluding
+_all_ var-named steering files (`todoFile`, `requirementsFile`, …), since any
+can be repointed outside `.gtd/` and edited during a review round.
+
+## Tests
+
+Add an e2e scenario: workflow with a root-level `reviewFile`, human ticks every
+box with no comment, assert the step routes to sign-off/squash rather than
+`feedback-collecting`.
+
+## Also update
+
+- `README.md` if behavior/config docs are affected.
+- STATES.md §10 if the unified template's review tail shape changes.

--- a/src/workflows/unified.flat.yaml
+++ b/src/workflows/unified.flat.yaml
@@ -1020,7 +1020,9 @@ states:
       # gate refuses an incomplete step, so review-deciding is entered exactly
       # once per round — nothing commits in between). It is FEEDBACK when the
       # human left a comment: a note in REVIEW.md (any edit beyond a "[ ]"->"[x]"
-      # tick) OR a hand-edit to any non-.gtd/ file this round. Otherwise it is a
+      # tick) OR a hand-edit to any file this round other than `.gtd/` or the
+      # state's own reviewFile (which is var-configurable and may live outside
+      # `.gtd/`, e.g. a root-level REVIEW.md — issue #128). Otherwise it is a
       # clean sign-off. This turn only CAPTURES the raw material into REVIEW_RAW.md
       # (the `feedback-collecting` agent then turns it into instructions); it does
       # NOT interpret it. Either way, remove REVIEW.md; what the resulting diff
@@ -1036,8 +1038,11 @@ states:
       # everything is plain bash.
       reviewFile="<%~ it.vars.reviewFile %>"
       reviewRawFile="<%~ it.vars.reviewRawFile %>"
-      # Which non-.gtd/ files did the human hand-edit this round?
-      codeFiles=$(git diff-tree --no-commit-id --name-only -r HEAD | grep -v '^\.gtd/')
+      # Which files did the human hand-edit this round, besides .gtd/ and the
+      # reviewFile itself (var-configurable — may live outside .gtd/, so it is
+      # excluded by exact path, not just the .gtd/ prefix)?
+      codeFiles=$(git diff-tree --no-commit-id --name-only -r HEAD \
+        | grep -v '^\.gtd/' | grep -vxF "$reviewFile")
       # A note is any REVIEW.md change beyond a checkbox flip: normalize every
       # "[ ]"/"[x]" to a placeholder, then compare the agent's original (HEAD^)
       # against the human's version (HEAD).

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -436,7 +436,9 @@ submachines:
           # gate refuses an incomplete step, so review-deciding is entered exactly
           # once per round — nothing commits in between). It is FEEDBACK when the
           # human left a comment: a note in REVIEW.md (any edit beyond a "[ ]"->"[x]"
-          # tick) OR a hand-edit to any non-.gtd/ file this round. Otherwise it is a
+          # tick) OR a hand-edit to any file this round other than `.gtd/` or the
+          # state's own reviewFile (which is var-configurable and may live outside
+          # `.gtd/`, e.g. a root-level REVIEW.md — issue #128). Otherwise it is a
           # clean sign-off. This turn only CAPTURES the raw material into REVIEW_RAW.md
           # (the `feedback-collecting` agent then turns it into instructions); it does
           # NOT interpret it. Either way, remove REVIEW.md; what the resulting diff
@@ -452,8 +454,11 @@ submachines:
           # everything is plain bash.
           reviewFile="<%~ it.vars.reviewFile %>"
           reviewRawFile="<%~ it.vars.reviewRawFile %>"
-          # Which non-.gtd/ files did the human hand-edit this round?
-          codeFiles=$(git diff-tree --no-commit-id --name-only -r HEAD | grep -v '^\.gtd/')
+          # Which files did the human hand-edit this round, besides .gtd/ and the
+          # reviewFile itself (var-configurable — may live outside .gtd/, so it is
+          # excluded by exact path, not just the .gtd/ prefix)?
+          codeFiles=$(git diff-tree --no-commit-id --name-only -r HEAD \
+            | grep -v '^\.gtd/' | grep -vxF "$reviewFile")
           # A note is any REVIEW.md change beyond a checkbox flip: normalize every
           # "[ ]"/"[x]" to a placeholder, then compare the agent's original (HEAD^)
           # against the human's version (HEAD).

--- a/tests/integration/features/review-signoff-outside-gtd.feature
+++ b/tests/integration/features/review-signoff-outside-gtd.feature
@@ -1,0 +1,50 @@
+@live
+Feature: Review sign-off reaches squashing even when reviewFile lives outside .gtd/ (issue #128)
+
+  `review-deciding`'s check script (`src/workflows/unified.yaml`) decides
+  sign-off vs. feedback by filtering out the human's own steering-file edit
+  before checking whether any OTHER file was hand-edited this round. The
+  filter used to assume every steering file lives under `.gtd/` (a hardcoded
+  `grep -v '^\.gtd/'`), so a `reviewFile` repointed to the repo root (a `vars:`
+  override, e.g. `REVIEW.md`) survived the filter as a "hand-edited code
+  file" — misclassifying every clean sign-off as feedback and looping forever
+  (reviewing -> await-review -> review-deciding -> feedback-collecting ->
+  feedback-building -> checking -> reviewing -> ...). The fix additionally
+  excludes the state's own `reviewFile` by exact path.
+
+  This scenario actually EXECUTES the rendered script (`I execute the printed
+  check script`) rather than simulating its outcome by hand — the bug lives in
+  the script's own shell logic, which `@inmem` scenarios never run (see
+  AGENTS.md and review-feedback-guards.feature, which simulate this same state
+  for the pure-engine routing rules instead).
+
+  Scenario: a clean sign-off (all boxes ticked, no comment, no code edit) reaches squashing, not feedback-collecting
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      vars:
+        reviewFile: REVIEW.md
+      """
+    And a commit "gtd(agent): checking → reviewing" that adds "REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: 0000000 -->
+
+      ## calc
+      - [ ] ./src/calc.ts#1 — new add function
+      """
+    And a commit "gtd(human): await-review → review-deciding" that adds "REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: 0000000 -->
+
+      ## calc
+      - [x] ./src/calc.ts#1 — new add function
+      """
+    When I run gtd next with "--json"
+    And I execute the printed check script
+    And I run gtd step check
+    Then it succeeds
+    And the last commit subject is "gtd(check): review-deciding → squashing"

--- a/tests/integration/support/steps/review-signoff.steps.ts
+++ b/tests/integration/support/steps/review-signoff.steps.ts
@@ -1,0 +1,25 @@
+import { When } from "quickpickle"
+import { execFile as execFileCb } from "node:child_process"
+import { promisify } from "node:util"
+import assert from "node:assert"
+import type { GtdWorld } from "../world.js"
+
+const execFile = promisify(execFileCb)
+
+// Actually executes a check-actor state's rendered script against the real
+// repo — the piece bin/gtd's own loop driver performs (`bash -c "$content"`,
+// exit code ignored) before capturing the outcome via `gtd step <actor>`. Reads
+// `content` from the last `gtd next --json` result, so a scenario composes it
+// as: `gtd next --json` -> this step -> `gtd step check`. @live only: the bug
+// class this exists to catch (issue #128) lives in the script's own shell
+// logic, which @inmem never runs (see AGENTS.md, review-feedback-guards.feature).
+When("I execute the printed check script", async (world: GtdWorld) => {
+  assert.strictEqual(world.tier, "live", "executing a rendered script requires an @live scenario")
+  const { content } = JSON.parse(world.lastResult.stdout) as { content: string }
+  try {
+    await execFile("bash", ["-c", content], { cwd: world.repoDir })
+  } catch {
+    // Exit code is deliberately ignored, exactly like bin/gtd's own `|| true`
+    // — the script encodes its outcome in the tree, not its exit status.
+  }
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
             "./tests/integration/support/steps/formatting.steps.ts",
             "./tests/integration/support/steps/gtd-loop.steps.ts",
             "./tests/integration/support/steps/lsp.steps.ts",
+            "./tests/integration/support/steps/review-signoff.steps.ts",
             "./tests/integration/support/steps/review-window.steps.ts",
           ],
           testTimeout: 300_000,


### PR DESCRIPTION
Fixes #128.

## Problem

`review-deciding`'s check script (`src/workflows/unified.yaml`) decided sign-off vs. feedback by filtering the human's own steering-file edit out of the round's diff with a hardcoded `grep -v '^\.gtd/'`. But `reviewFile` is var-configurable and may live outside `.gtd/` (e.g. a root-level `REVIEW.md`). In that case the human's checkbox-tick commit survived the filter, `codeFiles` was non-empty, and every clean sign-off was misclassified as feedback — looping review forever:

```
reviewing → await-review → review-deciding → feedback-collecting
→ feedback-building → checking → reviewing → …
```

## Fix

Additionally exclude the state's own `reviewFile` by exact path:

```bash
codeFiles=$(git diff-tree --no-commit-id --name-only -r HEAD \
  | grep -v '^\.gtd/' | grep -vxF "$reviewFile")
```

Applied to both `unified.yaml` and the compiled `unified.flat.yaml`.

## Test

Adds a `@live` scenario (`review-signoff-outside-gtd.feature`) that actually executes the rendered check script — the bug lives in the script's shell logic, which `@inmem` scenarios never run. With a root-level `reviewFile`, a clean sign-off now reaches `squashing` instead of `feedback-collecting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)