### PR TITLE
feat(loop): surface failing turn/check output on stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,12 @@ way to idle.
 Bare `gtd` prints one line per event — colored and emoji on a real terminal,
 plain ASCII under `NO_COLOR` or when piped — and redirects the noisier
 agent/check/step subprocess output to a per-repo/per-worktree log file (its path
-is the run's first output line, ready to `tail -f`).
+is the run's first output line, ready to `tail -f`). Any execution that FAILS
+also replays its last 20 lines of output inline on stderr, on top of the log
+still holding the complete record: an agent turn that fails stops the loop (it
+would fail identically next lap), while a check script that exits non-zero is
+reported as a warning and the loop carries on, because the outcome lives in the
+tree, not in the script's exit code.
 
 A workflow state can declare an optional `label:` — a human-readable display
 name surfaced in `gtd next --json`/`gtd status`. The driver uses it for its

--- a/bin/gtd
+++ b/bin/gtd
@@ -44,12 +44,12 @@ if [[ "$FANCY" == 1 ]]; then
   C_RESET=$'\e[0m'; C_BOLD=$'\e[1m'; C_DIM=$'\e[2m'
   C_CYAN=$'\e[36m'; C_GREEN=$'\e[32m'; C_YELLOW=$'\e[33m'; C_RED=$'\e[31m'
   M_TRANS="➡️"; M_AGENT="🤖"; M_CHECK="🔧"; M_HUMAN="✍️"
-  M_FIX="🔁"; M_COMMIT="✅"; M_SETTLE="🎉"; M_ERROR="❌"; M_ELLIPSIS="…"
+  M_FIX="🔁"; M_COMMIT="✅"; M_SETTLE="🎉"; M_ERROR="❌"; M_WARN="⚠️"; M_ELLIPSIS="…"
 else
   C_RESET=""; C_BOLD=""; C_DIM=""
   C_CYAN=""; C_GREEN=""; C_YELLOW=""; C_RED=""
   M_TRANS="->"; M_AGENT="[agent]"; M_CHECK="[check]"; M_HUMAN="[you]"
-  M_FIX="[fix]"; M_COMMIT="[commit]"; M_SETTLE="[done]"; M_ERROR="[err]"; M_ELLIPSIS="..."
+  M_FIX="[fix]"; M_COMMIT="[commit]"; M_SETTLE="[done]"; M_ERROR="[err]"; M_WARN="[warn]"; M_ELLIPSIS="..."
 fi
 
 # emit_file_rows <files> — render a commit's changed files as dim, indented
@@ -114,14 +114,68 @@ emit_error() {
 }
 
 # emit_log_pointer — the "see the log" line printed right after every
-# emit_error call, to stderr: suppression must never hide a failure, so every
-# error points at where the redirected subprocess output actually went.
+# emit_error call, to stderr: it names the log as the OVERFLOW channel — the
+# failing execution's own output is already replayed inline (see emit_block/
+# emit_output_since below); the log is where the rest of it, and the full
+# run's other output, lives.
 emit_log_pointer() {
   if [[ "$FANCY" == 1 ]]; then
     printf '%s📄 see %s%s\n' "$C_DIM" "$GTD_LOOP_LOG" "$C_RESET" >&2
   else
     printf '%ssee %s%s\n' "$C_DIM" "$GTD_LOOP_LOG" "$C_RESET" >&2
   fi
+}
+
+# Suppressed subprocess output goes to $GTD_LOOP_LOG in full, but a FAILING
+# execution also replays inline: mark the log's size before the call, print
+# what was appended since. Bounded to the last $ERR_TAIL_LINES lines — the log
+# holds the rest, and the overflow row says where.
+ERR_TAIL_LINES=20
+
+# log_offset — the log's current size in bytes (0 when it doesn't exist yet).
+log_offset() {
+  local n=0
+  if [[ -n "${GTD_LOOP_LOG:-}" && -f "$GTD_LOOP_LOG" ]]; then n="$(wc -c <"$GTD_LOOP_LOG")"; fi
+  printf '%s' "${n// /}"
+}
+
+# emit_block <text> — replay captured subprocess output to stderr, dim and
+# indented like emit_file_rows, capped at the LAST $ERR_TAIL_LINES lines with
+# an overflow row naming the log. Empty <text> prints nothing. CSI escapes are
+# stripped under FANCY=0 (the plain-ASCII promise), using a sed form (\e, not
+# \x1b) that both BSD and GNU sed accept.
+emit_block() {
+  local text="$1" total overflow
+  [[ -z "$text" ]] && return 0
+  if [[ "$FANCY" == 0 ]]; then
+    text="$(sed $'s/\e\\[[0-9;]*[a-zA-Z]//g' <<<"$text")"
+  fi
+  total="$(wc -l <<<"$text")"
+  total="${total// /}"
+  if ((total > ERR_TAIL_LINES)); then
+    overflow=$((total - ERR_TAIL_LINES))
+    printf '   %s%s (%d earlier lines in %s)%s\n' "$C_DIM" "$M_ELLIPSIS" "$overflow" "$GTD_LOOP_LOG" "$C_RESET" >&2
+    text="$(tail -n "$ERR_TAIL_LINES" <<<"$text")"
+  fi
+  while IFS= read -r line; do
+    printf '   %s%s%s\n' "$C_DIM" "$line" "$C_RESET" >&2
+  done <<<"$text"
+}
+
+# emit_output_since <offset> — emit_block over the log bytes appended since
+# <offset>.
+emit_output_since() {
+  local offset="$1" bytes=""
+  if [[ -n "${GTD_LOOP_LOG:-}" && -f "$GTD_LOOP_LOG" ]]; then
+    bytes="$(tail -c "+$((offset + 1))" "$GTD_LOOP_LOG" 2>/dev/null || true)"
+  fi
+  emit_block "$bytes"
+}
+
+# emit_warn <message> — a surfaced but NON-fatal failure (a check script that
+# exited non-zero).
+emit_warn() {
+  printf '%s %s%s%s\n' "$M_WARN" "$C_YELLOW" "$1" "$C_RESET" >&2
 }
 
 # ── Git-derivation helpers (parse_subject, report_commits) ──────────────────
@@ -375,9 +429,10 @@ fi
 
 while true; do
   if ! next_json="$(run_gtd next --json 2>&1)"; then
-    echo "gtd-loop: could not determine the next step:" >&2
-    echo "$next_json" >&2
-    echo "Run \`gtd status\` to inspect the repo." >&2
+    emit_error "could not determine the next step:
+$next_json
+Run \`gtd status\` to inspect the repo."
+    emit_log_pointer
     exit 1
   fi
 
@@ -394,17 +449,29 @@ while true; do
     # (or an outer wrapper) edits and re-launches; the opening move above
     # captures what they left.
     emit_gate "$state" "$label"
-    run_gtd next
+    if ! gate_out="$(run_gtd next 2>&1)"; then
+      emit_error "$gate_out"
+      emit_log_pointer
+      exit 1
+    fi
+    printf '%s\n' "$gate_out"
     exit 0
   fi
 
   if [[ "$kind" == "script" ]]; then
     emit_action "$M_CHECK" "$label"
-    # Execute the emitted wrapper verbatim; its exit code is deliberately
-    # ignored (`|| true` under `set -e`) — the script encodes its outcome in
-    # the tree, and `gtd step` captures whatever it left there via the state's
-    # own `on` patterns. Its own output goes to the log, not the terminal.
-    bash -c "$content" >>"$GTD_LOOP_LOG" 2>&1 || true
+    # Execute the emitted wrapper verbatim; its exit code decides nothing
+    # (the script encodes its outcome in the tree, and `gtd step` captures
+    # whatever it left there via the state's own `on` patterns) but a non-zero
+    # exit is surfaced as a warning — its own output goes to the log, and to
+    # the terminal too when it exits non-zero.
+    script_offset="$(log_offset)"
+    script_status=0
+    bash -c "$content" >>"$GTD_LOOP_LOG" 2>&1 || script_status=$?
+    if ((script_status != 0)); then
+      emit_warn "the check script at '$state' exited $script_status — continuing; the outcome is whatever it left in the tree:"
+      emit_output_since "$script_offset"
+    fi
     if ! step_out="$(run_gtd step "$actor" 2>&1)"; then
       printf '%s\n' "$step_out" >>"$GTD_LOOP_LOG"
       emit_error "$step_out"
@@ -478,24 +545,42 @@ $next_out"
   # driver-side equivalent, so the next rest is only ever handed a well-formed
   # file. gtd itself never validates at step time — this is the loop's job.
   emit_action "$M_AGENT" "$label"
-  run_agent_turn "$content" "$resume"
+  turn_offset="$(log_offset)"
+  agent_status=0
+  run_agent_turn "$content" "$resume" || agent_status=$?
+  if ((agent_status != 0)); then
+    emit_error "the agent turn at '$state' failed (exit $agent_status):"
+    emit_output_since "$turn_offset"
+    emit_log_pointer
+    exit 1
+  fi
 
   fix_attempt=0
   while ! validate_out="$(run_gtd validate 2>&1)"; do
     fix_attempt=$((fix_attempt + 1))
     if ((fix_attempt > 3)); then
+      printf '%s\n' "$validate_out" >>"$GTD_LOOP_LOG"
       emit_error "'$state' still fails \`gtd validate\` after 3 fix attempts:
 $validate_out
 Stopping rather than stepping with a malformed steering file."
       emit_log_pointer
       exit 1
     fi
+    printf '%s\n' "$validate_out" >>"$GTD_LOOP_LOG"
+    emit_action "$M_FIX" "attempt $fix_attempt"
     # Resume the same session when there is one (the agent just wrote the file);
     # otherwise a fresh invocation still gets the findings via the prompt.
     fix_resume=0
     [[ -n "$session_id" ]] && fix_resume=1
-    emit_action "$M_FIX" "attempt $fix_attempt"
-    run_agent_turn "$content"$'\n\n'"Your last turn does not pass \`gtd validate\`. Fix these format violations, then finish:"$'\n'"$validate_out" "$fix_resume"
+    turn_offset="$(log_offset)"
+    agent_status=0
+    run_agent_turn "$content"$'\n\n'"Your last turn does not pass \`gtd validate\`. Fix these format violations, then finish:"$'\n'"$validate_out" "$fix_resume" || agent_status=$?
+    if ((agent_status != 0)); then
+      emit_error "the agent's fix attempt $fix_attempt at '$state' failed (exit $agent_status):"
+      emit_output_since "$turn_offset"
+      emit_log_pointer
+      exit 1
+    fi
   done
 
   if ! step_out="$(run_gtd step "$actor" 2>&1)"; then

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -354,6 +354,60 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And stdout contains "[fix] attempt 1"
     And the git log contains "chore: planned"
 
+  Scenario: Does not print validate findings on a fix attempt, only logs them
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": planning
+          planning:
+            actor: agent
+            file: .gtd/PLAN.md
+            mode: qa
+            prompt: "Write .gtd/PLAN.md with the plan."
+            on:
+              "* **": done
+          done:
+            commit: "chore: planned"
+      """
+    And a commit "gtd(agent): planning" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      mkdir -p .gtd
+      case "$GTD_LOOP_PROMPT" in
+        *"does not pass"*)
+          cat > .gtd/PLAN.md <<'PLAN'
+      Plan: build the calculator. No open questions.
+      PLAN
+          ;;
+        *)
+          cat > .gtd/PLAN.md <<'PLAN'
+      Plan: build the calculator.
+
+      ## Open Questions
+
+      ###
+
+      Forgot to write the question.
+      PLAN
+          ;;
+      esac
+      """
+    When I run bare gtd
+    Then it succeeds
+    And stdout contains "[fix] attempt 1"
+    And stderr does not contain "has no question text"
+    And the log file contains "has no question text"
+
   Scenario: Renders a transition line and a bare self-loop capture line, logging what gtd step committed
     # `working -> checking` differs (a real transition), while `checking`'s own
     # "A .gtd/FEEDBACK.md": checking pattern targets itself (a self-loop, the
@@ -535,6 +589,32 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And stdout does not contain "CHECK: verifying the tree"
     And the log file contains "CHECK: verifying the tree"
 
+  Scenario: Surfaces a check script's failure output but still decides the outcome from the tree
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          checking:
+            actor: check
+            initial: true
+            script: |
+              echo "CHECK BOOM" >&2
+              mkdir -p .gtd
+              echo x > .gtd/FEEDBACK.md
+              exit 1
+            on:
+              "A .gtd/FEEDBACK.md": reviewing
+          reviewing:
+            actor: human
+            message: "sign off"
+      """
+    When I run bare gtd
+    Then it succeeds
+    And stderr contains "CHECK BOOM"
+    And stderr contains "exited 1 — continuing"
+    And stdout contains "checking → reviewing"
+
   Scenario: Renders plain ASCII markers with no ANSI escape codes under NO_COLOR
     Given a test project
     And a gtd config file at ".gtdrc" with:
@@ -624,6 +704,114 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     When I run bare gtd
     Then it fails
     And stderr contains "no progress at 'working'"
+    And stderr contains "see .git/gtd-loop.log"
+
+  Scenario: Prints the agent CLI's own failure output instead of exiting silently
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Build the package described below: write src/calc.ts exporting add(a, b)."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: "true"
+            on:
+              "A .gtd/FEEDBACK.md": working
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      echo "BOOM: agent exploded" >&2
+      exit 3
+      """
+    When I run bare gtd
+    Then it fails
+    And stderr contains "the agent turn at 'working' failed (exit 3)"
+    And stderr contains "BOOM: agent exploded"
+    And stderr contains "see .git/gtd-loop.log"
+
+  Scenario: Caps a failing turn's replayed output at 20 lines and points at the log
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            prompt: "Build the package described below: write src/calc.ts exporting add(a, b)."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: "true"
+            on:
+              "A .gtd/FEEDBACK.md": working
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      for i in $(seq 1 30); do printf "line %03d\n" "$i"; done
+      exit 1
+      """
+    When I run bare gtd
+    Then it fails
+    And stderr contains "line 030"
+    And stderr contains "(10 earlier lines in"
+    And stderr does not contain "line 001"
+    And the log file contains "line 001"
+
+  Scenario: Reports a mid-run failure to resolve the next step with the error marker and the log pointer
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          watching:
+            actor: check
+            initial: true
+            script: "true"
+            on:
+              "C": working
+          working:
+            actor: agent
+            prompt: "<%~ it.vars.missing.deep %>"
+            on:
+              "* **": done
+          done:
+            commit: "chore: done"
+      """
+    And a commit "gtd(check): watching" that adds "NOTE.md" with:
+      """
+      note
+      """
+    When I run bare gtd
+    Then it fails
+    And stderr contains "[err]"
+    And stderr contains "could not determine the next step"
+    And stderr contains "Cannot read properties of undefined"
     And stderr contains "see .git/gtd-loop.log"
 
   Scenario: Stops instead of stepping when a steering file still fails gtd validate after 3 fix attempts


### PR DESCRIPTION
## Problem

The loop redirected all agent/check subprocess output to the log file, so a failing agent turn or non-zero check script left the terminal with only a bare exit and a "see the log" pointer — diagnosing a failure meant tailing a separate file mid-incident.

## Change

`bin/gtd` gains `emit_block`/`emit_output_since`, which replay the failing execution's own output inline on stderr, capped at the last 20 lines with an overflow row naming the log for the rest.

The two failure modes stay distinct, per the engine's contract that a check's exit code decides nothing:

- **agent turn failure** → fatal, stops the loop (it would fail identically next lap)
- **check script non-zero exit** → warning only (`emit_warn`); the loop still trusts the tree, not the exit code, to decide the outcome

A mid-run `gtd next --json` failure and a steering-gate command failure are surfaced the same way, instead of exiting silently past the log pointer.

## Tests

188 new lines of scenarios in `tests/integration/features/gtd-loop.feature` covering each failure path.

## Docs

README updated to describe the stderr replay behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)