### PR TITLE
feat(lsp): offer option code actions from wrapped continuation lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,9 +483,11 @@ compiler's job at load time.
 per `review`-mode chunk that still has an unchecked hunk (an outline of the
 packages left to review) plus check/uncheck actions over those chunks,
 go-to-definition from a `review`-mode hunk line into the file it points at (at
-its `#line`), symbols over a `qa`-mode file's open questions, diagnostics for
-both (live as you edit), and a `gtd.openSteeringFile` command that jumps to the
-current state's steering file.
+its `#line`), symbols over a `qa`-mode file's open questions plus "pick this
+option"/"uncheck this option" code actions on each option — offered anywhere on
+the option's list item, including any wrapped continuation lines, not just its
+own `- [ ]` line — diagnostics for both (live as you edit), and a
+`gtd.openSteeringFile` command that jumps to the current state's steering file.
 
 It is config-driven via each state's `file:`/`mode:`, and falls back to basename
 dispatch (`REVIEW.md` → `review`) with no config in sight. `qa` and `review` are

--- a/src/Lsp.test.ts
+++ b/src/Lsp.test.ts
@@ -97,6 +97,30 @@ describe("questionSymbols", () => {
   it("returns no symbols when there is no Open Questions section", () => {
     expect(questionSymbols("# Plan\n\nJust prose.\n")).toEqual([])
   })
+
+  it("spans a wrapped option's range over its continuation lines while keeping selectionRange on the checkbox line", () => {
+    const doc = [
+      "## Open Questions",
+      "",
+      "### Which API?",
+      "",
+      "- [ ] REST, specifically",
+      "  the public v3 endpoint set",
+      "- [x] GraphQL",
+      "",
+    ].join("\n")
+    const symbols = questionSymbols(doc)
+    const [rest, graphql] = symbols[0]!.children!
+    expect(rest!.range).toEqual({
+      start: { line: 4, character: 0 },
+      end: { line: 5, character: "  the public v3 endpoint set".length },
+    })
+    expect(rest!.selectionRange).toEqual({
+      start: { line: 4, character: 0 },
+      end: { line: 4, character: "- [ ] REST, specifically".length },
+    })
+    expect(graphql!.range).toEqual(graphql!.selectionRange)
+  })
 })
 
 describe("questionCodeActions / toggleOptionEdit", () => {
@@ -143,6 +167,55 @@ describe("questionCodeActions / toggleOptionEdit", () => {
     expect(toggleOptionEdit(doc, 4)?.newText).toBe("x")
     expect(toggleOptionEdit(doc, 5)?.newText).toBe(" ")
     expect(toggleOptionEdit(doc, 3)).toBeUndefined() // blank line
+  })
+})
+
+describe("questionCodeActions on a wrapped multi-line option", () => {
+  const wrappedDoc = [
+    "## Open Questions",
+    "",
+    "### Which API?",
+    "",
+    "- [ ] REST, specifically",
+    "  the public v3 endpoint set",
+    "- [x] GraphQL, specifically",
+    "  the public v4 endpoint set",
+    "- [ ] _your answer_",
+    "",
+    "Some trailing prose after the list.",
+    "",
+  ].join("\n")
+  const uri = "file:///repo/.gtd/REQUIREMENTS.md"
+  const at = (
+    line: number,
+  ): { start: { line: number; character: number }; end: { line: number; character: number } } => ({
+    start: { line, character: 0 },
+    end: { line, character: 0 },
+  })
+
+  it("offers 'pick this option' from a continuation line, editing the checkbox line rather than the cursor line", () => {
+    const actions = questionCodeActions(uri, wrappedDoc, at(5)) // REST's continuation line
+    expect(actions).toHaveLength(1)
+    expect(actions[0]?.title).toBe("gtd: pick this option")
+    const edits = actions[0]?.edit?.changes?.[uri] ?? []
+    expect(edits.map((e) => e.range.start.line).sort()).toEqual([4, 6])
+    expect(edits.find((e) => e.range.start.line === 4)?.newText).toBe("x")
+    expect(edits.find((e) => e.range.start.line === 6)?.newText).toBe(" ")
+  })
+
+  it("offers 'uncheck this option' from a continuation line of the ticked option", () => {
+    const actions = questionCodeActions(uri, wrappedDoc, at(7)) // GraphQL's continuation line
+    expect(actions).toHaveLength(1)
+    expect(actions[0]?.title).toBe("gtd: uncheck this option")
+    const edits = actions[0]?.edit?.changes?.[uri] ?? []
+    expect(edits).toHaveLength(1)
+    expect(edits[0]?.range.start.line).toBe(6)
+  })
+
+  it("offers nothing on a blank line inside the option list, the ### heading, or prose separated from the list by a blank line", () => {
+    expect(questionCodeActions(uri, wrappedDoc, at(9))).toEqual([]) // blank line after the free-text option
+    expect(questionCodeActions(uri, wrappedDoc, at(2))).toEqual([]) // the ### heading
+    expect(questionCodeActions(uri, wrappedDoc, at(10))).toEqual([]) // trailing prose
   })
 })
 

