### PR TITLE
Polish workflow states: clearer names, edge action labels, status preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ driver runs `content` itself, then steps its actor; `"prompt"` means feed
 `content` to your agent, then run `gtd step <actor>` once it's done. gtd itself
 never executes anything — the driver owns running scripts.
 
+An `on` edge may also carry a short imperative `action` (e.g. `Accept plan`)
+alongside its existing `describe` sentence — a human-facing name for the choice
+itself, not just the underlying glob pattern. `gtd status` (plain and `--json`)
+and `gtd visualize`'s diagram and inspector all render the two composed
+together: the `action` leads when the edge declares one, with the raw pattern
+(and `describe`) still shown alongside it, so a human choosing between routes
+reads intent first, glob second.
+
 The unified workflow has **entry points behind a green-baseline gate, into one
 shared tail**. Every entry first runs your test suite and only starts once it's
 green — you never build (or review) on top of a red baseline; a red run halts
@@ -237,6 +245,21 @@ flag on any command other than `gtd step` are all usage errors.
 `--once` is a separate, bash-level flag handled entirely by the `bin/gtd` driver
 itself, stripped before anything reaches the bundle.
 
+### `gtd status`'s `Next:`/`next`
+
+Both plain and `--json` output include a headline preview of what would happen
+next: the first declared `on` edge whose pattern matches the pending changes AS
+A WHOLE (the same first-match-wins semantics `gtd step` itself uses), using its
+`action` when the edge declares one, else its raw pattern, alongside its target
+state. Plain output prints a `Next: <action-or-pattern> → <target>` line (or
+`Next: (no match — nothing would happen)`); `--json`'s `next` key mirrors it as
+`{ action?, pattern, target }`, or `null` on no match.
+
+This reports the **declared** route only: a capped `retry` may redirect
+elsewhere at real step time, which `Next:`/`next` does not apply — it previews
+what the declared `on` patterns would match, not a guarantee of where a real
+`gtd step` lands.
+
 ### Error envelope
 
 Every command, in `--json` mode, reports a failure as a machine-readable
@@ -346,7 +369,11 @@ workflow:
       commit: <string>
       on: # a mapping, DECLARATION ORDER PRESERVED
         "<pattern>": <targetState> # short form
-        "<pattern>": { to: <targetState>, describe: <sentence> } # with a route description
+        "<pattern>": {
+            to: <targetState>,
+            describe: <sentence>,
+            action: <label>,
+          } # description/action
       initial: true # exactly one state across the whole workflow
       retry:
         max: <number>

--- a/src/Edge.test.ts
+++ b/src/Edge.test.ts
@@ -668,6 +668,29 @@ describe("toTemplateEdges — OnEdge tuples to the `{ pattern, target, describe?
     const [edge] = toTemplateEdges([["* **", "next"]])
     expect("describe" in edge!).toBe(false)
   })
