### PR TITLE
workflow: decouple check scripts and prompts from hardcoded .gtd/

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ place (a `vars:` edit or a `GTD_VAR_plannerModel` override) instead of per
 state. Steering-file path vars (`feedbackFile`, `reviewFile`, …) work the same
 way, and now propagate to the `on` patterns that route on them too — a repointed
 path var actually reroutes the machine, not just the templates that read/write
-the file.
+the file. A separate `stateDir` var (default `.gtd`) names only where the check
+scripts keep their own scratch/bookkeeping, independent of the per-file vars —
+relocate one steering file without touching it.
 
 Bare `gtd` (or `gtd loop`) is a ready-to-run driver for the whole protocol —
 point it at a repo and it runs the loop until it's your turn. It is the only

--- a/STATES.md
+++ b/STATES.md
@@ -449,6 +449,22 @@ but validation is not a state in the machine: the producing agent self-validates
 with `gtd validate` before finishing (see §12). The simple flow's `.gtd/TODO.md`
 is a free-form plan with no `mode:`, so there is nothing to validate there.
 
+Every path in the tables below and in each agent prompt is a per-file `vars:`
+default (`vars.todoFile`, `vars.feedbackFile`, …), never a literal the machine
+special-cases — repointing a var reroutes every `on` pattern, script, and prompt
+that reads/writes it. A separate `vars.stateDir` (default `.gtd`) names only
+where the check scripts keep their OWN scratch/bookkeeping (the `.check-output`
+temp file, `review-deciding`'s exclusion of gtd's other state files from "did
+the human hand-edit code this round?") — independent of the per-file vars, so
+relocating one steering file outside `stateDir` (e.g. a root-level `REVIEW.md`,
+issue #128) needs no `stateDir` change, and each check script's
+`mkdir -p "$(dirname "$feedback")"` (etc.) creates that file's own parent
+directory regardless of where it lives. Each agent prompt's opening guard no
+longer names a directory either: it states the path-agnostic principle ("this
+workflow steers itself through its own state files — treat them as its private
+scratchpad, never as project code or documentation") and then names only the
+specific file(s) this turn's `vars:` entry owns.
+
 **Entry + shared states** (the simple-flow gate, the shared health/tail, and the
 `gtd review`/`gtd fix` gates — everything the entries share):
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -730,6 +730,15 @@ alongside every other config-shape finding (see
 ["Validation and errors"](#validation-and-errors)). Environment values are
 already strings.
 
+The bundled template also declares `stateDir: .gtd` — where its check scripts
+keep their own scratch/bookkeeping (the `.check-output` temp file,
+`review-deciding`'s exclusion of gtd's other state files when deciding whether
+the human hand-edited code this round). It is independent of the per-file vars
+(`todoFile`, `feedbackFile`, `reviewFile`, …): relocating one steering file
+outside `stateDir` needs no `stateDir` change (each check script creates that
+file's own parent directory as needed), and a project relocating its state
+wholesale sets both `stateDir` and the file vars it cares about.
+
 ```yaml
 # .gtdrc — overriding the unified template's testCommand
 vars:

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -159,6 +159,31 @@ loudly at load time rather than silently misinterpreting.
 or agent harness, upgrading the `gtd` binary also means re-copying that skill
 from this release.
 
+## Unreleased: bundled prompts no longer name `.gtd/`; a new `stateDir` var
+
+The bundled template's agent prompts used to open with a sentence naming `.gtd/`
+as the directory the agent must never touch except its own owned file. That
+framing broke down once a project repointed a steering-file var (e.g.
+`reviewFile`) outside `.gtd/`: the prompt still pointed the agent at a directory
+that no longer held the file it was writing. Every prompt's opener now states a
+path-agnostic principle instead — "this workflow steers itself through its own
+state files — treat them as its private scratchpad, never as project code or
+documentation" — and names only the specific file(s) its `vars:` entry owns.
+
+The check scripts also gained a new `vars.stateDir` (default `.gtd`) —
+independent of the per-file vars — naming only where they keep their own
+scratch/bookkeeping (the `.check-output` temp file, `review-deciding`'s
+exclusion of gtd's other state files). Each script now also creates its target
+file's own parent directory (`mkdir -p "$(dirname "$feedback")"`, etc.), so a
+per-file var repointed outside `stateDir` (or to a nested path with no existing
+parent) no longer fails to write.
+
+**Fully backward-compatible: no config change is needed.** Both `stateDir` and
+every per-file var keep their existing `.gtd/…` defaults, so an unconfigured
+repo renders byte-identical scripts and behavior to before. A repo that already
+relocated a steering-file var outside `.gtd/` (working around issue #128 for
+`reviewFile`) can keep its override as-is; nothing further to change.
+
 ## 7.4: `gtd-loop` is gone — bare `gtd` and `gtd loop` run it directly
 
 `gtd-loop`, the standalone loop-driver binary installed alongside `gtd`, no

--- a/src/workflows/unified.flat.yaml
+++ b/src/workflows/unified.flat.yaml
@@ -78,6 +78,10 @@
 
 vars:
   testCommand: npm test
+  # Where gtd keeps its own scratch/bookkeeping (the check scripts' temp output
+  # file, review-deciding's state-file exclusion). Independent of the per-file
+  # vars below — relocating a file wholesale means setting both.
+  stateDir: .gtd
   todoFile: .gtd/TODO.md
   requirementsFile: .gtd/REQUIREMENTS.md
   architectureFile: .gtd/ARCHITECTURE.md
@@ -111,11 +115,11 @@ states:
 
       To start one, create a steering file describing what you want built:
 
-      - `.gtd/TODO.md` — a short sketch — starts the SIMPLE flow (plan, build,
-        review).
-      - `.gtd/REQUIREMENTS.md` — the product requirements — starts the ADVANCED
-        flow (product + technical Q&A, package decomposition, parallel build,
-        per-package agentic review).
+      - `<%= it.vars.todoFile %>` — a short sketch — starts the SIMPLE flow
+        (plan, build, review).
+      - `<%= it.vars.requirementsFile %>` — the product requirements — starts
+        the ADVANCED flow (product + technical Q&A, package decomposition,
+        parallel build, per-package agentic review).
 
       What each change does next (then run `gtd step human`):
       <% it.edges.forEach(function (e) { if (e.describe) { %>
@@ -149,23 +153,24 @@ states:
       # gtd check turn — run the suite before starting new work; a red run
       # records .gtd/FEEDBACK.md (halt), a green run cleans it up (proceed).
       set +e
-      mkdir -p .gtd
+      mkdir -p "<%~ it.vars.stateDir %>"
       # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
       # newline after an interpolation tag, so no tag may be the last token on
       # a line — it would glue the next line's `else`/`fi` onto it and break
       # the script. Below this point everything is plain bash.
       feedback="<%~ it.vars.feedbackFile %>"
-      <%~ it.vars.testCommand %> > .gtd/.check-output 2>&1
+      mkdir -p "$(dirname "$feedback")"
+      <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
       code=$?
       if [ "$code" -ne 0 ]; then
-        if [ -s .gtd/.check-output ]; then
-          mv .gtd/.check-output "$feedback"
+        if [ -s <%~ it.vars.stateDir %>/.check-output ]; then
+          mv <%~ it.vars.stateDir %>/.check-output "$feedback"
         else
-          rm -f .gtd/.check-output
+          rm -f <%~ it.vars.stateDir %>/.check-output
           printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
       else
-        rm -f .gtd/.check-output
+        rm -f <%~ it.vars.stateDir %>/.check-output
         rm -f "$feedback"
       fi
     on:
@@ -203,9 +208,11 @@ states:
     model: <%= it.vars.plannerModel %>
     memory: plan
     prompt: |
-      You are an autonomous coding agent. `.gtd/` holds this workflow's own
-      state — never create, edit, or delete anything under `.gtd/` except
-      `<%= it.vars.todoFile %>`, which this prompt tells you to develop.
+      You are an autonomous coding agent. This workflow steers itself
+      through its own state files — treat them as its private scratchpad,
+      never as project code or documentation. The only state file this
+      turn touches is `<%= it.vars.todoFile %>`; develop it into the plan.
+      Do not create other files to hold notes or output.
 
       `<%= it.vars.todoFile %>` holds a short sketch of what to build — or, on a
       return lap, the plan you already wrote plus the human's edits and comments
@@ -262,10 +269,11 @@ states:
     model: <%= it.vars.coderModel %>
     memory: build
     prompt: |
-      You are an autonomous coding agent. `.gtd/` holds this workflow's own
-      state — never create or edit anything under `.gtd/` except deleting
-      `<%= it.vars.todoFile %>`, which this prompt tells you to delete once its
-      work is complete.
+      You are an autonomous coding agent. This workflow steers itself through
+      its own state files — treat them as its private scratchpad, never as
+      project code or documentation. The only state file this turn touches is
+      `<%= it.vars.todoFile %>`; delete it once its work is complete. Do not
+      create other files to hold notes or output.
 
       The plan to implement is: <%~ it.read(it.vars.todoFile) %>
 
@@ -287,23 +295,24 @@ states:
       # gtd check turn — run the suite before starting the advanced flow; a red
       # run records .gtd/FEEDBACK.md (halt), a green run cleans it up (proceed).
       set +e
-      mkdir -p .gtd
+      mkdir -p "<%~ it.vars.stateDir %>"
       # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
       # newline after an interpolation tag, so no tag may be the last token on
       # a line — it would glue the next line's `else`/`fi` onto it and break
       # the script. Below this point everything is plain bash.
       feedback="<%~ it.vars.feedbackFile %>"
-      <%~ it.vars.testCommand %> > .gtd/.check-output 2>&1
+      mkdir -p "$(dirname "$feedback")"
+      <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
       code=$?
       if [ "$code" -ne 0 ]; then
-        if [ -s .gtd/.check-output ]; then
-          mv .gtd/.check-output "$feedback"
+        if [ -s <%~ it.vars.stateDir %>/.check-output ]; then
+          mv <%~ it.vars.stateDir %>/.check-output "$feedback"
         else
-          rm -f .gtd/.check-output
+          rm -f <%~ it.vars.stateDir %>/.check-output
           printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
       else
-        rm -f .gtd/.check-output
+        rm -f <%~ it.vars.stateDir %>/.check-output
         rm -f "$feedback"
       fi
     on:
@@ -342,9 +351,11 @@ states:
     model: <%= it.vars.plannerModel %>
     memory: plan
     prompt: |
-      You are an autonomous coding agent. `.gtd/` holds this workflow's own
-      state — never create, edit, or delete anything under `.gtd/` except
-      `<%= it.vars.requirementsFile %>`, which this prompt tells you to develop.
+      You are an autonomous coding agent. This workflow steers itself
+      through its own state files — treat them as its private scratchpad,
+      never as project code or documentation. The only state file this turn
+      touches is `<%= it.vars.requirementsFile %>`; develop it. Do not
+      create other files to hold notes or output.
 
       `<%= it.vars.requirementsFile %>` holds the product requirements (or the
       plan you already wrote plus the human's answers on a return lap). Read it,
@@ -425,10 +436,12 @@ states:
     model: <%= it.vars.plannerModel %>
     memory: plan
     prompt: |
-      You are an autonomous coding agent. `.gtd/` holds this workflow's own
-      state — never create, edit, or delete anything under `.gtd/` except
-      `<%= it.vars.architectureFile %>` and `<%= it.vars.requirementsFile %>`,
-      which this prompt tells you to write and delete respectively.
+      You are an autonomous coding agent. This workflow steers itself
+      through its own state files — treat them as its private scratchpad,
+      never as project code or documentation. The only state files this
+      turn touches are `<%= it.vars.architectureFile %>` (write it) and
+      `<%= it.vars.requirementsFile %>` (delete it once its content is
+      folded in). Do not create other files to hold notes or output.
 
       Read `<%= it.vars.requirementsFile %>` (the converged product plan) and
       develop `<%= it.vars.architectureFile %>` from it in this one turn:
@@ -502,11 +515,12 @@ states:
     model: <%= it.vars.coderModel %>
     memory: build
     prompt: |
-      You are an autonomous coding agent. `.gtd/` holds this workflow's own
-      state — never create, edit, or delete anything under `.gtd/` except the
-      package files this prompt tells you to write (under
-      `<%= it.vars.packagesDir %>/`), and `<%= it.vars.architectureFile %>`,
-      which it tells you to delete.
+      You are an autonomous coding agent. This workflow steers itself through
+      its own state files — treat them as its private scratchpad, never as
+      project code or documentation. The only state files this turn touches
+      are the package files it writes under `<%= it.vars.packagesDir %>/` and
+      `<%= it.vars.architectureFile %>`, which it deletes. Do not create other
+      files to hold notes or output.
 
       Read `<%= it.vars.architectureFile %>` (the converged technical plan) and
       decompose it into an ordered set of WORK PACKAGES, one file each under
@@ -547,6 +561,7 @@ states:
       nextFile="<%~ it.vars.nextFile %>"
       next=$(ls <%~ it.vars.packagesDir %>/*.md 2>/dev/null | head -n 1)
       if [ -n "$next" ]; then
+        mkdir -p "$(dirname "$nextFile")"
         printf '%s' "$next" > "$nextFile"
       else
         rm -f "$nextFile"
@@ -562,11 +577,12 @@ states:
     model: <%= it.vars.coderModel %>
     memory: build
     prompt: |
-      You are an autonomous coding agent. `.gtd/` holds this workflow's own
-      state — never create, edit, or delete anything under `.gtd/`; in
-      particular do NOT delete the package file (the `spec-review` gate reads it
-      after you) and never touch `<%= it.vars.nextFile %>` — the `picking` state
-      owns it.
+      You are an autonomous coding agent. This workflow steers itself
+      through its own state files — treat them as its private scratchpad,
+      never as project code or documentation. This turn writes no state
+      file: do NOT delete the package file (the `spec-review` gate reads
+      it after you) and never touch `<%= it.vars.nextFile %>` — the
+      `picking` state owns it.
 
       The package to implement is: <%~ it.read(it.vars.nextFile) %>
 
@@ -590,23 +606,24 @@ states:
       # gtd check turn — run the suite; a red run records .gtd/FEEDBACK.md, a
       # green run cleans it up. The `on` rules decide what that means.
       set +e
-      mkdir -p .gtd
+      mkdir -p "<%~ it.vars.stateDir %>"
       # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
       # newline after an interpolation tag, so no tag may be the last token on
       # a line — it would glue the next line's `else`/`fi` onto it and break
       # the script. Below this point everything is plain bash.
       feedback="<%~ it.vars.feedbackFile %>"
-      <%~ it.vars.testCommand %> > .gtd/.check-output 2>&1
+      mkdir -p "$(dirname "$feedback")"
+      <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
       code=$?
       if [ "$code" -ne 0 ]; then
-        if [ -s .gtd/.check-output ]; then
-          mv .gtd/.check-output "$feedback"
+        if [ -s <%~ it.vars.stateDir %>/.check-output ]; then
+          mv <%~ it.vars.stateDir %>/.check-output "$feedback"
         else
-          rm -f .gtd/.check-output
+          rm -f <%~ it.vars.stateDir %>/.check-output
           printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
       else
-        rm -f .gtd/.check-output
+        rm -f <%~ it.vars.stateDir %>/.check-output
         rm -f "$feedback"
       fi
     on:
@@ -625,9 +642,12 @@ states:
       max: 3
       otherwise: adv-escalate
     prompt: |
-      You are an autonomous coding agent. `.gtd/` holds this workflow's own
-      state — never create, edit, or delete anything under `.gtd/` except
-      `<%= it.vars.feedbackFile %>`, which this prompt tells you to address.
+      You are an autonomous coding agent. This workflow steers itself
+      through its own state files — treat them as its private scratchpad,
+      never as project code or documentation. The only state file this
+      turn touches is `<%= it.vars.feedbackFile %>`; fix it per its
+      contents, or delete it if the feedback turns out to be wrong. Do not
+      create other files to hold notes or output.
 
       Read `<%= it.vars.feedbackFile %>` (the failing test output) and fix the
       code so the suite passes. Keep the change focused — do not refactor
@@ -673,10 +693,12 @@ states:
       otherwise: closing
     prompt: |
       You are an autonomous coding agent reviewing a freshly-built work package
-      against its own spec. `.gtd/` holds this workflow's own state — never
-      create, edit, or delete anything under `.gtd/` except
-      `<%= it.vars.specFeedbackFile %>`, which this prompt tells you to write
-      when — and only when — you find problems.
+      against its own spec. This workflow steers itself through its own
+      state files — treat them as its private scratchpad, never as project
+      code or documentation. The only state file this turn touches is
+      `<%= it.vars.specFeedbackFile %>`; write it only when — and only
+      when — you find problems. Do not create other files to hold notes or
+      output.
 
       The package spec is: <%~ it.read(it.vars.nextFile) %>
 
@@ -712,10 +734,11 @@ states:
     model: <%= it.vars.coderModel %>
     memory: fix
     prompt: |
-      You are an autonomous coding agent. `.gtd/` holds this workflow's own
-      state — never create, edit, or delete anything under `.gtd/` except
-      `<%= it.vars.specFeedbackFile %>`, which this prompt tells you to address
-      and then delete.
+      You are an autonomous coding agent. This workflow steers itself
+      through its own state files — treat them as its private scratchpad,
+      never as project code or documentation. The only state file this
+      turn touches is `<%= it.vars.specFeedbackFile %>`; address it, then
+      delete it. Do not create other files to hold notes or output.
 
       Read `<%= it.vars.specFeedbackFile %>` (the reviewer's concerns about the
       current package) and the package spec (`<%= it.read(it.vars.nextFile) %>`),
@@ -752,23 +775,24 @@ states:
       # gtd check turn — run the suite; a red run records .gtd/FEEDBACK.md, a
       # green run cleans it up. The `on` rules decide what that means.
       set +e
-      mkdir -p .gtd
+      mkdir -p "<%~ it.vars.stateDir %>"
       # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
       # newline after an interpolation tag, so no tag may be the last token on
       # a line — it would glue the next line's `else`/`fi` onto it and break
       # the script. Below this point everything is plain bash.
       feedback="<%~ it.vars.feedbackFile %>"
-      <%~ it.vars.testCommand %> > .gtd/.check-output 2>&1
+      mkdir -p "$(dirname "$feedback")"
+      <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
       code=$?
       if [ "$code" -ne 0 ]; then
-        if [ -s .gtd/.check-output ]; then
-          mv .gtd/.check-output "$feedback"
+        if [ -s <%~ it.vars.stateDir %>/.check-output ]; then
+          mv <%~ it.vars.stateDir %>/.check-output "$feedback"
         else
-          rm -f .gtd/.check-output
+          rm -f <%~ it.vars.stateDir %>/.check-output
           printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
       else
-        rm -f .gtd/.check-output
+        rm -f <%~ it.vars.stateDir %>/.check-output
         rm -f "$feedback"
       fi
     on:
@@ -787,9 +811,12 @@ states:
       max: 3
       otherwise: escalate
     prompt: |
-      You are an autonomous coding agent. `.gtd/` holds this workflow's own
-      state — never create, edit, or delete anything under `.gtd/` except
-      `<%= it.vars.feedbackFile %>`, which this prompt tells you to address.
+      You are an autonomous coding agent. This workflow steers itself
+      through its own state files — treat them as its private scratchpad,
+      never as project code or documentation. The only state file this
+      turn touches is `<%= it.vars.feedbackFile %>`; fix it per its
+      contents, or delete it if the feedback turns out to be wrong. Do not
+      create other files to hold notes or output.
 
       Read `<%= it.vars.feedbackFile %>` (the failing test output) and fix the
       code so the suite passes. Keep the change focused — do not refactor
@@ -833,23 +860,24 @@ states:
       # gtd check turn — run the suite before reviewing; a red run records
       # .gtd/FEEDBACK.md (halt), a green run cleans it up (proceed to reviewing).
       set +e
-      mkdir -p .gtd
+      mkdir -p "<%~ it.vars.stateDir %>"
       # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
       # newline after an interpolation tag, so no tag may be the last token on
       # a line — it would glue the next line's `else`/`fi` onto it and break
       # the script. Below this point everything is plain bash.
       feedback="<%~ it.vars.feedbackFile %>"
-      <%~ it.vars.testCommand %> > .gtd/.check-output 2>&1
+      mkdir -p "$(dirname "$feedback")"
+      <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
       code=$?
       if [ "$code" -ne 0 ]; then
-        if [ -s .gtd/.check-output ]; then
-          mv .gtd/.check-output "$feedback"
+        if [ -s <%~ it.vars.stateDir %>/.check-output ]; then
+          mv <%~ it.vars.stateDir %>/.check-output "$feedback"
         else
-          rm -f .gtd/.check-output
+          rm -f <%~ it.vars.stateDir %>/.check-output
           printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
       else
-        rm -f .gtd/.check-output
+        rm -f <%~ it.vars.stateDir %>/.check-output
         rm -f "$feedback"
       fi
     on:
@@ -890,23 +918,24 @@ states:
       # gtd check turn — run the suite to find what needs fixing; a red run
       # records .gtd/FEEDBACK.md (-> fixing), a green run cleans it up (-> idle).
       set +e
-      mkdir -p .gtd
+      mkdir -p "<%~ it.vars.stateDir %>"
       # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
       # newline after an interpolation tag, so no tag may be the last token on
       # a line — it would glue the next line's `else`/`fi` onto it and break
       # the script. Below this point everything is plain bash.
       feedback="<%~ it.vars.feedbackFile %>"
-      <%~ it.vars.testCommand %> > .gtd/.check-output 2>&1
+      mkdir -p "$(dirname "$feedback")"
+      <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
       code=$?
       if [ "$code" -ne 0 ]; then
-        if [ -s .gtd/.check-output ]; then
-          mv .gtd/.check-output "$feedback"
+        if [ -s <%~ it.vars.stateDir %>/.check-output ]; then
+          mv <%~ it.vars.stateDir %>/.check-output "$feedback"
         else
-          rm -f .gtd/.check-output
+          rm -f <%~ it.vars.stateDir %>/.check-output
           printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
       else
-        rm -f .gtd/.check-output
+        rm -f <%~ it.vars.stateDir %>/.check-output
         rm -f "$feedback"
       fi
     on:
@@ -930,11 +959,11 @@ states:
     # process's oldest), so everything below still reuses the same
     # reviewing/await-review/feedback machinery over <commitish>..HEAD.
     prompt: |
-      You are an autonomous coding agent. `.gtd/` holds this workflow's own
-      state — never create, edit, or delete anything under `.gtd/`. The one
-      file this prompt tells you to write is `<%= it.vars.reviewFile %>`;
-      write it at exactly that path (it may live outside `.gtd/`), and touch
-      nothing else under `.gtd/`.
+      You are an autonomous coding agent. This workflow steers itself
+      through its own state files — treat them as its private scratchpad,
+      never as project code or documentation. The only state file this
+      turn touches is `<%= it.vars.reviewFile %>`; write it at exactly
+      that path. Do not create other files to hold notes or output.
 
       Write `<%= it.vars.reviewFile %>` to help a human review the diff below in
       this EXACT format:
@@ -1033,18 +1062,19 @@ states:
       # also deletes REVIEW.md) is captured as feedback, not mistaken for a
       # sign-off.
       set +e
-      mkdir -p .gtd
       # Hoist the paths once, at the TOP: Eta's autoTrim eats the newline after
       # an interpolation tag, so no tag may be the last token on a line — it
       # would glue the next line onto it and break the script. Below this point
       # everything is plain bash.
+      stateDir="<%~ it.vars.stateDir %>"
       reviewFile="<%~ it.vars.reviewFile %>"
       reviewRawFile="<%~ it.vars.reviewRawFile %>"
-      # Which files did the human hand-edit this round, besides .gtd/ and the
-      # reviewFile itself (var-configurable — may live outside .gtd/, so it is
-      # excluded by exact path, not just the .gtd/ prefix)?
+      mkdir -p "$(dirname "$reviewRawFile")"
+      # Which files did the human hand-edit this round, besides stateDir and the
+      # reviewFile itself (var-configurable — may live outside stateDir, so it is
+      # excluded by exact path, not just the stateDir prefix)?
       codeFiles=$(git diff-tree --no-commit-id --name-only -r HEAD \
-        | grep -v '^\.gtd/' | grep -vxF "$reviewFile")
+        | grep -v "^$stateDir/" | grep -vxF "$reviewFile")
       # A note is any REVIEW.md change beyond a checkbox flip: normalize every
       # "[ ]"/"[x]" to a placeholder, then compare the agent's original (HEAD^)
       # against the human's version (HEAD).
@@ -1087,11 +1117,12 @@ states:
     memory: review
     prompt: |
       You are an autonomous coding agent turning raw review feedback into an
-      explicit instruction list for a builder. `.gtd/` holds this workflow's own
-      state — never create, edit, or delete anything under `.gtd/` except
-      `<%= it.vars.reviewRawFile %>` (delete it when done) and
-      `<%= it.vars.reviewFeedbackFile %>` (write it). Do NOT change any other
-      file — you classify, you do not build.
+      explicit instruction list for a builder. This workflow steers itself
+      through its own state files — treat them as its private scratchpad,
+      never as project code or documentation. The only state files this
+      turn touches are `<%= it.vars.reviewRawFile %>` (read it, then
+      delete it) and `<%= it.vars.reviewFeedbackFile %>` (write it) — do
+      NOT change any other file, you classify, you do not build.
 
       The raw review material is: <%~ it.read(it.vars.reviewRawFile) %>
 
@@ -1144,10 +1175,12 @@ states:
     # which legitimately makes no code change). The pure engine carries it inert.
     requireProgress: true
     prompt: |
-      You are an autonomous coding agent addressing review feedback. `.gtd/`
-      holds this workflow's own state — never create, edit, or delete anything
-      under `.gtd/` except `<%= it.vars.reviewFeedbackFile %>`, which this
-      prompt tells you to address and then delete.
+      You are an autonomous coding agent addressing review feedback. This
+      workflow steers itself through its own state files — treat them as
+      its private scratchpad, never as project code or documentation. The
+      only state file this turn touches is
+      `<%= it.vars.reviewFeedbackFile %>`; address it, then delete it. Do
+      not create other files to hold notes or output.
 
       The instructions to implement are: <%~ it.read(it.vars.reviewFeedbackFile) %>
 
@@ -1178,10 +1211,11 @@ states:
     model: <%= it.vars.coderModel %>
     memory: build
     prompt: |
-      You are an autonomous coding agent. The cycle is approved and done.
-      `.gtd/` holds this workflow's own state — never create, edit, or delete
-      anything under `.gtd/` except `<%= it.vars.commitMsgFile %>`, which this
-      prompt tells you to write.
+      You are an autonomous coding agent. The cycle is approved and done. This
+      workflow steers itself through its own state files — treat them as its
+      private scratchpad, never as project code or documentation. The only
+      state file this turn touches is `<%= it.vars.commitMsgFile %>`; write
+      it. Do not create other files to hold notes or output.
 
       Leave `<%= it.vars.commitMsgFile %>` uncommitted and finish your turn —
       entering this file squashes everything this process retains into one

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -50,12 +50,12 @@
 # The initial `idle` state FORKS on which steering file the human creates,
 # routing into that flow's OWN start gate:
 #
-#   * .gtd/REQUIREMENTS.md -> `adv-start-check` -> the ADVANCED flow (product +
-#     technical Q&A, package decomposition, per-package parallel build +
-#     agentic spec-review).
-#   * anything else (e.g. .gtd/TODO.md) -> `start-check` -> the SIMPLE flow (one
-#     grilling Q&A loop, a monolithic build, no decomposition, no agentic
-#     review).
+#   * the configured requirementsFile (default .gtd/REQUIREMENTS.md) ->
+#     `adv-start-check` -> the ADVANCED flow (product + technical Q&A, package
+#     decomposition, per-package parallel build + agentic spec-review).
+#   * anything else (e.g. the configured todoFile, default .gtd/TODO.md) ->
+#     `start-check` -> the SIMPLE flow (one grilling Q&A loop, a monolithic
+#     build, no decomposition, no agentic review).
 #
 # A third entry, `gtd review <commitish>`, jumps to `review-start-check`
 # (reviewEntry) and, once green, to `reviewing` to review a foreign branch
@@ -95,6 +95,10 @@
 
 vars:
   testCommand: npm test
+  # Where gtd keeps its own scratch/bookkeeping (the check scripts' temp output
+  # file, review-deciding's state-file exclusion). Independent of the per-file
+  # vars below — relocating a file wholesale means setting both.
+  stateDir: .gtd
   todoFile: .gtd/TODO.md
   requirementsFile: .gtd/REQUIREMENTS.md
   architectureFile: .gtd/ARCHITECTURE.md
@@ -116,7 +120,8 @@ vars:
 
 submachines:
   # ── DEDUP: the check/fix/escalate health triple ───────────────────────────
-  # Runs the suite; a red run records .gtd/FEEDBACK.md, a green run cleans it up.
+  # Runs the suite; a red run records the configured feedbackFile, a green run
+  # cleans it up.
   # The `on` rules turn that into "fix" vs "$onGreen". The fix turn retries up to
   # 3× before escalating to a human. Invoked for the shared build tail
   # (checking/fixing/escalate -> reviewing) and the advanced package loop
@@ -132,23 +137,24 @@ submachines:
           # gtd check turn — run the suite; a red run records .gtd/FEEDBACK.md, a
           # green run cleans it up. The `on` rules decide what that means.
           set +e
-          mkdir -p .gtd
+          mkdir -p "<%~ it.vars.stateDir %>"
           # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
           # newline after an interpolation tag, so no tag may be the last token on
           # a line — it would glue the next line's `else`/`fi` onto it and break
           # the script. Below this point everything is plain bash.
           feedback="<%~ it.vars.feedbackFile %>"
-          <%~ it.vars.testCommand %> > .gtd/.check-output 2>&1
+          mkdir -p "$(dirname "$feedback")"
+          <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
           code=$?
           if [ "$code" -ne 0 ]; then
-            if [ -s .gtd/.check-output ]; then
-              mv .gtd/.check-output "$feedback"
+            if [ -s <%~ it.vars.stateDir %>/.check-output ]; then
+              mv <%~ it.vars.stateDir %>/.check-output "$feedback"
             else
-              rm -f .gtd/.check-output
+              rm -f <%~ it.vars.stateDir %>/.check-output
               printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
             fi
           else
-            rm -f .gtd/.check-output
+            rm -f <%~ it.vars.stateDir %>/.check-output
             rm -f "$feedback"
           fi
         on:
@@ -166,9 +172,12 @@ submachines:
           max: 3
           otherwise: escalate
         prompt: |
-          You are an autonomous coding agent. `.gtd/` holds this workflow's own
-          state — never create, edit, or delete anything under `.gtd/` except
-          `<%= it.vars.feedbackFile %>`, which this prompt tells you to address.
+          You are an autonomous coding agent. This workflow steers itself
+          through its own state files — treat them as its private scratchpad,
+          never as project code or documentation. The only state file this
+          turn touches is `<%= it.vars.feedbackFile %>`; fix it per its
+          contents, or delete it if the feedback turns out to be wrong. Do not
+          create other files to hold notes or output.
 
           Read `<%= it.vars.feedbackFile %>` (the failing test output) and fix the
           code so the suite passes. Keep the change focused — do not refactor
@@ -197,7 +206,7 @@ submachines:
 
   # ── DEDUP: the green-baseline gate ─────────────────────────────────────────
   # Runs the suite before any work starts (its script is the health check's test
-  # wrapper — red -> .gtd/FEEDBACK.md, green -> remove it); the `on` rules turn
+  # wrapper — red -> the configured feedbackFile, green -> remove it); the `on` rules turn
   # that into "halt at blocked" vs "proceed to $onGreen". The script and blocked
   # message/describe differ per entry, so they ride in as `with:` params.
   assertGreen:
@@ -276,9 +285,11 @@ submachines:
         model: <%= it.vars.plannerModel %>
         memory: plan
         prompt: |
-          You are an autonomous coding agent. `.gtd/` holds this workflow's own
-          state — never create, edit, or delete anything under `.gtd/` except
-          `<%= it.vars.todoFile %>`, which this prompt tells you to develop.
+          You are an autonomous coding agent. This workflow steers itself
+          through its own state files — treat them as its private scratchpad,
+          never as project code or documentation. The only state file this
+          turn touches is `<%= it.vars.todoFile %>`; develop it into the plan.
+          Do not create other files to hold notes or output.
 
           `<%= it.vars.todoFile %>` holds a short sketch of what to build — or, on a
           return lap, the plan you already wrote plus the human's edits and comments
@@ -346,11 +357,11 @@ submachines:
         # process's oldest), so everything below still reuses the same
         # reviewing/await-review/feedback machinery over <commitish>..HEAD.
         prompt: |
-          You are an autonomous coding agent. `.gtd/` holds this workflow's own
-          state — never create, edit, or delete anything under `.gtd/`. The one
-          file this prompt tells you to write is `<%= it.vars.reviewFile %>`;
-          write it at exactly that path (it may live outside `.gtd/`), and touch
-          nothing else under `.gtd/`.
+          You are an autonomous coding agent. This workflow steers itself
+          through its own state files — treat them as its private scratchpad,
+          never as project code or documentation. The only state file this
+          turn touches is `<%= it.vars.reviewFile %>`; write it at exactly
+          that path. Do not create other files to hold notes or output.
 
           Write `<%= it.vars.reviewFile %>` to help a human review the diff below in
           this EXACT format:
@@ -449,18 +460,19 @@ submachines:
           # also deletes REVIEW.md) is captured as feedback, not mistaken for a
           # sign-off.
           set +e
-          mkdir -p .gtd
           # Hoist the paths once, at the TOP: Eta's autoTrim eats the newline after
           # an interpolation tag, so no tag may be the last token on a line — it
           # would glue the next line onto it and break the script. Below this point
           # everything is plain bash.
+          stateDir="<%~ it.vars.stateDir %>"
           reviewFile="<%~ it.vars.reviewFile %>"
           reviewRawFile="<%~ it.vars.reviewRawFile %>"
-          # Which files did the human hand-edit this round, besides .gtd/ and the
-          # reviewFile itself (var-configurable — may live outside .gtd/, so it is
-          # excluded by exact path, not just the .gtd/ prefix)?
+          mkdir -p "$(dirname "$reviewRawFile")"
+          # Which files did the human hand-edit this round, besides stateDir and the
+          # reviewFile itself (var-configurable — may live outside stateDir, so it is
+          # excluded by exact path, not just the stateDir prefix)?
           codeFiles=$(git diff-tree --no-commit-id --name-only -r HEAD \
-            | grep -v '^\.gtd/' | grep -vxF "$reviewFile")
+            | grep -v "^$stateDir/" | grep -vxF "$reviewFile")
           # A note is any REVIEW.md change beyond a checkbox flip: normalize every
           # "[ ]"/"[x]" to a placeholder, then compare the agent's original (HEAD^)
           # against the human's version (HEAD).
@@ -503,11 +515,12 @@ submachines:
         memory: review
         prompt: |
           You are an autonomous coding agent turning raw review feedback into an
-          explicit instruction list for a builder. `.gtd/` holds this workflow's own
-          state — never create, edit, or delete anything under `.gtd/` except
-          `<%= it.vars.reviewRawFile %>` (delete it when done) and
-          `<%= it.vars.reviewFeedbackFile %>` (write it). Do NOT change any other
-          file — you classify, you do not build.
+          explicit instruction list for a builder. This workflow steers itself
+          through its own state files — treat them as its private scratchpad,
+          never as project code or documentation. The only state files this
+          turn touches are `<%= it.vars.reviewRawFile %>` (read it, then
+          delete it) and `<%= it.vars.reviewFeedbackFile %>` (write it) — do
+          NOT change any other file, you classify, you do not build.
 
           The raw review material is: <%~ it.read(it.vars.reviewRawFile) %>
 
@@ -560,10 +573,12 @@ submachines:
         # which legitimately makes no code change). The pure engine carries it inert.
         requireProgress: true
         prompt: |
-          You are an autonomous coding agent addressing review feedback. `.gtd/`
-          holds this workflow's own state — never create, edit, or delete anything
-          under `.gtd/` except `<%= it.vars.reviewFeedbackFile %>`, which this
-          prompt tells you to address and then delete.
+          You are an autonomous coding agent addressing review feedback. This
+          workflow steers itself through its own state files — treat them as
+          its private scratchpad, never as project code or documentation. The
+          only state file this turn touches is
+          `<%= it.vars.reviewFeedbackFile %>`; address it, then delete it. Do
+          not create other files to hold notes or output.
 
           The instructions to implement are: <%~ it.read(it.vars.reviewFeedbackFile) %>
 
@@ -607,10 +622,12 @@ submachines:
           otherwise: $onApproved
         prompt: |
           You are an autonomous coding agent reviewing a freshly-built work package
-          against its own spec. `.gtd/` holds this workflow's own state — never
-          create, edit, or delete anything under `.gtd/` except
-          `<%= it.vars.specFeedbackFile %>`, which this prompt tells you to write
-          when — and only when — you find problems.
+          against its own spec. This workflow steers itself through its own
+          state files — treat them as its private scratchpad, never as project
+          code or documentation. The only state file this turn touches is
+          `<%= it.vars.specFeedbackFile %>`; write it only when — and only
+          when — you find problems. Do not create other files to hold notes or
+          output.
 
           The package spec is: <%~ it.read(it.vars.nextFile) %>
 
@@ -646,10 +663,11 @@ submachines:
         model: <%= it.vars.coderModel %>
         memory: fix
         prompt: |
-          You are an autonomous coding agent. `.gtd/` holds this workflow's own
-          state — never create, edit, or delete anything under `.gtd/` except
-          `<%= it.vars.specFeedbackFile %>`, which this prompt tells you to address
-          and then delete.
+          You are an autonomous coding agent. This workflow steers itself
+          through its own state files — treat them as its private scratchpad,
+          never as project code or documentation. The only state file this
+          turn touches is `<%= it.vars.specFeedbackFile %>`; address it, then
+          delete it. Do not create other files to hold notes or output.
 
           Read `<%= it.vars.specFeedbackFile %>` (the reviewer's concerns about the
           current package) and the package spec (`<%= it.read(it.vars.nextFile) %>`),
@@ -683,6 +701,7 @@ submachines:
           nextFile="<%~ it.vars.nextFile %>"
           next=$(ls <%~ it.vars.packagesDir %>/*.md 2>/dev/null | head -n 1)
           if [ -n "$next" ]; then
+            mkdir -p "$(dirname "$nextFile")"
             printf '%s' "$next" > "$nextFile"
           else
             rm -f "$nextFile"
@@ -698,11 +717,12 @@ submachines:
         model: <%= it.vars.coderModel %>
         memory: build
         prompt: |
-          You are an autonomous coding agent. `.gtd/` holds this workflow's own
-          state — never create, edit, or delete anything under `.gtd/`; in
-          particular do NOT delete the package file (the `spec-review` gate reads it
-          after you) and never touch `<%= it.vars.nextFile %>` — the `picking` state
-          owns it.
+          You are an autonomous coding agent. This workflow steers itself
+          through its own state files — treat them as its private scratchpad,
+          never as project code or documentation. This turn writes no state
+          file: do NOT delete the package file (the `spec-review` gate reads
+          it after you) and never touch `<%= it.vars.nextFile %>` — the
+          `picking` state owns it.
 
           The package to implement is: <%~ it.read(it.vars.nextFile) %>
 
@@ -772,23 +792,24 @@ use:
         # gtd check turn — run the suite before starting new work; a red run
         # records .gtd/FEEDBACK.md (halt), a green run cleans it up (proceed).
         set +e
-        mkdir -p .gtd
+        mkdir -p "<%~ it.vars.stateDir %>"
         # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
         # newline after an interpolation tag, so no tag may be the last token on
         # a line — it would glue the next line's `else`/`fi` onto it and break
         # the script. Below this point everything is plain bash.
         feedback="<%~ it.vars.feedbackFile %>"
-        <%~ it.vars.testCommand %> > .gtd/.check-output 2>&1
+        mkdir -p "$(dirname "$feedback")"
+        <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
         code=$?
         if [ "$code" -ne 0 ]; then
-          if [ -s .gtd/.check-output ]; then
-            mv .gtd/.check-output "$feedback"
+          if [ -s <%~ it.vars.stateDir %>/.check-output ]; then
+            mv <%~ it.vars.stateDir %>/.check-output "$feedback"
           else
-            rm -f .gtd/.check-output
+            rm -f <%~ it.vars.stateDir %>/.check-output
             printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
           fi
         else
-          rm -f .gtd/.check-output
+          rm -f <%~ it.vars.stateDir %>/.check-output
           rm -f "$feedback"
         fi
       blockedMessage: |
@@ -818,23 +839,24 @@ use:
         # gtd check turn — run the suite before starting the advanced flow; a red
         # run records .gtd/FEEDBACK.md (halt), a green run cleans it up (proceed).
         set +e
-        mkdir -p .gtd
+        mkdir -p "<%~ it.vars.stateDir %>"
         # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
         # newline after an interpolation tag, so no tag may be the last token on
         # a line — it would glue the next line's `else`/`fi` onto it and break
         # the script. Below this point everything is plain bash.
         feedback="<%~ it.vars.feedbackFile %>"
-        <%~ it.vars.testCommand %> > .gtd/.check-output 2>&1
+        mkdir -p "$(dirname "$feedback")"
+        <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
         code=$?
         if [ "$code" -ne 0 ]; then
-          if [ -s .gtd/.check-output ]; then
-            mv .gtd/.check-output "$feedback"
+          if [ -s <%~ it.vars.stateDir %>/.check-output ]; then
+            mv <%~ it.vars.stateDir %>/.check-output "$feedback"
           else
-            rm -f .gtd/.check-output
+            rm -f <%~ it.vars.stateDir %>/.check-output
             printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
           fi
         else
-          rm -f .gtd/.check-output
+          rm -f <%~ it.vars.stateDir %>/.check-output
           rm -f "$feedback"
         fi
       blockedMessage: |
@@ -866,23 +888,24 @@ use:
         # gtd check turn — run the suite before reviewing; a red run records
         # .gtd/FEEDBACK.md (halt), a green run cleans it up (proceed to reviewing).
         set +e
-        mkdir -p .gtd
+        mkdir -p "<%~ it.vars.stateDir %>"
         # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
         # newline after an interpolation tag, so no tag may be the last token on
         # a line — it would glue the next line's `else`/`fi` onto it and break
         # the script. Below this point everything is plain bash.
         feedback="<%~ it.vars.feedbackFile %>"
-        <%~ it.vars.testCommand %> > .gtd/.check-output 2>&1
+        mkdir -p "$(dirname "$feedback")"
+        <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
         code=$?
         if [ "$code" -ne 0 ]; then
-          if [ -s .gtd/.check-output ]; then
-            mv .gtd/.check-output "$feedback"
+          if [ -s <%~ it.vars.stateDir %>/.check-output ]; then
+            mv <%~ it.vars.stateDir %>/.check-output "$feedback"
           else
-            rm -f .gtd/.check-output
+            rm -f <%~ it.vars.stateDir %>/.check-output
             printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
           fi
         else
-          rm -f .gtd/.check-output
+          rm -f <%~ it.vars.stateDir %>/.check-output
           rm -f "$feedback"
         fi
       blockedMessage: |
@@ -907,9 +930,11 @@ use:
       authorFile: <%= it.vars.requirementsFile %>
       onAdvance: architecting
       authorPrompt: |
-        You are an autonomous coding agent. `.gtd/` holds this workflow's own
-        state — never create, edit, or delete anything under `.gtd/` except
-        `<%= it.vars.requirementsFile %>`, which this prompt tells you to develop.
+        You are an autonomous coding agent. This workflow steers itself
+        through its own state files — treat them as its private scratchpad,
+        never as project code or documentation. The only state file this turn
+        touches is `<%= it.vars.requirementsFile %>`; develop it. Do not
+        create other files to hold notes or output.
 
         `<%= it.vars.requirementsFile %>` holds the product requirements (or the
         plan you already wrote plus the human's answers on a return lap). Read it,
@@ -978,10 +1003,12 @@ use:
       authorFile: <%= it.vars.architectureFile %>
       onAdvance: decompose
       authorPrompt: |
-        You are an autonomous coding agent. `.gtd/` holds this workflow's own
-        state — never create, edit, or delete anything under `.gtd/` except
-        `<%= it.vars.architectureFile %>` and `<%= it.vars.requirementsFile %>`,
-        which this prompt tells you to write and delete respectively.
+        You are an autonomous coding agent. This workflow steers itself
+        through its own state files — treat them as its private scratchpad,
+        never as project code or documentation. The only state files this
+        turn touches are `<%= it.vars.architectureFile %>` (write it) and
+        `<%= it.vars.requirementsFile %>` (delete it once its content is
+        folded in). Do not create other files to hold notes or output.
 
         Read `<%= it.vars.requirementsFile %>` (the converged product plan) and
         develop `<%= it.vars.architectureFile %>` from it in this one turn:
@@ -1070,11 +1097,11 @@ states:
 
       To start one, create a steering file describing what you want built:
 
-      - `.gtd/TODO.md` — a short sketch — starts the SIMPLE flow (plan, build,
-        review).
-      - `.gtd/REQUIREMENTS.md` — the product requirements — starts the ADVANCED
-        flow (product + technical Q&A, package decomposition, parallel build,
-        per-package agentic review).
+      - `<%= it.vars.todoFile %>` — a short sketch — starts the SIMPLE flow
+        (plan, build, review).
+      - `<%= it.vars.requirementsFile %>` — the product requirements — starts
+        the ADVANCED flow (product + technical Q&A, package decomposition,
+        parallel build, per-package agentic review).
 
       What each change does next (then run `gtd step human`):
       <% it.edges.forEach(function (e) { if (e.describe) { %>
@@ -1104,10 +1131,11 @@ states:
     model: <%= it.vars.coderModel %>
     memory: build
     prompt: |
-      You are an autonomous coding agent. `.gtd/` holds this workflow's own
-      state — never create or edit anything under `.gtd/` except deleting
-      `<%= it.vars.todoFile %>`, which this prompt tells you to delete once its
-      work is complete.
+      You are an autonomous coding agent. This workflow steers itself through
+      its own state files — treat them as its private scratchpad, never as
+      project code or documentation. The only state file this turn touches is
+      `<%= it.vars.todoFile %>`; delete it once its work is complete. Do not
+      create other files to hold notes or output.
 
       The plan to implement is: <%~ it.read(it.vars.todoFile) %>
 
@@ -1127,11 +1155,12 @@ states:
     model: <%= it.vars.coderModel %>
     memory: build
     prompt: |
-      You are an autonomous coding agent. `.gtd/` holds this workflow's own
-      state — never create, edit, or delete anything under `.gtd/` except the
-      package files this prompt tells you to write (under
-      `<%= it.vars.packagesDir %>/`), and `<%= it.vars.architectureFile %>`,
-      which it tells you to delete.
+      You are an autonomous coding agent. This workflow steers itself through
+      its own state files — treat them as its private scratchpad, never as
+      project code or documentation. The only state files this turn touches
+      are the package files it writes under `<%= it.vars.packagesDir %>/` and
+      `<%= it.vars.architectureFile %>`, which it deletes. Do not create other
+      files to hold notes or output.
 
       Read `<%= it.vars.architectureFile %>` (the converged technical plan) and
       decompose it into an ordered set of WORK PACKAGES, one file each under
@@ -1166,23 +1195,24 @@ states:
       # gtd check turn — run the suite to find what needs fixing; a red run
       # records .gtd/FEEDBACK.md (-> fixing), a green run cleans it up (-> idle).
       set +e
-      mkdir -p .gtd
+      mkdir -p "<%~ it.vars.stateDir %>"
       # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
       # newline after an interpolation tag, so no tag may be the last token on
       # a line — it would glue the next line's `else`/`fi` onto it and break
       # the script. Below this point everything is plain bash.
       feedback="<%~ it.vars.feedbackFile %>"
-      <%~ it.vars.testCommand %> > .gtd/.check-output 2>&1
+      mkdir -p "$(dirname "$feedback")"
+      <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
       code=$?
       if [ "$code" -ne 0 ]; then
-        if [ -s .gtd/.check-output ]; then
-          mv .gtd/.check-output "$feedback"
+        if [ -s <%~ it.vars.stateDir %>/.check-output ]; then
+          mv <%~ it.vars.stateDir %>/.check-output "$feedback"
         else
-          rm -f .gtd/.check-output
+          rm -f <%~ it.vars.stateDir %>/.check-output
           printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
       else
-        rm -f .gtd/.check-output
+        rm -f <%~ it.vars.stateDir %>/.check-output
         rm -f "$feedback"
       fi
     on:
@@ -1199,10 +1229,11 @@ states:
     model: <%= it.vars.coderModel %>
     memory: build
     prompt: |
-      You are an autonomous coding agent. The cycle is approved and done.
-      `.gtd/` holds this workflow's own state — never create, edit, or delete
-      anything under `.gtd/` except `<%= it.vars.commitMsgFile %>`, which this
-      prompt tells you to write.
+      You are an autonomous coding agent. The cycle is approved and done. This
+      workflow steers itself through its own state files — treat them as its
+      private scratchpad, never as project code or documentation. The only
+      state file this turn touches is `<%= it.vars.commitMsgFile %>`; write
+      it. Do not create other files to hold notes or output.
 
       Leave `<%= it.vars.commitMsgFile %>` uncommitted and finish your turn —
       entering this file squashes everything this process retains into one

--- a/tests/integration/features/feedback-outside-gtd.feature
+++ b/tests/integration/features/feedback-outside-gtd.feature
@@ -1,0 +1,40 @@
+@live
+Feature: A red check writes feedbackFile even when it lives outside stateDir
+
+  The check scripts (`src/workflows/unified.yaml`) used to only ensure the
+  scratch directory (`.gtd`) existed (`mkdir -p .gtd`) before writing the
+  feedback file into it — fine while `feedbackFile` stayed under that same
+  directory, but once it is repointed elsewhere (a `vars:` override, e.g. a
+  nested `notes/FEEDBACK.md` whose parent directory was never created), the
+  write's redirection fails silently: the shell command errors out before
+  `printf` runs, the tree stays clean, and the check step wrongly reads that
+  as a passing suite (`checking`'s "C" pattern routes to `reviewing`) instead
+  of surfacing the failure. The fix adds a `mkdir -p "$(dirname "$feedback")"`
+  right after hoisting the feedback path, so a relocated feedbackFile's parent
+  directory is created regardless of where it lives — `stateDir` stays at its
+  default (`.gtd`) so the scratch check-output file still lands there
+  unaffected.
+
+  This scenario actually EXECUTES the rendered script (`I execute the printed
+  check script`) rather than simulating its outcome by hand — the bug lives in
+  the script's own shell logic, which `@inmem` scenarios never run (see
+  AGENTS.md and review-signoff-outside-gtd.feature, which covers the same
+  class of bug for `reviewFile`/issue #128).
+
+  Scenario: a red check writes the relocated feedbackFile and routes to fixing, not reviewing
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      vars:
+        feedbackFile: notes/FEEDBACK.md
+        testCommand: "false"
+      """
+    And a commit "gtd(agent): building → checking" that adds "NOTE.md" with:
+      """
+      a note
+      """
+    When I run gtd next with "--json"
+    And I execute the printed check script
+    And I run gtd step check
+    Then it succeeds
+    And the last commit subject is "gtd(check): checking → fixing"

--- a/tests/integration/features/templates-vars.feature
+++ b/tests/integration/features/templates-vars.feature
@@ -146,6 +146,19 @@ Feature: "it.vars" — the three-layer merged variable map every template sees
     Then it succeeds
     And stdout contains "npm test > .gtd/.check-output"
 
+  Scenario: a "GTD_VAR_stateDir" override relocates the check script's scratch output path
+    Given a test project
+    And the workflow
+    And a commit "gtd(agent): checking" that adds "src/thing.ts" with:
+      """
+      export const thing = 1
+      """
+    And an environment variable "GTD_VAR_stateDir" set to ".wf"
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "npm test > .wf/.check-output"
+    And stdout does not contain ".gtd/.check-output"
+
   Scenario: a top-level "vars:" overrides the workflow's own testCommand default
     Given a test project
     And a gtd config file at ".gtdrc" with:


### PR DESCRIPTION
## Summary

The bundled template's check scripts only ever `mkdir -p .gtd` before writing to a var-configurable `feedbackFile`/`reviewRawFile`/`nextFile`, so repointing one of those vars outside `.gtd/` (e.g. to a nested path with no existing parent) made the write silently fail — the redirect errored before the script could record failure output, the tree stayed clean, and the check step misread that as a green run. Agent prompts had the same assumption baked in, framing `.gtd/` itself as the boundary instead of naming the actual file(s) a turn owns.

## Changes

- Introduce a `stateDir` var (default `.gtd`), independent of the per-file vars, naming only where check scripts keep their own scratch/bookkeeping (the `.check-output` temp file, review-deciding's exclusion of gtd's own state files).
- Each script now `mkdir -p`s the parent directory of its actual target file before writing, so a relocated var works regardless of where it points.
- Every agent prompt's opener rewritten to a path-agnostic principle — state files are a private scratchpad, never project code — naming only the specific file(s) that turn's vars own, rather than hardcoding a directory.

## Compatibility

Fully backward compatible: both `stateDir` and every per-file var keep their existing `.gtd/...` defaults, so an unconfigured repo renders byte-identical scripts and behavior.

## Tests

Adds `feedback-outside-gtd.feature` and extends `templates-vars.feature`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)