### PR TITLE
feat(workflow): mechanically sweep spent steering files at check time

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ steering-file entries are chosen by which file you create:
   agent develops your sketch into a concrete plan — deciding open points itself
   rather than asking questions — and hands it back for you to accept as-is or
   edit. Editing sends it round again; accepting builds the plan in one turn and
-  runs your tests (looping on failures).
+  runs your tests (looping on failures) — the check run also mechanically sweeps
+  `.gtd/TODO.md` and other spent steering files, so a plan that's left in place
+  by mistake never leaks into the review diff or the final squash.
 - Create **`.gtd/REQUIREMENTS.md`** to start the **advanced** flow: two-phase
   product then technical Q&A (`.gtd/REQUIREMENTS.md` → `.gtd/ARCHITECTURE.md`) —
   each open question offers a couple of candidate answers plus a

--- a/STATES.md
+++ b/STATES.md
@@ -478,7 +478,7 @@ specific file(s) this turn's `vars:` entry owns.
 | `planning`             | Refining the plan            | agent | prompt  | `* **` → `plan-review`                                                                                         | —                  | `smart` | `plan`   | `vars.todoFile` / `prose`    |
 | `plan-review`          | Awaiting your review         | human | message | `C` → `building`; `* **` → `planning`                                                                          | —                  | —       | —        | `vars.todoFile` / `prose`    |
 | `building`             | Building                     | agent | prompt  | `* **` → `checking`                                                                                            | —                  | `base`  | `build`  | `vars.todoFile`              |
-| `checking`             | Running checks               | check | script  | `A`/`M .gtd/FEEDBACK.md` → `fixing`; `D .gtd/FEEDBACK.md` → `reviewing`; `C` → `reviewing`                     | —                  | —       | —        | —                            |
+| `checking`             | Running checks               | check | script  | `A`/`M .gtd/FEEDBACK.md` → `fixing`; `* **` → `reviewing`; `C` → `reviewing`                                   | —                  | —       | —        | —                            |
 | `fixing`               | Fixing the check             | agent | prompt  | `* **` → `checking`                                                                                            | max 3 → `escalate` | `base`  | `fix`    | `vars.feedbackFile`          |
 | `escalate`             | Escalating to a human        | human | message | `* **` → `checking`                                                                                            | —                  | —       | —        | `vars.feedbackFile`          |
 | `review-start-check`   | Checking the baseline        | check | script  | `A`/`M .gtd/FEEDBACK.md` → `review-start-blocked`; `D .gtd/FEEDBACK.md` → `reviewing`; `C` → `reviewing`       | —                  | —       | —        | —                            |
@@ -510,7 +510,7 @@ each fronted by the `adv-start-check` green-baseline gate):
 | `decompose`           | Decomposing into packages   | agent | prompt  | `* .gtd/packages/**` → `picking`                                                                                                     | —                      | `base`  | `build`  | —                              |
 | `picking`             | Picking the next package    | check | script  | `D .gtd/NEXT.md` → `reviewing`; `* .gtd/NEXT.md` → `adv-building`; `C` → `reviewing`                                                 | —                      | —       | —        | —                              |
 | `adv-building`        | Building                    | agent | prompt  | `* **` → `adv-checking`                                                                                                              | —                      | `base`  | `build`  | —                              |
-| `adv-checking`        | Running checks              | check | script  | `A`/`M .gtd/FEEDBACK.md` → `adv-fixing`; `D .gtd/FEEDBACK.md` → `spec-review`; `C` → `spec-review`                                   | —                      | —       | —        | —                              |
+| `adv-checking`        | Running checks              | check | script  | `A`/`M .gtd/FEEDBACK.md` → `adv-fixing`; `* **` → `spec-review`; `C` → `spec-review`                                                 | —                      | —       | —        | —                              |
 | `adv-fixing`          | Fixing the check            | agent | prompt  | `* **` → `adv-checking`                                                                                                              | max 3 → `adv-escalate` | `base`  | `fix`    | `vars.feedbackFile`            |
 | `adv-escalate`        | Escalating to a human       | human | message | `* **` → `adv-checking`                                                                                                              | —                      | —       | —        | `vars.feedbackFile`            |
 | `spec-review`         | Reviewing the package       | agent | prompt  | `A`/`M .gtd/SPEC_FEEDBACK.md` → `spec-fix`; `D .gtd/SPEC_FEEDBACK.md` → `closing`; `C` → `closing`                                   | max 3 → `closing`      | `smart` | `review` | —                              |