+
+  it("carries `action` alongside `describe` when both are present", () => {
+    expect(toTemplateEdges([["C", "building", "Change nothing.", "Accept plan"]])).toEqual([
+      { pattern: "C", target: "building", describe: "Change nothing.", action: "Accept plan" },
+    ])
+  })
+
+  it("carries `action` with no `describe` (the placeholder-in-slot-3 case)", () => {
+    expect(toTemplateEdges([["C", "building", undefined, "Accept plan"]])).toEqual([
+      { pattern: "C", target: "building", action: "Accept plan" },
+    ])
+  })
+
+  it("omits both describe and action keys entirely when neither is present", () => {
+    const [edge] = toTemplateEdges([["C", "building"]])
+    expect("describe" in edge!).toBe(false)
+    expect("action" in edge!).toBe(false)
+  })
+
+  it("omits the action key entirely (never `undefined`) when an edge carries none, even with a describe", () => {
+    const [edge] = toTemplateEdges([["C", "building", "Change nothing."]])
+    expect("action" in edge!).toBe(false)
+  })
 })
 
 describe("renderOnEdges — `on` pattern keys rendered against `it.vars`", () => {
@@ -691,6 +714,24 @@ describe("renderOnEdges — `on` pattern keys rendered against `it.vars`", () =>
       { feedbackFile: ".gtd/FEEDBACK.md" },
     )
     expect(rendered).toEqual([["A .gtd/FEEDBACK.md", "fixing", "Feedback was left."]])
+  })
+
+  it("preserves an edge's `action` alongside `describe`, never rendering it", () => {
+    const rendered = renderOnEdges(
+      [["A <%= it.vars.feedbackFile %>", "fixing", "Feedback was left.", "Accept plan"]],
+      { feedbackFile: ".gtd/FEEDBACK.md" },
+    )
+    expect(rendered).toEqual([
+      ["A .gtd/FEEDBACK.md", "fixing", "Feedback was left.", "Accept plan"],
+    ])
+  })
+
+  it("preserves an edge's `action` with no `describe` (the placeholder-in-slot-3 case)", () => {
+    const rendered = renderOnEdges(
+      [["A <%= it.vars.feedbackFile %>", "fixing", undefined, "Accept plan"]],
+      { feedbackFile: ".gtd/FEEDBACK.md" },
+    )
+    expect(rendered).toEqual([["A .gtd/FEEDBACK.md", "fixing", undefined, "Accept plan"]])
   })
 
   it("returns an empty list for `undefined` (a commit state's `on`)", () => {

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -338,34 +338,39 @@ export const resolveVars = (
 
 // ── Template context ─────────────────────────────────────────────────────────
 
-/** Map a state's raw `on` edges to the `{ pattern, target, describe? }` shape templates see as `it.edges`. `undefined` (a commit state, no `on`) yields an empty list. Callers pass already-rendered edges (see `renderOnEdges`) — this never renders anything itself. */
+/** Map a state's raw `on` edges to the `{ pattern, target, describe?, action? }` shape templates see as `it.edges`. `action` follows the same presence discipline as `describe` — included only when defined, never set to `undefined` — so an edge with an `action` but no `describe` (the slot-3 placeholder case) yields `{ pattern, target, action }` with no `describe` key at all. `undefined` (a commit state, no `on`) yields an empty list. Callers pass already-rendered edges (see `renderOnEdges`) — this never renders anything itself. */
 export const toTemplateEdges = (edges: readonly OnEdge[] | undefined): readonly TemplateEdge[] =>
-  (edges ?? []).map(([pattern, target, describe]) =>
-    describe !== undefined ? { pattern, target, describe } : { pattern, target },
-  )
+  (edges ?? []).map(([pattern, target, describe, action]) => ({
+    pattern,
+    target,
+    ...(describe !== undefined ? { describe } : {}),
+    ...(action !== undefined ? { action } : {}),
+  }))
 
 /**
  * Render every `on` edge's pattern key as an Eta template over `vars` ONLY
  * (`PatternTemplates.varsOnlyContext`) — a pattern names a path; it never
  * needs diffs/commit hashes, and restricting to `vars` avoids an ordering
  * circularity (the full `TemplateContext`'s `it.edges` is itself derived from
- * these same `on` edges). `target`/`describe` pass through verbatim —
- * `describe` is inert to the engine and is never rendered, unlike the pattern
- * key. Throws whatever Eta throws on a malformed pattern template; the caller
- * turns that into a step refusal / command error, exactly like a content
- * render failure.
+ * these same `on` edges). `target`/`describe`/`action` pass through verbatim —
+ * both `describe` and `action` are inert to the engine and are never
+ * rendered, unlike the pattern key; an edge carrying an `action` but no
+ * `describe` round-trips through the same slot-3 `undefined` placeholder
+ * `PatternConfig.compileOnEdge` produces. Throws whatever Eta throws on a
+ * malformed pattern template; the caller turns that into a step refusal /
+ * command error, exactly like a content render failure.
  */
 export const renderOnEdges = (
   edges: readonly OnEdge[] | undefined,
   vars: Record<string, string>,
 ): readonly OnEdge[] => {
   const ctx = varsOnlyContext(vars)
-  return (edges ?? []).map(
-    ([pattern, target, describe]): OnEdge =>
-      describe !== undefined
-        ? [renderStateTemplate(pattern, ctx), target, describe]
-        : [renderStateTemplate(pattern, ctx), target],
-  )
+  return (edges ?? []).map(([pattern, target, describe, action]): OnEdge => {
+    const renderedPattern = renderStateTemplate(pattern, ctx)
+    if (action !== undefined) return [renderedPattern, target, describe, action]
+    if (describe !== undefined) return [renderedPattern, target, describe]
+    return [renderedPattern, target]
+  })
 }
 
 /**

--- a/src/OpenQuestions.ts
+++ b/src/OpenQuestions.ts
@@ -1,7 +1,7 @@
 /**
  * Pure parser/validator for the "open questions" structure the ADVANCED flow's
  * steering files (`.gtd/REQUIREMENTS.md`, `.gtd/ARCHITECTURE.md`) follow in the
- * unified template's `adv-grilling`/`architecting` Q&A loops (see
+ * unified template's `product-qa`/`technical-qa` Q&A loops (see
  * `src/workflows/unified.yaml`) —
  * and for any custom workflow that reuses the same file/format. (The SIMPLE
  * flow's `.gtd/TODO.md` plan loop no longer uses this format — it iterates on a
@@ -28,7 +28,7 @@
  *
  * A question is answered/accepted by MOVING its `###` block from
  * `## Open Questions` down into `## Answered Questions` — the agent does this on
- * the next `adv-grilling`/`architecting` lap (a human leaving a suggestion untouched IS acceptance;
+ * the next `product-qa`/`technical-qa` lap (a human leaving a suggestion untouched IS acceptance;
  * an edit IS the answer — either way the whole batch resolves). Nothing here
  * enforces the move or the section order; that is the producing agent's prompt
  * contract, and this parser only reports the resulting status.

--- a/src/PatternConfig.test.ts
+++ b/src/PatternConfig.test.ts
@@ -686,6 +686,76 @@ describe("compileWorkflowConfig — config-shape validation", () => {
     ).toThrowError(/state "a": "on" entry for pattern "\* \*" has unknown key\(s\) explain/)
   })
 
+  it("compiles the `action` field through onto the edge's fourth element, alongside `describe`", () => {
+    const { definition } = compileWorkflowConfig(
+      {
+        states: {
+          gate: {
+            actor: "human",
+            message: "choose",
+            initial: true,
+            on: {
+              C: {
+                to: "accept",
+                describe: "Change nothing to accept and proceed.",
+                action: "Accept plan",
+              },
+              "* **": "revise",
+            },
+          },
+          accept: { commit: "chore: accept" },
+          revise: {
+            actor: "agent",
+            prompt: "revise",
+            on: { "* **": "gate" },
+          },
+        },
+      },
+      "/config-dir",
+    )
+    expect(definition.states["gate"]!.on).toEqual([
+      ["C", "accept", "Change nothing to accept and proceed.", "Accept plan"],
+      ["* **", "revise"],
+    ])
+  })
+
+  it("compiles an `action`-without-`describe` edge, placing an explicit `undefined` in the third slot", () => {
+    const { definition } = compileWorkflowConfig(
+      {
+        states: {
+          gate: {
+            actor: "human",
+            message: "choose",
+            initial: true,
+            on: { C: { to: "accept", action: "Accept plan" } },
+          },
+          accept: { commit: "chore: accept" },
+        },
+      },
+      "/config-dir",
+    )
+    expect(definition.states["gate"]!.on).toEqual([["C", "accept", undefined, "Accept plan"]])
+  })
+
+  it('rejects an object `on` entry whose "action" is not a string', () => {
+    expect(() =>
+      compileWorkflowConfig(
+        {
+          states: {
+            a: {
+              actor: "human",
+              message: "hi",
+              initial: true,
+              on: { "* *": { to: "b", action: 5 } },
+            },
+            b: { commit: "chore: b" },
+          },
+        },
+        "/dir",
+      ),
+    ).toThrowError(/state "a": "on.\* \*.action" must be a string/)
+  })
+
   it("compiles a `model` string through onto the state", () => {
     const { definition } = compileWorkflowConfig(
       {

--- a/src/PatternConfig.ts
+++ b/src/PatternConfig.ts
@@ -341,7 +341,30 @@ export const inlineWorkflowFileRefs = (
 
 // ── Per-state field compilers ────────────────────────────────────────────────
 
-const KNOWN_EDGE_KEYS: ReadonlySet<string> = new Set(["to", "describe"])
+const KNOWN_EDGE_KEYS: ReadonlySet<string> = new Set(["to", "describe", "action"])
+
+/** A missing/malformed field's failure sentinel, distinct from a legitimate `undefined` value. */
+const INVALID = Symbol("invalid edge field")
+
+/**
+ * Validate one optional string field (`describe` or `action`) off an edge
+ * object, pushing a finding and returning `INVALID` when it's present but not
+ * a string.
+ */
+const compileOptionalEdgeField = (
+  value: unknown,
+  pattern: string,
+  name: string,
+  field: "describe" | "action",
+  errors: string[],
+): string | undefined | typeof INVALID => {
+  if (value === undefined) return undefined
+  if (typeof value !== "string") {
+    errors.push(`state "${name}": "on.${pattern}.${field}" must be a string`)
+    return INVALID
+  }
+  return value
+}
 
 /**
  * Compile one `on` row's value into an `OnEdge` (or `undefined`, pushing a
@@ -369,16 +392,20 @@ const compileOnEdge = (
       `state "${name}": "on" entry for pattern "${pattern}" has unknown key(s) ${unknownKeys.join(", ")}`,
     )
   }
-  const { to, describe } = value
+  const { to, describe, action } = value
   if (typeof to !== "string") {
     errors.push(`state "${name}": "on.${pattern}.to" must be a target state name (string)`)
     return undefined
   }
-  if (describe !== undefined && typeof describe !== "string") {
-    errors.push(`state "${name}": "on.${pattern}.describe" must be a string`)
-    return undefined
-  }
-  return describe !== undefined ? [pattern, to, describe] : [pattern, to]
+  const describeField = compileOptionalEdgeField(describe, pattern, name, "describe", errors)
+  if (describeField === INVALID) return undefined
+  const actionField = compileOptionalEdgeField(action, pattern, name, "action", errors)
+  if (actionField === INVALID) return undefined
+  // `describe` may be `undefined` here even though `action` is set (an edge
+  // wanting an `action` but no `describe` passes an explicit `undefined`
+  // placeholder in slot 3 — see `OnEdge`'s positional-coupling doc).
+  if (actionField !== undefined) return [pattern, to, describeField, actionField]
+  return describeField !== undefined ? [pattern, to, describeField] : [pattern, to]
 }
 
 /**

--- a/src/PatternMachine.ts
+++ b/src/PatternMachine.ts
@@ -61,8 +61,22 @@ export interface RetryDef {
  * `"A <%= it.vars.feedbackFile %>"` and the engine still only ever matches a
  * literal string. `describe` exists only to be emitted verbatim so the
  * driving loop / a `message:` template can present it to a human.
+ *
+ * `action` is a fourth, OPTIONAL slot with the exact same discipline as
+ * `describe`: an imperative label (e.g. `"Accept plan"`) that is INERT to the
+ * engine — never read by `step`/`resolveState`/`matchesPattern`, and NEVER
+ * Eta-rendered. It exists only to be emitted verbatim to a consumer (a CLI
+ * message, `gtd status --json`, a visualization) — none of which are wired up
+ * yet; this type is pure plumbing. Because this is a positional tuple and not
+ * an object, an edge that wants an `action` but no `describe` must still pass
+ * an explicit placeholder in slot 3 (e.g. `undefined`) to reach slot 4.
  */
-export type OnEdge = readonly [pattern: string, target: StateName, describe?: string]
+export type OnEdge = readonly [
+  pattern: string,
+  target: StateName,
+  describe?: string | undefined,
+  action?: string,
+]
 
 /**
  * One state's declaration. Exactly one of `script`/`prompt`/`message`/
@@ -221,7 +235,7 @@ export interface StateDef {
    * question in its `qa`-mode `file:` is answered — EXACTLY ONE checkbox ticked
    * per question (and, when the ticked one is the trailing free-text slot, its
    * text is non-empty). This is what makes the advanced flow's answer gates
-   * (`adv-grilling-answer`/`architecting-answer`) require a decision on every
+   * (`product-answer`/`technical-answer`) require a decision on every
    * question before looping back or advancing. Like the review sign-off gate,
    * the PURE engine never reads it: the check lives at the edge
    * (`enforceAnswerCompletenessGate` in `src/program.ts`, over

--- a/src/PatternTemplates.test.ts
+++ b/src/PatternTemplates.test.ts
@@ -210,15 +210,15 @@ describe("renderStateTemplate — bundled `script` states render to valid bash",
 
   it("covers every bundled script state (guards against a state being dropped)", () => {
     expect(scriptStates.map(([name]) => name).sort()).toEqual([
-      "adv-checking",
-      "adv-start-check",
       "checking",
       "closing",
-      "fix-check",
+      "fix-precheck",
+      "package-checking",
       "picking",
+      "plan-precheck",
       "review-deciding",
-      "review-start-check",
-      "start-check",
+      "review-precheck",
+      "spec-precheck",
     ])
   })
 

--- a/src/PatternTemplates.ts
+++ b/src/PatternTemplates.ts
@@ -21,14 +21,15 @@ import { Eta } from "eta"
  * One resolved `on` edge, as a `message:`/`prompt:` template sees it in
  * `it.edges`: the raw pattern, its target state, and the optional
  * human-readable `describe` sentence the workflow author attached (see
- * `PatternMachine.OnEdge`). All three are LITERAL strings — none is
- * Eta-rendered (the pattern key never was; `describe` follows the same rule),
- * so a template renders `describe` verbatim, typically with `<%~ %>`.
+ * `PatternMachine.OnEdge`). All are LITERAL strings — none is Eta-rendered
+ * (the pattern key never was; `describe` and `action` follow the same rule),
+ * so a template renders `describe`/`action` verbatim, typically with `<%~ %>`.
  */
 export interface TemplateEdge {
   readonly pattern: string
   readonly target: string
   readonly describe?: string
+  readonly action?: string
 }
 
 /**

--- a/src/Submachines.test.ts
+++ b/src/Submachines.test.ts
@@ -235,3 +235,63 @@ describe("expandSubmachines — passthrough and errors", () => {
     expect(errors.some((e) => e.includes('unbound param "$missing"'))).toBe(true)
   })
 })
+
+// ── `action` field survives expansion (parity with `describe`) ──────────────
+
+describe("expandSubmachines — action field", () => {
+  it("a literal `action` string on an on-entry survives expansion unchanged", () => {
+    const errors: string[] = []
+    const out = expandSubmachines(
+      {
+        submachines: {
+          gate: {
+            params: ["onGreen"],
+            states: {
+              check: {
+                actor: "check",
+                script: "s",
+                on: { C: { to: "$onGreen", action: "Accept plan" } },
+              },
+            },
+          },
+        },
+        use: [{ submachine: "gate", as: { check: "c" }, with: { onGreen: "next" } }],
+        states: { next: { actor: "agent", prompt: "p", on: { "* **": "c" } } },
+      },
+      errors,
+    ) as { states: Record<string, Record<string, unknown>> }
+    expect(errors).toEqual([])
+    expect(out.states["c"]!.on).toEqual({ C: { to: "next", action: "Accept plan" } })
+  })
+
+  it("`action: $param` is substituted like `describe: $param`", () => {
+    const errors: string[] = []
+    const out = expandSubmachines(
+      {
+        submachines: {
+          gate: {
+            params: ["onGreen", "actionLabel"],
+            states: {
+              check: {
+                actor: "check",
+                script: "s",
+                on: { C: { to: "$onGreen", action: "$actionLabel" } },
+              },
+            },
+          },
+        },
+        use: [
+          {
+            submachine: "gate",
+            as: { check: "c" },
+            with: { onGreen: "next", actionLabel: "Accept plan" },
+          },
+        ],
+        states: { next: { actor: "agent", prompt: "p", on: { "* **": "c" } } },
+      },
+      errors,
+    ) as { states: Record<string, Record<string, unknown>> }
+    expect(errors).toEqual([])
+    expect(out.states["c"]!.on).toEqual({ C: { to: "next", action: "Accept plan" } })
+  })
+})

--- a/src/Submachines.ts
+++ b/src/Submachines.ts
@@ -132,6 +132,8 @@ const expandOn = (raw: unknown, ctx: ExpansionContext, errors: string[]): unknow
       if (typeof value["to"] === "string") next["to"] = resolveTarget(value["to"], ctx, errors)
       if (typeof value["describe"] === "string")
         next["describe"] = substituteScalar(value["describe"], ctx, errors)
+      if (typeof value["action"] === "string")
+        next["action"] = substituteScalar(value["action"], ctx, errors)
       out[pattern] = next
     } else {
       out[pattern] = value

--- a/src/Visualize.test.ts
+++ b/src/Visualize.test.ts
@@ -8,7 +8,7 @@ import {
   type CurrentStateModel,
 } from "./Visualize.js"
 import type { ResolvedRest } from "./Edge.js"
-import type { PendingChange } from "./PatternMachine.js"
+import type { OnEdge, PendingChange } from "./PatternMachine.js"
 
 // A small workflow authored with a sub-machine, so we exercise both the
 // compiled (flat) states AND the raw sub-machine grouping.
@@ -143,6 +143,40 @@ describe("buildVizModel", () => {
     })
   })
 
+  it("carries an on-edge's action when present, omits it when absent — all 4 describe/action combinations", () => {
+    const rawWithAction = {
+      states: {
+        a: {
+          actor: "human",
+          message: "a",
+          initial: true,
+          on: {
+            C: "b",
+            "A file1.md": { to: "b", describe: "d1" },
+            "A file2.md": { to: "b", action: "act2" },
+            "A file3.md": { to: "b", describe: "d3", action: "act3" },
+          },
+        },
+        b: { commit: "chore: b" },
+      },
+    }
+    const actionModel = buildVizModel(
+      compileWorkflowConfig(rawWithAction, "/dir").definition,
+      rawWithAction,
+      {},
+    )
+    const edges = actionModel.states.find((s) => s.name === "a")!.on
+    expect(edges).toEqual([
+      { pattern: "C", to: "b" },
+      { pattern: "A file1.md", to: "b", describe: "d1" },
+      { pattern: "A file2.md", to: "b", action: "act2" },
+      { pattern: "A file3.md", to: "b", describe: "d3", action: "act3" },
+    ])
+    // neither/describe-only edges must OMIT the `action` key entirely, not set it to `undefined`
+    expect(edges[0]).not.toHaveProperty("action")
+    expect(edges[1]).not.toHaveProperty("action")
+  })
+
   it("falls back to the raw pattern string when it fails to render", () => {
     const badRaw = {
       states: {
@@ -221,6 +255,27 @@ describe("buildCurrentStateModel", () => {
     expect(
       buildCurrentStateModel(restAt("planning"), [], onEdgesAt("planning")).retry,
     ).toBeUndefined()
+  })
+
+  it("carries an edge's action on both the matched AND an unmatched edge, omits it when absent", () => {
+    const onEdges: OnEdge[] = [
+      ["A .gtd/FEEDBACK.md", "start-blocked", undefined, "Reject"],
+      ["C", "planning", undefined, "Approve"],
+    ]
+    const changes: PendingChange[] = [{ status: "A", path: ".gtd/FEEDBACK.md" }]
+    const withAction = buildCurrentStateModel(restAt("start-check"), changes, onEdges)
+    expect(withAction.edges).toEqual([
+      { pattern: "A .gtd/FEEDBACK.md", to: "start-blocked", matched: true, action: "Reject" },
+      { pattern: "C", to: "planning", matched: false, action: "Approve" },
+    ])
+
+    const withoutAction = buildCurrentStateModel(
+      restAt("start-check"),
+      [],
+      onEdgesAt("start-check"),
+    )
+    // no source edge carries an action — the key must be OMITTED, not `action: undefined`
+    for (const edge of withoutAction.edges) expect(edge).not.toHaveProperty("action")
   })
 
   it("passes pending changes through", () => {

--- a/src/Visualize.ts
+++ b/src/Visualize.ts
@@ -54,6 +54,7 @@ export interface VizEdge {
   readonly pattern: string
   readonly to: string
   readonly describe?: string
+  readonly action?: string
 }
 
 /** One state, described for the viewer. */
@@ -105,8 +106,8 @@ const FLAG_KEYS = [
 // carried as its own `VizState.initial` field.
 const flagsOf = (def: StateDef): string[] => FLAG_KEYS.filter((k) => def[k] === true)
 
-const edgeToViz = ([pattern, to, describe]: OnEdge): VizEdge =>
-  describe !== undefined ? { pattern, to, describe } : { pattern, to }
+const edgeToViz = ([pattern, to, describe, action]: OnEdge): VizEdge =>
+  stripUndefined({ pattern, to, describe, action }) as unknown as VizEdge
 
 /** Drop keys whose value is `undefined` (so `exactOptionalPropertyTypes` optionals stay absent, not `undefined`). */
 const stripUndefined = (o: Record<string, unknown>): Record<string, unknown> => {
@@ -148,7 +149,7 @@ const renderPatternOrRaw = (pattern: string, vars: Record<string, string>): stri
   }
 }
 
-/** Render every `on` edge of every state against `vars` (pattern key only — `target`/`describe` pass through verbatim), keyed by state name. */
+/** Render every `on` edge of every state against `vars` (pattern key only — `target`/`describe`/`action` pass through verbatim), keyed by state name. */
 const renderedOnByState = (
   workflow: WorkflowDefinition,
   vars: Record<string, string>,
@@ -156,12 +157,13 @@ const renderedOnByState = (
   new Map(
     Object.entries(workflow.states).map(([name, def]) => [
       name,
-      (def.on ?? []).map(
-        ([pattern, target, describe]): OnEdge =>
-          describe !== undefined
-            ? [renderPatternOrRaw(pattern, vars), target, describe]
-            : [renderPatternOrRaw(pattern, vars), target],
-      ),
+      (def.on ?? []).map(([pattern, target, describe, action]): OnEdge => {
+        const renderedPattern = renderPatternOrRaw(pattern, vars)
+        if (action !== undefined) return [renderedPattern, target, describe, action]
+        return describe !== undefined
+          ? [renderedPattern, target, describe]
+          : [renderedPattern, target]
+      }),
     ]),
   )
 
@@ -220,6 +222,7 @@ export interface CurrentStateEdge {
   readonly pattern: string
   readonly to: string
   readonly matched: boolean
+  readonly action?: string
 }
 
 /** Where the active process rests right now, for the viewer's "Current state" panel — resolved once at page load, never polled. */
@@ -255,7 +258,12 @@ export const buildCurrentStateModel = (
     const parsed = parsePattern(patternStr)
     return parsed !== undefined && matchesPattern(parsed, changes)
   })
-  const edges = onEdges.map(([pattern, to], i) => ({ pattern, to, matched: i === matchedIndex }))
+  const edges = onEdges.map(([pattern, to, , action], i) => ({
+    pattern,
+    to,
+    matched: i === matchedIndex,
+    ...(action !== undefined ? { action } : {}),
+  }))
   return stripUndefined({
     state: rest.state,
     actor: rest.actor,

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -21,8 +21,10 @@ import {
   classifyFeedbackProgress,
   classifyReviewSignoff,
   cliErrorLine,
+  computeNextMatch,
   makeProgram,
 } from "./program.js"
+import type { OnEdge, PendingChange } from "./PatternMachine.js"
 import { InMemRepo } from "../tests/integration/support/inmem/Repo.js"
 import { inMemoryLayers } from "../tests/integration/support/inmem/layers.js"
 
@@ -365,9 +367,9 @@ describe("gtd review <commitish> — subcommand guards", () => {
     }
   })
 
-  it("the happy path writes one empty entry commit with a Gtd-Review-Base trailer, resting at the unified template's review-entry state (review-start-check)", async () => {
+  it("the happy path writes one empty entry commit with a Gtd-Review-Base trailer, resting at the unified template's review-entry state (review-precheck)", async () => {
     const repo = seededRepo()
-    // Pin the bundled unified template (whose `review-start-check` state
+    // Pin the bundled unified template (whose `review-precheck` state
     // declares `reviewEntry: true`) explicitly and commit it — this is the same
     // machine gtd runs as its built-in default, materialized via
     // `renderInitConfig` (see src/workflows/templates.ts).
@@ -382,9 +384,9 @@ describe("gtd review <commitish> — subcommand guards", () => {
 
     const { output, exit } = await runReview(repo, base)
     expect(Exit.isSuccess(exit)).toBe(true)
-    expect(output).toContain("committed: gtd(human): review-start-check")
+    expect(output).toContain("committed: gtd(human): review-precheck")
     expect(repo.commitHistory()).toHaveLength(before + 1)
-    expect(repo.lastCommitSubject()).toBe("gtd(human): review-start-check")
+    expect(repo.lastCommitSubject()).toBe("gtd(human): review-precheck")
     const message = repo.commitHistory().at(-1)!.message
     expect(message).toContain(`Gtd-Review-Base: ${base}`)
   })
@@ -392,7 +394,7 @@ describe("gtd review <commitish> — subcommand guards", () => {
 
 describe("gtd fix — subcommand guards", () => {
   // Like `gtd review`, `gtd fix`'s guards need a real (in-memory) repo to
-  // resolve against. Full happy-path coverage (fix-check running the suite,
+  // resolve against. Full happy-path coverage (fix-precheck running the suite,
   // dropping into the shared fixing loop or no-op'ing back to idle) lives in
   // tests/integration/features/fix-entry.feature.
 
@@ -486,16 +488,16 @@ describe("gtd fix — subcommand guards", () => {
     }
   })
 
-  it("the happy path writes one empty entry commit resting at the unified template's fix-entry state (fix-check)", async () => {
+  it("the happy path writes one empty entry commit resting at the unified template's fix-entry state (fix-precheck)", async () => {
     const repo = seededRepo()
     repo.writeFile(".gtdrc.json", renderInitConfig())
     repo.commitAllWithPrefix("chore: init gtd workflow")
     const before = repo.commitHistory().length
     const { output, exit } = await runFix(repo)
     expect(Exit.isSuccess(exit)).toBe(true)
-    expect(output).toContain("committed: gtd(human): fix-check")
+    expect(output).toContain("committed: gtd(human): fix-precheck")
     expect(repo.commitHistory()).toHaveLength(before + 1)
-    expect(repo.lastCommitSubject()).toBe("gtd(human): fix-check")
+    expect(repo.lastCommitSubject()).toBe("gtd(human): fix-precheck")
   })
 })
 
@@ -606,6 +608,159 @@ describe("gtd next --json / gtd status — label emission", () => {
     expect(Exit.isSuccess(exit)).toBe(true)
     const parsed = JSON.parse(output) as Record<string, unknown>
     expect(parsed).not.toHaveProperty("label")
+  })
+})
+
+describe("computeNextMatch", () => {
+  // Pure unit coverage — mirrors `PatternMachine.step`'s own `matchOn`
+  // first-match-wins semantics, but over the WHOLE change list at once
+  // (unlike `computeStatusChanges`, which checks each change in isolation).
+
+  it("picks the first matching edge in declaration order, ignoring later matches", () => {
+    const onEdges: readonly OnEdge[] = [
+      ["* NOTE.md", "first-target", undefined, "First action"],
+      ["M **/*.md", "second-target", undefined, "Second action"],
+    ]
+    const changes: readonly PendingChange[] = [{ status: "M", path: "NOTE.md" }]
+    expect(computeNextMatch(onEdges, changes)).toEqual({
+      action: "First action",
+      pattern: "* NOTE.md",
+      target: "first-target",
+    })
+  })
+
+  it("returns null when no declared pattern matches the pending changes", () => {
+    const onEdges: readonly OnEdge[] = [["A NOTE.md", "planned"]]
+    const changes: readonly PendingChange[] = [{ status: "M", path: "OTHER.md" }]
+    expect(computeNextMatch(onEdges, changes)).toBeNull()
+  })
+
+  it("returns null on a clean tree when the state declares no `C` row", () => {
+    const onEdges: readonly OnEdge[] = [["A NOTE.md", "planned"]]
+    expect(computeNextMatch(onEdges, [])).toBeNull()
+  })
+
+  it("matches a declared `C` row against a clean tree", () => {
+    const onEdges: readonly OnEdge[] = [["C", "idle", undefined, "Loop"]]
+    expect(computeNextMatch(onEdges, [])).toEqual({
+      action: "Loop",
+      pattern: "C",
+      target: "idle",
+    })
+  })
+})
+
+describe("gtd status — Next: preview", () => {
+  // Exercises `computeNextMatch` wired through `gtd status`'s plain-text
+  // `Next:` line and `--json`'s `next` key, using the same InMemRepo +
+  // inMemoryLayers + runProgram precedent as the label-emission block above.
+  // The workflow below carries one edge with an `action`, one without (falls
+  // back to the raw `pattern`), and leaves a third change unmatched by either.
+
+  const workflowWithNextEdges = [
+    "workflow:",
+    "  states:",
+    "    idle:",
+    "      actor: human",
+    "      initial: true",
+    "      message: write NOTE.md to start a cycle",
+    "      on:",
+    '        "* **": working',
+    "    working:",
+    "      actor: agent",
+    "      prompt: do the work described in NOTE.md",
+    "      on:",
+    '        "A PLAN.md":',
+    "          to: accepted",
+    "          action: Accept plan",
+    '        "M REVIEW.md": idle',
+    "    accepted:",
+    "      actor: human",
+    "      message: plan accepted",
+    "",
+  ].join("\n")
+
+  const seededRepoAt = (workflowYaml: string): InMemRepo => {
+    const repo = new InMemRepo()
+    repo.writeFile(".gitignore", "node_modules\n")
+    repo.writeFile("README.md", "# test project\n")
+    repo.writeFile(".gtdrc.yaml", workflowYaml)
+    repo.writeFile("REVIEW.md", "old review\n")
+    repo.commitAllWithPrefix("chore: add custom workflow")
+    repo.writeFile("NOTE.md", "a note\n")
+    repo.commitAllWithPrefix("gtd(human): working")
+    return repo
+  }
+
+  const runProgram = async (
+    repo: InMemRepo,
+    ...args: string[]
+  ): Promise<{ output: string; exit: Exit.Exit<void, Error> }> => {
+    let output = ""
+    const write = (chunk: string) => {
+      output += chunk
+    }
+    const argv = ["node", "gtd.js", ...args]
+    const exit = await Effect.runPromiseExit(
+      makeProgram({ argv, write }).pipe(Effect.provide(inMemoryLayers(repo))),
+    )
+    return { output, exit }
+  }
+
+  it("gtd status shows `Next:` with the action when the matched edge carries one", async () => {
+    const repo = seededRepoAt(workflowWithNextEdges)
+    repo.writeFile("PLAN.md", "the plan\n")
+    const { output, exit } = await runProgram(repo, "status")
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(output).toContain("Next: Accept plan → accepted")
+  })
+
+  it("gtd status --json's `next` carries the action when the matched edge has one", async () => {
+    const repo = seededRepoAt(workflowWithNextEdges)
+    repo.writeFile("PLAN.md", "the plan\n")
+    const { output, exit } = await runProgram(repo, "status", "--json")
+    expect(Exit.isSuccess(exit)).toBe(true)
+    const parsed = JSON.parse(output) as Record<string, unknown>
+    expect(parsed.next).toEqual({
+      action: "Accept plan",
+      pattern: "A PLAN.md",
+      target: "accepted",
+    })
+  })
+
+  it("gtd status falls back to the raw pattern when the matched edge carries no action", async () => {
+    const repo = seededRepoAt(workflowWithNextEdges)
+    repo.writeFile("REVIEW.md", "an updated review\n")
+    const { output, exit } = await runProgram(repo, "status")
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(output).toContain("Next: M REVIEW.md → idle")
+  })
+
+  it("gtd status --json's `next` omits `action` and falls back to `pattern` when the matched edge has none", async () => {
+    const repo = seededRepoAt(workflowWithNextEdges)
+    repo.writeFile("REVIEW.md", "an updated review\n")
+    const { output, exit } = await runProgram(repo, "status", "--json")
+    expect(Exit.isSuccess(exit)).toBe(true)
+    const parsed = JSON.parse(output) as Record<string, unknown>
+    expect(parsed.next).toEqual({ pattern: "M REVIEW.md", target: "idle" })
+  })
+
+  it("gtd status shows the no-match line when the pending change matches no declared pattern", async () => {
+    const repo = seededRepoAt(workflowWithNextEdges)
+    repo.writeFile("OTHER.md", "unrelated\n")
+    const { output, exit } = await runProgram(repo, "status")
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(output).toContain("Next: (no match — nothing would happen)")
+  })
+
+  it("gtd status --json's `next` is present-but-null (never omitted) on no match", async () => {
+    const repo = seededRepoAt(workflowWithNextEdges)
+    repo.writeFile("OTHER.md", "unrelated\n")
+    const { output, exit } = await runProgram(repo, "status", "--json")
+    expect(Exit.isSuccess(exit)).toBe(true)
+    const parsed = JSON.parse(output) as Record<string, unknown>
+    expect(parsed).toHaveProperty("next")
+    expect(parsed.next).toBeNull()
   })
 })
 
@@ -743,7 +898,7 @@ describe("classifyFeedbackProgress", () => {
 })
 
 describe("classifyAnswerCompleteness", () => {
-  const base = { file: ".gtd/REQUIREMENTS.md", stateName: "adv-grilling-answer", invoker: "human" }
+  const base = { file: ".gtd/REQUIREMENTS.md", stateName: "product-answer", invoker: "human" }
   const doc = (options: readonly string[]): string =>
     ["Build a thing.", "", "## Open Questions", "", "### Which API?", "", ...options, ""].join("\n")
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -491,7 +491,7 @@ const stepAsActor = (
     yield* enforceFeedbackProgressGate(invoker, rest, context, changes, decision.kind)
     // Answer-completeness gate (edge): at an `answerGate` qa state, refuse a
     // human step while any open question is not answered (exactly one tick each)
-    // — the advanced flow's adv-grilling-answer/architecting-answer gates.
+    // — the advanced flow's product-answer/technical-answer gates.
     yield* enforceAnswerCompletenessGate(worktree.read, invoker, rest, context, decision.kind)
     if (decision.kind === "commit") {
       const target = parseStateSubject(decision.subject)?.state
@@ -1209,7 +1209,7 @@ export const classifyAnswerCompleteness = (input: {
 /**
  * The answer-completeness gate (edge, like the sign-off gate above). At an
  * `answerGate: true` state with `mode: qa` (the unified template's
- * `adv-grilling-answer`/`architecting-answer`), a human step is refused unless
+ * `product-answer`/`technical-answer`), a human step is refused unless
  * every open question in the file is answered — the pure
  * `classifyAnswerCompleteness` decides over the WORKING-TREE contents. A no-op
  * when the state is not an answer gate (so the agent's own authoring step, which
@@ -1313,6 +1313,37 @@ const computeStatusChanges = (
     return { status: change.status, path: change.path, pattern: matchedRow?.[0] ?? null }
   })
 
+/** The first declared `on` edge that WOULD fire for `gtd next`/`gtd step` right now, for `gtd status` to preview. */
+interface NextMatch {
+  readonly action: string | undefined
+  readonly pattern: string
+  readonly target: string
+}
+
+/**
+ * First declared `on` edge (in declaration order) whose pattern matches the
+ * WHOLE pending change list — mirroring `PatternMachine.step`'s own
+ * first-match-wins semantics (`matchOn`) exactly, unlike `computeStatusChanges`
+ * above which matches each change independently. `null` when no edge matches,
+ * covering both a clean tree with no declared `C` row and a dirty tree
+ * matching none of the declared patterns.
+ *
+ * This reports the DECLARED route only: a capped `retry` target may redirect
+ * elsewhere at real step time (`applyRetry` in `PatternMachine.ts`), which
+ * this does not apply — same pre-retry, pure-over-already-fetched-inputs
+ * contract as `computeStatusChanges`.
+ */
+export const computeNextMatch = (
+  onEdges: readonly OnEdge[],
+  changes: readonly PendingChange[],
+): NextMatch | null => {
+  for (const [pattern, target, , action] of onEdges) {
+    const parsed = parsePattern(pattern)
+    if (parsed !== undefined && matchesPattern(parsed, changes)) return { action, pattern, target }
+  }
+  return null
+}
+
 /**
  * True when the per-model breakdown adds information beyond the `Cost:` total:
  * more than one model, or a single model that carries an actual `--model` tag
@@ -1331,12 +1362,45 @@ const costStatusLines = (cost: number, byModel: readonly ModelCost[]): string[] 
   return lines
 }
 
-/** `gtd status --json`'s emission — `{state, actor, changes, model?, memory?, label?, file?, mode?, cost?, costByModel?, edges?}`. `renderedOn` is the resting state's `on` edges already rendered against `it.vars` (`renderOnEdges`), so the emitted `edges[].pattern` carries the same rendered path as `changes[].pattern`. */
+/** Builds `{[key]: value}` for each entry whose value isn't `undefined` — the shared "omit absent optional fields" shape behind both `writeStatusJson` and `writeStatusPlain`. */
+const definedFields = (
+  entries: readonly (readonly [string, unknown])[],
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of entries) if (value !== undefined) result[key] = value
+  return result
+}
+
+/** `gtd status --json`'s `next` key — `null` on no match, else the matched edge's pattern/target plus its `action` when declared. */
+const nextField = (
+  next: NextMatch | null,
+): { action?: string; pattern: string; target: string } | null =>
+  next === null
+    ? null
+    : { ...definedFields([["action", next.action]]), pattern: next.pattern, target: next.target }
+
+/** `gtd status`'s `Next:` line — the plain-text counterpart to `nextField`. */
+const nextStatusLine = (next: NextMatch | null): string =>
+  next === null
+    ? "Next: (no match — nothing would happen)"
+    : `Next: ${next.action ?? next.pattern} → ${next.target}`
+
+/** `gtd status`'s `Pending:` block — `(clean)` when nothing is pending, else one indented line per change. */
+const pendingStatusLines = (statusChanges: readonly StatusChange[]): string[] =>
+  statusChanges.length === 0
+    ? ["Pending: (clean)"]
+    : [
+        "Pending:",
+        ...statusChanges.map((c) => `  ${c.status} ${c.path} -> ${c.pattern ?? "(no match)"}`),
+      ]
+
+/** `gtd status --json`'s emission — `{state, actor, changes, next, model?, memory?, label?, file?, mode?, cost?, costByModel?, edges?}`. `renderedOn` is the resting state's `on` edges already rendered against `it.vars` (`renderOnEdges`), so the emitted `edges[].pattern` carries the same rendered path as `changes[].pattern`. `next` is ALWAYS present (an object, or `null` on no match) — the headline conclusion, never omit-vs-null, same as `changes`. */
 const writeStatusJson = (
   write: (chunk: string) => void,
   rest: ResolvedRest,
   statusChanges: readonly StatusChange[],
   renderedOn: readonly OnEdge[],
+  next: NextMatch | null,
   model: string | undefined,
   memory: string | undefined,
   label: string | undefined,
@@ -1345,28 +1409,33 @@ const writeStatusJson = (
   costByModel: readonly ModelCost[],
 ): void => {
   const edges = toTemplateEdges(renderedOn)
+  const hasCost = cost > 0
   write(
     JSON.stringify({
       state: rest.state,
       actor: rest.actor,
       changes: statusChanges,
-      ...(model !== undefined ? { model } : {}),
-      ...(memory !== undefined ? { memory } : {}),
-      ...(label !== undefined ? { label } : {}),
-      ...(file !== undefined ? { file } : {}),
-      ...(rest.stateDef.mode !== undefined ? { mode: rest.stateDef.mode } : {}),
-      ...(cost > 0 ? { cost } : {}),
-      ...(cost > 0 ? { costByModel } : {}),
-      ...(edges.length > 0 ? { edges } : {}),
+      next: nextField(next),
+      ...definedFields([
+        ["model", model],
+        ["memory", memory],
+        ["label", label],
+        ["file", file],
+        ["mode", rest.stateDef.mode],
+        ["cost", hasCost ? cost : undefined],
+        ["costByModel", hasCost ? costByModel : undefined],
+        ["edges", edges.length > 0 ? edges : undefined],
+      ]),
     }) + "\n",
   )
 }
 
-/** `gtd status`'s plain-text emission — `State:`/`Awaits:`/`Label:`/`Model:`/`Memory:`/`File:`/`Mode:`/`Cost:`/`Pending:` lines. */
+/** `gtd status`'s plain-text emission — `State:`/`Awaits:`/`Label:`/`Model:`/`Memory:`/`File:`/`Mode:`/`Cost:`/`Pending:`/`Next:` lines. */
 const writeStatusPlain = (
   write: (chunk: string) => void,
   rest: ResolvedRest,
   statusChanges: readonly StatusChange[],
+  next: NextMatch | null,
   model: string | undefined,
   memory: string | undefined,
   label: string | undefined,
@@ -1374,21 +1443,21 @@ const writeStatusPlain = (
   cost: number,
   costByModel: readonly ModelCost[],
 ): void => {
-  const lines = [`State: ${rest.state}`, `Awaits: ${rest.actor}`]
-  if (label !== undefined) lines.push(`Label: ${label}`)
-  if (model !== undefined) lines.push(`Model: ${model}`)
-  if (memory !== undefined) lines.push(`Memory: ${memory}`)
-  if (file !== undefined) lines.push(`File: ${file}`)
-  if (rest.stateDef.mode !== undefined) lines.push(`Mode: ${rest.stateDef.mode}`)
-  lines.push(...costStatusLines(cost, costByModel))
-  if (statusChanges.length === 0) {
-    lines.push("Pending: (clean)")
-  } else {
-    lines.push("Pending:")
-    for (const c of statusChanges) {
-      lines.push(`  ${c.status} ${c.path} -> ${c.pattern ?? "(no match)"}`)
-    }
-  }
+  const optional = definedFields([
+    ["Label", label],
+    ["Model", model],
+    ["Memory", memory],
+    ["File", file],
+    ["Mode", rest.stateDef.mode],
+  ])
+  const lines = [
+    `State: ${rest.state}`,
+    `Awaits: ${rest.actor}`,
+    ...Object.entries(optional).map(([key, value]) => `${key}: ${value}`),
+    ...costStatusLines(cost, costByModel),
+    ...pendingStatusLines(statusChanges),
+    nextStatusLine(next),
+  ]
   write(lines.join("\n") + "\n")
 }
 
@@ -1408,12 +1477,14 @@ const runStatusCommand = (
     const label = yield* renderLabel(rest.stateDef, context)
     const file = yield* renderFile(rest.stateDef, context)
     const statusChanges = computeStatusChanges(renderedOn, changes)
+    const next = computeNextMatch(renderedOn, changes)
     if (json) {
       writeStatusJson(
         write,
         rest,
         statusChanges,
         renderedOn,
+        next,
         model,
         memory,
         label,
@@ -1426,6 +1497,7 @@ const runStatusCommand = (
         write,
         rest,
         statusChanges,
+        next,
         model,
         memory,
         label,

--- a/src/visualize.html
+++ b/src/visualize.html
@@ -989,6 +989,11 @@
         border-radius: 6px;
         white-space: nowrap;
       }
+      .edge .act {
+        font-size: 12.5px;
+        font-weight: 700;
+        color: var(--accent);
+      }
       .edge .arr {
         color: var(--text-faint);
       }
@@ -1518,7 +1523,7 @@
         states.forEach((s) => {
           ;(s.on || []).forEach((e) => {
             if (!inSet.has(e.to) || !byName[e.to]) return
-            addEdge(solid, unitId(s.name), unitId(e.to), e.pattern)
+            addEdge(solid, unitId(s.name), unitId(e.to), e.action || e.pattern)
           })
           if (s.retry && inSet.has(s.retry.otherwise)) {
             addEdge(dashed, unitId(s.name), unitId(s.retry.otherwise), "retry ×" + s.retry.max)
@@ -1535,7 +1540,7 @@
               emittedGhosts.add(e.to)
               lines.push(ghostLine(target))
             }
-            lines.push(`  ${idFor(s.name)} -->|${mlabel(e.pattern)}| e${idFor(e.to)}`)
+            lines.push(`  ${idFor(s.name)} -->|${mlabel(e.action || e.pattern)}| e${idFor(e.to)}`)
           })
           if (s.retry && byName[s.retry.otherwise] && !inSet.has(s.retry.otherwise)) {
             const target = byName[s.retry.otherwise]
@@ -1984,19 +1989,22 @@
         }
         panel.classList.remove("hidden")
         const a = CURRENT.actor
-        const edgeRow = (pattern, to, matched, retryOf) => {
+        const edgeRow = (pattern, to, matched, retryOf, action) => {
           const t = byName[to]
           return (
             `<div class="edge${matched ? " cur-matched" : ""}"><div class="er">` +
+            `${action ? `<span class="act">${esc(action)}</span>` : ""}` +
             `<span class="pat">${retryOf ? "after " + esc(retryOf) + " tries" : "if " + esc(pattern)}</span>` +
             `<span class="arr">→</span>` +
             `<button class="goto" data-actor="${t ? actorOf(t) : "unknown"}" data-to="${esc(to)}">${esc(to)}</button>` +
             `${matched ? '<span class="cur-tag">current match</span>' : ""}</div></div>`
           )
         }
-        const rows = (CURRENT.edges || []).map((e) => edgeRow(e.pattern, e.to, e.matched)).join("")
+        const rows = (CURRENT.edges || [])
+          .map((e) => edgeRow(e.pattern, e.to, e.matched, undefined, e.action))
+          .join("")
         const retryRow = CURRENT.retry
-          ? edgeRow(null, CURRENT.retry.otherwise, false, CURRENT.retry.max)
+          ? edgeRow(null, CURRENT.retry.otherwise, false, CURRENT.retry.max, undefined)
           : ""
         panel.innerHTML =
           `<div class="cur-head"><span class="cur-name">${esc(CURRENT.state)}</span>` +
@@ -2187,7 +2195,9 @@
                 const t = byName[e.to]
                 const ta = t ? actorOf(t) : "unknown"
                 return (
-                  `<div class="edge"><div class="er"><span class="pat">${esc(e.pattern)}</span><span class="arr">→</span>` +
+                  `<div class="edge"><div class="er">${
+                    e.action ? `<span class="act">${esc(e.action)}</span>` : ""
+                  }<span class="pat">${esc(e.pattern)}</span><span class="arr">→</span>` +
                   `<button class="goto" data-actor="${ta}" data-to="${esc(e.to)}">${esc(e.to)}</button></div>` +
                   `${e.describe ? `<div class="em">${esc(e.describe)}</div>` : ""}</div>`
                 )

--- a/src/workflows/templates.test.ts
+++ b/src/workflows/templates.test.ts
@@ -40,16 +40,16 @@ describe("the bundled unified workflow template", () => {
     // idle routes `.gtd/REQUIREMENTS.md` to the advanced flow's start gate and
     // everything else (e.g. `.gtd/TODO.md`) to the simple flow's start gate —
     // the REQUIREMENTS row is declared first so it wins. Each gate runs the
-    // suite before proceeding to planning/adv-grilling.
+    // suite before proceeding to planning/product-qa.
     const { definition } = compileTemplate()
     const idle = definition.states.idle!
     const targets = (idle.on ?? []).map(([, to]) => to)
-    expect(targets).toContain("adv-start-check")
-    expect(targets).toContain("start-check")
+    expect(targets).toContain("spec-precheck")
+    expect(targets).toContain("plan-precheck")
     // The gates proceed to the planning states once green.
-    expect((definition.states["start-check"]!.on ?? []).map(([, to]) => to)).toContain("planning")
-    expect((definition.states["adv-start-check"]!.on ?? []).map(([, to]) => to)).toContain(
-      "adv-grilling",
+    expect((definition.states["plan-precheck"]!.on ?? []).map(([, to]) => to)).toContain("planning")
+    expect((definition.states["spec-precheck"]!.on ?? []).map(([, to]) => to)).toContain(
+      "product-qa",
     )
   })
 

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -32,7 +32,7 @@
 #   * assertGreen (dedup ×3)  — the green-baseline gate (check + human blocked)
 #                               guarding the simple, advanced and review entries.
 #   * qaLoop (dedup ×2)       — the checkbox Q&A author/answer loop shared by the
-#                               product (adv-grilling) and technical (architecting)
+#                               product (product-qa) and technical (technical-qa)
 #                               phases of the advanced flow.
 #   * planLoop (encap)        — the simple flow's plan-iteration loop.
 #   * humanReview (encap)     — the shared review tail (reviewing → await-review →
@@ -44,22 +44,22 @@
 #
 # EVERY entry first runs the test suite and only proceeds when it is GREEN — you
 # never start new work (or a review) on top of a red baseline. A red run halts
-# at a human `*-start-blocked` gate (fix the failures and re-run, exactly like
+# at a human `*-blocked` gate (fix the failures and re-run, exactly like
 # the `escalate` states), or is what `gtd fix` exists to repair.
 #
 # The initial `idle` state FORKS on which steering file the human creates,
 # routing into that flow's OWN start gate:
 #
 #   * the configured requirementsFile (default .gtd/REQUIREMENTS.md) ->
-#     `adv-start-check` -> the ADVANCED flow (product + technical Q&A, package
+#     `spec-precheck` -> the ADVANCED flow (product + technical Q&A, package
 #     decomposition, per-package parallel build + agentic spec-review).
 #   * anything else (e.g. the configured todoFile, default .gtd/TODO.md) ->
-#     `start-check` -> the SIMPLE flow (one grilling Q&A loop, a monolithic
+#     `plan-precheck` -> the SIMPLE flow (one grilling Q&A loop, a monolithic
 #     build, no decomposition, no agentic review).
 #
-# A third entry, `gtd review <commitish>`, jumps to `review-start-check`
+# A third entry, `gtd review <commitish>`, jumps to `review-precheck`
 # (reviewEntry) and, once green, to `reviewing` to review a foreign branch
-# through the same shared tail. A fourth, `gtd fix`, jumps to `fix-check`
+# through the same shared tail. A fourth, `gtd fix`, jumps to `fix-precheck`
 # (fixEntry): a red suite drops straight into the shared `fixing` loop and out
 # through the review + squash tail; a green suite is a no-op back to `idle`.
 #
@@ -85,7 +85,7 @@
 # The shared health segment (`checking`/`fixing`/`escalate`) serves the simple
 # build and the feedback loop — its green edge targets
 # `reviewing`. The advanced per-package loop keeps its OWN health triple
-# (`adv-checking`/`adv-fixing`/`adv-escalate`) because its green edge targets
+# (`package-checking`/`package-fixing`/`package-escalate`) because its green edge targets
 # the per-package `spec-review` gate instead.
 #
 # Every `on` pattern's path below is written as the matching var's Eta
@@ -113,7 +113,7 @@ vars:
   # The two opaque model tiers every agent state draws from — repoint them here
   # (or via a top-level `.gtdrc` `vars:` key / a `GTD_PLANNERMODEL` env var)
   # to change every state on that tier at once. `plannerModel` (default "smart")
-  # is the heavier tier for the one-shot planning/architecting/review turns;
+  # is the heavier tier for the one-shot planning/technical-qa/review turns;
   # `coderModel` (default "base") is the tier for the build/fix turns.
   plannerModel: smart
   coderModel: base
@@ -125,7 +125,7 @@ submachines:
   # The `on` rules turn that into "fix" vs "$onGreen". The fix turn retries up to
   # 3× before escalating to a human. Invoked for the shared build tail
   # (checking/fixing/escalate -> reviewing) and the advanced package loop
-  # (adv-checking/adv-fixing/adv-escalate -> spec-review).
+  # (package-checking/package-fixing/package-escalate -> spec-review).
   makeGreen:
     params: [onGreen, escalateDescribe, checkLabel, fixLabel, escalateLabel]
     states:
@@ -133,7 +133,7 @@ submachines:
         actor: check
         label: $checkLabel
         # NOT the shared `&suiteCheck` anchor (that lives on `assertGreen`,
-        # aliased by it and by `fix-check`): this script also sweeps spent
+        # aliased by it and by `fix-precheck`): this script also sweeps spent
         # steering files (`todoFile`, `reviewRawFile`, `reviewFeedbackFile`) —
         # a mechanic the entry/fix gates must NOT run, since they execute
         # before planning, while a fresh sketch legitimately still exists.
@@ -216,11 +216,12 @@ submachines:
 
           What each change does next (then run `gtd step human`):
           <% it.edges.forEach(function (e) { if (e.describe) { %>
-          <%~ "- " + e.describe + "\n" %>
+          <%~ "- " + (e.action ? "**" + e.action + "** — " : "") + e.describe + "\n" %>
           <% } }) %>
         on:
           "* **":
             to: check
+            action: Retry check
             describe: $escalateDescribe
 
   # ── DEDUP: the green-baseline gate ─────────────────────────────────────────
@@ -234,9 +235,9 @@ submachines:
       check:
         actor: check
         label: $checkLabel
-        # Anchored here and aliased by `fix-check` (`gtd fix` entry): one
+        # Anchored here and aliased by `fix-precheck` (`gtd fix` entry): one
         # suite-check script shared by all four call sites (this submachine's
-        # ×3 uses plus `fix-check`) instead of four source copies. These gates
+        # ×3 uses plus `fix-precheck`) instead of four source copies. These gates
         # run BEFORE planning, so — unlike `makeGreen.check` — they must NOT
         # sweep `todoFile`/`requirementsFile`: the human's fresh sketch still
         # legitimately exists here.
@@ -284,13 +285,14 @@ submachines:
         on:
           "* **":
             to: check
+            action: Retry check
             describe: $blockedDescribe
 
   # ── DEDUP: the checkbox Q&A author/answer loop ─────────────────────────────
   # The agent develops a plan file, surfacing `## Open Questions` as checkbox
   # lists; the human answers (answerGate refuses an unanswered step) and either
-  # advances or sends it back. Invoked for the product (adv-grilling) and
-  # technical (architecting) phases of the advanced flow.
+  # advances or sends it back. Invoked for the product (product-qa) and
+  # technical (technical-qa) phases of the advanced flow.
   qaLoop:
     params:
       [
@@ -324,9 +326,11 @@ submachines:
         on:
           "C":
             to: $onAdvance
+            action: Accept answers
             describe: $advanceDescribe
           "* **":
             to: author
+            action: Revise answers
             describe: $editDescribe
 
   # ── ENCAPSULATION: the simple flow's plan-iteration loop ───────────────────
@@ -368,9 +372,9 @@ submachines:
           not commit, and do not run `gtd step agent` yourself; the harness does
           that.
         on:
-          "* **": plan-review
+          "* **": await-plan
 
-      plan-review:
+      await-plan:
         actor: human
         label: Awaiting your review
         file: <%= it.vars.todoFile %>
@@ -382,19 +386,20 @@ submachines:
 
           What each change does next (then run `gtd step human`):
           <% it.edges.forEach(function (e) { if (e.describe) { %>
-          <%~ "- " + e.describe + "\n" %>
+          <%~ "- " + (e.action ? "**" + e.action + "** — " : "") + e.describe + "\n" %>
           <% } }) %>
         on:
           "C":
             to: $onAccept
+            action: Accept plan
             describe: >-
-              Change nothing to accept the plan as-is and move on to implementation
-              (**building**).
+              change nothing to move on to implementation (**building**).
           "* **":
             to: planning
+            action: Revise plan
             describe: >-
-              Edit the plan — rewrite a step, add a constraint, or leave an inline
-              comment — to send it back for another round (**planning**).
+              rewrite a step, add a constraint, or leave an inline comment to
+              send it back for another round (**planning**).
 
   # ── ENCAPSULATION: the shared review tail ──────────────────────────────────
   humanReview:
@@ -408,7 +413,7 @@ submachines:
         model: <%= it.vars.plannerModel %>
         memory: review
         # `gtd review <commitish>` (a plain non-gtd branch, e.g. a colleague's PR)
-        # does NOT enter here directly — it enters `review-start-check` (reviewEntry)
+        # does NOT enter here directly — it enters `review-precheck` (reviewEntry)
         # first, which runs the green-baseline gate and, once green, transitions
         # here. The `Gtd-Review-Base:` trailer rides on that entry commit (the
         # process's oldest), so everything below still reuses the same
@@ -474,10 +479,10 @@ submachines:
 
           When you've been through the whole diff, run `gtd step human`:
 
-          - Tick EVERY box and leave no comment — no note in
-            `<%= it.vars.reviewFile %>`, no code edit — to sign off and collapse the
-            cycle into one commit (**squashing**).
-          - Leave a comment to request changes — a note on a
+          - **Sign off** — tick EVERY box and leave no comment — no note in
+            `<%= it.vars.reviewFile %>`, no code edit — to collapse the cycle into
+            one commit (**squashing**).
+          - **Request changes** — leave a comment: a note on a
             `<%= it.vars.reviewFile %>` line, or a direct code edit — to send it to a
             build + re-review round (**review-deciding** → **feedback-building**). A
             code edit counts as your own fix: the agent completes the follow-through
@@ -733,7 +738,7 @@ submachines:
           Delete `<%= it.vars.specFeedbackFile %>` once every concern is addressed.
           Leave everything else uncommitted and finish your turn.
         on:
-          "* **": adv-checking
+          "* **": package-checking
 
   # ── ENCAPSULATION: the advanced flow's per-package build queue ─────────────
   packageLoop:
@@ -757,7 +762,7 @@ submachines:
           # Below this point everything is plain bash.
           nextFile="<%~ it.vars.nextFile %>"
           # Sweep the advanced flow's spent Q&A steering files: requirementsFile
-          # is consumed by architecting, architectureFile by decompose — both are
+          # is consumed by technical-qa, architectureFile by decompose — both are
           # gone by the time the package queue starts. No-op if already removed.
           requirements="<%~ it.vars.requirementsFile %>"
           architecture="<%~ it.vars.architectureFile %>"
@@ -771,10 +776,10 @@ submachines:
           fi
         on:
           "D <%= it.vars.nextFile %>": $onDrained
-          "* <%= it.vars.nextFile %>": adv-building
+          "* <%= it.vars.nextFile %>": package-building
           "C": $onDrained
 
-      adv-building:
+      package-building:
         actor: agent
         label: Building
         model: <%= it.vars.coderModel %>
@@ -799,7 +804,7 @@ submachines:
           Leave the package file in place and everything else uncommitted, then
           finish your turn.
         on:
-          "* **": adv-checking
+          "* **": package-checking
 
       closing:
         actor: check
@@ -826,28 +831,26 @@ use:
     with:
       onGreen: reviewing
       escalateDescribe: >-
-        Fix the failure yourself — edit the code and/or `.gtd/FEEDBACK.md` —
-        to re-run the check (**checking**).
+        edit the code and/or `.gtd/FEEDBACK.md` yourself (**checking**).
       checkLabel: Running checks
       fixLabel: Fixing the check
       escalateLabel: Escalating to a human
-  # Advanced package health triple: adv-checking/adv-fixing/adv-escalate -> spec-review.
+  # Advanced package health triple: package-checking/package-fixing/package-escalate -> spec-review.
   - submachine: makeGreen
-    name: pkg
-    as: { check: adv-checking, fix: adv-fixing, escalate: adv-escalate }
+    name: package
+    as: { check: package-checking, fix: package-fixing, escalate: package-escalate }
     with:
       onGreen: spec-review
       escalateDescribe: >-
-        Fix the failure yourself — edit the code and/or
-        `.gtd/FEEDBACK.md` — to re-run the check (**adv-checking**).
+        edit the code and/or `.gtd/FEEDBACK.md` yourself (**package-checking**).
       checkLabel: Running checks
       fixLabel: Fixing the check
       escalateLabel: Escalating to a human
 
   # Green-baseline gate: simple flow entry.
   - submachine: assertGreen
-    name: start
-    as: { check: start-check, blocked: start-blocked }
+    name: plan
+    as: { check: plan-precheck, blocked: plan-blocked }
     with:
       onGreen: planning
       blockedMessage: |
@@ -856,42 +859,42 @@ use:
 
         What each change does next (then run `gtd step human`):
         <% it.edges.forEach(function (e) { if (e.describe) { %>
-        <%~ "- " + e.describe + "\n" %>
+        <%~ "- " + (e.action ? "**" + e.action + "** — " : "") + e.describe + "\n" %>
         <% } }) %>
       blockedDescribe: >-
-        Fix the failing tests — edit the code and/or `.gtd/FEEDBACK.md` — to
-        re-run the baseline check (**start-check**). To repair the baseline as
-        its own separate reviewed commit instead, abandon this start and run
-        `gtd fix` from a clean `idle`.
+        edit the code and/or `.gtd/FEEDBACK.md` to fix the failing tests
+        (**plan-precheck**). To repair the baseline as its own separate
+        reviewed commit instead, abandon this start and run `gtd fix` from a
+        clean `idle`.
       checkLabel: Checking the baseline
       blockedLabel: Baseline is red
 
   # Green-baseline gate: advanced flow entry.
   - submachine: assertGreen
-    name: adv-start
-    as: { check: adv-start-check, blocked: adv-start-blocked }
+    name: spec
+    as: { check: spec-precheck, blocked: spec-blocked }
     with:
-      onGreen: adv-grilling
+      onGreen: product-qa
       blockedMessage: |
         The test baseline is red — gtd will not start new work on a broken suite.
         `<%= it.vars.feedbackFile %>` holds the failing output.
 
         What each change does next (then run `gtd step human`):
         <% it.edges.forEach(function (e) { if (e.describe) { %>
-        <%~ "- " + e.describe + "\n" %>
+        <%~ "- " + (e.action ? "**" + e.action + "** — " : "") + e.describe + "\n" %>
         <% } }) %>
       blockedDescribe: >-
-        Fix the failing tests — edit the code and/or `.gtd/FEEDBACK.md` — to
-        re-run the baseline check (**adv-start-check**). To repair the baseline
-        as its own separate reviewed commit instead, abandon this start and run
-        `gtd fix` from a clean `idle`.
+        edit the code and/or `.gtd/FEEDBACK.md` to fix the failing tests
+        (**spec-precheck**). To repair the baseline as its own separate
+        reviewed commit instead, abandon this start and run `gtd fix` from a
+        clean `idle`.
       checkLabel: Checking the baseline
       blockedLabel: Baseline is red
 
   # Green-baseline gate: `gtd review` entry (reviewEntry -> reviewing).
   - submachine: assertGreen
-    name: review-start
-    as: { check: review-start-check, blocked: review-start-blocked }
+    name: review
+    as: { check: review-precheck, blocked: review-blocked }
     set:
       check: { reviewEntry: true }
     with:
@@ -902,21 +905,21 @@ use:
 
         What each change does next (then run `gtd step human`):
         <% it.edges.forEach(function (e) { if (e.describe) { %>
-        <%~ "- " + e.describe + "\n" %>
+        <%~ "- " + (e.action ? "**" + e.action + "** — " : "") + e.describe + "\n" %>
         <% } }) %>
       blockedDescribe: >-
-        Fix the failing tests — edit the code and/or `.gtd/FEEDBACK.md` — to
-        re-run the baseline check (**review-start-check**).
+        edit the code and/or `.gtd/FEEDBACK.md` to fix the failing tests
+        (**review-precheck**).
       checkLabel: Checking the baseline
       blockedLabel: Baseline is red
 
-  # Advanced flow: product Q&A loop (adv-grilling/adv-grilling-answer -> architecting).
+  # Advanced flow: product Q&A loop (product-qa/product-answer -> technical-qa).
   - submachine: qaLoop
-    name: grill
-    as: { author: adv-grilling, answer: adv-grilling-answer }
+    name: product
+    as: { author: product-qa, answer: product-answer }
     with:
       authorFile: <%= it.vars.requirementsFile %>
-      onAdvance: architecting
+      onAdvance: technical-qa
       authorPrompt: |
         You are an autonomous coding agent. This workflow steers itself
         through its own state files — treat them as its private scratchpad,
@@ -969,24 +972,24 @@ use:
 
         What each change does next (then run `gtd step human`):
         <% it.edges.forEach(function (e) { if (e.describe) { %>
-        <%~ "- " + e.describe + "\n" %>
+        <%~ "- " + (e.action ? "**" + e.action + "** — " : "") + e.describe + "\n" %>
         <% } }) %>
       advanceDescribe: >-
-        With no open questions left (the agent surfaced none, or you deleted
-        the section and it finalized the plan), change nothing to accept the
-        product plan and move on to technical architecting (**architecting**).
+        with no open questions left (the agent surfaced none, or you deleted
+        the section and it finalized the plan), change nothing to move on to
+        technical Q&A (**technical-qa**).
       editDescribe: >-
-        Tick exactly one option per open question (replace `_your answer_` for
+        tick exactly one option per open question (replace `_your answer_` for
         your own) to send the plan back for the agent to fold your answers in
-        (**adv-grilling**). Delete a question to skip it, or delete the whole
+        (**product-qa**). Delete a question to skip it, or delete the whole
         `## Open Questions` section to accept the plan as-is.
       authorLabel: Refining the product plan
       answerLabel: Awaiting your answers
 
-  # Advanced flow: technical Q&A loop (architecting/architecting-answer -> decompose).
+  # Advanced flow: technical Q&A loop (technical-qa/technical-answer -> decompose).
   - submachine: qaLoop
-    name: arch
-    as: { author: architecting, answer: architecting-answer }
+    name: technical
+    as: { author: technical-qa, answer: technical-answer }
     with:
       authorFile: <%= it.vars.architectureFile %>
       onAdvance: decompose
@@ -1036,22 +1039,21 @@ use:
 
         What each change does next (then run `gtd step human`):
         <% it.edges.forEach(function (e) { if (e.describe) { %>
-        <%~ "- " + e.describe + "\n" %>
+        <%~ "- " + (e.action ? "**" + e.action + "** — " : "") + e.describe + "\n" %>
         <% } }) %>
       advanceDescribe: >-
-        With no open questions left (the agent surfaced none, or you deleted
-        the section and it finalized the plan), change nothing to accept the
-        technical plan and move on to decomposing the work into packages
-        (**decompose**).
+        with no open questions left (the agent surfaced none, or you deleted
+        the section and it finalized the plan), change nothing to move on to
+        decomposing the work into packages (**decompose**).
       editDescribe: >-
-        Tick exactly one option per open question (replace `_your answer_` for
+        tick exactly one option per open question (replace `_your answer_` for
         your own) to send the plan back for the agent to fold your answers in
-        (**architecting**). Delete a question to skip it, or delete the whole
+        (**technical-qa**). Delete a question to skip it, or delete the whole
         `## Open Questions` section to accept the plan as-is.
       authorLabel: Refining the technical plan
       answerLabel: Awaiting your answers
 
-  # Simple flow plan-iteration loop (planning/plan-review -> building).
+  # Simple flow plan-iteration loop (planning/await-plan -> building).
   - submachine: planLoop
     with:
       onAccept: building
@@ -1066,7 +1068,7 @@ use:
     with:
       onApproved: closing
 
-  # Advanced per-package build queue (picking/adv-building/closing -> reviewing).
+  # Advanced per-package build queue (picking/package-building/closing -> reviewing).
   - submachine: packageLoop
     with:
       onDrained: reviewing
@@ -1093,23 +1095,25 @@ states:
 
       What each change does next (then run `gtd step human`):
       <% it.edges.forEach(function (e) { if (e.describe) { %>
-      <%~ "- " + e.describe + "\n" %>
+      <%~ "- " + (e.action ? "**" + e.action + "** — " : "") + e.describe + "\n" %>
       <% } }) %>
     on:
       "* <%= it.vars.requirementsFile %>":
-        to: adv-start-check
+        to: spec-precheck
+        action: Start advanced flow
         describe: >-
-          Save the product requirements to `.gtd/REQUIREMENTS.md` to start the
-          ADVANCED flow — gtd first checks the test baseline is green, then the
-          agent develops them through product then technical Q&A, decomposes the
-          work into packages, and builds each in parallel (**adv-start-check**).
+          save the product requirements to `.gtd/REQUIREMENTS.md` — gtd first
+          checks the test baseline is green, then the agent develops them
+          through product then technical Q&A, decomposes the work into
+          packages, and builds each in parallel (**spec-precheck**).
       "* **":
-        to: start-check
+        to: plan-precheck
+        action: Start simple flow
         describe: >-
-          Save a short sketch to `.gtd/TODO.md` (or any other change) to start
-          the SIMPLE flow — gtd first checks the test baseline is green, then the
-          agent reads it, explores the codebase, and develops it into a concrete
-          implementation plan (**start-check**).
+          save a short sketch to `.gtd/TODO.md` (or any other change) — gtd
+          first checks the test baseline is green, then the agent reads it,
+          explores the codebase, and develops it into a concrete
+          implementation plan (**plan-precheck**).
 
   # ── Simple flow: monolithic build (plan loop is the `planLoop` sub-machine) ─
   building:
@@ -1174,7 +1178,7 @@ states:
   # `gtd fix` enters HERE (fixEntry): run the suite, then a red run drops
   # straight into the shared `fixing` loop (-> checking -> review + squash
   # tail); a green run is a no-op back to `idle` (nothing to fix).
-  fix-check:
+  fix-precheck:
     actor: check
     fixEntry: true
     label: Checking the baseline

--- a/tests/integration/features/abandon.feature
+++ b/tests/integration/features/abandon.feature
@@ -24,10 +24,10 @@ Feature: gtd abandon — end the process underway without completing it
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): idle → start-check"
+    And the last commit subject is "gtd(human): idle → plan-precheck"
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): start-check → planning"
+    And the last commit subject is "gtd(check): plan-precheck → planning"
     When I run gtd with args "abandon"
     Then it succeeds
     And stdout contains "abandoned the process resting at \"planning\""
@@ -72,7 +72,7 @@ Feature: gtd abandon — end the process underway without completing it
     Then it succeeds
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): review-start-check → reviewing"
+    And the last commit subject is "gtd(check): review-precheck → reviewing"
     Given a file ".gtd/REVIEW.md" with:
       """
       # Review: abc1234
@@ -107,7 +107,7 @@ Feature: gtd abandon — end the process underway without completing it
     When I run gtd with args "abandon --json"
     Then it succeeds
     And stdout contains "\"abandoned\":true"
-    And stdout contains "\"from\":\"start-check\""
+    And stdout contains "\"from\":\"plan-precheck\""
     And stdout contains "\"state\":\"idle\""
 
   Scenario: --json reports the no-op too, without an error envelope

--- a/tests/integration/features/default-workflow.feature
+++ b/tests/integration/features/default-workflow.feature
@@ -3,7 +3,7 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
 
   Comprehensive coverage of the SIMPLE entry of `src/workflows/unified.yaml`
   (started by creating `.gtd/TODO.md`) through the SHARED tail: the
-  planning/plan-review iteration loop, a check/fix round, the fix-retry-escalate
+  planning/await-plan iteration loop, a check/fix round, the fix-retry-escalate
   path once `fixing`'s cap (max 3) is reached, the human review gate and its
   `review-deciding` arbiter (a COMMENT — a note or a code edit — is feedback; an
   all-ticked no-comment step is sign-off), the sign-off gate's refusals (an
@@ -15,7 +15,7 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
   editing it — no `qa` mode, no open-questions Q&A (that lives in the ADVANCED
   flow). REVIEW.md checkboxes aren't validated by an in-machine state either —
   the producing agent self-validates via `gtd validate` (covered in
-  validate.feature), so `planning` hands straight to `plan-review` and
+  validate.feature), so `planning` hands straight to `await-plan` and
   `reviewing` straight to `await-review`. The remaining `check`-actor states
   here (`checking`, `review-deciding`) are simulated by writing their verdict
   files directly and running `gtd step check` — @inmem never executes the
@@ -30,14 +30,14 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): idle → start-check"
+    And the last commit subject is "gtd(human): idle → plan-precheck"
 
-    # start-check: green baseline gate — a clean tree (tests pass) -> planning
+    # plan-precheck: green baseline gate — a clean tree (tests pass) -> planning
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): start-check → planning"
+    And the last commit subject is "gtd(check): plan-precheck → planning"
 
-    # planning: develops the sketch into a concrete plan and hands to plan-review
+    # planning: develops the sketch into a concrete plan and hands to await-plan
     Given ".gtd/TODO.md" is modified to:
       """
       Build a thing. Implementation plan: add src/thing.ts exporting `thing`,
@@ -45,12 +45,12 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): planning → plan-review"
+    And the last commit subject is "gtd(agent): planning → await-plan"
 
-    # plan-review: accept the plan as-is with a clean step -> building
+    # await-plan: accept the plan as-is with a clean step -> building
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): plan-review → building"
+    And the last commit subject is "gtd(human): await-plan → building"
 
     # building: implements the plan directly, deletes TODO.md when done
     Given the file ".gtd/TODO.md" is deleted
@@ -393,8 +393,8 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
       """
     When I run gtd next
     Then it succeeds
-    And stdout contains "Tick EVERY box and leave no comment"
-    And stdout contains "Leave a comment to request changes"
+    And stdout contains "**Sign off** — tick EVERY box and leave no comment"
+    And stdout contains "**Request changes** — leave a comment"
     And stdout contains "no comment is refused"
 
   Scenario: a code edit at await-review is feedback — it routes to review-deciding (which turns it into a fix + re-review round)
@@ -460,20 +460,20 @@ Feature: The bundled unified workflow — simple-flow full-cycle journeys
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): idle → start-check"
+    And the last commit subject is "gtd(human): idle → plan-precheck"
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): start-check → planning"
+    And the last commit subject is "gtd(check): plan-precheck → planning"
     Given ".gtd/TODO.md" is modified to:
       """
       Build a second thing. Plan: add src/thing2.ts exporting `thing2`.
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): planning → plan-review"
+    And the last commit subject is "gtd(agent): planning → await-plan"
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): plan-review → building"
+    And the last commit subject is "gtd(human): await-plan → building"
     Given a file "src/thing2.ts" with:
       """
       export const thing2 = 1

--- a/tests/integration/features/driver-json-status.feature
+++ b/tests/integration/features/driver-json-status.feature
@@ -112,6 +112,78 @@ Feature: Driver protocol — gtd next --json content kinds, gtd status pattern m
     And stdout contains "A DONE.md -> A DONE.md"
     And stdout contains "A scratch.txt -> (no match)"
 
+  Scenario: gtd status previews the declared edge that would fire next, action included, and gtd status --json carries the same in "next"
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "..."
+            on:
+              "A DONE.md":
+                to: done
+                action: "Finish up"
+          done:
+            commit: "chore: done"
+      """
+    And a commit "gtd(human): working" that adds "NOTE.md" with:
+      """
+      a note
+      """
+    And a file "DONE.md" with:
+      """
+      done!
+      """
+    When I run gtd status
+    Then it succeeds
+    And stdout contains "Next: Finish up → done"
+    When I run gtd status with "--json"
+    Then it succeeds
+    And stdout contains "\"next\":{\"action\":\"Finish up\",\"pattern\":\"A DONE.md\",\"target\":\"done\"}"
+
+  Scenario: gtd status reports no match in "next" when the pending change matches no declared pattern
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "..."
+            on:
+              "A DONE.md": done
+          done:
+            commit: "chore: done"
+      """
+    And a commit "gtd(human): working" that adds "NOTE.md" with:
+      """
+      a note
+      """
+    And a file "scratch.txt" with:
+      """
+      not matched by any pattern
+      """
+    When I run gtd status
+    Then it succeeds
+    And stdout contains "Next: (no match — nothing would happen)"
+    When I run gtd status with "--json"
+    Then it succeeds
+    And stdout contains "\"next\":null"
+
   Scenario: gtd next --json carries the state's declared model hint, and gtd status shows it too
     Given a test project
     And a gtd config file at ".gtdrc" with:

--- a/tests/integration/features/entry-gate.feature
+++ b/tests/integration/features/entry-gate.feature
@@ -2,10 +2,10 @@
 Feature: The green-baseline entry gate — every entry runs the suite before starting
 
   The bundled unified template gates EVERY entry on a green test baseline
-  (STATES.md §10): `idle` forks into a per-flow `*-start-check` state that runs
+  (STATES.md §10): `idle` forks into a per-flow `*-precheck` state that runs
   the suite before any planning starts. A green run (a clean tree — the check
-  script removed .gtd/FEEDBACK.md) proceeds into `planning`/`adv-grilling`; a
-  red run (the script left .gtd/FEEDBACK.md) halts at a human `*-start-blocked`
+  script removed .gtd/FEEDBACK.md) proceeds into `planning`/`product-qa`; a
+  red run (the script left .gtd/FEEDBACK.md) halts at a human `*-blocked`
   gate that loops back to the check once the human repairs the failures — the
   same shape as `escalate`. `@inmem` scenarios never execute the check script;
   they simulate its outcome by writing (red) or not writing (green)
@@ -22,20 +22,20 @@ Feature: The green-baseline entry gate — every entry runs the suite before sta
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): idle → start-check"
+    And the last commit subject is "gtd(human): idle → plan-precheck"
     # A clean tree at the gate = tests pass = green -> planning.
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): start-check → planning"
+    And the last commit subject is "gtd(check): plan-precheck → planning"
 
-  Scenario: simple flow — a red baseline halts at start-blocked, then a fix re-runs the gate to green
+  Scenario: simple flow — a red baseline halts at plan-blocked, then a fix re-runs the gate to green
     Given a file ".gtd/TODO.md" with:
       """
       Build a thing.
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): idle → start-check"
+    And the last commit subject is "gtd(human): idle → plan-precheck"
     # Simulate a red run: the check script left the failing output behind.
     Given a file ".gtd/FEEDBACK.md" with:
       """
@@ -43,7 +43,7 @@ Feature: The green-baseline entry gate — every entry runs the suite before sta
       """
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): start-check → start-blocked"
+    And the last commit subject is "gtd(check): plan-precheck → plan-blocked"
     # The halt message tells the human the baseline is red and names gtd fix.
     When I run gtd next
     Then it succeeds
@@ -57,36 +57,36 @@ Feature: The green-baseline entry gate — every entry runs the suite before sta
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): start-blocked → start-check"
+    And the last commit subject is "gtd(human): plan-blocked → plan-precheck"
     # Re-run the gate: now green -> planning.
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): start-check → planning"
+    And the last commit subject is "gtd(check): plan-precheck → planning"
 
-  Scenario: advanced flow — a green baseline proceeds from the gate into adv-grilling
+  Scenario: advanced flow — a green baseline proceeds from the gate into product-qa
     Given a file ".gtd/REQUIREMENTS.md" with:
       """
       Build a widget with product requirements.
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): idle → adv-start-check"
+    And the last commit subject is "gtd(human): idle → spec-precheck"
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): adv-start-check → adv-grilling"
+    And the last commit subject is "gtd(check): spec-precheck → product-qa"
 
-  Scenario: advanced flow — a red baseline halts at adv-start-blocked
+  Scenario: advanced flow — a red baseline halts at spec-blocked
     Given a file ".gtd/REQUIREMENTS.md" with:
       """
       Build a widget with product requirements.
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): idle → adv-start-check"
+    And the last commit subject is "gtd(human): idle → spec-precheck"
     Given a file ".gtd/FEEDBACK.md" with:
       """
       compile error: baseline broken
       """
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): adv-start-check → adv-start-blocked"
+    And the last commit subject is "gtd(check): spec-precheck → spec-blocked"

--- a/tests/integration/features/fix-entry.feature
+++ b/tests/integration/features/fix-entry.feature
@@ -1,11 +1,11 @@
 @inmem
 Feature: gtd fix — start a process that goes straight into repairing failing tests
 
-  The bundled unified template declares `fixEntry: true` on `fix-check`
+  The bundled unified template declares `fixEntry: true` on `fix-precheck`
   (STATES.md §10). `gtd fix` starts a BRAND NEW process there — it requires a
   clean tree resting at the initial state, exactly like `gtd review`, and writes
-  one empty `gtd(human): fix-check` entry commit (no `Gtd-Review-Base:` trailer:
-  a fix reviews its own fixes from the ordinary process start). `fix-check` runs
+  one empty `gtd(human): fix-precheck` entry commit (no `Gtd-Review-Base:` trailer:
+  a fix reviews its own fixes from the ordinary process start). `fix-precheck` runs
   the suite: a red run drops straight into the shared `fixing` loop (-> checking
   -> review + squash tail); a green run is a no-op back to `idle`. `@inmem`
   scenarios never execute the check script; they simulate its outcome by writing
@@ -15,16 +15,16 @@ Feature: gtd fix — start a process that goes straight into repairing failing t
     Given a test project
     And the workflow
 
-  Scenario: gtd fix enters at the fix-check gate
+  Scenario: gtd fix enters at the fix-precheck gate
     When I run gtd with args "fix"
     Then it succeeds
-    And the last commit subject is "gtd(human): fix-check"
+    And the last commit subject is "gtd(human): fix-precheck"
 
   Scenario: a green suite is a no-op back to idle — nothing to fix
     Given I record the commit count
     When I run gtd with args "fix"
     Then it succeeds
-    And the last commit subject is "gtd(human): fix-check"
+    And the last commit subject is "gtd(human): fix-precheck"
     # A clean tree at the gate = tests pass = nothing to fix -> idle. The
     # empty entry commit and the no-op check are collapsed away entirely — a
     # no-op probe must never dirty the log.
@@ -37,7 +37,7 @@ Feature: gtd fix — start a process that goes straight into repairing failing t
   Scenario: a red suite drops into the shared fixing loop and out through checking to reviewing
     When I run gtd with args "fix"
     Then it succeeds
-    And the last commit subject is "gtd(human): fix-check"
+    And the last commit subject is "gtd(human): fix-precheck"
     # Simulate a red run: the check script left the failing output behind.
     Given a file ".gtd/FEEDBACK.md" with:
       """
@@ -45,7 +45,7 @@ Feature: gtd fix — start a process that goes straight into repairing failing t
       """
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): fix-check → fixing"
+    And the last commit subject is "gtd(check): fix-precheck → fixing"
     # fixing: the agent addresses the feedback and deletes it.
     Given the file ".gtd/FEEDBACK.md" is deleted
     And a file "src/repair.ts" with:

--- a/tests/integration/features/formatting.feature
+++ b/tests/integration/features/formatting.feature
@@ -142,7 +142,7 @@ Feature: Markdown formatting is the project's own tool, plugged into a steering-
 
   Scenario: prettier plugged into the bundled default's plan mode via a top-level modes: key formats the agent-authored plan at planning
     # No `workflow:` re-declaration: the bundled default already gives
-    # `planning`/`plan-review` `mode: prose` (see unified.yaml); a top-level
+    # `planning`/`await-plan` `mode: prose` (see unified.yaml); a top-level
     # `modes:` key alone is enough to plug a formatter into it.
     Given a test project
     And prettier is available in the test project
@@ -158,10 +158,10 @@ Feature: Markdown formatting is the project's own tool, plugged into a steering-
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): planning → plan-review"
+    And the last commit subject is "gtd(agent): planning → await-plan"
     And ".gtd/TODO.md" has no lines longer than 80 characters
 
-  Scenario: prettier plugged into the bundled default's plan mode formats the human-edited plan at plan-review
+  Scenario: prettier plugged into the bundled default's plan mode formats the human-edited plan at await-plan
     Given a test project
     And prettier is available in the test project
     And a gtd config file at ".gtdrc" with:
@@ -170,7 +170,7 @@ Feature: Markdown formatting is the project's own tool, plugged into a steering-
         prose:
           format: "npx prettier --write <%= it.file %>"
       """
-    And a commit "gtd(agent): plan-review" that adds ".gtd/TODO.md" with:
+    And a commit "gtd(agent): await-plan" that adds ".gtd/TODO.md" with:
       """
       A plan.
       """
@@ -180,7 +180,7 @@ Feature: Markdown formatting is the project's own tool, plugged into a steering-
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): plan-review → planning"
+    And the last commit subject is "gtd(human): await-plan → planning"
     And ".gtd/TODO.md" has no lines longer than 80 characters
 
   Scenario: gtd validate formats the plan file and reports it valid — prose has no validator to fail

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -960,7 +960,7 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And the git log does not contain "checking → reviewing"
 
   Scenario: gtd fix on a green baseline leaves the log untouched
-    # A green suite is nothing to fix: the empty `gtd(human): fix-check` entry
+    # A green suite is nothing to fix: the empty `gtd(human): fix-precheck` entry
     # commit and the no-op check are collapsed away rather than left as
     # permanent bookkeeping commits.
     Given a test project

--- a/tests/integration/features/retained-history.feature
+++ b/tests/integration/features/retained-history.feature
@@ -96,10 +96,10 @@ Feature: gtd restore — undo a squash (or an abandon) by hard-resetting to the 
       """
       chore: initial commit
       chore: init gtd workflow
-      gtd(human): idle → start-check
-      gtd(check): start-check → planning
-      gtd(agent): planning → plan-review
-      gtd(human): plan-review → building
+      gtd(human): idle → plan-precheck
+      gtd(check): plan-precheck → planning
+      gtd(agent): planning → await-plan
+      gtd(human): await-plan → building
       gtd(agent): building → checking
       gtd(check): checking → reviewing
       gtd(agent): reviewing → await-review
@@ -140,7 +140,7 @@ Feature: gtd restore — undo a squash (or an abandon) by hard-resetting to the 
     Then it succeeds
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): start-check → planning"
+    And the last commit subject is "gtd(check): plan-precheck → planning"
 
     When I run gtd with args "abandon"
     Then it succeeds
@@ -153,7 +153,7 @@ Feature: gtd restore — undo a squash (or an abandon) by hard-resetting to the 
 
     When I run gtd with args "restore"
     Then it succeeds
-    And the last commit subject is "gtd(check): start-check → planning"
+    And the last commit subject is "gtd(check): plan-precheck → planning"
     And the git ref "refs/worktree/gtd/history" does not exist
 
   Scenario: work-on-top refusal — a commit made after the squash is never discarded
@@ -382,10 +382,10 @@ Feature: gtd restore — undo a squash (or an abandon) by hard-resetting to the 
       chore: initial commit
       chore: init gtd workflow
       feat: cycle one
-      gtd(human): idle → start-check
-      gtd(check): start-check → planning
-      gtd(agent): planning → plan-review
-      gtd(human): plan-review → building
+      gtd(human): idle → plan-precheck
+      gtd(check): plan-precheck → planning
+      gtd(agent): planning → await-plan
+      gtd(human): await-plan → building
       gtd(agent): building → checking
       gtd(check): checking → reviewing
       gtd(agent): reviewing → await-review
@@ -402,7 +402,7 @@ Feature: gtd restore — undo a squash (or an abandon) by hard-resetting to the 
     Then it succeeds
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): start-check → planning"
+    And the last commit subject is "gtd(check): plan-precheck → planning"
 
     When I run gtd with args "abandon"
     Then it succeeds

--- a/tests/integration/features/review-entry.feature
+++ b/tests/integration/features/review-entry.feature
@@ -10,7 +10,7 @@ Feature: gtd review <commitish> — start a review process from an ordinary bran
   template's `reviewing` → `await-review` → feedback laps, and the
   `await-review` review checkout window) then operates over that diff with no
   duplicated logic. The unified template declares `reviewEntry: true` on
-  `review-start-check` — the green-baseline gate that runs the suite and, once
+  `review-precheck` — the green-baseline gate that runs the suite and, once
   green, transitions to `reviewing`.
 
   Background:
@@ -25,13 +25,13 @@ Feature: gtd review <commitish> — start a review process from an ordinary bran
       """
     When I run gtd with args "review base"
     Then it succeeds
-    And the last commit subject is "gtd(human): review-start-check"
+    And the last commit subject is "gtd(human): review-precheck"
     And the last commit body contains "Gtd-Review-Base:"
     And the last commit body contains the hash of "base"
     # The green-baseline gate: a clean tree (tests pass) advances to reviewing.
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): review-start-check → reviewing"
+    And the last commit subject is "gtd(check): review-precheck → reviewing"
     When I run gtd next
     Then it succeeds
     And stdout contains "## Full diff under review"

--- a/tests/integration/features/smoke.feature
+++ b/tests/integration/features/smoke.feature
@@ -11,7 +11,7 @@ Feature: v3 pattern-machine smoke — simple workflow hops, gtd next --json, cus
   both refusal shapes) has its own dedicated feature files — see
   refusals.feature, default-workflow.feature, retry.feature, squash.feature.
 
-  Scenario: the simple workflow's happy path advances idle -> start-check -> planning -> plan-review -> building -> checking
+  Scenario: the simple workflow's happy path advances idle -> plan-precheck -> planning -> await-plan -> building -> checking
     Given a test project
     And the workflow
     And a file ".gtd/TODO.md" with:
@@ -20,21 +20,21 @@ Feature: v3 pattern-machine smoke — simple workflow hops, gtd next --json, cus
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): idle → start-check"
+    And the last commit subject is "gtd(human): idle → plan-precheck"
     # The green-baseline gate: a clean tree (tests pass) advances to planning.
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): start-check → planning"
+    And the last commit subject is "gtd(check): plan-precheck → planning"
     Given ".gtd/TODO.md" is modified to:
       """
       Build a thing. Developed into a concrete plan.
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): planning → plan-review"
+    And the last commit subject is "gtd(agent): planning → await-plan"
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): plan-review → building"
+    And the last commit subject is "gtd(human): await-plan → building"
     Given a file "src/thing.ts" with:
       """
       export const thing = 1

--- a/tests/integration/features/unified-advanced-flow.feature
+++ b/tests/integration/features/unified-advanced-flow.feature
@@ -3,20 +3,20 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
 
   Coverage of the ADVANCED entry of `src/workflows/unified.yaml` (started by
   creating `.gtd/REQUIREMENTS.md`): the two-phase product/technical Q&A
-  (adv-grilling ⇄ answer, architecting ⇄ answer), package decomposition, the
-  per-package build loop (picking → adv-building → adv-checking), the
+  (product-qa ⇄ answer, technical-qa ⇄ answer), package decomposition, the
+  per-package build loop (picking → package-building → package-checking), the
   per-package agentic `spec-review` gate (issues → spec-fix → re-check →
   re-review; clean = approval → closing), and the queue closing out to the
   SHARED tail (`reviewing`) once every package is done.
 
   The Q&A phases use the qa checkbox format: the agent surfaces each open
   question with candidate-answer checkboxes plus a `- [ ] _your answer_` slot,
-  and the `answerGate` on adv-grilling-answer/architecting-answer refuses a step
+  and the `answerGate` on product-answer/technical-answer refuses a step
   while any open question lacks exactly one tick. Ticking loops back to the
   agent (which folds answers in); a clean step advances only when no open
   questions remain (agent surfaced none, or the human deleted the section).
 
-  Check-actor states (picking, adv-checking, closing, review-deciding) are
+  Check-actor states (picking, package-checking, closing, review-deciding) are
   simulated by writing their verdict files directly and running
   `gtd step check` — @inmem never executes the scripts themselves.
 
@@ -29,7 +29,7 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): idle → adv-start-check"
+    And the last commit subject is "gtd(human): idle → spec-precheck"
 
   Scenario: idle forks on the entry file — TODO.md (anything else) starts the simple flow gate
     Given a test project
@@ -40,12 +40,12 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): idle → start-check"
+    And the last commit subject is "gtd(human): idle → plan-precheck"
 
   Scenario: the answer gate refuses an unanswered open question, then ticking loops back and a converged plan advances
     Given a test project
     And the workflow
-    And a commit "gtd(agent): adv-grilling-answer" that adds ".gtd/REQUIREMENTS.md" with:
+    And a commit "gtd(agent): product-answer" that adds ".gtd/REQUIREMENTS.md" with:
       """
       Build a widget.
 
@@ -62,7 +62,7 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
     Then it fails
     And stderr contains "not answered"
     And stderr contains "Which storage backend?"
-    # tick exactly one option -> loops back to adv-grilling to fold the answer in
+    # tick exactly one option -> loops back to product-qa to fold the answer in
     Given ".gtd/REQUIREMENTS.md" is modified to:
       """
       Build a widget.
@@ -77,12 +77,12 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): adv-grilling-answer → adv-grilling"
+    And the last commit subject is "gtd(human): product-answer → product-qa"
 
   Scenario: the accept-all escape — deleting the whole Open Questions section is allowed and loops to the agent to finalize
     Given a test project
     And the workflow
-    And a commit "gtd(agent): adv-grilling-answer" that adds ".gtd/REQUIREMENTS.md" with:
+    And a commit "gtd(agent): product-answer" that adds ".gtd/REQUIREMENTS.md" with:
       """
       Build a widget.
 
@@ -101,12 +101,12 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): adv-grilling-answer → adv-grilling"
+    And the last commit subject is "gtd(human): product-answer → product-qa"
 
   Scenario: a ticked free-text slot with text is a valid answer; the placeholder alone is refused
     Given a test project
     And the workflow
-    And a commit "gtd(agent): architecting-answer" that adds ".gtd/ARCHITECTURE.md" with:
+    And a commit "gtd(agent): technical-answer" that adds ".gtd/ARCHITECTURE.md" with:
       """
       Modules: widget.ts, store.ts.
 
@@ -122,7 +122,7 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
     When I run gtd step human
     Then it fails
     And stderr contains "not answered"
-    # replace the placeholder with real text -> answered, loops to architecting
+    # replace the placeholder with real text -> answered, loops to technical-qa
     Given ".gtd/ARCHITECTURE.md" is modified to:
       """
       Modules: widget.ts, store.ts.
@@ -137,7 +137,7 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): architecting-answer → architecting"
+    And the last commit subject is "gtd(human): technical-answer → technical-qa"
 
   Scenario: the advanced flow runs product + technical Q&A, decomposes into a package, builds it, fails and passes the spec-review gate, then closes out to review
     Given a test project
@@ -148,28 +148,28 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): idle → adv-start-check"
+    And the last commit subject is "gtd(human): idle → spec-precheck"
 
-    # adv-start-check: green baseline gate — a clean tree (tests pass) -> adv-grilling
+    # spec-precheck: green baseline gate — a clean tree (tests pass) -> product-qa
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): adv-start-check → adv-grilling"
+    And the last commit subject is "gtd(check): spec-precheck → product-qa"
 
-    # adv-grilling: develops the product plan in REQUIREMENTS.md
+    # product-qa: develops the product plan in REQUIREMENTS.md
     Given ".gtd/REQUIREMENTS.md" is modified to:
       """
       Build a widget. Product plan: it exposes a `widget()` factory.
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): adv-grilling → adv-grilling-answer"
+    And the last commit subject is "gtd(agent): product-qa → product-answer"
 
-    # adv-grilling-answer: accept with a clean step -> architecting
+    # product-answer: accept with a clean step -> technical-qa
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): adv-grilling-answer → architecting"
+    And the last commit subject is "gtd(human): product-answer → technical-qa"
 
-    # architecting: writes ARCHITECTURE.md, deletes REQUIREMENTS.md
+    # technical-qa: writes ARCHITECTURE.md, deletes REQUIREMENTS.md
     Given the file ".gtd/REQUIREMENTS.md" is deleted
     And a file ".gtd/ARCHITECTURE.md" with:
       """
@@ -177,12 +177,12 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): architecting → architecting-answer"
+    And the last commit subject is "gtd(agent): technical-qa → technical-answer"
 
