### PR TITLE
feat(loop): add --no-notify/GTD_NO_NOTIFY to silence desktop alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,11 +186,12 @@ to halting and printing the gate instead, if you'd rather edit and re-launch it
 yourself; pass `--edit`/`-e` to force the editor open at the gate right now,
 overriding an ambient `GTD_NO_EDIT`/`--no-edit`. Pass `--once` to restrict a run
 to exactly one beat — one human gate, one check, or one agent turn — instead of
-driving all the way to idle; it combines freely with `--edit`/`--no-edit`. Bare
-`gtd` prints one line per event — colored and emoji on a real terminal, plain
-ASCII under `NO_COLOR` or when piped — and redirects the noisier
-agent/check/step subprocess output to a per-repo/per-worktree log file.
-`gtd log` opens that logfile in your editor. See
+driving all the way to idle; it combines freely with `--edit`/`--no-edit`. Pass
+`--no-notify` (or set `GTD_NO_NOTIFY`) to suppress Herdr desktop notifications
+while keeping Herdr sidebar state reporting on. Bare `gtd` prints one line per
+event — colored and emoji on a real terminal, plain ASCII under `NO_COLOR` or
+when piped — and redirects the noisier agent/check/step subprocess output to a
+per-repo/per-worktree log file. `gtd log` opens that logfile in your editor. See
 [Driving the loop](docs/loop.md).
 
 Before wiring gtd into a repo, note the

--- a/bin/gtd
+++ b/bin/gtd
@@ -3,15 +3,17 @@ set -euo pipefail
 
 # This file is the single published `bin` entry: `bin/gtd`. Before anything
 # else, it dispatches on $1:
-#   - `--no-edit` / `--edit` (`-e`) / `--once` (bare, or immediately after
-#     `loop`, in any order/combination — see the flag-parsing block below) ->
-#     stripped here; `--no-edit` disables the loop's automatic editor
-#     launching for this run, `--edit` forces it on for this run (overriding
-#     an ambient `GTD_NO_EDIT`/`--no-edit` — the two are mutually exclusive),
-#     and `--once` restricts the loop to exactly one beat (one human gate, one
-#     script check+step, or one agent prompt+step) before exiting. Dispatch
-#     then continues on the remaining arguments as if none of them had ever
-#     been given.
+#   - `--no-edit` / `--edit` (`-e`) / `--once` / `--no-notify` (bare, or
+#     immediately after `loop`, in any order/combination — see the
+#     flag-parsing block below) -> stripped here; `--no-edit` disables the
+#     loop's automatic editor launching for this run, `--edit` forces it on
+#     for this run (overriding an ambient `GTD_NO_EDIT`/`--no-edit` — the two
+#     are mutually exclusive), `--once` restricts the loop to exactly one beat
+#     (one human gate, one script check+step, or one agent prompt+step) before
+#     exiting, and `--no-notify` (or `GTD_NO_NOTIFY`) suppresses the loop's
+#     Herdr desktop notifications for this run while leaving its silent Herdr
+#     pane-state reporting untouched. Dispatch then continues on the
+#     remaining arguments as if none of them had ever been given.
 #   - `edit [path]` -> handled entirely here in bash, never forwarded to the
 #     bundle: opens `${VISUAL:-$EDITOR}` on `path`, or (no `path` given) on the
 #     resolved rest's `.file` (or `.` when absent). Low-level plumbing now that
@@ -224,22 +226,25 @@ resolve_log_path() {
   fi
 }
 
