### PR TITLE
fix(check): stamp red output and collapse no-op fix commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ handful of commands drive it:
   `<commitish>..HEAD` (e.g. a colleague's PR branch), reusing the workflow's
   existing review/feedback machinery over that diff.
 - **`gtd fix`** — start a brand new process that goes straight into repairing
-  the current failing tests, then runs the shared review/squash tail (a no-op if
-  the suite is already green).
+  the current failing tests, then runs the shared review/squash tail. If the
+  suite is already green there is nothing to fix, and the log is left untouched
+  — no commit is left behind.
 - **`gtd abandon`** — end the process underway without completing it: rewind to
   the commit it started from, keeping everything it produced as uncommitted
   changes (nothing is discarded).
@@ -166,7 +167,8 @@ squash keeps and describes only the fixes made _during_ the review (not the
 reviewed changeset); a clean sign-off with no fixes becomes an empty
 `chore: human review` commit. A fourth entry, `gtd fix`, starts from a clean
 `idle` and goes straight into repairing a red baseline — repair, review, and
-squash into one commit (a no-op if the suite is already green). See
+squash into one commit. If the suite is already green there is nothing to fix,
+and the log is left untouched — no commit is left behind. See
 [STATES.md](STATES.md#10-the-bundled-workflow-template) for the full shape. The
 workflow is just `.gtdrc` config — edit it or write your own (see
 [Configuration](docs/configuration.md)). Every agent state routes its model

--- a/STATES.md
+++ b/STATES.md
@@ -413,8 +413,9 @@ start gate:
 A third entry, `gtd review <commitish>`, enters `review-start-check`
 (`reviewEntry: true`) and, once green, `reviewing`. A fourth, `gtd fix`, enters
 `fix-check` (`fixEntry: true`): a red suite drops straight into the shared
-`fixing` loop and out through the review + squash tail; a green suite is a no-op
-back to `idle` (nothing to fix).
+`fixing` loop and out through the review + squash tail; a green suite leaves the
+log untouched — nothing to fix, so the empty `gtd(human): fix-check` entry
+commit is collapsed away rather than left as a permanent no-op probe (§11).
 
 The four entries converge at `reviewing` → `await-review`. Ticking a `- [ ]` box
 means only "I reviewed this hunk"; a **comment** — not an unticked box — is what
@@ -561,8 +562,15 @@ instructions are best-effort, not the guarantee). A red run leaves
 (`* **` catches any sweep the script performed, and a bare `C` covers a
 sweep-free green run) — because the only red signal at this state is
 `.gtd/FEEDBACK.md`, so any other pending change is by construction the script's
-own cleanup. `fixing`'s `retry: { max: 3, otherwise: escalate }` redirects the
-fourth consecutive entry to the `escalate` human gate.
+own cleanup. A red run also STAMPS `.gtd/FEEDBACK.md` with an HTML comment
+carrying the current (pre-check) HEAD short hash: HEAD always advances between
+two checks (a `fixing`/`escalate` commit sits between them), so a still-red
+re-run whose test output is otherwise byte-identical to the last committed
+`.gtd/FEEDBACK.md` still registers as an `M` — without the stamp, git would see
+no diff at all (content, not exit code, is what `git diff` sees) and the clean
+tree would false-green into `reviewing`. `fixing`'s
+`retry: { max: 3, otherwise: escalate }` redirects the fourth consecutive entry
+to the `escalate` human gate.
 
 **Review — REVIEW.md checkboxes.** `reviewing` (agent, `plannerModel`) writes
 `.gtd/REVIEW.md` grouping the diff into reviewable chunks in the exact
@@ -723,10 +731,12 @@ ordinary process start). `fix-check` runs the suite: a **red** run leaves
 `.gtd/FEEDBACK.md` and drops straight into the shared `fixing` loop (→
 `checking` → the review + squash tail), so a broken baseline is repaired,
 reviewed, and squashed into one commit; a **green** run