-    # architecting-answer: accept with a clean step -> decompose
+    # technical-answer: accept with a clean step -> decompose
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): architecting-answer → decompose"
+    And the last commit subject is "gtd(human): technical-answer → decompose"
 
     # decompose: writes one package file, deletes ARCHITECTURE.md
     Given the file ".gtd/ARCHITECTURE.md" is deleted
@@ -202,21 +202,21 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
       """
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): picking → adv-building"
+    And the last commit subject is "gtd(check): picking → package-building"
 
-    # adv-building: implements the package's tasks, leaving the package file
+    # package-building: implements the package's tasks, leaving the package file
     Given a file "src/widget.ts" with:
       """
       export const widget = () => ({})
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): adv-building → adv-checking"
+    And the last commit subject is "gtd(agent): package-building → package-checking"
 
-    # adv-checking (green): a clean step moves to the spec-review gate
+    # package-checking (green): a clean step moves to the spec-review gate
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): adv-checking → spec-review"
+    And the last commit subject is "gtd(check): package-checking → spec-review"
 
     # spec-review (issues): the reviewer writes SPEC_FEEDBACK.md -> spec-fix
     Given a file ".gtd/SPEC_FEEDBACK.md" with:
@@ -227,7 +227,7 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
     Then it succeeds
     And the last commit subject is "gtd(agent): spec-review → spec-fix"
 
