### PR TITLE
feat(loop): recover when a resumed agent session is gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,13 @@ name surfaced in `gtd next --json`/`gtd status`. The driver uses it for its
 per-beat progress lines; an outer wrapper (a terminal multiplexer, a notifier)
 can use it the same way.
 
+A state can also declare an optional `memory:` scope label: consecutive agent
+turns sharing the same label continue one agent session (remembered in the git
+dir, so it survives restarts across the same worktree), while a changed or
+absent label starts a fresh one. If the remembered session no longer exists
+(retention expired, `~/.claude/projects` wiped, a machine change), the driver
+degrades to a fresh session with a warning instead of stopping the loop.
+
 ### Terminal-multiplexer status: a herdr wrapper
 
 [herdr](https://herdr.dev) shows a per-pane status in its sidebar. This wrapper

--- a/bin/gtd
+++ b/bin/gtd
@@ -172,6 +172,23 @@ emit_output_since() {
   emit_block "$bytes"
 }
 
+# A resume that failed because the session it names no longer exists — claude
+# prints "No conversation found with session ID: <uuid>". Loose on purpose: any
+# adapter whose CLI says something session-shaped gets the same recovery
+# instead of stopping the loop.
+SESSION_GONE_RE='no conversation found with session id|no such session|session (id )?[^ ]*( was)? not found|session [^ ]* does not exist'
+
+# session_gone_since <offset> — true when the log bytes appended since <offset>
+# carry the missing-session signature above. Blind (returns false) when no log
+# is configured, so recovery is best-effort, never a hard dependency.
+session_gone_since() {
+  local offset="$1" bytes=""
+  if [[ -n "${GTD_LOOP_LOG:-}" && -f "$GTD_LOOP_LOG" ]]; then
+    bytes="$(tail -c "+$((offset + 1))" "$GTD_LOOP_LOG" 2>/dev/null || true)"
+  fi
+  [[ -n "$bytes" ]] && grep -qiE "$SESSION_GONE_RE" <<<"$bytes"
+}
+
 # emit_warn <message> — a surfaced but NON-fatal failure (a check script that
 # exited non-zero).
 emit_warn() {
@@ -330,7 +347,18 @@ fi
 # still resumes one planning session. The scope, session id, and a
 # resume-or-fresh flag are exported as $GTD_LOOP_MEMORY / $GTD_LOOP_SESSION_ID
 # / $GTD_LOOP_MEMORY_RESUME; the default adapter turns them into
-# `--resume`/`--session-id`. An adapter that ignores them keeps working.
+# `--resume`/`--session-id`. An adapter that ignores them keeps working. A
+# remembered session that has since vanished (the retention window elapsed, a
+# wiped `~/.claude/projects`, a machine change) degrades to a fresh session
+# with a warning rather than failing the turn — see run_agent_turn's own
+# comment.
+
+# new_session_id — mints an opaque session id for a fresh memory scope
+# (uuidgen, falling back to the kernel's random uuid, or empty when neither is
+# available — the default adapter then omits --session-id entirely).
+new_session_id() {
+  uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || echo ""
+}
 
 prev_state=""
 prev_content=""
@@ -362,7 +390,7 @@ fi
 # the resume flag; the memory scope ($memory/$session_id) is read from the
 # enclosing iteration, so a same-turn re-prompt (the validate gate) resumes the
 # same session.
-run_agent_turn() {
+invoke_agent() {
   local prompt="$1" do_resume="$2" cmd="${GTD_LOOP_AGENT_CMD:-}"
   if [[ -z "$cmd" ]]; then
     cmd='claude -p "$GTD_LOOP_PROMPT"'
@@ -377,6 +405,33 @@ run_agent_turn() {
   GTD_LOOP_PROMPT="$prompt" GTD_LOOP_MODEL="$model" GTD_LOOP_MEMORY="$memory" \
     GTD_LOOP_SESSION_ID="$session_id" GTD_LOOP_MEMORY_RESUME="$do_resume" bash -c "$cmd" \
     >>"${GTD_LOOP_LOG:-/dev/null}" 2>&1
+}
+
+# run_agent_turn <prompt> <resume> — invoke_agent, with one recovery: a
+# resumed turn (do_resume == 1) that fails AND whose output carries the
+# missing-session signature (session_gone_since) means the marker's session no
+# longer exists on disk. Rather than failing the turn (and every turn after
+# it, since the dead id would just be resumed again), mint a fresh session,
+# rewrite $memory_marker with it — the self-healing part, so a later launch
+# doesn't repeat this — and retry the SAME prompt once with resume off. $resume
+# and $session_id are the enclosing iteration's globals; recovery rewrites them
+# too, so a later validate-gate re-prompt in the same turn resumes the newly
+# pinned session. Blind to the failure mode when session_gone_since can't tell
+# (no log configured): a genuine agent failure then correctly propagates.
+run_agent_turn() {
+  local prompt="$1" do_resume="$2" offset status=0
+  offset="$(log_offset)"
+  invoke_agent "$prompt" "$do_resume" && return 0
+  status=$?
+  if [[ "$do_resume" == "1" ]] && session_gone_since "$offset"; then
+    emit_warn "the remembered agent session for '$memory' is gone — continuing in a fresh session (this turn starts without its previous context)"
+    session_id="$(new_session_id)"
+    resume=0
+    printf '%s\n%s\n' "$memory" "$session_id" >"$memory_marker"
+    invoke_agent "$prompt" 0
+    return $?
+  fi
+  return $status
 }
 
 # The furthest commit already reported to the terminal by report_commits (see
@@ -528,7 +583,7 @@ $next_out"
       resume=1
       session_id="$prev_session"
     else
-      session_id="$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || echo "")"
+      session_id="$(new_session_id)"
     fi
     printf '%s\n%s\n' "$memory" "$session_id" >"$memory_marker"
   else

--- a/tests/integration/features/gtd-loop.feature
+++ b/tests/integration/features/gtd-loop.feature
@@ -291,6 +291,87 @@ Feature: gtd loop — the packaged reference loop driver (v3)
     And the log file contains "AGENT MEMORY=fix RESUME=1"
     And stdout contains "[you]  idle"
 
+  Scenario: Recovers when the remembered session has vanished instead of stalling the loop
+    # Same "fix" scope re-entering twice as the scenario above, except the stub
+    # simulates the remembered session having vanished: on the SECOND "fixing"
+    # entry (GTD_LOOP_MEMORY_RESUME=1, the doomed resume) it prints claude's
+    # exact missing-session message and exits 1 instead of doing real work.
+    # run_agent_turn must recognise that as recoverable — warn, mint a fresh
+    # session, retry with RESUME=0 — rather than stopping the loop, so the run
+    # still reaches its human gate at "idle".
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        states:
+          idle:
+            actor: human
+            initial: true
+            message: "write NOTE.md to start a cycle"
+            on:
+              "* **": working
+          working:
+            actor: agent
+            memory: work
+            prompt: "Create src/fix.ts for the initial build."
+            on:
+              "* **": checking
+          checking:
+            actor: check
+            script: |
+              set +e
+              mkdir -p .gtd
+              c=".git/testcount"
+              n=$(cat "$c" 2>/dev/null || echo 0)
+              n=$((n + 1))
+              echo "$n" > "$c"
+              if [ "$n" -lt 3 ]; then echo "fail $n" > .gtd/FEEDBACK.md; else rm -f .gtd/FEEDBACK.md; fi
+            on:
+              "A .gtd/FEEDBACK.md": fixing
+              "M .gtd/FEEDBACK.md": fixing
+              "D .gtd/FEEDBACK.md": done
+              "C": done
+          fixing:
+            actor: agent
+            memory: fix
+            prompt: "Fix the failing check."
+            on:
+              "* **": checking
+          done:
+            commit: "chore: fixed"
+      """
+    And a commit "gtd(agent): working" that adds "NOTE.md" with:
+      """
+      Build a calculator.
+      """
+    And a stub agent script that responds to prompts with:
+      """
+      echo "AGENT MEMORY=${GTD_LOOP_MEMORY} RESUME=${GTD_LOOP_MEMORY_RESUME}"
+      if [ "${GTD_LOOP_MEMORY_RESUME}" = "1" ]; then
+        echo "No conversation found with session ID: ${GTD_LOOP_SESSION_ID}" >&2
+        exit 1
+      fi
+      case "$GTD_LOOP_PROMPT" in
+        *"initial build"*)
+          mkdir -p src
+          echo 'export const x = 1' > src/fix.ts
+          ;;
+        *"Fix the failing"*)
+          echo "// touched at ${GTD_LOOP_MEMORY}" >> src/fix.ts
+          ;;
+        *)
+          echo "gtd-loop test stub: unrecognized prompt" >&2
+          exit 1
+          ;;
+      esac
+      """
+    When I run bare gtd
+    Then it succeeds
+    And the log file contains "AGENT MEMORY=fix RESUME=1"
+    And the log file contains "AGENT MEMORY=fix RESUME=0" 2 times
+    And stderr contains "is gone — continuing in a fresh session"
+    And stdout contains "[you]  idle"
+
   Scenario: Runs the self-validation gate after a producing agent turn and re-prompts until the steering file is well-formed
     # `planning` declares file:/mode: (.gtd/PLAN.md as `qa`), so its output has
     # a checkable format. The stub writes a MALFORMED plan first (a bare `###`

--- a/tests/integration/support/steps/gtd-loop.steps.ts
+++ b/tests/integration/support/steps/gtd-loop.steps.ts
@@ -169,6 +169,29 @@ Then("the log file contains {string}", (world: GtdWorld, text: string) => {
   )
 })
 
+// Counts NON-OVERLAPPING occurrences — used to prove a recovered retry ran
+// (e.g. "AGENT MEMORY=fix RESUME=0" appearing twice: once for the scope's
+// first entry, once for the retry after a doomed resume), which a plain
+// "contains" assertion can't distinguish from a single occurrence.
+Then(
+  "the log file contains {string} {int} times",
+  (world: GtdWorld, text: string, count: number) => {
+    const path = join(world.repoDir, loopLogPath(world))
+    const content = existsSync(path) ? readFileSync(path, "utf-8") : ""
+    let actual = 0
+    let idx = 0
+    while ((idx = content.indexOf(text, idx)) !== -1) {
+      actual++
+      idx += text.length
+    }
+    assert.strictEqual(
+      actual,
+      count,
+      `Expected the log file ("${loopLogPath(world)}") to contain "${text}" exactly ${count} times, found ${actual}. Got:\n${content}`,
+    )
+  },
+)
+
 // The plain-ASCII rendering proof: no ANSI escape sequence (ESC "[") anywhere.
 // Built from a char code rather than a regex literal to avoid embedding a
 // literal control character in source.


### PR DESCRIPTION
## Problem

A state's `memory:` scope pins an agent session id in the git dir, so consecutive turns in the same scope resume one session. That marker outlives the session itself: once Claude's retention window elapses (or `~/.claude/projects` is wiped, or the worktree moves machines), every resumed turn in that scope fails with `No conversation found with session ID: <uuid>` — and keeps failing, because the loop resumes the same dead id again next beat. The loop stalls.

## Change

`bin/gtd` now treats that as recoverable:

- `session_gone_since <offset>` scans the log bytes appended by the just-failed turn for a missing-session signature (`SESSION_GONE_RE` — deliberately loose so other adapters' phrasings hit the same path). Blind when no `GTD_LOOP_LOG` is configured, so recovery is best-effort and never a hard dependency.
- `run_agent_turn` wraps the renamed `invoke_agent`: a *resumed* turn that fails with that signature warns, mints a fresh session id, **rewrites the memory marker** (self-healing — a later launch doesn't repeat the recovery), and retries the same prompt once with resume off. It also rewrites the enclosing `$resume`/`$session_id`, so a same-turn validate-gate re-prompt resumes the newly pinned session.
- Any other failure propagates unchanged.
- Session-id minting is factored into `new_session_id()` (used by both the fresh-scope path and recovery).

## Tests

New `gtd-loop.feature` scenario: same two-entry `fix` scope as the existing memory scenario, but the stub prints claude's exact missing-session message and exits 1 on any `GTD_LOOP_MEMORY_RESUME=1` invocation. Asserts the warning reaches stderr, `RESUME=0` ran twice (first entry + recovered retry), and the run still reaches its human gate at `idle`.

Supporting step: `the log file contains {string} {int} times` — a counting assertion, since plain `contains` can't tell one occurrence from two.

README documents the degradation under the `memory:` scope paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)