### PR TITLE
fix(loop): track reported HEAD and turn state to stop false signals

### DIFF
--- a/bin/gtd
+++ b/bin/gtd
@@ -8,7 +8,8 @@ set -euo pipefail
 #     flag-parsing block below) -> stripped here; `--no-edit` disables the
 #     loop's automatic editor launching for this run, `--edit` forces it on
 #     for this run (overriding an ambient `GTD_NO_EDIT`/`--no-edit` — the two
-#     are mutually exclusive), `--once` restricts the loop to exactly one beat
+#     are mutually exclusive: naming both together is a dedicated usage error,
+#     exit 2), `--once` restricts the loop to exactly one beat
 #     (one human gate, one script check+step, or one agent prompt+step) before
 #     exiting, and `--no-notify` (or `GTD_NO_NOTIFY`) suppresses the loop's
 #     Herdr desktop notifications for this run while leaving its silent Herdr
@@ -183,11 +184,14 @@ parse_subject() {
   fi
 }
 
-# report_commits <head_before> — walks <head_before>..HEAD in order, emitting
-# a transition/commit line per new commit; returns non-zero (having emitted
-# nothing) when there were no new commits.
+# report_commits — walks "$reported_head"..HEAD in order, emitting a
+# transition/commit line per new commit, and advances $reported_head to HEAD
+# when it reported at least one; returns non-zero (having emitted nothing,
+# and leaving $reported_head unchanged) when there were no new commits. Global
+# rather than per-beat so the review checkout window's HEAD rewinds between
+# beats never cause an already-reported commit to replay.
 report_commits() {
-  local head_before="$1" sha subject files reported=0
+  local sha subject files reported=0
   while IFS= read -r sha; do
     [[ -z "$sha" ]] && continue
     reported=1
@@ -198,7 +202,10 @@ report_commits() {
       transition) emit_transition "$S_FROM" "$S_TO" "$files" ;;
       capture | squash) emit_commit "$subject" "$files" ;;
     esac
-  done < <(git rev-list --reverse "$head_before"..HEAD)
+  done < <(git rev-list --reverse "$reported_head"..HEAD)
+  if [[ "$reported" == 1 ]]; then
+    reported_head="$(git rev-parse HEAD)"
+  fi
   [[ "$reported" == 1 ]]
 }
 
@@ -230,15 +237,17 @@ resolve_log_path() {
 # recognised in exactly two positions — bare (e.g. `gtd --edit --once`) or
 # immediately after `loop` (e.g. `gtd loop --once`) — in any order, each at
 # most once. `--edit` and `--no-edit` are mutually exclusive (forcing and
-# suppressing the editor in the same run is not a coherent request);
-# `--no-notify` conflicts with nothing (it's orthogonal to editing and to
-# `--once`). A recognised, valid combination is stripped here before anything
-# below looks at "$@", so the bundle's own unknown-option guard never sees it;
-# anything else (an unknown flag, a duplicate/conflicting one, or a flag mixed
-# with a real subcommand) is left untouched and falls through to the existing
-# dispatch below, which forwards a non-flag first argument to the bundle
-# (whose own unknown-option guard rejects it) or rejects a `loop` invocation
-# carrying an unrecognised extra argument.
+# suppressing the editor in the same run is not a coherent request): naming
+# both, with no other unrecognised token present, is rejected right here with
+# a dedicated usage error (exit 2) — it never reaches the bundle's own
+# unknown-option guard. `--no-notify` conflicts with nothing (it's orthogonal
+# to editing and to `--once`). A recognised, valid combination is stripped
+# here before anything below looks at "$@", so the bundle's own unknown-option
+# guard never sees it; anything else (an unknown flag, a duplicate flag, or a
+# flag mixed with a real subcommand) is left untouched and falls through to
+# the existing dispatch below, which forwards a non-flag first argument to the
+# bundle (whose own unknown-option guard rejects it) or rejects a `loop`
+# invocation carrying an unrecognised extra argument.
 edit_disabled=0
 edit_forced=0
 once_mode=0
@@ -255,6 +264,7 @@ else
 fi
 
 valid_combo=1
+saw_unknown=0
 n_no_edit=0
 n_edit=0
 n_once=0
@@ -265,10 +275,17 @@ for a in ${loop_flag_args[@]+"${loop_flag_args[@]}"}; do
   --edit | -e) n_edit=$((n_edit + 1)) ;;
   --once) n_once=$((n_once + 1)) ;;
   --no-notify) n_no_notify=$((n_no_notify + 1)) ;;