-    # spec-fix: addresses the concern, deletes SPEC_FEEDBACK.md -> adv-checking
+    # spec-fix: addresses the concern, deletes SPEC_FEEDBACK.md -> package-checking
     Given the file ".gtd/SPEC_FEEDBACK.md" is deleted
     And "src/widget.ts" is modified to:
       """
@@ -235,12 +235,12 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
       """
     When I run gtd step agent
     Then it succeeds
-    And the last commit subject is "gtd(agent): spec-fix → adv-checking"
+    And the last commit subject is "gtd(agent): spec-fix → package-checking"
 
-    # adv-checking (green) -> spec-review again
+    # package-checking (green) -> spec-review again
     When I run gtd step check
     Then it succeeds
-    And the last commit subject is "gtd(check): adv-checking → spec-review"
+    And the last commit subject is "gtd(check): package-checking → spec-review"
 
     # spec-review (clean = approval): the reviewer writes nothing -> closing
     When I run gtd step agent

--- a/tests/integration/features/validate.feature
+++ b/tests/integration/features/validate.feature
@@ -19,16 +19,16 @@ Feature: gtd validate — self-validating the resolved rest's steering file
   human gate is only ever handed a well-formed file.
 
   In the bundled template the ADVANCED flow uses the `qa` mode
-  (`.gtd/REQUIREMENTS.md` at adv-grilling, `.gtd/ARCHITECTURE.md` at
-  architecting). The SIMPLE flow's `.gtd/TODO.md` iterates on a free-form plan
+  (`.gtd/REQUIREMENTS.md` at product-qa, `.gtd/ARCHITECTURE.md` at
+  technical-qa). The SIMPLE flow's `.gtd/TODO.md` iterates on a free-form plan
   under the format-only `prose` mode: it validates cleanly regardless of
   content (there is no validator to fail), but still formats on a declared
   `format:` command — formatting.feature covers that.
 