--- a/src/Lsp.ts
+++ b/src/Lsp.ts
@@ -135,7 +135,7 @@ export const questionSymbols = (content: string): DocumentSymbol[] => {
     const children: DocumentSymbol[] = question.options.map((option) => ({
       name: `${option.checked ? "[x]" : "[ ]"} ${option.text || "your answer"}`,
       kind: SymbolKind.Boolean,
-      range: lineRange(lines, option.sourceLine),
+      range: spanRange(lines, option.sourceLine, option.endLine),
       selectionRange: lineRange(lines, option.sourceLine),
     }))
     return {
@@ -337,11 +337,12 @@ const optionCodeAction = (
 }
 
 /**
- * Code actions for a `qa`-mode file: on an open question's option line, "pick
- * this option" (radio semantics — check it and uncheck every sibling in the
- * same question, so exactly one stays ticked) or "uncheck this option" when it
- * is already the chosen one. No action off an option line, or on an
- * answered-section (prose) question.
+ * Code actions for a `qa`-mode file: anywhere on an open question's option's
+ * list item — its `- [ ]` line or any of its wrapped continuation lines (see
+ * `QuestionOption.endLine`) — "pick this option" (radio semantics — check it
+ * and uncheck every sibling in the same question, so exactly one stays
+ * ticked) or "uncheck this option" when it is already the chosen one. No
+ * action off an option's span, or on an answered-section (prose) question.
  */
 export const questionCodeActions = (uri: string, content: string, range: Range): CodeAction[] => {
   const { questions } = parseOpenQuestions(content)
@@ -349,7 +350,9 @@ export const questionCodeActions = (uri: string, content: string, range: Range):
   const actions: CodeAction[] = []
   for (const question of questions) {
     if (question.status !== "open") continue
-    const option = question.options.find((o) => o.sourceLine === cursorLine)
+    const option = question.options.find(
+      (o) => cursorLine >= o.sourceLine && cursorLine <= o.endLine,
+    )
     if (!option) continue
     const action = optionCodeAction(uri, content, question, option)
     if (action) actions.push(action)

--- a/src/OpenQuestions.test.ts
+++ b/src/OpenQuestions.test.ts
@@ -159,9 +159,9 @@ describe("parseOpenQuestions", () => {
       )
       const [question] = result.questions
       expect(question!.options).toEqual([
-        { checked: false, text: "REST", freeText: false, sourceLine: 4 },
-        { checked: false, text: "GraphQL", freeText: false, sourceLine: 5 },
-        { checked: false, text: "", freeText: true, sourceLine: 6 },
+        { checked: false, text: "REST", freeText: false, sourceLine: 4, endLine: 4 },
+        { checked: false, text: "GraphQL", freeText: false, sourceLine: 5, endLine: 5 },
+        { checked: false, text: "", freeText: true, sourceLine: 6, endLine: 6 },
       ])
       expect(question!.answered).toBe(false)
     })
@@ -185,7 +185,13 @@ describe("parseOpenQuestions", () => {
       const question = result.questions[0]!
       expect(question.answered).toBe(true)
       const chosen = question.options.find((o) => o.checked)!
-      expect(chosen).toEqual({ checked: true, text: "use tRPC", freeText: true, sourceLine: 6 })
+      expect(chosen).toEqual({
+        checked: true,
+        text: "use tRPC",
+        freeText: true,
+        sourceLine: 6,
+        endLine: 6,
+      })
     })
 
     it("is unanswered when the free-text slot is ticked but still the placeholder", () => {
@@ -199,6 +205,7 @@ describe("parseOpenQuestions", () => {
         text: "",
         freeText: true,
         sourceLine: 6,
+        endLine: 6,
       })
     })
 
@@ -219,6 +226,7 @@ describe("parseOpenQuestions", () => {
         text: FREE_TEXT_PLACEHOLDER,
         freeText: false,
         sourceLine: 4,
+        endLine: 4,
       })
       expect(last!.freeText).toBe(true)
     })
@@ -230,6 +238,76 @@ describe("parseOpenQuestions", () => {
       const question = parseOpenQuestions(content).questions[0]!
       expect(question.options).toEqual([])
       expect(question.answered).toBe(false)
+    })
+  })
+
+  describe("option line span (endLine)", () => {
+    const q = (lines: readonly string[]): string =>
+      ["## Open Questions", "", "### Which API?", ...lines, ""].join("\n")
+
+    it("a single-line option's endLine equals its own sourceLine", () => {
+      const result = parseOpenQuestions(q(["", "- [ ] REST", "- [ ] GraphQL"]))
+      const [rest, graphql] = result.questions[0]!.options
+      expect(rest).toMatchObject({ sourceLine: 4, endLine: 4 })
+      expect(graphql).toMatchObject({ sourceLine: 5, endLine: 5 })
+    })
+
+    it("an indented wrap over two continuation lines extends endLine to the last one", () => {
+      const result = parseOpenQuestions(
+        q(["", "- [ ] REST, specifically", "  a JSON:API-flavored", "  REST endpoint set"]),
+      )
+      const [option] = result.questions[0]!.options
+      expect(option).toMatchObject({ sourceLine: 4, endLine: 6 })
+    })
+
+    it("an unindented (lazy) wrap gets the same span as an indented one", () => {
+      const result = parseOpenQuestions(
+        q(["", "- [ ] REST, specifically", "a JSON:API-flavored", "REST endpoint set"]),
+      )
+      const [option] = result.questions[0]!.options
+      expect(option).toMatchObject({ sourceLine: 4, endLine: 6 })
+    })
+
+    it("the next checkbox line ends the previous option's span", () => {
+      const result = parseOpenQuestions(
+        q(["", "- [ ] REST, specifically", "a wrapped line", "- [ ] GraphQL"]),
+      )
+      const [rest, graphql] = result.questions[0]!.options
+      expect(rest).toMatchObject({ sourceLine: 4, endLine: 5 })
+      expect(graphql).toMatchObject({ sourceLine: 6, endLine: 6 })
+    })
+
+    it("a blank line ends the span, so trailing prose after it stays out of the last option's span", () => {
+      const result = parseOpenQuestions(
+        q(["", "- [ ] _your answer_", "a wrapped answer", "", "some trailing prose"]),
+      )
+      const [option] = result.questions[0]!.options
+      expect(option).toMatchObject({ sourceLine: 4, endLine: 5 })
+    })
+
+    it("the last body line ends the span at the block end, with no overrun past the next heading", () => {
+      const content = [
+        "## Open Questions",
+        "",
+        "### Which API?",
+        "",
+        "- [ ] REST",
+        "a wrapped line",
+        "another wrapped line",
+      ].join("\n")
+      const result = parseOpenQuestions(content)
+      const [option] = result.questions[0]!.options
+      expect(option).toMatchObject({ sourceLine: 4, endLine: 6 })
+    })
+
+    it("answered/text stay derived from the checkbox line alone for a wrapped ticked free-text option", () => {
+      const result = parseOpenQuestions(
+        q(["", "- [ ] REST", "- [x] use tRPC", "a wrapped continuation of the answer"]),
+      )
+      const question = result.questions[0]!
+      expect(question.answered).toBe(true)
+      const chosen = question.options.find((o) => o.checked)!
+      expect(chosen).toMatchObject({ text: "use tRPC", sourceLine: 5, endLine: 6 })
     })
   })
 })