@@ -549,11 +549,20 @@ discipline, deletes `.gtd/TODO.md`, and steps to `checking`.
 
 `checking` is a `script` state: the driver runs its inline test wrapper
 (`<%~ it.vars.testCommand %>`, default `npm test` — overridable via a top-level
-`.gtdrc` `vars:` key or `GTD_TESTCOMMAND`) and steps the `check` actor. A red
-run leaves `.gtd/FEEDBACK.md` (`A`/`M` → `fixing`); a green run moves to
-`reviewing` (`D .gtd/FEEDBACK.md` cleaning a prior red run, or `C`). `fixing`'s
-`retry: { max: 3, otherwise: escalate }` redirects the fourth consecutive entry
-to the `escalate` human gate.
+`.gtdrc` `vars:` key or `GTD_TESTCOMMAND`) and steps the `check` actor. Before
+the suite runs, the same script mechanically sweeps every steering file spent by
+the states that lead here — `.gtd/TODO.md` (from `building`),
+`.gtd/REVIEW_RAW.md` (from `feedback-collecting`), `.gtd/REVIEW_FEEDBACK.md`
+(from `feedback-building`) — with an idempotent `rm -f`, so a leaked plan or
+raw-feedback file never rides into the review diff or the final squash even when
+the producing agent's own delete instruction was skipped (the prompts' delete
+instructions are best-effort, not the guarantee). A red run leaves
+`.gtd/FEEDBACK.md` (`A`/`M` → `fixing`); a green run moves to `reviewing`
+(`* **` catches any sweep the script performed, and a bare `C` covers a
+sweep-free green run) — because the only red signal at this state is
+`.gtd/FEEDBACK.md`, so any other pending change is by construction the script's
+own cleanup. `fixing`'s `retry: { max: 3, otherwise: escalate }` redirects the
+fourth consecutive entry to the `escalate` human gate.
 
 **Review — REVIEW.md checkboxes.** `reviewing` (agent, `plannerModel`) writes
 `.gtd/REVIEW.md` grouping the diff into reviewable chunks in the exact
@@ -674,13 +683,17 @@ agent finalize lap, so the answers are always merged before advancing).
 A clean step moves to `decompose`, which reads `.gtd/ARCHITECTURE.md` and writes
 an ordered set of **work packages** under `.gtd/packages/` (one file each), then
 deletes `.gtd/ARCHITECTURE.md`. Each package file describes a set of
-**independent** tasks. `picking` is the deterministic queue arbiter: it takes
-the first package file (by name) into `.gtd/NEXT.md`, or removes `.gtd/NEXT.md`
-when the queue is empty (`D .gtd/NEXT.md` → `reviewing`, closing out to the
-shared tail). `adv-building` reads the package in `.gtd/NEXT.md` and implements
-ALL its tasks in one turn, **fanning the independent tasks out to parallel
-subagents** — gtd stays a single-branch serial machine; the parallelism is the
-agent's, inside one turn. It leaves the package file in place for review.
+**independent** tasks. `picking` is the deterministic queue arbiter: before
+picking, its script also mechanically sweeps `.gtd/REQUIREMENTS.md` and
+`.gtd/ARCHITECTURE.md` — spent by `architecting` and `decompose` respectively by
+the time the package queue starts — with an idempotent `rm -f`, the same
+best-effort-prompt-plus-mechanical-guarantee pattern `checking` uses. It then
+takes the first package file (by name) into `.gtd/NEXT.md`, or removes
+`.gtd/NEXT.md` when the queue is empty (`D .gtd/NEXT.md` → `reviewing`, closing
+out to the shared tail). `adv-building` reads the package in `.gtd/NEXT.md` and
+implements ALL its tasks in one turn, **fanning the independent tasks out to
+parallel subagents** — gtd stays a single-branch serial machine; the parallelism
+is the agent's, inside one turn. It leaves the package file in place for review.
 
 `adv-checking` runs the suite (a red run → `adv-fixing`, capped to
 `adv-escalate`); a green run reaches the per-package `spec-review` gate. There

--- a/src/workflows/unified.flat.yaml
+++ b/src/workflows/unified.flat.yaml
@@ -561,6 +561,12 @@ states:
       # it would glue the next line's `else`/`fi` onto it and break the script.
       # Below this point everything is plain bash.
       nextFile="<%~ it.vars.nextFile %>"