-  Scenario: a well-formed REQUIREMENTS.md at adv-grilling validates cleanly
+  Scenario: a well-formed REQUIREMENTS.md at product-qa validates cleanly
     Given a test project
     And the workflow
-    And a commit "gtd(human): adv-grilling" that adds ".gtd/REQUIREMENTS.md" with:
+    And a commit "gtd(human): product-qa" that adds ".gtd/REQUIREMENTS.md" with:
       """
       Build a thing. Plan: add src/thing.ts exporting `thing`.
 
@@ -42,10 +42,10 @@ Feature: gtd validate — self-validating the resolved rest's steering file
     Then it succeeds
     And stdout contains ".gtd/REQUIREMENTS.md: valid"
 
-  Scenario: a malformed REQUIREMENTS.md at adv-grilling fails with the parser's finding
+  Scenario: a malformed REQUIREMENTS.md at product-qa fails with the parser's finding
     Given a test project
     And the workflow
-    And a commit "gtd(human): adv-grilling" that adds ".gtd/REQUIREMENTS.md" with:
+    And a commit "gtd(human): product-qa" that adds ".gtd/REQUIREMENTS.md" with:
       """
       Build a thing.
 
@@ -63,7 +63,7 @@ Feature: gtd validate — self-validating the resolved rest's steering file
   Scenario: --json reports the valid verdict structurally
     Given a test project
     And the workflow