-  *) valid_combo=0 ;;
+  *) saw_unknown=1 ;;
   esac
 done
-if ((n_no_edit > 1 || n_edit > 1 || n_once > 1 || n_no_notify > 1 || (n_no_edit >= 1 && n_edit >= 1))); then
+# A pure loop-flag invocation (no unrecognised token) naming both --edit and
+# --no-edit gets a dedicated usage error here, rather than falling through to
+# the bundle's own unknown-option rejection below.
+if [[ "$saw_unknown" == 0 ]] && ((n_edit >= 1 && n_no_edit >= 1)); then
+  echo "gtd: --edit and --no-edit are mutually exclusive" >&2
+  exit 2
+fi
+if ((saw_unknown == 1 || n_no_edit > 1 || n_edit > 1 || n_once > 1 || n_no_notify > 1)); then
   valid_combo=0
 fi
 
@@ -455,7 +472,7 @@ Fix the reported issue and re-run gtd-loop."
   # A new commit was captured — render it, then return normally so the
   # caller keeps driving, unless --once says this one human gate is the whole
   # run.
-  report_commits "$head_before"
+  report_commits
   if [[ "$once_mode" == 1 ]]; then
     exit 0
   fi
@@ -468,6 +485,7 @@ trap 'code=$?; if [ "$code" -ne 0 ]; then
 
 prev_state=""
 prev_content=""
+prev_head=""
 # Where the last "prompt" turn's `memory` scope + session id are remembered
 # across iterations and across restarts. In the git dir, never the work tree.
 memory_marker="$(worktree_git_dir 2>/dev/null || echo .git)/gtd-loop-memory"
@@ -512,6 +530,12 @@ run_agent_turn() {
     >>"${GTD_LOOP_LOG:-/dev/null}" 2>&1
 }
 
+# The furthest commit already reported to the terminal by report_commits (see
+# its own comment) — a global high-water mark rather than a per-beat
+# head_before, so a review checkout window's HEAD rewind between beats never
+# causes an already-printed transition to replay.
+reported_head="$(git rev-parse HEAD 2>/dev/null || echo none)"
+
 # Opening move: capture the human's pending edit so gtd-loop is the ONLY command
 # a human runs. A human acts at a gate by editing files (a plan answer, a review
 # tick, a code fix) and re-launching the loop — they should never have to run
@@ -553,7 +577,11 @@ Fix the reported issue and re-run gtd-loop."
       emit_log_pointer
       exit 1
     fi
-    if [[ "$once_mode" == 1 && "$opening_head_before" != "$(git rev-parse HEAD 2>/dev/null || echo none)" ]]; then
+    # This branch reports nothing today — advance the marker past whatever was
+    # just (silently) captured so the first loop-body beat below doesn't newly
+    # print it.
+    reported_head="$(git rev-parse HEAD 2>/dev/null || echo none)"
+    if [[ "$once_mode" == 1 && "$opening_head_before" != "$reported_head" ]]; then
       exit 0
     fi
   else
@@ -598,7 +626,6 @@ while true; do
 
   if [[ "$kind" == "script" ]]; then
     emit_action "$M_CHECK" "$label"
-    head_before="$(git rev-parse HEAD 2>/dev/null || echo none)"
     # Execute the emitted wrapper verbatim; its exit code is deliberately
     # ignored (`|| true` under `set -e`) — the script encodes its outcome in
     # the tree, and `gtd step` captures whatever it left there via the state's
@@ -611,7 +638,7 @@ while true; do
       exit 1
     fi
     printf '%s\n' "$step_out" >>"$GTD_LOOP_LOG"