-(`C`/`D .gtd/FEEDBACK.md`) is a no-op back to `idle` — there was nothing to fix.
-This is the standalone counterpart to the entry gates: the gates REFUSE to start
-new work on a red baseline, and `gtd fix` is the dedicated way to get back to
-green.
+(`C`/`D .gtd/FEEDBACK.md`) leaves the log untouched — there was nothing to fix,
+so the empty entry commit (and the no-op check that follows it) is collapsed
+away at the edge exactly like `gtd abandon`, rather than left as a permanent
+`gtd(check): fix-check → idle` bookkeeping commit (§11). This is the standalone
+counterpart to the entry gates: the gates REFUSE to start new work on a red
+baseline, and `gtd fix` is the dedicated way to get back to green.
 
 **Models and memory.** Every agent state draws its `model` from one of two
 `vars` tiers (`plannerModel` default `smart` for planning/architecting/review
@@ -864,6 +874,20 @@ so `computeProcessRun` reads it back unchanged.
 `.gtd/` workflow plumbing (the review doc, plan/feedback files) is pinned back
 to the real head's index while the window is open, so the editor's unstaged view
 shows only the actual code changes.
+
+**Collapsing a no-op return to the initial state.** A related edge behavior, not
+the review window itself but the same "engine oblivious, edge decides" shape:
+when a `gtd step` commit would return the machine to the workflow's initial
+state while the process retains no changes at all (`it.retainedDiff` empty), gtd
+mixed-resets past every commit that process made — exactly like `gtd abandon` —
+instead of writing that commit. The bundled template's only affected edge is
+`fix-check`'s green outcome (§10): a green `gtd fix` writes an empty
+`gtd(human): fix-check` entry commit and then finds nothing to fix, so without
+this collapse it would leave two permanent no-op commits
+(`gtd(human): fix-check` + `gtd(check): fix-check → idle`) behind on every
+probe. The pure engine still decides the target state and produces an ordinary
+`"commit"` decision; only whether that commit is actually WRITTEN is an edge
+concern.
 
 ## 12. Steering-file modes (`gtd validate`)
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -65,6 +65,7 @@ import {
   isReviewWindowState,
   matchesPattern,
   parsePattern,
+  parseStateSubject,
   reviewEntryStateOf,
   stateSubject,
   step,
@@ -495,6 +496,25 @@ const stepAsActor = (
     // human step while any open question is not answered (exactly one tick each)
     // — the advanced flow's adv-grilling-answer/architecting-answer gates.
     yield* enforceAnswerCompletenessGate(worktree.read, invoker, rest, context, decision.kind)
+    if (decision.kind === "commit") {
+      const target = parseStateSubject(decision.subject)?.state
+      if (
+        target === initialStateOf(rest.def) &&
+        context.retainedDiff.trim() === "" &&
+        run.startParentHash !== EMPTY_TREE
+      ) {
+        // A process that returns to its initial state having kept nothing (a
+        // green `gtd fix`: an empty entry commit + a green check that changed
+        // nothing) leaves no useful history — mixed-reset past its commits
+        // like `gtd abandon` rather than committing a `→ idle` turn, so a
+        // no-op probe never dirties the log. Pure engine is oblivious; this is
+        // an edge concern like the review window and the steering gate.
+        const tip = yield* git.resolveRef("HEAD")
+        yield* retainHistory(git, tip, run.startParentHash)
+        yield* git.mixedResetTo(run.startParentHash)
+        return { state: target, subject: null, cost: null, model: null }
+      }
+    }
     const outcome = yield* executeDecision(git, run, executable, context, cost, model)
     return {
       state: rest.state,

--- a/src/workflows/unified.flat.yaml
+++ b/src/workflows/unified.flat.yaml
@@ -169,6 +169,12 @@ states:
           rm -f <%~ it.vars.stateDir %>/.check-output
           printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
+        # A repeat identical failure would otherwise leave FEEDBACK.md
+        # byte-identical to its committed copy — no diff, so the check would
+        # look GREEN. Stamp each red run with the current HEAD (which always
+        # advances between checks) so a still-red re-run always re-registers
+        # as an M/A edit and takes the red edge.
+        printf '\n<!-- gtd check %s -->\n' "$(git rev-parse --short HEAD 2>/dev/null || echo pending)" >> "$feedback"
       else
         rm -f <%~ it.vars.stateDir %>/.check-output
         rm -f "$feedback"
@@ -313,6 +319,12 @@ states:
           rm -f <%~ it.vars.stateDir %>/.check-output
           printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
+        # A repeat identical failure would otherwise leave FEEDBACK.md
+        # byte-identical to its committed copy — no diff, so the check would
+        # look GREEN. Stamp each red run with the current HEAD (which always
+        # advances between checks) so a still-red re-run always re-registers
+        # as an M/A edit and takes the red edge.
+        printf '\n<!-- gtd check %s -->\n' "$(git rev-parse --short HEAD 2>/dev/null || echo pending)" >> "$feedback"
       else
         rm -f <%~ it.vars.stateDir %>/.check-output
         rm -f "$feedback"
@@ -638,6 +650,12 @@ states:
           rm -f <%~ it.vars.stateDir %>/.check-output
           printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
+        # A repeat identical failure would otherwise leave FEEDBACK.md
+        # byte-identical to its committed copy — no diff, so the check would
+        # look GREEN. Stamp each red run with the current HEAD (which always
+        # advances between checks) so a still-red re-run always re-registers
+        # as an M/A edit and takes the red edge.
+        printf '\n<!-- gtd check %s -->\n' "$(git rev-parse --short HEAD 2>/dev/null || echo pending)" >> "$feedback"
       else
         rm -f <%~ it.vars.stateDir %>/.check-output
         rm -f "$feedback"
@@ -815,6 +833,12 @@ states:
           rm -f <%~ it.vars.stateDir %>/.check-output
           printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
+        # A repeat identical failure would otherwise leave FEEDBACK.md
+        # byte-identical to its committed copy — no diff, so the check would
+        # look GREEN. Stamp each red run with the current HEAD (which always
+        # advances between checks) so a still-red re-run always re-registers
+        # as an M/A edit and takes the red edge.
+        printf '\n<!-- gtd check %s -->\n' "$(git rev-parse --short HEAD 2>/dev/null || echo pending)" >> "$feedback"
       else
         rm -f <%~ it.vars.stateDir %>/.check-output
         rm -f "$feedback"
@@ -900,6 +924,12 @@ states:
           rm -f <%~ it.vars.stateDir %>/.check-output
           printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
+        # A repeat identical failure would otherwise leave FEEDBACK.md
+        # byte-identical to its committed copy — no diff, so the check would
+        # look GREEN. Stamp each red run with the current HEAD (which always
+        # advances between checks) so a still-red re-run always re-registers
+        # as an M/A edit and takes the red edge.
+        printf '\n<!-- gtd check %s -->\n' "$(git rev-parse --short HEAD 2>/dev/null || echo pending)" >> "$feedback"
       else
         rm -f <%~ it.vars.stateDir %>/.check-output
         rm -f "$feedback"
@@ -958,6 +988,12 @@ states:
           rm -f <%~ it.vars.stateDir %>/.check-output
           printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
         fi
+        # A repeat identical failure would otherwise leave FEEDBACK.md
+        # byte-identical to its committed copy — no diff, so the check would
+        # look GREEN. Stamp each red run with the current HEAD (which always
+        # advances between checks) so a still-red re-run always re-registers
+        # as an M/A edit and takes the red edge.
+        printf '\n<!-- gtd check %s -->\n' "$(git rev-parse --short HEAD 2>/dev/null || echo pending)" >> "$feedback"
       else
         rm -f <%~ it.vars.stateDir %>/.check-output
         rm -f "$feedback"

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -166,6 +166,12 @@ submachines:
               rm -f <%~ it.vars.stateDir %>/.check-output
               printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
             fi
+            # A repeat identical failure would otherwise leave FEEDBACK.md
+            # byte-identical to its committed copy — no diff, so the check would
+            # look GREEN. Stamp each red run with the current HEAD (which always
+            # advances between checks) so a still-red re-run always re-registers
+            # as an M/A edit and takes the red edge.
+            printf '\n<!-- gtd check %s -->\n' "$(git rev-parse --short HEAD 2>/dev/null || echo pending)" >> "$feedback"
           else
             rm -f <%~ it.vars.stateDir %>/.check-output
             rm -f "$feedback"
@@ -255,6 +261,12 @@ submachines:
               rm -f <%~ it.vars.stateDir %>/.check-output
               printf 'the test command failed with exit code %s and produced no output.' "$code" > "$feedback"
             fi
+            # A repeat identical failure would otherwise leave FEEDBACK.md
+            # byte-identical to its committed copy — no diff, so the check would
+            # look GREEN. Stamp each red run with the current HEAD (which always
+            # advances between checks) so a still-red re-run always re-registers
+            # as an M/A edit and takes the red edge.
+            printf '\n<!-- gtd check %s -->\n' "$(git rev-parse --short HEAD 2>/dev/null || echo pending)" >> "$feedback"
           else
             rm -f <%~ it.vars.stateDir %>/.check-output
             rm -f "$feedback"

--- a/tests/integration/features/fix-entry.feature
+++ b/tests/integration/features/fix-entry.feature
@@ -21,13 +21,18 @@ Feature: gtd fix — start a process that goes straight into repairing failing t
     And the last commit subject is "gtd(human): fix-check"
 
   Scenario: a green suite is a no-op back to idle — nothing to fix
+    Given I record the commit count
     When I run gtd with args "fix"
     Then it succeeds
     And the last commit subject is "gtd(human): fix-check"
-    # A clean tree at the gate = tests pass = nothing to fix -> idle.
+    # A clean tree at the gate = tests pass = nothing to fix -> idle. The
+    # empty entry commit and the no-op check are collapsed away entirely — a
+    # no-op probe must never dirty the log.
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): fix-check → idle"
+    And the commit count is unchanged
+    And the git status is clean
+    And the git log does not contain "gtd("
 
   Scenario: a red suite drops into the shared fixing loop and out through checking to reviewing
     When I run gtd with args "fix"

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -1689,3 +1689,44 @@ Feature: gtd loop — the packaged reference loop driver (v3)
       pane report-agent test-pane --source herdr:gtd --agent gtd --state working --message reviewing
       """
     And the git log contains "chore: build reviewed"
+
+  Scenario: A still-red suite whose output repeats identically across checks never false-greens into review
+    # Drives the REAL bundled unified template (not a custom .gtdrc) through
+    # `gtd fix`: a suite that always fails with byte-identical output must
+    # never be mistaken for green just because a re-run produces no diff.
+    Given a test project
+    And the workflow
+    And GTD_TESTCOMMAND is set to "sh -c 'echo boom; exit 1'"
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"the failing test output"*)
+          echo x >> scratch.txt
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    When I run "fix" via gtd
+    Then it succeeds
+    When I run bare gtd
+    Then it succeeds
+    And stdout contains "[you]  Escalating to a human"
+    And the git log does not contain "checking → reviewing"
+
+  Scenario: gtd fix on a green baseline leaves the log untouched
+    # A green suite is nothing to fix: the empty `gtd(human): fix-check` entry
+    # commit and the no-op check are collapsed away rather than left as
+    # permanent bookkeeping commits.
+    Given a test project
+    And the workflow
+    And GTD_TESTCOMMAND is set to "true"
+    And I record the commit count
+    When I run "fix" via gtd
+    Then it succeeds
+    When I run bare gtd
+    Then it succeeds
+    And the commit count is unchanged
+    And stdout contains "[done] settled — nothing left to do"

--- a/tests/integration/support/steps/gtd-loop.steps.ts
+++ b/tests/integration/support/steps/gtd-loop.steps.ts
@@ -103,6 +103,7 @@ function gtdLoopEnv(world: GtdWorld): NodeJS.ProcessEnv {
     GTD_LOOP_LOG: world.gtdLoopLogOverride,
     GIT_DIR: world.gitDirOverride,
     NO_COLOR: world.noColorOverride,
+    GTD_TESTCOMMAND: world.gtdTestCommandOverride,
   }
   for (const [key, value] of Object.entries(overrides)) {
     if (value !== undefined) env[key] = value
@@ -166,6 +167,15 @@ Given("GIT_DIR points at a separate git dir", (world: GtdWorld) => {
 // NO_COLOR convention (https://no-color.org) alongside the piped-stdout case.
 Given("NO_COLOR is set to {string}", (world: GtdWorld, value: string) => {
   world.noColorOverride = value
+})
+
+// Sets $GTD_TESTCOMMAND explicitly — the bundled template's `checking`/
+// `fix-check` script reads `it.vars.testCommand`, whose highest-precedence
+// layer is this env var (see src/Edge.ts's `resolveVars`), so this reroutes
+// the real check script at a controlled, deterministic suite instead of the
+// default "npm test".
+Given("GTD_TESTCOMMAND is set to {string}", (world: GtdWorld, value: string) => {
+  world.gtdTestCommandOverride = value
 })
 
 function toFailedResult(err: unknown): { exitCode: number; stdout: string; stderr: string } {

--- a/tests/integration/support/world.ts
+++ b/tests/integration/support/world.ts
@@ -58,6 +58,8 @@ export class GtdWorld extends QuickPickleWorld {
   leakedGtdLoopLog: string | undefined = undefined
   /** Explicit `$NO_COLOR` value a scenario wants exported (loop rendering scenarios, @live only). */
   noColorOverride: string | undefined = undefined
+  /** Explicit `$GTD_TESTCOMMAND` value a scenario wants exported — overrides the bundled template's `vars.testCommand` for a real `checking`/`fix-check` script run (`gtd-loop` @live scenarios only). */
+  gtdTestCommandOverride: string | undefined = undefined
 
   /** Environment variables the in-memory tier's `EnvVars` layer exposes (`it.vars`'s highest-precedence `GTD_<UPPERCASE-name>` layer) — never mutates the real `process.env`. Set by `Given an environment variable "..." set to "..."`. */
   envVars: Record<string, string> = {}


### PR DESCRIPTION
## Summary

Two related check-semantics bugs, both stemming from the fact that a commit is only recognized by its diff, not by any prior knowledge of outcome:

- **False-green on identical red output.** A `checking`/`fix-check` run that fails with byte-identical output to the last committed `FEEDBACK.md` produced no diff at all, so a still-red re-run was indistinguishable from green and could false-green straight into review. Fixed by stamping every red run with an HTML comment carrying the current HEAD short hash; HEAD always advances between two checks, so the stamp guarantees a real diff on every red re-run.

- **No-op `gtd fix` bookkeeping noise.** A green `gtd fix` on an already-passing suite still wrote a permanent empty `gtd(human): fix-check` entry commit followed by a no-op `gtd(check): fix-check -> idle` commit. Fixed at the edge in `program.ts`: when a commit would return the machine to its initial state with no retained diff, gtd mixed-resets past the process's commits instead of writing the turn, exactly like `gtd abandon`. The pure engine still decides the target state; only whether the commit is written is an edge concern, so this generalizes to any state that empties back to idle, not just fix-check.

## Docs & tests

- Updated STATES.md / README.md to describe the collapsed no-op behavior.
- Added gtd-loop / fix-entry feature coverage for both the stamped-failure and collapsed-commit cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)