-    And a commit "gtd(human): adv-grilling" that adds ".gtd/REQUIREMENTS.md" with:
+    And a commit "gtd(human): product-qa" that adds ".gtd/REQUIREMENTS.md" with:
       """
       Build a thing. Plan: add src/thing.ts.
       """
@@ -128,7 +128,7 @@ Feature: gtd validate — self-validating the resolved rest's steering file
   Scenario: plain `gtd next` appends the self-validation instruction at a producing agent state
     Given a test project
     And the workflow
-    And a commit "gtd(human): adv-grilling" that adds ".gtd/REQUIREMENTS.md" with:
+    And a commit "gtd(human): product-qa" that adds ".gtd/REQUIREMENTS.md" with:
       """
       Build a thing.
       """
@@ -140,13 +140,13 @@ Feature: gtd validate — self-validating the resolved rest's steering file
   Scenario: `gtd next --json` withholds the instruction — the driving loop owns the validate-and-retry step
     Given a test project
     And the workflow
-    And a commit "gtd(human): adv-grilling" that adds ".gtd/REQUIREMENTS.md" with:
+    And a commit "gtd(human): product-qa" that adds ".gtd/REQUIREMENTS.md" with:
       """
       Build a thing.
       """
     When I run gtd next with "--json"
     Then it succeeds