-# --no-edit / --edit (-e) / --once govern only the loop driver, recognised in
-# exactly two positions — bare (e.g. `gtd --edit --once`) or immediately after
-# `loop` (e.g. `gtd loop --once`) — in any order, each at most once. `--edit`
-# and `--no-edit` are mutually exclusive (forcing and suppressing the editor
-# in the same run is not a coherent request). A recognised, valid combination
-# is stripped here before anything below looks at "$@", so the bundle's own
-# unknown-option guard never sees it; anything else (an unknown flag, a
-# duplicate/conflicting one, or a flag mixed with a real subcommand) is left
-# untouched and falls through to the existing dispatch below, which forwards a
-# non-flag first argument to the bundle (whose own unknown-option guard
-# rejects it) or rejects a `loop` invocation carrying an unrecognised extra
-# argument.
+# --no-edit / --edit (-e) / --once / --no-notify govern only the loop driver,
+# recognised in exactly two positions — bare (e.g. `gtd --edit --once`) or
+# immediately after `loop` (e.g. `gtd loop --once`) — in any order, each at
+# most once. `--edit` and `--no-edit` are mutually exclusive (forcing and
+# suppressing the editor in the same run is not a coherent request);
+# `--no-notify` conflicts with nothing (it's orthogonal to editing and to
+# `--once`). A recognised, valid combination is stripped here before anything
+# below looks at "$@", so the bundle's own unknown-option guard never sees it;
+# anything else (an unknown flag, a duplicate/conflicting one, or a flag mixed
+# with a real subcommand) is left untouched and falls through to the existing
+# dispatch below, which forwards a non-flag first argument to the bundle
+# (whose own unknown-option guard rejects it) or rejects a `loop` invocation
+# carrying an unrecognised extra argument.
 edit_disabled=0
 edit_forced=0
 once_mode=0
+notify_disabled=0
 [[ -n "${GTD_NO_EDIT:-}" ]] && edit_disabled=1
+[[ -n "${GTD_NO_NOTIFY:-}" ]] && notify_disabled=1
 
 if [[ "${1:-}" == "loop" ]]; then
   loop_form=1
@@ -253,15 +258,17 @@ valid_combo=1
 n_no_edit=0
 n_edit=0
 n_once=0
+n_no_notify=0
 for a in ${loop_flag_args[@]+"${loop_flag_args[@]}"}; do
   case "$a" in
   --no-edit) n_no_edit=$((n_no_edit + 1)) ;;
   --edit | -e) n_edit=$((n_edit + 1)) ;;
   --once) n_once=$((n_once + 1)) ;;
+  --no-notify) n_no_notify=$((n_no_notify + 1)) ;;
   *) valid_combo=0 ;;
   esac
 done
-if ((n_no_edit > 1 || n_edit > 1 || n_once > 1 || (n_no_edit >= 1 && n_edit >= 1))); then
+if ((n_no_edit > 1 || n_edit > 1 || n_once > 1 || n_no_notify > 1 || (n_no_edit >= 1 && n_edit >= 1))); then
   valid_combo=0
 fi
 
@@ -269,6 +276,7 @@ if [[ "$valid_combo" == 1 ]]; then
   ((n_no_edit >= 1)) && edit_disabled=1
   ((n_edit >= 1)) && edit_forced=1
   ((n_once >= 1)) && once_mode=1
+  ((n_no_notify >= 1)) && notify_disabled=1
   # --edit overrides an ambient GTD_NO_EDIT/--no-edit for THIS run — the
   # explicit ask to force the editor wins over the suppressing default.
   ((edit_forced)) && edit_disabled=0
@@ -380,7 +388,11 @@ herdr_report() {  # $1=state (working|blocked|idle)  $2=message
     --source herdr:gtd --agent gtd --state "$1" --message "$2"
 }
 
+# Suppressible via GTD_NO_NOTIFY/--no-notify (set into $notify_disabled at
+# parse time, above) — the OS popup this call makes is the only thing that
+# opts out; herdr_report/herdr_release (silent sidebar status) are unaffected.
 herdr_notify() {  # $1=title  $2=body
+  [[ "$notify_disabled" == 1 ]] && return 0
   herdr_ok || return 0
   herdr_run notification show "$1" --body "$2" --sound request
 }

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -281,3 +281,9 @@ label tracked from the last completed iteration, when it fires outside the
 normal per-iteration flow. `report-agent` claims display authority for the
 `herdr:gtd` source, so `working` is re-reported every lap rather than once, to
 stay fresh against Herdr's own heuristic detection of the inner agent process.
+
+Set `GTD_NO_NOTIFY` (any non-empty value) or pass `--no-notify` to suppress the
+two `notification show` calls above (the human-gate halt and the exit trap) for
+this run — the OS popup + sound only. `report-agent`/`release-agent` (the silent
+Herdr sidebar status) are untouched either way, mirroring
+`--no-edit`/`GTD_NO_EDIT`'s flag/env shape.

--- a/skills/loop/SKILL.md
+++ b/skills/loop/SKILL.md
@@ -208,7 +208,9 @@ mapping). A human-gate editor session (editing on) is reported `blocked` for the
 duration of the edit, flipping back to `working` once the editor closes and the
 loop resumes driving. This is purely additive: it never changes the dispatch
 contract above (`kind` → message/script/prompt), never gates a step, and is a