-    if ! report_commits "$head_before"; then
+    if ! report_commits; then
       herdr_report idle "$label"
       herdr_release
       emit_settled "$state"
@@ -626,9 +653,14 @@ while true; do
   fi
 
   # kind == "prompt": stall detection (skills/loop/SKILL.md) — the same
-  # agent-owned state and content repeating means the last dispatch made no
-  # progress; stop rather than spin on it.
-  if [[ "$state" == "$prev_state" && "$content" == "$prev_content" ]]; then
+  # agent-owned state and content repeating, WITH NO COMMIT authored since the
+  # last time we saw this beat, means the last dispatch made no progress; stop
+  # rather than spin on it. The HEAD check is what distinguishes a genuine
+  # stall from a return lap through a human gate (e.g. plan-review ->
+  # planning): a static prompt looks identical to last time, but a commit
+  # landed in between, so HEAD has moved and this isn't a stall.
+  cur_head="$(git rev-parse HEAD 2>/dev/null || echo none)"
+  if [[ "$state" == "$prev_state" && "$content" == "$prev_content" && "$cur_head" == "$prev_head" ]]; then
     next_out="$(run_gtd next 2>&1)" || true
     emit_error "no progress at '$state' — the agent's last turn changed nothing. Stopping to avoid spinning.
 $next_out"
@@ -637,6 +669,7 @@ $next_out"
   fi
   prev_state="$state"
   prev_content="$content"
+  prev_head="$cur_head"
 
   # Agent-memory scope: compare this turn's `memory` label against the last
   # prompt turn's (persisted in $memory_marker). Same non-empty label AND a
@@ -673,7 +706,6 @@ $next_out"
   # driver-side equivalent, so the next rest is only ever handed a well-formed
   # file. gtd itself never validates at step time — this is the loop's job.
   emit_action "$M_AGENT" "$label"
-  head_before="$(git rev-parse HEAD 2>/dev/null || echo none)"
   run_agent_turn "$content" "$resume"
 
   fix_attempt=0
@@ -704,7 +736,7 @@ Stopping rather than stepping with a malformed steering file."
   # A no-op step (nothing matched a declared pattern on a clean tree) reports
   # zero commits here — report_commits returns non-zero, and that's fine: the
   # NEXT iteration's stall check is what catches unchanged state/content.
-  report_commits "$head_before" || true
+  report_commits || true
   if [[ "$once_mode" == 1 ]]; then
     exit 0
   fi

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,10 +113,12 @@ each recognized bare (`gtd --no-edit`) or immediately after `loop`
 `gtd loop` are themselves equivalent. All three combine freely with each other,
 in any order (e.g. `gtd --edit --once`, `gtd loop --once --edit`), except
 `--edit`/`--no-edit` together, which conflict (forcing and suppressing the
-editor in the same run is not a coherent request). Any other placement (e.g.
-`gtd step --once`), a duplicated flag (`gtd --once --once`), or the
-`--edit`/`--no-edit` conflict is a usage error, surfaced via whatever guard the
-misplaced argument first reaches (the compiled bundle's own
+editor in the same run is not a coherent request): naming both, in either
+position, is rejected right in `bin/gtd` with a dedicated usage error
+(`gtd: --edit and --no-edit are mutually exclusive`, exit 2) — it never reaches
+the compiled bundle. Any other placement (e.g. `gtd step --once`) or a
+duplicated flag (`gtd --once --once`) is still a usage error, but surfaced via
+whatever guard the misplaced argument first reaches (the compiled bundle's own
 unknown-option/unknown-command rejection for a misplaced flag, or
 `gtd: 'loop' takes no arguments` for one misplaced after `loop`) — never
 silently ignored or silently resolved one way.

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -625,6 +625,71 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And stderr contains "no progress at 'working'"
     And stderr contains "see .git/gtd-loop.log"
 