-    And stdout contains "\"state\":\"adv-grilling\""
+    And stdout contains "\"state\":\"product-qa\""
     And stdout does not contain "gtd validate"
 
   Scenario: gtd validate leaves the file untouched when the mode declares no formatter
@@ -156,7 +156,7 @@ Feature: gtd validate — self-validating the resolved rest's steering file
     # formatting.feature).
     Given a test project
     And the workflow
-    And a commit "gtd(human): adv-grilling" that adds ".gtd/REQUIREMENTS.md" with:
+    And a commit "gtd(human): product-qa" that adds ".gtd/REQUIREMENTS.md" with:
       """
       Build a thing. This is a deliberately long single prose line that clearly exceeds the eighty character print width, and nothing rewraps it.
       """
@@ -165,13 +165,13 @@ Feature: gtd validate — self-validating the resolved rest's steering file
     And the git status is clean
 
   Scenario: the step gate runs format + validate after a human edits the steering file — a malformed edit is refused
-    # A human answers at adv-grilling-answer but leaves a `### ` question heading
+    # A human answers at product-answer but leaves a `### ` question heading
     # with no question text. Stepping runs the same gate the producing agent
     # gets, so the malformed edit is refused and nothing is committed — the
     # evaluation happens after a human edit too.
     Given a test project
     And the workflow