-complete no-op outside Herdr.
+complete no-op outside Herdr. The `notification show` calls are suppressible via
+`GTD_NO_NOTIFY`/`--no-notify`, so a custom driver honoring the same contract
+knows notifications (unlike pane reporting) are opt-out.
 
 ## Notes
 

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -1328,6 +1328,121 @@ Feature: gtd loop — the packaged reference loop driver (v3)
       notification show gtd needs you
       """
 
+  Scenario: GTD_NO_NOTIFY set to a non-empty value suppresses the human-gate notification but still reports blocked
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Build the package described below: write src/calc.ts exporting add(a, b)."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: |
+              if [ -f src/calc.ts ] && grep -q add src/calc.ts; then rm -f .gtd/FEEDBACK.md; else mkdir -p .gtd && echo "missing add" > .gtd/FEEDBACK.md; fi
+            on:
+              "A .gtd/FEEDBACK.md": working
+              "M .gtd/FEEDBACK.md": working
+              "C": done
+          done:
+            commit: "chore: calculator done"
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Build the package described below"*)
+          mkdir -p src
+          cat > src/calc.ts <<'CALC'
+      export const add = (a, b) => a + b
+      CALC
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    And a fake herdr binary
+    And GTD_NO_NOTIFY is set to "1"
+    When I run bare gtd
+    Then it succeeds
+    And stdout contains "[you]  idle"
+    And the fake herdr log contains, in order:
+      """
+      pane report-agent test-pane --source herdr:gtd --agent gtd --state blocked --message idle
+      """
+    And the fake herdr log does not contain "notification show"
+
+  Scenario: --no-notify suppresses the human-gate notification but still reports blocked
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Build the package described below: write src/calc.ts exporting add(a, b)."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: |
+              if [ -f src/calc.ts ] && grep -q add src/calc.ts; then rm -f .gtd/FEEDBACK.md; else mkdir -p .gtd && echo "missing add" > .gtd/FEEDBACK.md; fi
+            on:
+              "A .gtd/FEEDBACK.md": working
+              "M .gtd/FEEDBACK.md": working
+              "C": done
+          done:
+            commit: "chore: calculator done"
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Build the package described below"*)
+          mkdir -p src
+          cat > src/calc.ts <<'CALC'
+      export const add = (a, b) => a + b
+      CALC
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    And a fake herdr binary
+    When I run gtd loop --no-notify
+    Then it succeeds
+    And stdout contains "[you]  idle"
+    And the fake herdr log contains, in order:
+      """
+      pane report-agent test-pane --source herdr:gtd --agent gtd --state blocked --message idle
+      """
+    And the fake herdr log does not contain "notification show"
+
   Scenario: Reports idle and releases the pane to Herdr when a script rest settles cleanly
     Given a test project
     And a gtd config file at ".gtdrc" with:
@@ -1400,6 +1515,47 @@ Feature: gtd loop — the packaged reference loop driver (v3)
       pane report-agent test-pane --source herdr:gtd --agent gtd --state blocked --message working: exited 1
       notification show gtd stopped
       """