+      # Sweep the advanced flow's spent Q&A steering files: requirementsFile
+      # is consumed by architecting, architectureFile by decompose — both are
+      # gone by the time the package queue starts. No-op if already removed.
+      requirements="<%~ it.vars.requirementsFile %>"
+      architecture="<%~ it.vars.architectureFile %>"
+      rm -f "$requirements" "$architecture"
       next=$(ls <%~ it.vars.packagesDir %>/*.md 2>/dev/null | head -n 1)
       if [ -n "$next" ]; then
         mkdir -p "$(dirname "$nextFile")"
@@ -609,12 +615,20 @@ states:
       # green run cleans it up. The `on` rules decide what that means.
       set +e
       mkdir -p "<%~ it.vars.stateDir %>"
-      # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
-      # newline after an interpolation tag, so no tag may be the last token on
-      # a line — it would glue the next line's `else`/`fi` onto it and break
+      # Hoist every path once, at the TOP: Eta's autoTrim eats the newline
+      # after an interpolation tag, so no tag may be the last token on a
+      # line — it would glue the next line's `else`/`fi` onto it and break
       # the script. Below this point everything is plain bash.
       feedback="<%~ it.vars.feedbackFile %>"
       mkdir -p "$(dirname "$feedback")"
+      # Sweep steering files spent by the states that led here: the plan
+      # (building), the raw review capture (feedback-collecting), and the
+      # feedback instructions (feedback-building) — each `rm -f` is a
+      # no-op when the file is already gone or never existed on this path.
+      todo="<%~ it.vars.todoFile %>"
+      reviewRaw="<%~ it.vars.reviewRawFile %>"
+      reviewFeedback="<%~ it.vars.reviewFeedbackFile %>"
+      rm -f "$todo" "$reviewRaw" "$reviewFeedback"
       <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
       code=$?
       if [ "$code" -ne 0 ]; then
@@ -631,7 +645,7 @@ states:
     on:
       "A <%= it.vars.feedbackFile %>": adv-fixing
       "M <%= it.vars.feedbackFile %>": adv-fixing
-      "D <%= it.vars.feedbackFile %>": spec-review
+      "* **": spec-review
       "C": spec-review
 
   adv-fixing:
@@ -778,12 +792,20 @@ states:
       # green run cleans it up. The `on` rules decide what that means.
       set +e
       mkdir -p "<%~ it.vars.stateDir %>"
-      # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
-      # newline after an interpolation tag, so no tag may be the last token on
-      # a line — it would glue the next line's `else`/`fi` onto it and break
+      # Hoist every path once, at the TOP: Eta's autoTrim eats the newline
+      # after an interpolation tag, so no tag may be the last token on a
+      # line — it would glue the next line's `else`/`fi` onto it and break
       # the script. Below this point everything is plain bash.
       feedback="<%~ it.vars.feedbackFile %>"
       mkdir -p "$(dirname "$feedback")"
+      # Sweep steering files spent by the states that led here: the plan
+      # (building), the raw review capture (feedback-collecting), and the
+      # feedback instructions (feedback-building) — each `rm -f` is a
+      # no-op when the file is already gone or never existed on this path.
+      todo="<%~ it.vars.todoFile %>"
+      reviewRaw="<%~ it.vars.reviewRawFile %>"
+      reviewFeedback="<%~ it.vars.reviewFeedbackFile %>"
+      rm -f "$todo" "$reviewRaw" "$reviewFeedback"
       <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
       code=$?
       if [ "$code" -ne 0 ]; then
@@ -800,7 +822,7 @@ states:
     on:
       "A <%= it.vars.feedbackFile %>": fixing
       "M <%= it.vars.feedbackFile %>": fixing
-      "D <%= it.vars.feedbackFile %>": reviewing
+      "* **": reviewing
       "C": reviewing
 
   fixing:

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -132,21 +132,31 @@ submachines:
       check:
         actor: check
         label: $checkLabel
-        # Anchored here and aliased by `assertGreen` (the green-baseline gate,
-        # ×3) and `fix-check` (`gtd fix` entry): one suite-check script shared
-        # by all six call sites instead of five source copies.
-        script: &suiteCheck |
+        # NOT the shared `&suiteCheck` anchor (that lives on `assertGreen`,
+        # aliased by it and by `fix-check`): this script also sweeps spent
+        # steering files (`todoFile`, `reviewRawFile`, `reviewFeedbackFile`) —
+        # a mechanic the entry/fix gates must NOT run, since they execute
+        # before planning, while a fresh sketch legitimately still exists.
+        script: |
           #!/usr/bin/env bash
           # gtd check turn — run the suite; a red run records .gtd/FEEDBACK.md, a
           # green run cleans it up. The `on` rules decide what that means.
           set +e
           mkdir -p "<%~ it.vars.stateDir %>"
-          # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
-          # newline after an interpolation tag, so no tag may be the last token on
-          # a line — it would glue the next line's `else`/`fi` onto it and break
+          # Hoist every path once, at the TOP: Eta's autoTrim eats the newline
+          # after an interpolation tag, so no tag may be the last token on a
+          # line — it would glue the next line's `else`/`fi` onto it and break
           # the script. Below this point everything is plain bash.
           feedback="<%~ it.vars.feedbackFile %>"
           mkdir -p "$(dirname "$feedback")"
+          # Sweep steering files spent by the states that led here: the plan
+          # (building), the raw review capture (feedback-collecting), and the
+          # feedback instructions (feedback-building) — each `rm -f` is a
+          # no-op when the file is already gone or never existed on this path.
+          todo="<%~ it.vars.todoFile %>"
+          reviewRaw="<%~ it.vars.reviewRawFile %>"
+          reviewFeedback="<%~ it.vars.reviewFeedbackFile %>"
+          rm -f "$todo" "$reviewRaw" "$reviewFeedback"
           <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
           code=$?
           if [ "$code" -ne 0 ]; then
@@ -163,7 +173,7 @@ submachines:
         on:
           "A <%= it.vars.feedbackFile %>": fix
           "M <%= it.vars.feedbackFile %>": fix
-          "D <%= it.vars.feedbackFile %>": $onGreen
+          "* **": $onGreen
           "C": $onGreen
       fix:
         actor: agent
@@ -218,7 +228,37 @@ submachines:
       check:
         actor: check
         label: $checkLabel
-        script: *suiteCheck
+        # Anchored here and aliased by `fix-check` (`gtd fix` entry): one
+        # suite-check script shared by all four call sites (this submachine's
+        # ×3 uses plus `fix-check`) instead of four source copies. These gates
+        # run BEFORE planning, so — unlike `makeGreen.check` — they must NOT
+        # sweep `todoFile`/`requirementsFile`: the human's fresh sketch still
+        # legitimately exists here.
+        script: &suiteCheck |
+          #!/usr/bin/env bash
+          # gtd check turn — run the suite; a red run records .gtd/FEEDBACK.md, a
+          # green run cleans it up. The `on` rules decide what that means.
+          set +e
+          mkdir -p "<%~ it.vars.stateDir %>"
+          # Hoist the feedback path once, at the TOP: Eta's autoTrim eats the
+          # newline after an interpolation tag, so no tag may be the last token on
+          # a line — it would glue the next line's `else`/`fi` onto it and break
+          # the script. Below this point everything is plain bash.
+          feedback="<%~ it.vars.feedbackFile %>"
+          mkdir -p "$(dirname "$feedback")"
+          <%~ it.vars.testCommand %> > <%~ it.vars.stateDir %>/.check-output 2>&1
+          code=$?
+          if [ "$code" -ne 0 ]; then
+            if [ -s <%~ it.vars.stateDir %>/.check-output ]; then
+              mv <%~ it.vars.stateDir %>/.check-output "$feedback"
+            else
+              rm -f <%~ it.vars.stateDir %>/.check-output
+              printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
+            fi
+          else
+            rm -f <%~ it.vars.stateDir %>/.check-output
+            rm -f "$feedback"
+          fi
         on:
           "A <%= it.vars.feedbackFile %>": blocked
           "M <%= it.vars.feedbackFile %>": blocked
@@ -704,6 +744,12 @@ submachines:
           # it would glue the next line's `else`/`fi` onto it and break the script.
           # Below this point everything is plain bash.
           nextFile="<%~ it.vars.nextFile %>"
+          # Sweep the advanced flow's spent Q&A steering files: requirementsFile
+          # is consumed by architecting, architectureFile by decompose — both are
+          # gone by the time the package queue starts. No-op if already removed.
+          requirements="<%~ it.vars.requirementsFile %>"
+          architecture="<%~ it.vars.architectureFile %>"
+          rm -f "$requirements" "$architecture"
           next=$(ls <%~ it.vars.packagesDir %>/*.md 2>/dev/null | head -n 1)
           if [ -n "$next" ]; then
             mkdir -p "$(dirname "$nextFile")"

--- a/tests/integration/features/default-workflow.feature
+++ b/tests/integration/features/default-workflow.feature
@@ -273,6 +273,23 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
     And the last commit subject is "gtd(check): checking → reviewing"
     And ".gtd/FEEDBACK.md" does not exist
 
+  Scenario: a green check run mechanically sweeps a leaked TODO.md and still moves on to reviewing (sole D .gtd/TODO.md)
+    Given a test project
+    And the workflow
+    And a commit "gtd(agent): building" that adds "src/thing.ts" with:
+      """
+      export const thing = 1
+      """
+    And a commit "gtd(agent): checking" that adds ".gtd/TODO.md" with:
+      """
+      Build a thing.
+      """
+    Given the file ".gtd/TODO.md" is deleted
+    When I run gtd step check
+    Then it succeeds
+    And the last commit subject is "gtd(check): checking → reviewing"
+    And ".gtd/TODO.md" does not exist
+
   Scenario: repeated check failures escalate once fixing's retry cap (3) is reached
     Given a test project
     And the workflow

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -67,6 +67,68 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And the git log contains "chore: calculator done"
     And "src/calc.ts" exists
 
+  Scenario: A check script's own cleanup mechanic (a sole swept deletion) advances the cycle instead of stalling
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Build the package described below: write src/calc.ts exporting add(a, b), and also leave a leaked.md scratch file behind."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: |
+              rm -f leaked.md
+              if [ -f src/calc.ts ] && grep -q add src/calc.ts; then rm -f .gtd/FEEDBACK.md; else mkdir -p .gtd && echo "missing add" > .gtd/FEEDBACK.md; fi
+            on:
+              "A .gtd/FEEDBACK.md": working
+              "M .gtd/FEEDBACK.md": working
+              "* **": reviewing
+              "C": reviewing
+          reviewing:
+            actor: human
+            message: "sign off to finish"
+            on:
+              "* **": done
+          done:
+            commit: "chore: calculator done"
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Build the package described below"*)
+          mkdir -p src
+          cat > src/calc.ts <<'CALC'
+      export const add = (a, b) => a + b
+      CALC
+          echo "scratch notes" > leaked.md
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    When I run bare gtd
+    Then it succeeds
+    And stdout contains "[you]  reviewing"
+    And the last commit subject is "gtd(check): checking → reviewing"
+    And "leaked.md" does not exist
+    And "src/calc.ts" exists
+
   Scenario: Captures the human's pending edit at the opening gate, so the human only runs gtd
     # The machine rests at the initial human gate `idle` (no gtd commit — the
     # test project's "chore: initial commit" resolves to the initial state) with


### PR DESCRIPTION
## Summary

Prompt-level delete instructions for `TODO.md`, `REQUIREMENTS.md`, `ARCHITECTURE.md`, `REVIEW_RAW.md` and `REVIEW_FEEDBACK.md` are best-effort — an agent can skip them, leaking a stale plan or raw-feedback file into the review diff and final squash. The build/fix `checking` states and the advanced flow's `picking` state now `rm -f` these files themselves before running the suite, so cleanup no longer depends on the producing agent remembering.

Because this mechanical sweep can be the only change on a green run, the `checking` states' `D <feedbackFile>` on-pattern (which only matched a feedback file disappearing) is widened to `* **`, catching any sweep output while a bare `C` still covers a sweep-free green run. The entry/fix gates (`assertGreen`, `fix-check`) intentionally keep the old narrower script and pattern via their own `&suiteCheck` anchor — they run before planning, when a fresh human sketch legitimately still exists and must not be swept.

## Changes

- `src/workflows/unified.yaml` / `unified.flat.yaml` — sweep spent steering files in `checking`/`picking`; widen the green-run on-pattern
- `STATES.md`, `README.md` — document the mechanical sweep
- `tests/integration/features/default-workflow.feature`, `gtd-loop.feature` — cover the sweep behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)