-    And a commit "gtd(human): adv-grilling-answer" that adds ".gtd/REQUIREMENTS.md" with:
+    And a commit "gtd(human): product-answer" that adds ".gtd/REQUIREMENTS.md" with:
       """
       Build a thing. Plan: do it.
       """
@@ -188,12 +188,12 @@ Feature: gtd validate — self-validating the resolved rest's steering file
     When I run gtd step human
     Then it fails
     And stderr contains "is not valid"
-    And the last commit subject is "gtd(human): adv-grilling-answer"
+    And the last commit subject is "gtd(human): product-answer"
 
-  Scenario: the step gate captures a human's valid edit (routing it back to adv-grilling)
+  Scenario: the step gate captures a human's valid edit (routing it back to product-qa)
     Given a test project
     And the workflow
-    And a commit "gtd(human): adv-grilling-answer" that adds ".gtd/REQUIREMENTS.md" with:
+    And a commit "gtd(human): product-answer" that adds ".gtd/REQUIREMENTS.md" with:
       """
       Build a thing.
       """
@@ -204,4 +204,4 @@ Feature: gtd validate — self-validating the resolved rest's steering file
       """
     When I run gtd step human
     Then it succeeds
-    And the last commit subject is "gtd(human): adv-grilling-answer → adv-grilling"
+    And the last commit subject is "gtd(human): product-answer → product-qa"

--- a/tests/integration/features/visualize.feature
+++ b/tests/integration/features/visualize.feature
@@ -43,3 +43,28 @@ Feature: gtd visualize — an interactive diagram of the active workflow
     When I run gtd with args "visualize --port abc"
     Then it fails
     And stderr contains "--port must be an integer"
+
+  Scenario: --json labels an edge by its declared action, falling back to the raw pattern when none is declared
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **":
+                to: reviewing
+                action: "Accept the plan"
+          reviewing:
+            actor: agent
+            prompt: "review NOTE.md"
+            on:
+              "A FEEDBACK.md": idle
+      """
+    When I run gtd with args "visualize --json"
+    Then it succeeds
+    And stdout contains "Accept the plan"
+    And stdout contains "A FEEDBACK.md"

--- a/tests/integration/support/steps/gtd-loop.steps.ts
+++ b/tests/integration/support/steps/gtd-loop.steps.ts
@@ -94,7 +94,7 @@ Given("NO_COLOR is set to {string}", (world: GtdWorld, value: string) => {
 })
 
 // Sets $GTD_TESTCOMMAND explicitly — the bundled template's `checking`/
-// `fix-check` script reads `it.vars.testCommand`, whose highest-precedence
+// `fix-precheck` script reads `it.vars.testCommand`, whose highest-precedence
 // layer is this env var (see src/Edge.ts's `resolveVars`), so this reroutes
 // the real check script at a controlled, deterministic suite instead of the
 // default "npm test".

--- a/tests/integration/support/world.ts
+++ b/tests/integration/support/world.ts
@@ -46,7 +46,7 @@ export class GtdWorld extends QuickPickleWorld {
   leakedGtdLoopLog: string | undefined = undefined
   /** Explicit `$NO_COLOR` value a scenario wants exported (loop rendering scenarios, @live only). */
   noColorOverride: string | undefined = undefined
-  /** Explicit `$GTD_TESTCOMMAND` value a scenario wants exported — overrides the bundled template's `vars.testCommand` for a real `checking`/`fix-check` script run (`gtd-loop` @live scenarios only). */
+  /** Explicit `$GTD_TESTCOMMAND` value a scenario wants exported — overrides the bundled template's `vars.testCommand` for a real `checking`/`fix-precheck` script run (`gtd-loop` @live scenarios only). */
   gtdTestCommandOverride: string | undefined = undefined
 
   /** Environment variables the in-memory tier's `EnvVars` layer exposes (`it.vars`'s highest-precedence `GTD_<UPPERCASE-name>` layer) — never mutates the real `process.env`. Set by `Given an environment variable "..." set to "..."`. */


### PR DESCRIPTION
## Summary

Polish pass on the bundled `unified.yaml` workflow and the surfaces that render it.

- **Renamed states for clarity.** The bundled template's state names had grown inconsistent and opaque (`adv-grilling`, `architecting`, `start-check`, `adv-checking`, `plan-review`, …). Renamed to a consistent, self-describing scheme (`product-qa`, `technical-qa`, `plan-precheck`, `spec-precheck`, `package-checking`, `await-plan`, …) so the workflow reads coherently end to end. Pure rename, no behavior change — every test, e2e feature, and doc reference updated to match.
- **Edge `action` labels.** Added an optional `action` field alongside `describe` on `on` edges: a short imperative label (e.g. "Accept plan") naming the human choice itself, distinct from the underlying glob pattern. Same presence discipline as `describe`, inert to the engine (never matched or rendered by the machine), threaded through to consumers. `gtd status`, `gtd visualize` (diagram + inspector), and the workflow's message templates now lead with the action when set, falling back to the raw pattern otherwise.
- **`gtd status` next preview.** Added a `Next:` preview: the first declared `on` edge whose pattern matches the pending changes as a whole, using the same first-match-wins semantics as `gtd step`. Previews the *declared* route only — a capped `retry` may redirect at real step time — so it's advisory.

## Test plan

- Unit + integration tests updated for the renamed states and new `action` field
- New coverage: `driver-json-status.feature`, `visualize.feature`, `Edge.test.ts`, `PatternConfig.test.ts`, `Submachines.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)