--- a/src/OpenQuestions.ts
+++ b/src/OpenQuestions.ts
@@ -24,7 +24,10 @@
  * both read. Base VALIDATION stays loose (the checkbox convention is NOT
  * required — a plain prose body is still valid); the only reported error is the
  * empty-`###` one. An ANSWERED question is prose (the agent drops the checkboxes
- * when it resolves and moves it down), so it carries no options.
+ * when it resolves and moves it down), so it carries no options. Each option
+ * also carries an `endLine` spanning any wrapped continuation lines
+ * (`QuestionOption.endLine`) — for editor tooling only; it feeds no validation
+ * and no `answered` decision.
  *
  * A question is answered/accepted by MOVING its `###` block from
  * `## Open Questions` down into `## Answered Questions` — the agent does this on
@@ -63,7 +66,7 @@ export type OpenQuestionStatus = "open" | "answered"
  */
 export const FREE_TEXT_PLACEHOLDER = "_your answer_"
 
-/** One checkbox option under an OPEN question: its ticked state, its text (the free-text placeholder normalized to `""`), and its source line for editor tooling. */
+/** One checkbox option under an OPEN question: its ticked state, its text (the free-text placeholder normalized to `""`), and its source line span for editor tooling. */
 export interface QuestionOption {
   readonly checked: boolean
   /** Text after the `- [ ]`/`- [x]` marker, trimmed. The unfilled free-text placeholder (`FREE_TEXT_PLACEHOLDER`) normalizes to `""`. */
@@ -72,6 +75,8 @@ export interface QuestionOption {
   readonly freeText: boolean
   /** 0-based line index of this option's own `- [ ]`/`- [x]` line, for editor tooling. */
   readonly sourceLine: number
+  /** 0-based line index of the LAST line of this option's list item — equal to `sourceLine` for a single-line option, greater when the item's text wraps onto continuation lines. Editor tooling maps a cursor anywhere in `sourceLine..endLine` to this option. */
+  readonly endLine: number
 }
 
 export interface OpenQuestion {
@@ -169,14 +174,32 @@ const splitQuestionBlocks = (lines: readonly string[], start: number): readonly 
 const CHECKBOX_RE = /^\s*[-*]\s*\[([ xX])\]\s?(.*)$/
 
 /**
+ * The body index of the last line belonging to the list item that starts at
+ * `index`: the run of following lines that are neither blank nor a checkbox of
+ * their own (see the span rule in the module doc). Indentation is NOT
+ * required — an unindented lazy wrap is as much part of the item as an
+ * indented one.
+ */
+const itemEndIndex = (body: readonly string[], index: number): number => {
+  let end = index
+  for (let i = index + 1; i < body.length; i += 1) {
+    const line = body[i]!
+    if (line.trim().length === 0 || CHECKBOX_RE.test(line)) break
+    end = i
+  }
+  return end
+}
+
+/**
  * Extracts the checkbox options from a question block's body, in document
  * order. The LAST option is the free-text slot (`freeText: true`); its text is
  * normalized to `""` when it still carries the unfilled `FREE_TEXT_PLACEHOLDER`.
  * `bodyStart` is the absolute 0-based line index of `body[0]` (the line right
- * after the `###` heading), so each option carries its true source line.
+ * after the `###` heading), so each option carries its true source line and
+ * span (`itemEndIndex`).
  */
 const parseOptions = (body: readonly string[], bodyStart: number): QuestionOption[] => {
-  const raw: { checked: boolean; text: string; sourceLine: number }[] = []
+  const raw: { checked: boolean; text: string; sourceLine: number; bodyIndex: number }[] = []
   body.forEach((line, i) => {
     const match = CHECKBOX_RE.exec(line)
     if (!match) return
@@ -184,6 +207,7 @@ const parseOptions = (body: readonly string[], bodyStart: number): QuestionOptio
       checked: match[1] !== " ",
       text: match[2]!.trim(),
       sourceLine: bodyStart + i,
+      bodyIndex: i,
     })
   })
   const lastIndex = raw.length - 1
@@ -191,7 +215,13 @@ const parseOptions = (body: readonly string[], bodyStart: number): QuestionOptio
     const freeText = i === lastIndex
     const normalized =
       freeText && option.text.trim().toLowerCase() === FREE_TEXT_PLACEHOLDER ? "" : option.text
-    return { checked: option.checked, text: normalized, freeText, sourceLine: option.sourceLine }
+    return {
+      checked: option.checked,
+      text: normalized,
+      freeText,
+      sourceLine: option.sourceLine,
+      endLine: bodyStart + itemEndIndex(body, option.bodyIndex),
+    }
   })
 }
 