+  Scenario: A human-gate return lap runs the agent's fold turn instead of false-stalling
+    # planning's prompt is STATIC (no rendered diff/hash in it), so a return lap
+    # through plan-review back to planning presents the identical state+content
+    # the driver last saw — without HEAD tracking, the stall check mistakes that
+    # for no progress, even though a commit (plan-review -> planning) landed in
+    # between.
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": planning
+          planning:
+            actor: agent
+            file: .gtd/PLAN.md
+            prompt: "Refine the plan in .gtd/PLAN.md."
+            on:
+              "* **": plan-review
+          plan-review:
+            actor: human
+            file: .gtd/PLAN.md
+            message: "review the plan"
+            on:
+              "C": building
+              "* **": planning
+          building:
+            actor: agent
+            prompt: "Build it: write src/app.ts."
+            on:
+              "* **": done
+          done:
+            commit: "chore: plan built"
+      """
+    And a commit "gtd(human): idle → planning" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Refine the plan"*)
+          mkdir -p .gtd
+          echo "- refined" >> .gtd/PLAN.md
+          ;;
+        *"Build it"*)
+          mkdir -p src
+          echo "export const app = () => {}" > src/app.ts
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    And $EDITOR is a script that appends "looks good, one tweak" on its first open only
+    When I run bare gtd
+    Then it succeeds
+    And the git log contains "chore: plan built"
+    And stderr does not contain "no progress at 'planning'"
+
   Scenario: Stops instead of stepping when a steering file still fails gtd validate after 3 fix attempts
     Given a test project
     And a gtd config file at ".gtdrc" with:
@@ -1162,8 +1227,97 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     Given a test project
     And the workflow
     When I run "--edit --no-edit" via gtd
-    Then it fails
-    And stderr contains "unknown option"
+    Then the exit code is 2
+    And stderr contains "--edit and --no-edit are mutually exclusive"
+
+  Scenario: --edit combined with --no-edit after loop is a usage error rather than picking one silently
+    Given a test project
+    And the workflow
+    When I run "loop --edit --no-edit" via gtd
+    Then the exit code is 2
+    And stderr contains "--edit and --no-edit are mutually exclusive"
+
+  Scenario: Prints each transition once even after the review checkout window rewinds HEAD
+    # await-review opens a real review checkout window (reviewWindow: true, no
+    # `mode: review` so the plain "D .gtd/REVIEW.md" pattern is the sign-off,
+    # not the sign-off gate). While the window is open report_commits sees a
+    # rewound HEAD; deciding is a non-squash check between the sign-off and the
+    # squash, keeping the earlier transitions reachable at the window-close
+    # beat — a driver with a per-beat head_before would re-print them there.
+    # `idle` stays a silent check-actor no-op (same idiom as the herdr-report
+    # scenario above) so settling back to it after `done` never reopens the
+    # editor a second time — the fake editor here DELETES its target, which
+    # would abort the run if reopened on "." at idle.
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: check
+            initial: true
+            script: "true"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Write src/app.ts."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: "true"
+            on:
+              "C": reviewing
+          reviewing:
+            actor: agent
+            file: .gtd/REVIEW.md
+            prompt: "Write .gtd/REVIEW.md listing the changes to review."
+            on:
+              "* **": await-review
+          await-review:
+            actor: human
+            file: .gtd/REVIEW.md
+            message: "sign off by deleting .gtd/REVIEW.md"
+            reviewWindow: true
+            on:
+              "D .gtd/REVIEW.md": deciding
+          deciding:
+            actor: check
+            script: "true"
+            on:
+              "C": done
+          done:
+            commit: "chore: reviewed"
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      case "$GTD_LOOP_PROMPT" in
+        *"Write src/app.ts"*)
+          mkdir -p src
+          echo "export const app = () => {}" > src/app.ts
+          ;;
+        *"Write .gtd/REVIEW.md"*)
+          mkdir -p .gtd
+          echo "- added src/app.ts" > .gtd/REVIEW.md
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    And $EDITOR is a script that deletes the opened file
+    When I run bare gtd
+    Then it succeeds
+    And the git log contains "chore: reviewed"
+    And stdout contains "working → checking" exactly 1 times
+    And stdout contains "checking → reviewing" exactly 1 times
+    And stdout contains "reviewing → await-review" exactly 1 times
 
   # The scenarios below prove bin/gtd's --once flag (see once_mode in bin/gtd):
   # it restricts the loop to exactly one beat — one script check+step, or one

--- a/tests/integration/support/steps/common.steps.ts
+++ b/tests/integration/support/steps/common.steps.ts
@@ -218,6 +218,27 @@ Then("stdout does not contain {string}", (world: GtdWorld, text: string) => {
   )
 })
 
+// Counts NON-OVERLAPPING occurrences of `text` in stdout — used to prove a
+// transition line was printed exactly once even when the review checkout
+// window rewinds HEAD between beats (see the report_commits monotonic marker).
+Then(
+  "stdout contains {string} exactly {int} times",
+  (world: GtdWorld, text: string, count: number) => {
+    const stdout = world.lastResult.stdout
+    let actual = 0
+    let idx = 0
+    while ((idx = stdout.indexOf(text, idx)) !== -1) {
+      actual++
+      idx += text.length
+    }
+    assert.strictEqual(
+      actual,
+      count,
+      `Expected stdout to contain "${text}" exactly ${count} times, found ${actual}. Got:\n${stdout}`,
+    )
+  },
+)
+
 Then("stderr matches {string}", (world: GtdWorld, pattern: string) => {
   assert.ok(
     new RegExp(pattern).test(world.lastResult.stderr),

--- a/tests/integration/support/steps/edit.steps.ts
+++ b/tests/integration/support/steps/edit.steps.ts
@@ -48,6 +48,37 @@ Given(
   },
 )
 
+// Stateful across invocations within one scenario: opens 1 appends `text` to
+// the opened file, every later open is a no-op (still logged) — proves a
+// human-gate return lap (edit, then a later clean accept) without a second
+// step. The open count is tracked in a counter file living alongside the fake
+// editor script itself (same pattern as the --once scenario's .git/testcount).
+Given(
+  "$EDITOR is a script that appends {string} on its first open only",
+  (world: GtdWorld, text: string) => {
+    writeFakeEditor(
+      world,
+      [
+        `c="$(dirname -- "$0")/opencount"`,
+        `n=$(cat "$c" 2>/dev/null || echo 0)`,
+        `n=$((n + 1))`,
+        `echo "$n" > "$c"`,
+        `if [ "$n" -eq 1 ]; then`,
+        `  mkdir -p "$(dirname -- "$1")"`,
+        `  printf '%s\\n' ${shQuote(text)} >> "$1"`,
+        `fi`,
+      ].join("\n"),
+    )
+  },
+)
+
+// Deletes the opened file outright — the review checkout window's sign-off
+// gate (a plain `D <file>` pattern) is triggered by deleting the steering
+// file, not editing it.
+Given("$EDITOR is a script that deletes the opened file", (world: GtdWorld) => {
+  writeFakeEditor(world, `rm -f -- "$1"`)
+})
+
 // The "closed the editor without changing anything" case: it still records
 // that it ran (for the invocation-log assertions below), but never touches
 // the target path.


### PR DESCRIPTION
## Summary

Fixes two false-signal bugs in the `bin/gtd` loop driver, plus a usage-error gap.

- **Replayed transitions on review-window rewind.** `report_commits` used a per-beat `head_before`, so when the review checkout window rewinds HEAD between beats, already-printed transitions replayed. Replaced with a global `reported_head` high-water mark, advanced only after a beat that actually reports commits — a rewind never re-emits an already-shown transition.
- **False stall on human-gate return laps.** The prompt-stall check compared only state+content across beats, so a return lap through a static prompt (e.g. `plan-review -> planning`) looked identical to a genuine stall and aborted the run even though a commit had landed in between. Now tracks HEAD alongside state/content and only declares a stall when none of the three moved.
- **`--edit`/`--no-edit` together** now gets a dedicated usage error (exit 2) in `bin/gtd` instead of falling through to the bundle's generic unknown-option rejection.

## Testing

New `gtd-loop.feature` scenarios cover the return-lap and review-window-rewind cases, plus the `--edit`/`--no-edit` usage error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)