+
+  Scenario: --no-notify suppresses the exit-trap notification
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Build the package described below: write src/calc.ts exporting add(a, b)."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: "true"
+            on:
+              "A .gtd/FEEDBACK.md": working
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      : # does nothing — the build prompt is never acted on
+      """
+    And a fake herdr binary
+    When I run gtd loop --no-notify
+    Then it fails
+    And stderr contains "no progress at 'working'"
+    And the fake herdr log contains, in order:
+      """
+      pane report-agent test-pane --source herdr:gtd --agent gtd --state blocked --message working: exited 1
+      """
+    And the fake herdr log does not contain "notification show"
 
   Scenario: Reports blocked to Herdr while the loop's editor is open at a human gate, then working once it closes
     # Same shape as "With editing on, an edit matching the gate's pattern lets

--- a/tests/integration/support/steps/gtd-loop.steps.ts
+++ b/tests/integration/support/steps/gtd-loop.steps.ts
@@ -98,6 +98,7 @@ function gtdLoopEnv(world: GtdWorld): NodeJS.ProcessEnv {
   scrubInheritedLoopEnv(env, world)
   const overrides: Record<string, string | undefined> = {
     GTD_NO_EDIT: noEditValue(world),
+    GTD_NO_NOTIFY: world.gtdNoNotifyOverride,
     GTD_LOOP_AGENT_CMD: world.stubAgentPath ? `bash "${world.stubAgentPath}"` : undefined,
     GTD_LOOP_LOG: world.gtdLoopLogOverride,
     GIT_DIR: world.gitDirOverride,
@@ -116,6 +117,14 @@ function gtdLoopEnv(world: GtdWorld): NodeJS.ProcessEnv {
 // distinct from the --no-edit flag itself.
 Given("GTD_NO_EDIT is set to {string}", (world: GtdWorld, value: string) => {
   world.gtdNoEditOverride = value
+})
+
+// Sets $GTD_NO_NOTIFY explicitly (a non-empty value disables the loop's
+// Herdr desktop notifications, identically to passing --no-notify) — for
+// scenarios asserting on the env-var form of that switch specifically,
+// distinct from the --no-notify flag itself.
+Given("GTD_NO_NOTIFY is set to {string}", (world: GtdWorld, value: string) => {
+  world.gtdNoNotifyOverride = value
 })
 
 // Sets $GTD_LOOP_LOG explicitly — the single-explicit-path override
@@ -230,6 +239,22 @@ Then("the fake herdr log contains, in order:", (world: GtdWorld, block: string) 
     )
     cursor = idx + line.length
   }
+})
+
+// Asserts a substring never appears anywhere in the fake herdr log — the
+// negative counterpart to "contains, in order", for scenarios proving a
+// suppressed call (e.g. --no-notify) never reached herdr at all.
+Then("the fake herdr log does not contain {string}", (world: GtdWorld, needle: string) => {
+  if (!world.fakeHerdrLogPath) {
+    throw new Error(
+      'no fake herdr binary was provisioned for this scenario — add "Given a fake herdr binary"',
+    )
+  }
+  const log = readFileSync(world.fakeHerdrLogPath, "utf-8")
+  assert.ok(
+    !log.includes(needle),
+    `Expected fake herdr log NOT to contain "${needle}".\nFull log:\n${log}`,
+  )
 })
 
 // Resolves the loop's log file path the same way bin/gtd's resolve_log_path

--- a/tests/integration/support/world.ts
+++ b/tests/integration/support/world.ts
@@ -48,6 +48,8 @@ export class GtdWorld extends QuickPickleWorld {
   fakeEditorLogPath: string | undefined = undefined
   /** Explicit `$GTD_NO_EDIT` value a scenario wants exported, overriding the tier's usual default (`gtd-loop` scenarios only). */
   gtdNoEditOverride: string | undefined = undefined
+  /** Explicit `$GTD_NO_NOTIFY` value a scenario wants exported (`gtd-loop` Herdr-notification scenarios only). */
+  gtdNoNotifyOverride: string | undefined = undefined
   /** Explicit `$GTD_LOOP_LOG` value a scenario wants exported (`gtd log`/loop logging scenarios, @live only). */
   gtdLoopLogOverride: string | undefined = undefined
   /** A stray `$GIT_DIR` value a scenario wants injected into the spawned bin/gtd's env — proving per-worktree state (log, memory marker) stays keyed to the cwd worktree, never the inherited GIT_DIR (@live only). */


### PR DESCRIPTION
## Summary

Running the loop in Herdr already reports state to the sidebar, but the OS notification popup+sound on every human gate and on exit becomes noisy when driving several loops at once or running unattended. This adds a `--no-notify` flag and `GTD_NO_NOTIFY` env var, mirroring the existing `--no-edit`/`GTD_NO_EDIT` flag/env shape, that suppresses only the `notification show` calls in `herdr_notify`.

`herdr_report`/`herdr_release` (the silent sidebar status) are left untouched, so Herdr's pane state stays accurate even with desktop alerts off.

Flags stay orthogonal — `--no-notify` controls desktop alerts only and implies nothing about `--no-edit`.

## Changes

- `bin/gtd` — `--no-notify`/`GTD_NO_NOTIFY` wiring around `herdr_notify`
- `README.md` + `docs/loop.md` — document the new flag/env
- `skills/loop/SKILL.md` — driver contract note
- `tests/integration/features/gtd-loop.feature` + steps/world — scenarios covering the flag and env var

## Test plan

- [ ] `npm test` (cucumber integration scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)