--- a/tests/integration/features/lsp.feature
+++ b/tests/integration/features/lsp.feature
@@ -14,8 +14,11 @@ Feature: gtd lsp — the steering-file LSP server (stdio)
   hand-authored current state and asking the client to show its steering
   file (`window/showDocument`). A final scenario proves go-to-definition: a
   `textDocument/definition` on a `.gtd/REVIEW.md` hunk pointer line returns a
-  `Location` in the referenced file at its `#line` (basename fallback). Real
-  subprocess I/O (spawn + stdio JSON-RPC framing), so this runs @live.
+  `Location` in the referenced file at its `#line` (basename fallback). One
+  more scenario proves a `qa`-mode code action is offered from a wrapped
+  option's continuation line, not just its own `- [ ]` line (see
+  `QuestionOption.endLine` in src/OpenQuestions.ts). Real subprocess I/O
+  (spawn + stdio JSON-RPC framing), so this runs @live.
 
   Scenario: the initialize handshake succeeds and advertises symbol/code-action support
     Given a test project
@@ -132,3 +135,42 @@ Feature: gtd lsp — the steering-file LSP server (stdio)
       """
     Then the LSP response has no error
     And the LSP response result points to "src/calc.ts" at line 4
+
+  Scenario: a code action is offered on a wrapped option's continuation line, not just its checkbox line
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "go"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            file: ".gtd/PLAN.md"
+            mode: qa
+            prompt: "develop the plan"
+            on:
+              "* **": idle
+      """
+    And an LSP server started in the test project
+    When the LSP client sends an initialize request
+    Then the LSP response has no error
+    When the LSP client requests code actions at line 9 in ".gtd/PLAN.md" containing:
+      """
+      Build a calculator.
+
+      ## Open Questions
+
+      ### Which API?
+
+      - [ ] REST
+      - [ ] GraphQL
+      - [ ] _your answer_
+        a wrapped continuation of the free-text answer
+      """
+    Then the LSP response has no error
+    And the LSP response result contains a code action titled "gtd: pick this option"

