### PR TITLE
refactor(vars): rename env override prefix to GTD_<UPPERCASE-name>

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,13 +212,13 @@ module-global registry (no v2-style `activeWorkflow()`/`setActiveWorkflow`):
 `ConfigOperations { workflow, workflowVars, rcVars }` flows through the
 `ConfigService` Context tag like any other Effect dependency, read fresh each
 invocation — nothing to reset between tests. `src/Edge.ts`'s `resolveVars`
-merges `workflowVars`/`rcVars` with a third layer — every `GTD_VAR_`-prefixed
-entry of an injected `EnvVars` Context tag (mirroring `Cwd`/`WorktreeReader`,
-never `process.env` read directly) — into the flat `Record<string, string>`
-every template sees as `it.vars`. The engine still blesses NO variable NAMES:
-`testCommand` (the bundled templates' own `vars:` entry, read by `checking`'s
-script) is workflow-authored data like any other `it.vars` key, not a name gtd
-itself interprets.
+merges `workflowVars`/`rcVars` with a third layer — for each declared var name,
+a `GTD_<UPPERCASE-name>` entry of an injected `EnvVars` Context tag (mirroring
+`Cwd`/`WorktreeReader`, never `process.env` read directly), if defined — into
+the flat `Record<string, string>` every template sees as `it.vars`. The engine
+still blesses NO variable NAMES: `testCommand` (the bundled templates' own
+`vars:` entry, read by `checking`'s script) is workflow-authored data like any
+other `it.vars` key, not a name gtd itself interprets.
 
 The commit grammar's closed actor set still DERIVES from the active definition
 (`declaredActors` in `src/PatternMachine.ts`), so custom actor names parse

--- a/README.md
+++ b/README.md
@@ -169,11 +169,10 @@ workflow is just `.gtdrc` config — edit it or write your own (see
 [Configuration](docs/configuration.md)). Every agent state routes its model
 through two `vars` tiers — `plannerModel` (heavier planning and review) and
 `coderModel` (the coding turns) — so you can repoint the models globally in one
-place (a `vars:` edit or a `GTD_VAR_plannerModel` override) instead of per
-state. Steering-file path vars (`feedbackFile`, `reviewFile`, …) work the same
-way, and now propagate to the `on` patterns that route on them too — a repointed
-path var actually reroutes the machine, not just the templates that read/write
-the file.
+place (a `vars:` edit or a `GTD_PLANNERMODEL` override) instead of per state.
+Steering-file path vars (`feedbackFile`, `reviewFile`, …) work the same way, and
+now propagate to the `on` patterns that route on them too — a repointed path var
+actually reroutes the machine, not just the templates that read/write the file.
 
 Bare `gtd` (or `gtd loop`) is a ready-to-run driver for the whole protocol —
 point it at a repo and it runs the loop until it's your turn. It is the only

--- a/STATES.md
+++ b/STATES.md
@@ -531,8 +531,8 @@ discipline, deletes `.gtd/TODO.md`, and steps to `checking`.
 
 `checking` is a `script` state: the driver runs its inline test wrapper
 (`<%~ it.vars.testCommand %>`, default `npm test` — overridable via a top-level
-`.gtdrc` `vars:` key or `GTD_VAR_testCommand`) and steps the `check` actor. A
-red run leaves `.gtd/FEEDBACK.md` (`A`/`M` → `fixing`); a green run moves to
+`.gtdrc` `vars:` key or `GTD_TESTCOMMAND`) and steps the `check` actor. A red
+run leaves `.gtd/FEEDBACK.md` (`A`/`M` → `fixing`); a green run moves to
 `reviewing` (`D .gtd/FEEDBACK.md` cleaning a prior red run, or `C`). `fixing`'s
 `retry: { max: 3, otherwise: escalate }` redirects the fourth consecutive entry
 to the `escalate` human gate.
@@ -700,7 +700,7 @@ green.
 **Models and memory.** Every agent state draws its `model` from one of two
 `vars` tiers (`plannerModel` default `smart` for planning/architecting/review
 turns, `coderModel` default `base` for build/fix turns), repointable in one
