### PR TITLE
feat(modes): add format-only `prose` built-in mode

### DIFF
--- a/.gtdrc.json
+++ b/.gtdrc.json
@@ -13,6 +13,9 @@
     },
     "review": {
       "format": "npx prettier --write <%= it.file %>"
+    },
+    "prose": {
+      "format": "npx prettier --write <%= it.file %>"
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,9 +69,12 @@ touches `src/PatternMachine.ts` (types + `validateDefinition`),
 A new steering-file FORMAT is neither: `mode:` names a pluggable mode, so a
 workflow declares its own `modes:` entry (a `format:`/`validate:` shell command
 pair) — no gtd change at all. Only the two built-in VALIDATORS (`qa`/`review`)
-live in code, because `gtd lsp` needs their parsers in process; gtd ships no
-formatter at all (there is no `gtd format` subcommand and no bundled prettier —
-a project plugs its own into a mode's `format:`).
+live in code, because `gtd lsp` needs their parsers in process; a third built-in
+name, `prose`, is recognized with no code of its own — a format-only mode (no
+validator) the simple flow's plan file uses (see
+`PatternMachine.isKnownBuiltInMode`). gtd ships no formatter at all (there is no
+`gtd format` subcommand and no bundled prettier — a project plugs its own into a
+mode's `format:`).
 
 ### The Pattern-Machine Module Map
 

--- a/README.md
+++ b/README.md
@@ -61,15 +61,16 @@ gtd init
 This writes a minimal `.gtdrc.json` seeding the one variable most projects
 change — the test command (`vars.testCommand`, defaulting to `npm test`) — plus
 a top-level `modes:` block suggesting **Prettier** as the steering-file
-formatter (`npx prettier --write` for the built-in `qa`/`review` modes — format
-only, so gtd still validates); edit or drop either freely (point `testCommand`
-at your suite, swap Prettier for dprint or a script, delete a key). It writes
-**no** `workflow:` key — the machine is built in — so review and commit the file
-before your first `gtd step`. `gtd init` takes no argument and refuses to
-clobber an existing config; it may also run in a plain parent directory (not a
-git repo) to seed a shared config a nested repo picks up. To customize the
-machine itself, add a `workflow:` key (there is no default fallback to merge
-over — a `workflow:` is the whole definition). See
+formatter (`npx prettier --write` for the built-in `qa`/`review`/`prose` modes —
+format only, so gtd still validates the `qa`/`review` ones; `prose`, used by the
+simple flow's plan file, has no validator to begin with); edit or drop either
+freely (point `testCommand` at your suite, swap Prettier for dprint or a script,
+delete a key). It writes **no** `workflow:` key — the machine is built in — so
+review and commit the file before your first `gtd step`. `gtd init` takes no
+argument and refuses to clobber an existing config; it may also run in a plain
+parent directory (not a git repo) to seed a shared config a nested repo picks
+up. To customize the machine itself, add a `workflow:` key (there is no default
+fallback to merge over — a `workflow:` is the whole definition). See
 [Configuration](docs/configuration.md#gtd-init) for the details.
 
 ## How it works
@@ -206,12 +207,16 @@ diagnostics for both (live as you edit), and a `gtd.openSteeringFile` command
 that jumps to the current state's steering file. Config-driven via each state's
 `file:`/`mode:` (see [CLI reference](docs/cli.md#gtd-lsp)) — falls back to
 basename dispatch (`REVIEW.md` → `review`) with no config in sight. `qa` and
-`review` are gtd's built-in steering-file MODES — validators, not formatters: a
-mode's `format:` and `validate:` are shell commands a workflow (or a project's
-`.gtdrc`) declares for itself, so you bring your own formatter and your own
-checkers (see
-[Configuration](docs/configuration.md#modes--pluggable-steering-file-modes)).
-Both halves are enforced by `gtd validate` and the `gtd step` gate.
+`review` are gtd's built-in steering-file MODES with a VALIDATOR gtd itself
+implements; a mode's `format:` and `validate:` are shell commands a workflow (or
+a project's `.gtdrc`) declares for itself, so you bring your own formatter and
+your own checkers (see
+[Configuration](docs/configuration.md#modes--pluggable-steering-file-modes)). A
+third built-in, `prose` — format-only, no validator, used by the simple flow's
+plan file — has no live editor support: `gtd lsp` publishes no symbols or
+diagnostics for it, though `gtd validate` and the `gtd step` gate still format
+and validate it like any other mode. Both halves are enforced by `gtd validate`
+and the `gtd step` gate.
 
 Herdr integration: a workflow state can declare an optional `label:` — a
 human-readable display name surfaced in `gtd next --json`/`gtd status`. The

--- a/STATES.md
+++ b/STATES.md
@@ -447,7 +447,9 @@ Steering-file formats (`.gtd/REQUIREMENTS.md`/`.gtd/ARCHITECTURE.md` open
 questions — the advanced flow only, `.gtd/REVIEW.md` checkboxes) are checkable
 but validation is not a state in the machine: the producing agent self-validates
 with `gtd validate` before finishing (see §12). The simple flow's `.gtd/TODO.md`
-is a free-form plan with no `mode:`, so there is nothing to validate there.
+is a free-form plan under the format-only `prose` mode: it still runs a
+`modes:`-declared `format:` command before either `planning`/`plan-review`
+steps, but there is no gtd-side schema to validate against.
 
 **Entry + shared states** (the simple-flow gate, the shared health/tail, and the
 `gtd review`/`gtd fix` gates — everything the entries share):
@@ -457,8 +459,8 @@ is a free-form plan with no `mode:`, so there is nothing to validate there.
 | `idle` (initial)       | Idle                         | human | message | `* .gtd/REQUIREMENTS.md` → `adv-start-check`; `* **` → `start-check`                                           | —                  | —       | —        | —                            |
 | `start-check`          | Checking the baseline        | check | script  | `A`/`M .gtd/FEEDBACK.md` → `start-blocked`; `D .gtd/FEEDBACK.md` → `planning`; `C` → `planning`                | —                  | —       | —        | —                            |
 | `start-blocked`        | Baseline is red              | human | message | `* **` → `start-check`                                                                                         | —                  | —       | —        | `vars.feedbackFile`          |
-| `planning`             | Refining the plan            | agent | prompt  | `* **` → `plan-review`                                                                                         | —                  | `smart` | `plan`   | `vars.todoFile`              |
-| `plan-review`          | Awaiting your review         | human | message | `C` → `building`; `* **` → `planning`                                                                          | —                  | —       | —        | `vars.todoFile`              |
+| `planning`             | Refining the plan            | agent | prompt  | `* **` → `plan-review`                                                                                         | —                  | `smart` | `plan`   | `vars.todoFile` / `prose`    |
+| `plan-review`          | Awaiting your review         | human | message | `C` → `building`; `* **` → `planning`                                                                          | —                  | —       | —        | `vars.todoFile` / `prose`    |
 | `building`             | Building                     | agent | prompt  | `* **` → `checking`                                                                                            | —                  | `base`  | `build`  | `vars.todoFile`              |
 | `checking`             | Running checks               | check | script  | `A`/`M .gtd/FEEDBACK.md` → `fixing`; `D .gtd/FEEDBACK.md` → `reviewing`; `C` → `reviewing`                     | —                  | —       | —        | —                            |
 | `fixing`               | Fixing the check             | agent | prompt  | `* **` → `checking`                                                                                            | max 3 → `escalate` | `base`  | `fix`    | `vars.feedbackFile`          |
@@ -876,9 +878,18 @@ workflow without being declared — and they are validators ONLY: **gtd ships no
 formatter**, so `qa`/`review` reformat nothing until a project gives them a
 `format:` command. `gtd init` seeds one by default: the scaffolded `.gtdrc.json`
 carries a top-level `modes:` block suggesting `npx prettier --write` as the
-`format:` for both (validation still gtd's own) — an ordinary declared layer the
-project edits or drops, not privileged machinery (see
+`format:` for all three built-ins (validation still gtd's own for `qa`/`review`)
+— an ordinary declared layer the project edits or drops, not privileged
+machinery (see
 [docs/configuration.md](docs/configuration.md#modes--pluggable-steering-file-modes)).
+
+There is a third built-in mode, **`prose`** — a known name a state's `mode:` may
+use with no `modes:` declaration at all, but it ships **no validator**: it
+resolves to "format if a `modes:` layer gives it one, validate nothing"
+(`PatternMachine.isKnownBuiltInMode`/`FORMAT_ONLY_BUILT_IN_MODES`). It exists
+for a curated, free-form document with no gtd-side schema — the simple flow's
+plan file (see §10) — where a validator would either misapply a schema or have
+nothing to check.
 
 The two halves resolve **independently**, each from the first layer that
 provides it (`resolveSteeringMode` in `src/SteeringMode.ts`) — so extending a
@@ -940,19 +951,21 @@ In the unified template (§10) this covers `adv-grilling` (REQUIREMENTS.md/`qa`)
 `architecting` (ARCHITECTURE.md/`qa`) and `reviewing` (REVIEW.md/`review`) — the
 states that author a steering file — and, through the `gtd step` gate, the human
 gates `adv-grilling-answer`, `architecting-answer` and `await-review` that edit
-those same files. (The simple flow's `planning` authors `.gtd/TODO.md` with no
-`mode:`, so it is not gated here.) It replaced the old in-machine
+those same files. The simple flow's `planning`/`plan-review` are gated too, on
+the format-only `prose` mode (§10): a `modes:` `format:` command still runs and
+still blocks the step on a hard tooling failure, but there is no validator to
+fail on content. It replaced the old in-machine
 `todo-validating`/`review-validating` states and their `.gtd/FORMAT.md` bounce
 loop (see
 [docs/design/steering-file-validation-command.md](docs/design/steering-file-validation-command.md));
 modes became pluggable afterwards (see
 [docs/design/pluggable-steering-modes.md](docs/design/pluggable-steering-modes.md)).
 
-**Known limitation — the editor sees only the built-ins.** `gtd lsp` publishes
-diagnostics, document symbols and code actions for `qa`/`review` files only: gtd
-never runs a mode's shell command per keystroke over an unsaved buffer. A
-custom-mode file is still formatted and validated by `gtd validate` and the
-`gtd step` gate.
+**Known limitation — the editor sees only the validator built-ins.** `gtd lsp`
+publishes diagnostics, document symbols and code actions for `qa`/`review` files
+only: gtd never runs a mode's shell command per keystroke over an unsaved
+buffer. A `prose` file (the format-only built-in) and a custom-mode file are
+both still formatted and validated by `gtd validate` and the `gtd step` gate.
 
 ## 13. Sub-machines (compile-time expansion)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,7 +88,7 @@ workflow:
       model: <string> # optional, opaque harness hint — forbidden on a commit state
       memory: <string> # optional, opaque memory-scope label — forbidden on a commit state
       file: <string> # optional, an Eta template naming the state's steering file — forbidden on a commit state
-      mode: <modeName> # optional, requires "file" — a built-in (qa/review) or a `modes:` entry; forbidden on a commit state
+      mode: <modeName> # optional, requires "file" — a built-in (qa/review/prose) or a `modes:` entry; forbidden on a commit state
 ```
 
 See [STATES.md](../STATES.md#1-the-model) for what each field means to the
@@ -332,10 +332,17 @@ implements itself:
 | `qa`     | The open-questions format (`## Open Questions` near the top and `## Answered Questions` at the bottom, one `###` sub-heading per question with a free-form body; status is positional, no marker line). The bundled advanced flow additionally writes each open question as a checkbox list (candidate answers + a `- [ ] _your answer_` slot) and gates the human's answer step with `answerGate` (exactly one tick per question) — but that convention + gate live in the workflow/edge, not in this validator, which only checks the structure above. |
 | `review` | The checkbox review format (`# Review: <hash>` header, `<!-- base: <hash> -->` comment, `##` chunks, `- [ ]` pointers).                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
+A THIRD name, `prose`, is also built in but ships **no validator at all** — a
+known mode name a state's `mode:` may use with no `modes:` declaration, that
+formats (once a `modes:` layer gives it a `format:` command) but never
+validates. It is for a curated, free-form document with no gtd-side schema — the
+bundled template's simple-flow plan file (`.gtd/TODO.md` at
+`planning`/`plan-review`) uses it.
+
 Any other name must be declared in a `modes:` map (next section) — as must a
-`format:` command for these two, since gtd ships no formatter. A `mode:` naming
-neither a built-in nor a declared mode is a load error listing both sets (typos
-must not silently disable the format gate or editor support).
+`format:` command for any of the three built-ins, since gtd ships no formatter.
+A `mode:` naming neither a built-in nor a declared mode is a load error listing
+both sets (typos must not silently disable the format gate or editor support).
 
 What a mode buys the state: before capturing a turn out of it, `gtd step`
 formats that file in place and validates it, refusing the step when it is
@@ -416,9 +423,12 @@ declares it:
 1. the top-level `.gtdrc` `modes:` key (the project's own layer, cwd→home
    deep-merged like any other config key);
 2. the active workflow's own `modes:` map;
-3. for the two built-in NAMES only, gtd's in-process validator — `qa` →
-   `src/OpenQuestions.ts`, `review` → `src/ReviewDoc.ts`. There is no built-in
-   formatter at this layer: **gtd ships no formatter**, so bring your own.
+3. for the two VALIDATOR built-in names only, gtd's in-process validator — `qa`
+   → `src/OpenQuestions.ts`, `review` → `src/ReviewDoc.ts`. The third built-in,
+   `prose`, has no in-process validator to fall back to, so it validates nothing
+   unless a `modes:` layer above declares its own `validate:`. There is no
+   built-in formatter at this layer for any of the three: **gtd ships no
+   formatter**, so bring your own.
 
 So for a state declaring `mode: qa`:
 
@@ -444,6 +454,7 @@ edit or drop it to taste. It is what a scaffolded `.gtdrc.json` contains
   "modes": {
     "qa": { "format": "npx prettier --write <%= it.file %>" },
     "review": { "format": "npx prettier --write <%= it.file %>" },
+    "prose": { "format": "npx prettier --write <%= it.file %>" },
   },
 }
 ```
@@ -451,7 +462,8 @@ edit or drop it to taste. It is what a scaffolded `.gtdrc.json` contains
 **Known limitation — no live editor support for a custom mode.** `gtd lsp`
 publishes diagnostics, document symbols and code actions for the built-in
 `qa`/`review` formats only (gtd never runs a mode command per keystroke over an
-unsaved buffer). A file whose validation is a command is still formatted and
+unsaved buffer). A file whose validation is a command — and a `prose` file,
+which has no validator to publish diagnostics for — is still formatted and
 validated by `gtd validate` and the `gtd step` capture gate.
 
 ### `reviewWindow:`/`reviewBase:` — the review checkout window
@@ -852,15 +864,18 @@ mode the default workflow uses:
 ```jsonc
 "modes": {
   "qa": { "format": "npx prettier --write <%= it.file %>" },
-  "review": { "format": "npx prettier --write <%= it.file %>" }
+  "review": { "format": "npx prettier --write <%= it.file %>" },
+  "prose": { "format": "npx prettier --write <%= it.file %>" }
 }
 ```
 
 Only `format:` is declared, so gtd's built-in `qa`/`review` validators still do
-the validating (the two halves layer independently). gtd ships no formatter, so
-this is the one default it suggests: a fresh repo auto-formats its steering
-files out of the box, and you edit or drop the block freely (swap Prettier for
-dprint, point at a script, or delete the key).
+the validating, and `prose` (a format-only built-in with no validator of its own
+— see the `mode:` section above) still validates nothing (the two halves layer
+independently). gtd ships no formatter, so this is the one default it suggests:
+a fresh repo auto-formats its steering files out of the box, and you edit or
+drop the block freely (swap Prettier for dprint, point at a script, or delete
+the key).
 
 The built-in default workflow has three entry points into a shared review/squash
 tail (all walked through in

--- a/src/Lsp.ts
+++ b/src/Lsp.ts
@@ -35,9 +35,11 @@
  * `qa`-format file; a custom workflow that wants qa validation on TODO.md
  * declares it with `file:`+`mode: qa`, which the config-driven map covers.)
  *
- * KNOWN LIMITATION — this server understands only the two BUILT-IN modes
- * (`qa`/`review`, whose parsers it owns). A workflow-declared mode (a `modes:`
- * entry, whose validation is a shell command — see `src/SteeringMode.ts`)
+ * KNOWN LIMITATION — this server understands only the two VALIDATOR built-in
+ * modes (`qa`/`review`, whose parsers it owns). A workflow-declared mode (a
+ * `modes:` entry, whose validation is a shell command — see
+ * `src/SteeringMode.ts`) — and the third built-in, `prose` (a format-only
+ * name with no in-process parser — see `PatternMachine.isKnownBuiltInMode`) —
  * dispatches to no symbols, no code actions, and an empty diagnostic list: gtd
  * never runs a mode's command per keystroke over an unsaved buffer. Such a
  * file is still formatted and validated by `gtd validate` and the `gtd step`

--- a/src/PatternConfig.test.ts
+++ b/src/PatternConfig.test.ts
@@ -997,7 +997,7 @@ describe("compileWorkflowConfig — config-shape validation", () => {
         },
         "/dir",
       ),
-    ).toThrowError(/"mode" must name a built-in mode \(qa, review\).*\(got "yolo"\)/)
+    ).toThrowError(/"mode" must name a built-in mode \(qa, review, prose\).*\(got "yolo"\)/)
   })
 
   it("rejects a malformed `retry` block", () => {

--- a/src/PatternMachine.test.ts
+++ b/src/PatternMachine.test.ts
@@ -1021,6 +1021,31 @@ describe("validateDefinition", () => {
     expect(errors).toEqual([])
   })
 
+  it("accepts a state declaring `mode: prose` with no `modes:` declaration", () => {
+    const errors = validateDefinition({
+      states: {
+        a: {
+          actor: "h",
+          message: "x",
+          initial: true,
+          file: ".gtd/TODO.md",
+          mode: "prose",
+          on: [],
+        },
+      },
+    })
+    expect(errors).toEqual([])
+  })
+
+  it("rejects `mode: prose` without a sibling `file`", () => {
+    const errors = validateDefinition({
+      states: {
+        a: { actor: "h", message: "x", initial: true, mode: "prose", on: [] },
+      },
+    })
+    expect(errors).toContain('state "a": "mode" requires "file"')
+  })
+
   it("rejects an empty-string `file`", () => {
     const errors = validateDefinition({
       states: {
@@ -1054,7 +1079,7 @@ describe("validateDefinition", () => {
       },
     })
     expect(errors).toContain(
-      'state "a": "mode" must name a built-in mode (qa, review) or one declared in "modes" (none declared) (got "yolo")',
+      'state "a": "mode" must name a built-in mode (qa, review, prose) or one declared in "modes" (none declared) (got "yolo")',
     )
   })
 
@@ -1074,7 +1099,7 @@ describe("validateDefinition", () => {
       },
     })
     expect(rejected).toContain(
-      'state "a": "mode" must name a built-in mode (qa, review) or one declared in "modes" (adr) (got "adrs")',
+      'state "a": "mode" must name a built-in mode (qa, review, prose) or one declared in "modes" (adr) (got "adrs")',
     )
   })
 
@@ -1297,7 +1322,7 @@ describe("validateDefinition", () => {
     })
     expect(errors).toContain('state "a": "file" must be a non-empty string')
     expect(errors).toContain(
-      'state "a": "mode" must name a built-in mode (qa, review) or one declared in "modes" (none declared) (got "yolo")',
+      'state "a": "mode" must name a built-in mode (qa, review, prose) or one declared in "modes" (none declared) (got "yolo")',
     )
     expect(errors).toContain('state "a": "on" target "ghost" is not a defined state')
   })

--- a/src/PatternMachine.ts
+++ b/src/PatternMachine.ts
@@ -277,17 +277,36 @@ export type BuiltInMode = "qa" | "review"
 
 const BUILT_IN_MODES: readonly BuiltInMode[] = ["qa", "review"]
 
+/**
+ * Built-in mode names that ship NO validator at all — just a recognized name a
+ * state's `mode:` may use without a `modes:` declaration, so it resolves to
+ * "format if a `modes:` layer gives it one, validate nothing" (see
+ * `src/SteeringMode.ts`'s `resolveSteeringMode`). `prose` is the one entry: a
+ * curated free-form document with no gtd-side schema (the simple flow's plan
+ * file), distinct from the schema'd `qa`/`review` built-ins.
+ */
+const FORMAT_ONLY_BUILT_IN_MODES = ["prose"] as const
+
+/** Every built-in mode name — the validator tier (`BUILT_IN_MODES`) plus the format-only tier (`FORMAT_ONLY_BUILT_IN_MODES`) — used where a `mode:` just needs to be a KNOWN name, not necessarily one with a validator. */
+const KNOWN_BUILT_IN_MODES: readonly StateMode[] = [
+  ...BUILT_IN_MODES,
+  ...FORMAT_ONLY_BUILT_IN_MODES,
+]
+
 /** True when `mode` names one of gtd's own in-process implementations (see `BUILT_IN_MODES`) — the edge's dispatch, and a type guard so it can pick the parser. */
 export const isBuiltInMode = (mode: StateMode): mode is BuiltInMode =>
   (BUILT_IN_MODES as readonly StateMode[]).includes(mode)
+
+/** True when `mode` names any built-in — validator tier or format-only tier (see `KNOWN_BUILT_IN_MODES`) — without implying a validator exists. */
+export const isKnownBuiltInMode = (mode: StateMode): boolean => KNOWN_BUILT_IN_MODES.includes(mode)
 
 /** The mode names the definition declares in `modes:` (empty when it declares none). */
 const declaredModes = (def: WorkflowDefinition): readonly StateMode[] =>
   Object.keys(def.modes ?? {})
 
-/** Every mode name a state's `mode:` may legally name under `def`: the built-ins plus the declared ones (a declared name shadowing a built-in appears once). */
+/** Every mode name a state's `mode:` may legally name under `def`: the built-ins (validator and format-only tiers) plus the declared ones (a declared name shadowing a built-in appears once). */
 export const knownModes = (def: WorkflowDefinition): readonly StateMode[] =>
-  Array.from(new Set([...BUILT_IN_MODES, ...declaredModes(def)]))
+  Array.from(new Set([...KNOWN_BUILT_IN_MODES, ...declaredModes(def)]))
 
 /** A workflow: named states, plus the optional steering-file `modes:` they may name. Exactly one state must declare `initial: true`. */
 export interface WorkflowDefinition {
@@ -902,7 +921,7 @@ const validateMode = (def: WorkflowDefinition, name: string, state: StateDef): s
   const errors: string[] = []
   if (!knownModes(def).includes(state.mode)) {
     errors.push(
-      `state "${name}": "mode" must name a built-in mode (${BUILT_IN_MODES.join(", ")}) or one declared in "modes" (${
+      `state "${name}": "mode" must name a built-in mode (${KNOWN_BUILT_IN_MODES.join(", ")}) or one declared in "modes" (${
         declaredModes(def).length > 0 ? declaredModes(def).join(", ") : "none declared"
       }) (got "${state.mode}")`,
     )

--- a/src/SteeringMode.test.ts
+++ b/src/SteeringMode.test.ts
@@ -100,8 +100,21 @@ describe("resolveSteeringMode", () => {
     const def = commandsDef({ adr: { validate: "adr-lint" } })
     expect(resolveSteeringMode(def, "nope")).toBeUndefined()
     expect(unknownModeMessage(def, "drafting", "nope")).toBe(
-      'state "drafting": mode "nope" is not defined by the active workflow (known modes: qa, review, adr)',
+      'state "drafting": mode "nope" is not defined by the active workflow (known modes: qa, review, prose, adr)',
     )
+  })
+
+  it("resolves `prose` with no declared mode to a validator-less, formatter-less mode", () => {
+    const def: WorkflowDefinition = { states: {} }
+    expect(resolveSteeringMode(def, "prose")).toEqual({ mode: "prose" })
+  })
+
+  it("adds a formatter to `prose` without adding any validation", () => {
+    const def = commandsDef({ prose: { format: "npx prettier --write <%= it.file %>" } })
+    expect(resolveSteeringMode(def, "prose")).toEqual({
+      mode: "prose",
+      format: "npx prettier --write <%= it.file %>",
+    })
   })
 })
 

--- a/src/SteeringMode.ts
+++ b/src/SteeringMode.ts
@@ -4,6 +4,7 @@ import { parseOpenQuestions } from "./OpenQuestions.js"
 import { parseReviewDoc } from "./ReviewDoc.js"
 import {
   isBuiltInMode,
+  isKnownBuiltInMode,
   knownModes,
   type BuiltInMode,
   type StateMode,
@@ -30,14 +31,18 @@ import { renderModeCommand, type TemplateContext } from "./PatternTemplates.js"
  *   script of its own and plugs it into whichever mode it wants formatted. No
  *   command, no formatting.
  * - **validate** — a `modes:` entry's `validate:` command if declared;
- *   otherwise, for the two BUILT-IN names (`PatternMachine.BuiltInMode`), gtd's
- *   own pure parser: `qa` → `src/OpenQuestions.ts`, `review` →
+ *   otherwise, for the two VALIDATOR built-in names (`PatternMachine.BuiltInMode`),
+ *   gtd's own pure parser: `qa` → `src/OpenQuestions.ts`, `review` →
  *   `src/ReviewDoc.ts`. Those stay in process because `gtd lsp` publishes the
- *   same parsers as live diagnostics.
+ *   same parsers as live diagnostics. A third built-in, `prose`
+ *   (`PatternMachine.isKnownBuiltInMode`), is FORMAT-ONLY: it is a known mode
+ *   name with no in-process parser, so it validates nothing unless a `modes:`
+ *   entry declares its own `validate:` command.
  *
  * That per-half layering is what makes a built-in mode EXTENSIBLE rather than
  * all-or-nothing: `modes: { qa: { format: "npx prettier --write <%= it.file %>" } }`
- * adds formatting to `qa` and keeps gtd's open-questions validation.
+ * adds formatting to `qa` and keeps gtd's open-questions validation; the same
+ * shape on `prose` adds formatting with no validation to add or keep.
  *
  * A command is an Eta template rendered with `it.file` bound to the rendered
  * steering-file path, then executed verbatim via `bash -c`. The contract is the
@@ -65,18 +70,22 @@ export interface ResolvedMode {
 
 /**
  * Resolve a `mode:` name, half by half: a declared `format:`/`validate:` wins,
- * and an undeclared `validate:` falls back to the built-in parser of the same
- * name. `undefined` for a name that is neither declared nor built in —
- * `validateDefinition` rejects that at load time, so the edge only ever sees it
- * as a defensive case.
+ * and an undeclared `validate:` falls back to the built-in PARSER of the same
+ * name — only `qa`/`review` have one (`isBuiltInMode`). `prose` is a known
+ * built-in NAME with no parser (`isKnownBuiltInMode`), so it resolves without
+ * a declaration to `{ mode: "prose" }` — no format, no validate — and gains
+ * formatting only, never validation, from a `modes:` layer. `undefined` for a
+ * name that is neither declared nor a known built-in — `validateDefinition`
+ * rejects that at load time, so the edge only ever sees it as a defensive
+ * case.
  */
 export const resolveSteeringMode = (
   def: WorkflowDefinition,
   mode: StateMode,
 ): ResolvedMode | undefined => {
   const declared = def.modes?.[mode]
+  if (declared === undefined && !isKnownBuiltInMode(mode)) return undefined
   const builtIn = isBuiltInMode(mode)
-  if (declared === undefined && !builtIn) return undefined
   const validate: ResolvedValidator | undefined =
     declared?.validate !== undefined
       ? { kind: "command", command: declared.validate }

--- a/src/workflows/templates.ts
+++ b/src/workflows/templates.ts
@@ -26,11 +26,13 @@ export const INIT_VARS = {
 /**
  * The top-level `modes:` block `gtd init` seeds into the scaffolded
  * `.gtdrc.json` as a ready-to-edit suggestion: a `format:` command for each
- * built-in steering-file mode the bundled default uses (`qa` for the plan /
- * open-questions files, `review` for REVIEW.md), so a fresh project's steering
- * files are auto-formatted with Prettier before gtd validates them. Only
- * `format:` is declared — gtd's built-in `qa`/`review` validators still do the
- * validating (the two halves layer independently — see STATES.md §12 /
+ * built-in steering-file mode the bundled default uses (`qa` for the
+ * open-questions files, `review` for REVIEW.md, `prose` for the simple flow's
+ * plan file), so a fresh project's steering files are auto-formatted with
+ * Prettier before gtd validates them. Only `format:` is declared — gtd's
+ * built-in `qa`/`review` validators still do the validating, and `prose` (a
+ * format-only built-in — see `PatternMachine.isKnownBuiltInMode`) still
+ * validates nothing (the two halves layer independently — see STATES.md §12 /
  * docs/configuration.md `modes:`). gtd ships no formatter, so this is the one
  * place a default is suggested; a project edits or drops it freely (swap
  * Prettier for dprint, point at a script, delete the key).
@@ -38,6 +40,7 @@ export const INIT_VARS = {
 export const MODES_SUGGESTION = {
   qa: { format: "npx prettier --write <%= it.file %>" },
   review: { format: "npx prettier --write <%= it.file %>" },
+  prose: { format: "npx prettier --write <%= it.file %>" },
 } as const
 
 /**

--- a/src/workflows/unified.flat.yaml
+++ b/src/workflows/unified.flat.yaml
@@ -200,6 +200,7 @@ states:
     actor: agent
     label: Refining the plan
     file: <%= it.vars.todoFile %>
+    mode: prose
     model: <%= it.vars.plannerModel %>
     memory: plan
     prompt: |
@@ -234,6 +235,7 @@ states:
     actor: human
     label: Awaiting your review
     file: <%= it.vars.todoFile %>
+    mode: prose
     message: |
       `<%= it.vars.todoFile %>` holds the proposed implementation plan. Read it,
       then either accept it as-is or edit it — rewrite a step, add a

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -273,6 +273,7 @@ submachines:
         actor: agent
         label: Refining the plan
         file: <%= it.vars.todoFile %>
+        mode: prose
         model: <%= it.vars.plannerModel %>
         memory: plan
         prompt: |
@@ -307,6 +308,7 @@ submachines:
         actor: human
         label: Awaiting your review
         file: <%= it.vars.todoFile %>
+        mode: prose
         message: |
           `<%= it.vars.todoFile %>` holds the proposed implementation plan. Read it,
           then either accept it as-is or edit it — rewrite a step, add a

--- a/tests/integration/features/config-errors.feature
+++ b/tests/integration/features/config-errors.feature
@@ -114,7 +114,7 @@ Feature: An invalid "workflow:" config fails loudly at load time, naming the sta
     When I run gtd status
     Then it fails
     And stderr contains "workflow config:"
-    And stderr contains "\"mode\" must name a built-in mode (qa, review)"
+    And stderr contains "\"mode\" must name a built-in mode (qa, review, prose)"
     And stderr contains "declared in \"modes\" (adr)"
     And stderr contains "got \"adrs\""
 

--- a/tests/integration/features/formatting.feature
+++ b/tests/integration/features/formatting.feature
@@ -140,6 +140,67 @@ Feature: Markdown formatting is the project's own tool, plugged into a steering-
     When I commit with message "review: test formatting"
     Then ".gtd/REVIEW.md" has no lines longer than 80 characters
 
+  Scenario: prettier plugged into the bundled default's plan mode via a top-level modes: key formats the agent-authored plan at planning
+    # No `workflow:` re-declaration: the bundled default already gives
+    # `planning`/`plan-review` `mode: prose` (see unified.yaml); a top-level
+    # `modes:` key alone is enough to plug a formatter into it.
+    Given a test project
+    And prettier is available in the test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      modes:
+        prose:
+          format: "npx prettier --write <%= it.file %>"
+      """
+    And a commit "gtd(human): planning" that adds ".gtd/TODO.md" with:
+      """
+      This is a deliberately long single prose line for the plan file that clearly exceeds the eighty character print width.
+      """
+    When I run gtd step agent
+    Then it succeeds
+    And the last commit subject is "gtd(agent): planning → plan-review"
+    And ".gtd/TODO.md" has no lines longer than 80 characters
+
+  Scenario: prettier plugged into the bundled default's plan mode formats the human-edited plan at plan-review
+    Given a test project
+    And prettier is available in the test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      modes:
+        prose:
+          format: "npx prettier --write <%= it.file %>"
+      """
+    And a commit "gtd(agent): plan-review" that adds ".gtd/TODO.md" with:
+      """
+      A plan.
+      """
+    And ".gtd/TODO.md" is modified to:
+      """
+      A plan. This edited line is deliberately far longer than eighty characters so the formatter has to rewrap it before the turn is captured.
+      """
+    When I run gtd step human
+    Then it succeeds
+    And the last commit subject is "gtd(human): plan-review → planning"
+    And ".gtd/TODO.md" has no lines longer than 80 characters
+
+  Scenario: gtd validate formats the plan file and reports it valid — prose has no validator to fail
+    Given a test project
+    And prettier is available in the test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      modes:
+        prose:
+          format: "npx prettier --write <%= it.file %>"
+      """
+    And a commit "gtd(human): planning" that adds ".gtd/TODO.md" with:
+      """
+      This is a deliberately long single prose line for the plan file that clearly exceeds the eighty character print width.
+      """
+    When I run gtd with args "validate"
+    Then it succeeds
+    And stdout contains ".gtd/TODO.md: valid"
+    And ".gtd/TODO.md" has no lines longer than 80 characters
+
   Scenario: Pre-commit hook does not modify other markdown files
     Given a test project
     And prettier is available in the test project

--- a/tests/integration/features/validate.feature
+++ b/tests/integration/features/validate.feature
@@ -18,10 +18,12 @@ Feature: gtd validate — self-validating the resolved rest's steering file
   dedicated state, the producing agent self-validates before finishing, so a
   human gate is only ever handed a well-formed file.
 
-  In the bundled template only the ADVANCED flow uses the `qa` mode
+  In the bundled template the ADVANCED flow uses the `qa` mode
   (`.gtd/REQUIREMENTS.md` at adv-grilling, `.gtd/ARCHITECTURE.md` at
   architecting). The SIMPLE flow's `.gtd/TODO.md` iterates on a free-form plan
-  with no `mode:`, so there is nothing to validate at planning/plan-review.
+  under the format-only `prose` mode: it validates cleanly regardless of
+  content (there is no validator to fail), but still formats on a declared
+  `format:` command — formatting.feature covers that.
 
   Scenario: a well-formed REQUIREMENTS.md at adv-grilling validates cleanly
     Given a test project
@@ -109,9 +111,10 @@ Feature: gtd validate — self-validating the resolved rest's steering file
     Then it succeeds
     And stdout contains "nothing to validate at \"idle\""
 
-  Scenario: the simple flow's TODO.md declares no mode — nothing to validate at planning
+  Scenario: the simple flow's TODO.md is `prose`-moded — it validates cleanly with no findings to check
     # The SIMPLE flow iterates on a free-form plan; planning declares `file:`
-    # but no `mode:`, so validate has nothing to check.
+    # + `mode: prose`, a format-only built-in with no validator, so any
+    # content validates cleanly.
     Given a test project
     And the workflow
     And a commit "gtd(human): planning" that adds ".gtd/TODO.md" with:
@@ -120,7 +123,7 @@ Feature: gtd validate — self-validating the resolved rest's steering file
       """
     When I run gtd with args "validate"
     Then it succeeds
-    And stdout contains "nothing to validate at \"planning\""
+    And stdout contains ".gtd/TODO.md: valid"
 
   Scenario: plain `gtd next` appends the self-validation instruction at a producing agent state
     Given a test project


### PR DESCRIPTION
## Summary

Adds `prose` as a third built-in steering-file mode: a **format-only** mode with no validator, so the simple flow's planning/plan-review states (`TODO.md`) can be auto-formatted like the `qa`/`review` steering files without needing a schema to validate against.

- Recognizes `prose` in `PatternMachine.ts` (`isKnownBuiltInMode`/`FORMAT_ONLY_BUILT_IN_MODES`) — resolves with no `modes:` declaration, ships no validator. `resolveSteeringMode` only adds formatting when a `modes:` layer declares `format:`, never validation.
- Keeps each built-in's two halves independent: `qa`/`review` gain a formatter without losing their validator; `prose` gains a formatter with nothing to validate.
- Wires `mode: prose` onto the bundled template's `planning`/`plan-review` states, seeds it in `gtd init`'s `modes:` suggestion alongside `qa`/`review`.
- Updates STATES.md, docs/configuration.md, README, AGENTS.md, and tests to reflect the three-mode built-in set.

## Test plan

- [ ] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)