--- a/tests/integration/support/steps/lsp.steps.ts
+++ b/tests/integration/support/steps/lsp.steps.ts
@@ -179,6 +179,26 @@ When(
   },
 )
 
+When(
+  "the LSP client requests code actions at line {int} in {string} containing:",
+  async (world: GtdWorld, line: number, path: string, content: string) => {
+    const client = clients.get(world)!
+    const uri = pathToFileURL(join(world.repoDir, path)).toString()
+    notify(client, "textDocument/didOpen", {
+      textDocument: { uri, languageId: "markdown", version: 1, text: content },
+    })
+    const response = await request(client, "textDocument/codeAction", {
+      textDocument: { uri },
+      range: {
+        start: { line, character: 0 },
+        end: { line, character: 0 },
+      },
+      context: { diagnostics: [] },
+    })
+    ;(world as unknown as { lspLastResponse: JsonRpcResponse }).lspLastResponse = response
+  },
+)
+
 Then(
   "the LSP response result points to {string} at line {int}",
   (world: GtdWorld, path: string, line: number) => {
@@ -252,6 +272,18 @@ Then(
     assert.ok(
       symbols.some((s) => s.name === name),
       `Expected a symbol named "${name}". Got: ${JSON.stringify(symbols.map((s) => s.name))}`,
+    )
+  },
+)
+
+Then(
+  "the LSP response result contains a code action titled {string}",
+  (world: GtdWorld, title: string) => {
+    const response = (world as unknown as { lspLastResponse: JsonRpcResponse }).lspLastResponse
+    const actions = response.result as ReadonlyArray<{ title: string }>
+    assert.ok(
+      actions.some((a) => a.title === title),
+      `Expected a code action titled "${title}". Got: ${JSON.stringify(actions.map((a) => a.title))}`,
     )
   },
 )


### PR DESCRIPTION
## What

`QuestionOption` gains an `endLine` spanning a checkbox option's wrapped continuation lines — indented or lazy (unindented) — up to the next checkbox, a blank line, or the end of the question block.

`questionCodeActions` and the option's document-symbol `range` now use `sourceLine..endLine` instead of an exact `sourceLine` match, so **"pick this option"/"uncheck this option" fire from anywhere on a long option's list item**, not just its own `- [ ]` line. The symbol's `selectionRange` stays on the checkbox line.

## Why

Long option text wraps in an editor as real continuation lines. Putting the cursor on one and asking for code actions previously returned nothing — the action only existed on the exact `- [ ]` line, which is the least likely place the cursor lands when you're reading the option's text.

## Scope

`answered`/`text`/`checked` stay derived from the checkbox line alone. `endLine` is additive, editor-tooling-only metadata: it feeds no validation and no `answered` decision. The picked-option edit still targets the checkbox line, never the cursor line.

## Tests

- `src/OpenQuestions.test.ts` — span rules: single line, indented wrap, lazy wrap, next checkbox ends the span, blank line ends the span, block end with no overrun past the next heading, and `answered`/`text` unaffected by a wrap
- `src/Lsp.test.ts` — code actions from a continuation line (pick + uncheck), nothing on a blank line / `###` heading / trailing prose, and the widened symbol range
- `tests/integration/features/lsp.feature` — `@live` end-to-end: `textDocument/codeAction` on a wrapped free-text option's continuation line returns "gtd: pick this option"

README's `gtd lsp` section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)