-place (a `vars:` edit or a `GTD_VAR_` override). Each also declares a `memory:`
+place (a `vars:` edit or a `GTD_` override). Each also declares a `memory:`
 scope label (`plan`/`build`/`fix`/`review`) — an opaque hint the `--json`
 commands emit verbatim so a memory-aware driver retains an agent's memory within
 a loop (same label across laps) and clears it at a phase boundary. gtd never

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -358,7 +358,7 @@ a filename var the same way `file:`/content does — e.g.
 every pattern's key against `it.vars` ALONE (no diffs/commit hashes — a pattern
 only ever needs to name a path) before handing the edges to the pure engine,
 which only ever matches plain, already-rendered strings. This is what lets a
-repointed filename var (`.gtdrc`'s top-level `vars:`, or a `GTD_VAR_` override)
+repointed filename var (`.gtdrc`'s top-level `vars:`, or a `GTD_` override)
 reroute the machine consistently: `file:` (and any template reading/ writing
 that path) and the `on` map that decides what a change to it MEANS both follow
 the same var. A pattern written with a literal `.gtd/…` path instead of the var
@@ -718,11 +718,13 @@ layers, **later wins**:
    inside it) — per-repo tuning without redefining the whole workflow. Subject
    to the same cwd→home deep merge as everything else in `.gtdrc` (innermost
    wins per-key).
-3. **`GTD_VAR_<name>` environment variables** — highest precedence, checked at
-   every invocation. The prefix is stripped and the REMAINING CASE matched
-   exactly: `GTD_VAR_testCommand` sets `testCommand`, not `TESTCOMMAND` or
-   `testcommand`. This is the only layer that may introduce a name neither
-   config layer declared.
+3. **`GTD_<UPPERCASE-name>` environment variables** — highest precedence,
+   checked at every invocation, case-insensitively against each name already
+   declared by layer 1 or 2: `GTD_TESTCOMMAND` overrides `testCommand`. Unlike
+   the other two layers, the environment can only OVERRIDE a name a config layer
+   already declared — an uppercased env key can't round-trip back to an
+   arbitrary camelCase name, so a `GTD_*` var matching no declared name is
+   silently ignored.
 
 Values in layers 1–2 must be YAML scalars (string/number/boolean) — coerced to
 strings at load time; an object or array value is a load error, collected
@@ -740,7 +742,7 @@ vars:
 # highest precedence — beats both the workflow default and the .gtdrc value above.
 # The var is read at render time, so it shows up in the script `gtd next` prints
 # (and in what the loop driver then executes).
-GTD_VAR_testCommand="npm run test -- --bail" gtd next
+GTD_TESTCOMMAND="npm run test -- --bail" gtd next
 ```
 
 A template reads any of it as `it.vars.<name>`:
@@ -753,7 +755,7 @@ workflow:
     working:
       actor: agent
       prompt: "Assigned reviewer: <%= it.vars.reviewer %>"
-      model: "<%= it.vars.reviewModel %>" # a GTD_VAR_reviewModel override, or a .gtdrc vars: entry
+      model: "<%= it.vars.reviewModel %>" # a GTD_REVIEWMODEL override, or a .gtdrc vars: entry
       on:
         "* **": done
 ```

--- a/docs/design/state-file-association.md
+++ b/docs/design/state-file-association.md
@@ -63,10 +63,10 @@ Prompts and scripts that already name these files switch to the vars
 (`<%~ it.vars.todoFile %>` etc.) so each filename has ONE source of truth in
 templates. **Known limitation, documented:** `on` pattern keys are NOT Eta
 templates — the default's patterns keep literal `.gtd/…` paths, so repointing a
-filename var (`.gtdrc`/`GTD_VAR_`) without also overriding the workflow's
-patterns desyncs the machine. The vars are a DRY mechanism inside templates and
-the state↔file association, not a rename switch. (Making pattern keys var-aware
-at compile time is noted as possible future work.)
+filename var (`.gtdrc`/`GTD_`) without also overriding the workflow's patterns
+desyncs the machine. The vars are a DRY mechanism inside templates and the
+state↔file association, not a rename switch. (Making pattern keys var-aware at
+compile time is noted as possible future work.)
 
 The advanced flow of the bundled unified template (see STATES.md §10) gains the
 same `file:`/`mode:` annotations (it is the LSP-heavy flow), including
@@ -81,8 +81,8 @@ same `file:`/`mode:` annotations (it is the LSP-heavy flow), including
   code path. Config is (re)loaded lazily per request (it is small); no watcher
   needed for v1.
 - **Path→mode dispatch:** compile the definition, render every state's `file:`
-  (vars-layer context; the LSP process's env supplies `GTD_VAR_` overrides like
-  any invocation), and build a map of absolute rendered paths → mode. Document
+  (vars-layer context; the LSP process's env supplies `GTD_` overrides like any
+  invocation), and build a map of absolute rendered paths → mode. Document
   features dispatch on that map: `qa` files get question symbols + parser-error
   diagnostics; `review` files get one headline symbol per chunk that still has
   an unchecked hunk (an outline of the packages left to review — no hunk

--- a/docs/design/state-machine-validation.md
+++ b/docs/design/state-machine-validation.md
@@ -190,10 +190,10 @@ errors as load errors, closing gap #8 without executing anything impure
 
 One step further, the **undefined-variable lint**: scan template source for
 `it.vars.<name>` references and compare against the merged
-workflow-`vars:`/rc-`vars:` keys. Because a third layer (`GTD_VAR_*` env vars)
-can legitimately supply a name at run time, an unknown name is a **warning**,
-not an error. (A full "render with a tracking proxy and record misses" approach
-also works but executes template code at load — scanning the source is safer and
+workflow-`vars:`/rc-`vars:` keys. Because a third layer (`GTD_*` env vars) can
+legitimately supply a name at run time, an unknown name is a **warning**, not an
+error. (A full "render with a tracking proxy and record misses" approach also
+works but executes template code at load — scanning the source is safer and
 catches the common typo just as well.)
 
 ### 3.7 Domain cross-checks (gtd-specific lints)

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -42,7 +42,7 @@ upgrading.
   [Configuration](configuration.md)). A check's command now lives inline in its
   own `script:` content, reading a workflow-declared `it.vars` entry (the
   unified template's `testCommand`, overridable via the top-level `vars:` key or
-  a `GTD_VAR_testCommand` environment variable — see
+  a `GTD_TESTCOMMAND` environment variable — see
   [Configuration's "Variables"](configuration.md#variables)) rather than a
   blessed `testCommand` config key; squashing is a `commit:` state instead of a
   boolean flag; there is no learning phase, no decision log, and no model
@@ -158,6 +158,22 @@ loudly at load time rather than silently misinterpreting.
 **Re-copy the loop skill.** If you vendor `skills/loop/` into a consuming repo
 or agent harness, upgrading the `gtd` binary also means re-copying that skill
 from this release.
+
+## The var-override env prefix is now `GTD_<UPPERCASE-name>`, not `GTD_VAR_<name>`
+
+The environment-variable layer of `it.vars` (see
+[Configuration's "Variables"](configuration.md#variables)) changed its naming
+scheme: the exact-case `GTD_VAR_<name>` prefix is gone, replaced by
+`GTD_<UPPERCASE-name>` matched case-insensitively against each name already
+declared by the workflow's own `vars:` or the top-level `.gtdrc` `vars:` key.
+`GTD_VAR_testCommand` becomes `GTD_TESTCOMMAND`; `GTD_VAR_plannerModel` becomes
+`GTD_PLANNERMODEL`.
+
+This is also a narrowing, not just a rename: because an uppercased env key can't
+round-trip back to an arbitrary camelCase name, the environment can no longer
+introduce a var no config layer declared — a `GTD_*` env var matching no
+declared name is now silently ignored, where it previously appeared verbatim
+under its post-prefix name.
 
 ## 7.4: `gtd-loop` is gone — bare `gtd` and `gtd loop` run it directly
 

--- a/skills/authoring/SKILL.md
+++ b/skills/authoring/SKILL.md
@@ -231,7 +231,7 @@ well-formed files. It is a no-op when the file is absent.
 ## Variables
 
 `it.vars` merges three layers (later wins): `workflow.vars` (the workflow's own
-defaults) → top-level `.gtdrc` `vars:` → `GTD_VAR_<name>` environment variables.
+defaults) → top-level `.gtdrc` `vars:` → `GTD_<NAME>` environment variables.
 Values are scalars only (objects/arrays are rejected). gtd blesses **no** names
 — `testCommand`, `plannerModel`, etc. in the bundled templates are ordinary
 authored data, not keys gtd interprets. Use `vars:` to make one value (a test

--- a/src/Edge.test.ts
+++ b/src/Edge.test.ts
@@ -616,31 +616,34 @@ describe("resolveVars — the three-layer `it.vars` merge (workflow < rc < env)"
     ).toEqual({ testCommand: "npm run check", reviewer: "alice" })
   })
 
-  it("a `GTD_VAR_`-prefixed environment variable beats both the workflow default and the rc value", () => {
+  it("a `GTD_<UPPERCASE>` environment variable beats both the workflow default and the rc value", () => {
     expect(
       resolveVars(
         { testCommand: "npm test" },
         { testCommand: "npm run check" },
-        { GTD_VAR_testCommand: "echo env-wins" },
+        { GTD_TESTCOMMAND: "echo env-wins" },
       ),
     ).toEqual({ testCommand: "echo env-wins" })
   })
 
-  it("an env var may introduce a name neither config layer declared", () => {
-    expect(resolveVars({}, {}, { GTD_VAR_brandNew: "hello" })).toEqual({ brandNew: "hello" })
+  it("ignores a `GTD_*` env var whose uppercased name matches no declared var", () => {
+    expect(resolveVars({}, {}, { GTD_BRANDNEW: "hello" })).toEqual({})
   })
 
-  it("matches the `GTD_VAR_` prefix by exact remaining case — `testCommand`, not `testcommand`", () => {
-    expect(resolveVars({}, {}, { GTD_VAR_testCommand: "a", GTD_VAR_TESTCOMMAND: "b" })).toEqual({
-      testCommand: "a",
-      TESTCOMMAND: "b",
-    })
-  })
-
-  it("ignores env entries without the `GTD_VAR_` prefix, and an unset (`undefined`-valued) entry", () => {
+  it("matches only the fully-uppercased name — `GTD_TestCommand` (not all-caps) does not override", () => {
     expect(
-      resolveVars({}, {}, { PATH: "/usr/bin", GTD_VAR_kept: "yes", GTD_VAR_unset: undefined }),
-    ).toEqual({ kept: "yes" })
+      resolveVars({ testCommand: "npm test" }, {}, { GTD_TestCommand: "not-uppercase" }),
+    ).toEqual({ testCommand: "npm test" })
+  })
+
+  it("ignores env entries matching no declared var (e.g. the loop driver's own GTD_LOOP_LOG), and skips an unset (`undefined`-valued) entry for a declared var", () => {
+    expect(
+      resolveVars(
+        { kept: "default", unset: "default" },
+        {},
+        { PATH: "/usr/bin", GTD_KEPT: "yes", GTD_LOOP_LOG: "/tmp/log", GTD_UNSET: undefined },
+      ),
+    ).toEqual({ kept: "yes", unset: "default" })
   })
 })
 

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -307,24 +307,20 @@ export const computeProcessRun = (
 
 // ── Variables (`it.vars`) ────────────────────────────────────────────────────
 
-/** The `GTD_VAR_`-prefix stripped, exact-case, from every matching entry — the highest-precedence `it.vars` layer. A `value === undefined` entry (a name declared-but-unset in the environment) is skipped, never coerced to the string `"undefined"`. */
-const envVarsFrom = (env: Readonly<Record<string, string | undefined>>): Record<string, string> => {
-  const PREFIX = "GTD_VAR_"
-  const out: Record<string, string> = {}
-  for (const [key, value] of Object.entries(env)) {
-    if (value === undefined || !key.startsWith(PREFIX)) continue
-    out[key.slice(PREFIX.length)] = value
-  }
-  return out
-}
+const PREFIX = "GTD_"
 
 /**
  * Assemble the merged `it.vars` map every template sees, from three layers
  * (later wins): the active workflow's own declared `vars:` defaults
  * (`ConfigOperations.workflowVars`), the top-level `.gtdrc` `vars:` key
- * (`ConfigOperations.rcVars`), and every `GTD_VAR_`-prefixed environment
- * variable (exact-case name match after the prefix) — the only layer that
- * may introduce a name neither config layer declared. Pure: `env` is
+ * (`ConfigOperations.rcVars`), and — for each name declared by either of
+ * those two layers — a `GTD_<UPPERCASE-name>` environment variable, if
+ * defined. Unlike the first two layers, the environment can only OVERRIDE a
+ * name some config layer already declared; it can never introduce a new one
+ * (an uppercased env key can't round-trip back to an arbitrary camelCase
+ * name), so a `GTD_*` var matching no declared name is silently ignored. A
+ * `value === undefined` entry (a name declared-but-unset in the environment)
+ * is skipped, never coerced to the string `"undefined"`. Pure: `env` is
  * whatever the caller's `EnvVars` service handed it, never `process.env`
  * read directly here.
  */
@@ -332,7 +328,14 @@ export const resolveVars = (
   workflowVars: Record<string, string>,
   rcVars: Record<string, string>,
   env: Readonly<Record<string, string | undefined>>,
-): Record<string, string> => ({ ...workflowVars, ...rcVars, ...envVarsFrom(env) })
+): Record<string, string> => {
+  const merged = { ...workflowVars, ...rcVars }
+  for (const name of Object.keys(merged)) {
+    const value = env[PREFIX + name.toUpperCase()]
+    if (value !== undefined) merged[name] = value
+  }
+  return merged
+}
 
 // ── Template context ─────────────────────────────────────────────────────────
 

--- a/src/EnvVars.ts
+++ b/src/EnvVars.ts
@@ -5,7 +5,7 @@ import { Context, Layer } from "effect"
  * `WorktreeReader`: the one impure value (`process.env`) a caller needs is
  * handed in via `all`, never read directly, so `src/Edge.ts`'s `resolveVars`
  * (the three-layer `it.vars` merge — workflow default < `.gtdrc` `vars:` <
- * `GTD_VAR_`-prefixed env, highest precedence) stays a pure function of its
+ * `GTD_`-prefixed uppercase-name env, highest precedence) stays a pure function of its
  * arguments, and the in-memory test world can substitute its own env map
  * without ever touching the real `process.env`.
  */

--- a/src/PatternConfig.ts
+++ b/src/PatternConfig.ts
@@ -53,7 +53,7 @@ import { expandSubmachines } from "./Submachines.js"
  * A sibling `vars:` key INSIDE the `workflow:` value declares the workflow's
  * OWN defaults for the merged `it.vars` template map (see
  * `PatternTemplates.TemplateContext.vars`) — the lowest-precedence of its
- * three layers (a top-level `.gtdrc` `vars:` key, then `GTD_VAR_`-prefixed
+ * three layers (a top-level `.gtdrc` `vars:` key, then `GTD_<UPPERCASE-name>`
  * environment variables, both assembled by `src/Edge.ts`'s `resolveVars`,
  * override it here). Every value must be a YAML scalar (string/number/
  * boolean) — `compileVarsMap` coerces it to a string; an object/array value

--- a/src/PatternTemplates.ts
+++ b/src/PatternTemplates.ts
@@ -99,8 +99,10 @@ export interface TemplateContext {
    * assembled by `src/Edge.ts`'s `resolveVars` from three layers (later
    * wins): the workflow's own declared `vars:` defaults
    * (`CompiledWorkflowConfig.vars`), the top-level `.gtdrc` `vars:` key, and
-   * `GTD_VAR_`-prefixed environment variables (exact-case match after the
-   * prefix). Always a flat `Record<string, string>` — every source value is
+   * `GTD_<UPPERCASE-name>` environment variables, matched case-insensitively
+   * against each declared name (an env var can only override a name some
+   * config layer already declares, never introduce one). Always a flat
+   * `Record<string, string>` — every source value is
    * coerced to a string at load time (env vars are naturally strings; YAML
    * scalars in the first two layers are coerced by `PatternConfig.ts`'s
    * `compileVarsMap`). No name is blessed by the engine: `it.vars` is empty

--- a/src/workflows/unified.flat.yaml
+++ b/src/workflows/unified.flat.yaml
@@ -90,7 +90,7 @@ vars:
   specFeedbackFile: .gtd/SPEC_FEEDBACK.md
   commitMsgFile: .gtd/COMMIT_MSG.md
   # The two opaque model tiers every agent state draws from — repoint them here
-  # (or via a top-level `.gtdrc` `vars:` key / a `GTD_VAR_plannerModel` env var)
+  # (or via a top-level `.gtdrc` `vars:` key / a `GTD_PLANNERMODEL` env var)
   # to change every state on that tier at once. `plannerModel` (default "smart")
   # is the heavier tier for the one-shot planning/architecting/review turns;
   # `coderModel` (default "base") is the tier for the build/fix turns.

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -107,7 +107,7 @@ vars:
   specFeedbackFile: .gtd/SPEC_FEEDBACK.md
   commitMsgFile: .gtd/COMMIT_MSG.md
   # The two opaque model tiers every agent state draws from — repoint them here
-  # (or via a top-level `.gtdrc` `vars:` key / a `GTD_VAR_plannerModel` env var)
+  # (or via a top-level `.gtdrc` `vars:` key / a `GTD_PLANNERMODEL` env var)
   # to change every state on that tier at once. `plannerModel` (default "smart")
   # is the heavier tier for the one-shot planning/architecting/review turns;
   # `coderModel` (default "base") is the tier for the build/fix turns.

--- a/tests/integration/features/on-pattern-templates.feature
+++ b/tests/integration/features/on-pattern-templates.feature
@@ -4,7 +4,7 @@ Feature: "on" pattern keys are Eta templates over "it.vars"
   Pins that an `on` pattern key is rendered against `it.vars` at the edge
   (`src/Edge.ts`'s `renderOnEdges`) before the pure engine ever matches it —
   see `STATES.md` §3 and `docs/configuration.md`'s "on:" section. Repointing a
-  path var (a top-level `.gtdrc` `vars:` key, or a `GTD_VAR_` override) reroutes
+  path var (a top-level `.gtdrc` `vars:` key, or a `GTD_` override) reroutes
   a templated `on` pattern along with any `file:`/content template reading or
   writing the same path, instead of desyncing the machine.
 
@@ -83,7 +83,7 @@ Feature: "on" pattern keys are Eta templates over "it.vars"
     Then it fails
     And stderr contains "RENAMED.md"
 
-  Scenario: a "GTD_VAR_" override reroutes a templated "on" pattern the same way
+  Scenario: a "GTD_" override reroutes a templated "on" pattern the same way
     Given a test project
     And a gtd config file at ".gtdrc" with:
       """
@@ -115,7 +115,7 @@ Feature: "on" pattern keys are Eta templates over "it.vars"
       """
       the env-repointed output
       """
-    And an environment variable "GTD_VAR_outFile" set to "ENV_OUT.md"
+    And an environment variable "GTD_OUTFILE" set to "ENV_OUT.md"
     When I run gtd step agent
     Then it succeeds
     And the last commit subject is "gtd(agent): working → captured"

--- a/tests/integration/features/templates-vars.feature
+++ b/tests/integration/features/templates-vars.feature
@@ -4,7 +4,7 @@ Feature: "it.vars" — the three-layer merged variable map every template sees
   Pins the merged `it.vars` map (see `src/Edge.ts`'s `resolveVars` and
   `docs/configuration.md`'s "Variables" section): a workflow's own declared
   `vars:` defaults, overridden by a top-level `.gtdrc` `vars:` key, overridden
-  by a `GTD_VAR_<name>` environment variable — later wins, and `model:` is
+  by a `GTD_<NAME>` environment variable — later wins, and `model:` is
   now rendered through the same `it.vars`-carrying template context as
   content.
 
@@ -71,7 +71,7 @@ Feature: "it.vars" — the three-layer merged variable map every template sees
     And stdout contains "Assigned reviewer: bob"
     And stdout does not contain "alice"
 
-  Scenario: a "GTD_VAR_" environment variable beats both the workflow default and the ".gtdrc" value
+  Scenario: a "GTD_" environment variable beats both the workflow default and the ".gtdrc" value
     Given a test project
     And a gtd config file at ".gtdrc" with:
       """
@@ -99,14 +99,14 @@ Feature: "it.vars" — the three-layer merged variable map every template sees
       """
       a note
       """
-    And an environment variable "GTD_VAR_reviewer" set to "carol"
+    And an environment variable "GTD_REVIEWER" set to "carol"
     When I run gtd next
     Then it succeeds
     And stdout contains "Assigned reviewer: carol"
     And stdout does not contain "alice"
     And stdout does not contain "bob"
 
-  Scenario: an environment variable may introduce a name neither config layer declared
+  Scenario: an environment variable matching no declared var name is ignored, not introduced
     Given a test project
     And a gtd config file at ".gtdrc" with:
       """
@@ -130,10 +130,10 @@ Feature: "it.vars" — the three-layer merged variable map every template sees
       """
       a note
       """
-    And an environment variable "GTD_VAR_brandNew" set to "hello"
+    And an environment variable "GTD_BRANDNEW" set to "hello"
     When I run gtd next
     Then it succeeds
-    And stdout contains "Brand new: hello"
+    And stdout does not contain "hello"
 
   Scenario: the simple workflow's "checking" script renders "npm test" from its own declared default
     Given a test project
@@ -182,14 +182,14 @@ Feature: "it.vars" — the three-layer merged variable map every template sees
     And stdout contains "echo overridden"
     And stdout does not contain "npm test >"
 
-  Scenario: a "GTD_VAR_testCommand" environment variable overrides the simple workflow's own testCommand
+  Scenario: a "GTD_TESTCOMMAND" environment variable overrides the simple workflow's own testCommand
     Given a test project
     And the workflow
     And a commit "gtd(agent): checking" that adds "src/thing.ts" with:
       """
       export const thing = 1
       """
-    And an environment variable "GTD_VAR_testCommand" set to "echo env-wins"
+    And an environment variable "GTD_TESTCOMMAND" set to "echo env-wins"
     When I run gtd next
     Then it succeeds
     And stdout contains "echo env-wins"
@@ -311,14 +311,14 @@ Feature: "it.vars" — the three-layer merged variable map every template sees
     And stdout contains "\"state\":\"building\""
     And stdout contains "\"model\":\"base\""
 
-  Scenario: a "GTD_VAR_plannerModel" override repoints every planner-tier state at once
+  Scenario: a "GTD_PLANNERMODEL" override repoints every planner-tier state at once
     Given a test project
     And the workflow
     And a commit "gtd(human): planning" that adds ".gtd/TODO.md" with:
       """
       a sketch
       """
-    And an environment variable "GTD_VAR_plannerModel" set to "opus"
+    And an environment variable "GTD_PLANNERMODEL" set to "opus"
     When I run gtd next with "--json"
     Then it succeeds
     And stdout contains "\"model\":\"opus\""

--- a/tests/integration/support/steps/config.steps.ts
+++ b/tests/integration/support/steps/config.steps.ts
@@ -104,7 +104,7 @@ const scaffoldUnifiedWorkflow = (world: GtdWorld): void => {
 Given("the workflow", (world: GtdWorld) => scaffoldUnifiedWorkflow(world))
 
 // Sets an environment variable the in-memory tier's `EnvVars` layer exposes —
-// exactly the `GTD_VAR_`-prefixed highest-precedence layer of the merged
+// exactly the `GTD_<UPPERCASE-name>` highest-precedence layer of the merged
 // `it.vars` (see src/Edge.ts's `resolveVars`). Never touches the real
 // `process.env`: `world.envVars` flows straight into `inMemoryLayers`.
 Given(

--- a/tests/integration/support/world.ts
+++ b/tests/integration/support/world.ts
@@ -57,7 +57,7 @@ export class GtdWorld extends QuickPickleWorld {
   /** Explicit `$NO_COLOR` value a scenario wants exported (loop rendering scenarios, @live only). */
   noColorOverride: string | undefined = undefined
 
-  /** Environment variables the in-memory tier's `EnvVars` layer exposes (`it.vars`'s highest-precedence `GTD_VAR_` layer) — never mutates the real `process.env`. Set by `Given an environment variable "..." set to "..."`. */
+  /** Environment variables the in-memory tier's `EnvVars` layer exposes (`it.vars`'s highest-precedence `GTD_<UPPERCASE-name>` layer) — never mutates the real `process.env`. Set by `Given an environment variable "..." set to "..."`. */
   envVars: Record<string, string> = {}
 
   /** Dispatch: routes to the live or in-process implementation based on this.tier. */


### PR DESCRIPTION
## Summary

Replaces the exact-case `GTD_VAR_<name>` env override with `GTD_<UPPERCASE-name>`, matched case-insensitively against names already declared by the workflow's own `vars:` or the top-level `.gtdrc` `vars:`.

Exact-case matching was a footgun (`GTD_VAR_testCommand` vs `GTD_VAR_TESTCOMMAND` silently diverged) and let any `GTD_VAR_`-prefixed variable inject an arbitrary new name into `it.vars`. Uppercasing and requiring a prior declaration trades that flexibility for safety: an uppercased key can't round-trip back to camelCase, so the env layer can only override a declared var, never introduce one. Unrelated `GTD_`-prefixed variables (e.g. the loop driver's own `GTD_LOOP_LOG`) are now silently ignored instead of leaking into `it.vars`.

## Changes

- `resolveVars` in `src/Edge.ts` + tests
- Docs/specs: `AGENTS.md`, `README.md`, `STATES.md`, `docs/configuration.md`, `docs/design/*`, `docs/upgrading.md`, authoring skill
- Feature files: `templates-vars`, `on-pattern-templates`

## Test plan

- [ ] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)