### PR TITLE
fix(review-window): leave new files untracked instead of intent-to-add

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,15 @@ description, and must be preserved:
   window). `src/program.ts` calls the edge; it never reaches into `GitService`
   directly. The review window and the steering-file gate are deliberately
   invisible to the pure engine — don't "simplify" them back into it.
+- **The review window issues no whole-tree index WRITE, and every git index
+  write tolerates `index.lock` contention.** gtd shares one worktree index with
+  the reviewer's editor SCM, `gtd lsp`, and git-aware prompts, which all write
+  the index to refresh their stat cache when the window's `git reset --mixed`
+  wakes them. So `openReviewWindow` leaves new files UNTRACKED (never
+  `git add --intent-to-add .` — that both lost the lock race and truncated
+  discarded files to zero bytes), and all index writers in `src/Git.ts` go
+  through `withIndexLockRetry`. Don't add a whole-tree index write to the window
+  or a raw `exec` that bypasses the retry.
 
 A workflow is DATA, not code: there is no engine-side wiring to trace when a
 workflow's shape changes.

--- a/README.md
+++ b/README.md
@@ -117,18 +117,23 @@ steering-file entries are chosen by which file you create:
 Both flows converge on the same tail: an agent hands you a `.gtd/REVIEW.md`
 checkbox review of the diff — the prompt never inlines the diff itself; it names
 the commit the changes are based at and the agent runs `git diff` to read the
-range before writing the review. Tick a box as you review each hunk (ticking
-just records "I read this"), and leave a **comment** to request changes: a note
-on a line, an inline `// TODO`-style comment in the code, or a direct code edit.
-Any comment sends a build + re-review round — an agent first turns your comments
-into an explicit instruction list, then a build turn implements it (a re-review
-then covers only the follow-through, and a hand-edit is treated as your own fix
-the agent completes without reverting your lines; a comment can't be silently
-dropped — a build turn that addresses nothing is refused). Ticking every box
-with no comment is the sign-off, which collapses the whole cycle into one commit
-(a **squash finale** whose message an agent drafts). Stepping with a box still
-unticked and no comment is refused (finish reviewing first), as is deleting
-`.gtd/REVIEW.md`.
+range before writing the review. While the cycle rests at that gate, gtd opens a
+**review checkout window**: HEAD is rewound to the review base with the working
+tree untouched, so the whole reviewable change shows up as ordinary uncommitted
+changes in your editor's normal git integration (and files added during the
+cycle show up as ordinary untracked files, so discarding one deletes it). The
+window closes on the next gtd invocation. Tick a box as you review each hunk
+(ticking just records "I read this"), and leave a **comment** to request
+changes: a note on a line, an inline `// TODO`-style comment in the code, or a
+direct code edit. Any comment sends a build + re-review round — an agent first
+turns your comments into an explicit instruction list, then a build turn
+implements it (a re-review then covers only the follow-through, and a hand-edit
+is treated as your own fix the agent completes without reverting your lines; a
+comment can't be silently dropped — a build turn that addresses nothing is
+refused). Ticking every box with no comment is the sign-off, which collapses the
+whole cycle into one commit (a **squash finale** whose message an agent drafts).
+Stepping with a box still unticked and no comment is refused (finish reviewing
+first), as is deleting `.gtd/REVIEW.md`.
 
 The same review tail also has a direct entry point — `gtd review <commitish>`
 starts a brand new process reviewing `<commitish>..HEAD` with no cycle of its

--- a/src/Edge.test.ts
+++ b/src/Edge.test.ts
@@ -60,7 +60,6 @@ const stubGit = (overrides: Partial<GitOperations>): GitOperations => ({
   mixedResetTo: notImplemented("mixedResetTo"),
   hardResetTo: notImplemented("hardResetTo"),
   restoreStagedFrom: notImplemented("restoreStagedFrom"),
-  addIntentToAdd: notImplemented("addIntentToAdd"),
   ...overrides,
 })
 

--- a/src/Git.test.ts
+++ b/src/Git.test.ts
@@ -5,7 +5,7 @@ import { execSync } from "node:child_process"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { Effect } from "effect"
 import { NodeContext } from "@effect/platform-node"
-import { GitService } from "./Git.js"
+import { GitService, isIndexLockError, withIndexLockRetry } from "./Git.js"
 import { Cwd } from "./Cwd.js"
 import { InMemRepo } from "../tests/integration/support/inmem/Repo.js"
 import { makeGitServiceLayer } from "../tests/integration/support/inmem/layers.js"
@@ -488,3 +488,79 @@ for (const [tierName, makeTier] of tiers) {
     })
   })
 }
+
+// ---------------------------------------------------------------------------
+// index.lock contention retry — the review window shares one worktree index
+// with the reviewer's editor/lsp/prompt, all of which write the index to
+// refresh their stat cache when a `git reset --mixed` wakes them. gtd's own
+// index writes must ride out the resulting `index.lock` race, not fail on it.
+// ---------------------------------------------------------------------------
+
+describe("index.lock retry", () => {
+  it("recognizes git's index.lock contention message and nothing else", () => {
+    expect(
+      isIndexLockError(
+        new Error(
+          "git add -A failed (exit 128): fatal: Unable to create " +
+            "'/repo/.git/index.lock': File exists.\n\nAnother git process seems to be running",
+        ),
+      ),
+    ).toBe(true)
+    // A different non-zero exit (a rejected commit, a missing ref) must NOT retry.
+    expect(isIndexLockError(new Error("git commit failed (exit 1): nothing to commit"))).toBe(false)
+  })
+
+  it("retries a transient lock error to success, but propagates any other failure at once", async () => {
+    let lockAttempts = 0
+    await expect(
+      Effect.runPromise(
+        withIndexLockRetry(
+          Effect.suspend(() => {
+            lockAttempts += 1
+            return lockAttempts < 3
+              ? Effect.fail(new Error("Unable to create 'index.lock': File exists"))
+              : Effect.succeed("ok")
+          }),
+        ),
+      ),
+    ).resolves.toBe("ok")
+    expect(lockAttempts).toBe(3)
+
+    let otherAttempts = 0
+    const res = await Effect.runPromise(
+      Effect.either(
+        withIndexLockRetry(
+          Effect.suspend(() => {
+            otherAttempts += 1
+            return Effect.fail(new Error("nothing to commit"))
+          }),
+        ),
+      ),
+    )
+    expect(res._tag).toBe("Left")
+    expect(otherAttempts).toBe(1)
+  })
+
+  it("a real index-writing command survives a lock that clears mid-flight", async () => {
+    const lock = join(repoDir, ".git", "index.lock")
+    writeFileSync(lock, "")
+    // Release the lock 50ms in — after the first attempt fails, well within the
+    // jittered backoff budget (~315ms+ before the 6 retries exhaust). Without
+    // the retry, `git add -A` fails on its first, immediate attempt.
+    const timer = setTimeout(() => {
+      try {
+        rmSync(lock)
+      } catch {
+        // already removed
+      }
+    }, 50)
+    try {
+      writeFileSync(join(repoDir, "new.txt"), "content")
+      await runLive(Effect.flatMap(GitService, (g) => g.commitAllWithPrefix("gtd(test): capture")))
+    } finally {
+      clearTimeout(timer)
+    }
+    expect(existsSync(lock)).toBe(false)
+    expect(gitExec("log", "-1", "--pretty=%s")).toBe("gtd(test): capture")
+  })
+})

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -118,12 +118,6 @@ export interface GitWriterOperations {
     source: string,
     paths: ReadonlyArray<string>,
   ) => Effect.Effect<void, Error>
-  /**
-   * `git add --intent-to-add .` — register untracked files in the index with
-   * an empty placeholder so they render as additions (with content hunks) in
-   * `git diff` and editor SCM views, without staging their content.
-   */
-  readonly addIntentToAdd: () => Effect.Effect<void, Error>
 }
 
 export interface GitOperations extends GitReaderOperations, GitWriterOperations {}
@@ -359,8 +353,6 @@ const makeGitImpl = (executor: CommandExecutor.CommandExecutor, root: string): G
             // makes `git restore` complain — the pin is best-effort plumbing.
             Effect.catchAll(() => Effect.void),
           ),
-
-    addIntentToAdd: () => exec("git", "add", "--intent-to-add", ".").pipe(Effect.asVoid),
   }
 }
 

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -1,5 +1,5 @@
 import { Command, CommandExecutor } from "@effect/platform"
-import { Context, Effect, Layer, Option, Stream } from "effect"
+import { Context, Duration, Effect, Layer, Option, Schedule, Stream } from "effect"
 import { Cwd } from "./Cwd.js"
 
 export interface GitReaderOperations {
@@ -150,42 +150,78 @@ const parseNameStatus = (out: string): Array<{ path: string; status: string }> =
 }
 
 /**
+ * True when `error` is git's `index.lock` contention failure — another process
+ * held the index lock when git tried to take it. gtd shares one worktree index
+ * with every git-aware tool the reviewer runs (editor SCM, `gtd lsp`,
+ * git-aware shell prompts): each refreshes its stat cache by WRITING the index
+ * whenever a `git reset --mixed` in the review window wakes it, so gtd's own
+ * index writes lose the `index.lock` race often on a large repo (where each
+ * write takes long enough for the windows to overlap). The lock failure is a
+ * pure "couldn't start" — git did nothing — so the losing command is safe to
+ * retry verbatim (see `withIndexLockRetry`).
+ */
+export const isIndexLockError = (error: Error): boolean =>
+  /index\.lock[\s\S]*File exists|Another git process seems to be running/i.test(error.message)
+
+/**
+ * Retry an index-writing git command through transient `index.lock` contention
+ * with jittered exponential backoff (~10ms → ~640ms, capped at 6 retries), and
+ * ONLY on that error — any other failure propagates on the first attempt. This
+ * is the general defense for the concurrent reality `isIndexLockError`
+ * describes; it covers every index writer (`git add -A`, `reset`, `restore`),
+ * not just the review window's own steps.
+ */
+export const withIndexLockRetry = <A, R>(
+  eff: Effect.Effect<A, Error, R>,
+): Effect.Effect<A, Error, R> =>
+  Effect.retry(eff, {
+    schedule: Schedule.intersect(
+      Schedule.recurs(6),
+      Schedule.exponential(Duration.millis(10), 2),
+    ).pipe(Schedule.jittered),
+    while: (error: Error) => isIndexLockError(error),
+  })
+
+/**
  * Run a command and return its stdout — FAILING on a non-zero exit code with
  * the command line and stderr in the error message. `Command.string` alone
  * only collects stdout and silently ignores exit codes, which used to make
  * gtd report success on rejected commits (hooks, gpg), resolve Idle outside a
  * repository, and lose files whose quoted paths broke a swallowed `git add`.
  * Callers that expect a probe to fail (missing refs, empty repos) handle it
- * with an explicit `catchAll`.
+ * with an explicit `catchAll`. `index.lock` contention is retried transparently
+ * (`withIndexLockRetry`) before any caller's `catchAll` sees it.
  */
 const run = (
   root: string,
   ...args: [string, ...Array<string>]
 ): Effect.Effect<string, Error, CommandExecutor.CommandExecutor> =>
-  Effect.scoped(
-    Effect.gen(function* () {
-      const executor = yield* CommandExecutor.CommandExecutor
-      const process = yield* executor.start(
-        Command.make(...args).pipe(
-          Command.workingDirectory(root),
-          Command.stdout("pipe"),
-          Command.stderr("pipe"),
-        ),
-      )
-      const collect = (stream: typeof process.stdout) =>
-        stream.pipe(Stream.decodeText(), Stream.mkString)
-      const [stdout, stderr, exitCode] = yield* Effect.all(
-        [collect(process.stdout), collect(process.stderr), process.exitCode],
-        { concurrency: "unbounded" },
-      )
-      if (exitCode !== 0) {
-        return yield* Effect.fail(
-          new Error(`${args.join(" ")} failed (exit ${exitCode}): ${stderr.trim()}`),
+  withIndexLockRetry(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const executor = yield* CommandExecutor.CommandExecutor
+        const process = yield* executor.start(
+          Command.make(...args).pipe(
+            Command.workingDirectory(root),
+            Command.stdout("pipe"),
+            Command.stderr("pipe"),
+          ),
         )
-      }
-      return stdout
-    }),
-  ).pipe(Effect.mapError((e) => (e instanceof Error ? e : new Error(String(e)))))
+        const collect = (stream: typeof process.stdout) =>
+          stream.pipe(Stream.decodeText(), Stream.mkString)
+        const [stdout, stderr, exitCode] = yield* Effect.all(
+          [collect(process.stdout), collect(process.stderr), process.exitCode],
+          { concurrency: "unbounded" },
+        )
+        if (exitCode !== 0) {
+          return yield* Effect.fail(
+            new Error(`${args.join(" ")} failed (exit ${exitCode}): ${stderr.trim()}`),
+          )
+        }
+        return stdout
+      }),
+    ).pipe(Effect.mapError((e) => (e instanceof Error ? e : new Error(String(e))))),
+  )
 
 const makeGitImpl = (executor: CommandExecutor.CommandExecutor, root: string): GitOperations => {
   const exec = (...args: [string, ...Array<string>]) =>

--- a/src/RetainedHistory.test.ts
+++ b/src/RetainedHistory.test.ts
@@ -42,7 +42,6 @@ const stubGit = (overrides: Partial<GitOperations>): GitOperations => ({
   mixedResetTo: notImplemented("mixedResetTo"),
   hardResetTo: notImplemented("hardResetTo"),
   restoreStagedFrom: notImplemented("restoreStagedFrom"),
-  addIntentToAdd: notImplemented("addIntentToAdd"),
   ...overrides,
 })
 

--- a/src/ReviewWindow.ts
+++ b/src/ReviewWindow.ts
@@ -211,8 +211,8 @@ export const closeReviewWindow: Effect.Effect<{ readonly closed: boolean }, Erro
  * is nothing to surface and the window stays closed.
  *
  * Ordering is crash-safe: base ref → head ref → mixed reset → `.gtd/` index
- * pin → intent-to-add. A crash before the head-ref write leaves only a stale
- * base ref (overwritten on the next open); a crash after it leaves HEAD ==
+ * pin. A crash before the head-ref write leaves only a stale base ref
+ * (overwritten on the next open); a crash after it leaves HEAD ==
  * review-head, which the next invocation's close restores as a no-op.
  */
 export const openReviewWindow: Effect.Effect<
@@ -246,9 +246,25 @@ export const openReviewWindow: Effect.Effect<
   // the reviewable diff — pin its index entries back to the saved head so the
   // editor's unstaged view shows only the code changes.
   yield* git.restoreStagedFrom(REVIEW_HEAD_REF, [".gtd"])
-  // Files added since the base would otherwise show as untracked; register
-  // them so editors render proper content diffs (and "discard" stays a
-  // coherent reject-this-file gesture).
-  yield* git.addIntentToAdd()
+  // Files added since the base are left UNTRACKED, deliberately — do not
+  // "improve" this with a `git add --intent-to-add .` (gtd ≤ 8.2 did):
+  //
+  // - Discarding an intent-to-add path (`git checkout -- <path>`, i.e. an
+  //   editor's "discard changes") TRUNCATES it to zero bytes instead of
+  //   removing it, and the survivor is then committed by the next step's
+  //   `git add -A` — so rejecting a new file during review silently landed an
+  //   empty one. Untracked, discard deletes the file, which is the gesture the
+  //   reviewer meant.
+  // - It was the one whole-tree index WRITE in the open sequence, taken
+  //   milliseconds after the mixed reset above wakes every watcher on the repo
+  //   (editor SCM, `gtd lsp`, git-aware prompts — all of which write the index
+  //   to refresh their stat cache), so it lost the `index.lock` race often
+  //   enough to fail the whole invocation over a cosmetic step.
+  //
+  // The cost is that a terminal `git diff` no longer lists new files at the
+  // gate (`git status` does); the editor SCM views this window exists for show
+  // them either way, and the engine is indifferent — `changedPaths` unions
+  // `git ls-files --others` in, so the resting state's `on` patterns see an
+  // untracked add as `A` exactly like a staged one.
   return { opened: true }
 })

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -56,8 +56,6 @@ const failingGitLayer = Layer.succeed(GitService, {
   hardResetTo: () => Effect.fail(new Error("GitService must not be called for --version/--help")),
   restoreStagedFrom: () =>
     Effect.fail(new Error("GitService must not be called for --version/--help")),
-  addIntentToAdd: () =>
-    Effect.fail(new Error("GitService must not be called for --version/--help")),
 })
 
 // Minimal stub ConfigService — satisfies the type but never loaded for flags.

--- a/tests/integration/features/review-window.feature
+++ b/tests/integration/features/review-window.feature
@@ -11,7 +11,10 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
   linked worktrees sharing one `.git` each get their own window; every gtd
   invocation restores it BEFORE reading or mutating state, so the pure machine
   never sees the window and the reviewer's own edits are captured by the
-  resting state's own `on` patterns like any other pending change.
+  resting state's own `on` patterns like any other pending change. Files added
+  since the base surface as ORDINARY UNTRACKED files (see the scenario below);
+  the step decision is indifferent, since `changedPaths` unions
+  `git ls-files --others` in and reports them as `A` either way.
 
   The bundled unified workflow declares `reviewWindow: true` on
   `await-review`. Each scenario builds a cycle that rests there: the
@@ -52,6 +55,24 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
     And the git status contains "src/other.ts"
     # …while `.gtd/` plumbing stays out of the untracked noise.
     And the git status does not contain "?? .gtd/"
+
+  Scenario: Files added since the base stay untracked — never intent-to-add index entries
+    When I run gtd next
+    Then it succeeds
+    # git's ordinary new-file state, deliberately: an editor's "discard changes"
+    # then DELETES the file — the reject-this-file gesture a reviewer means —
+    # instead of truncating an intent-to-add entry to zero bytes and leaving a
+    # survivor the next `gtd step human` would commit.
+    And the git status contains "?? src/calc.ts"
+    And the git status contains "?? src/other.ts"
+    And the git status does not contain "AM src/calc.ts"
+
+  @live
+  Scenario: Real git agrees — the new file is untracked and keeps its content
+    When I run gtd next
+    Then it succeeds
+    And the git status contains "?? src/calc.ts"
+    And "src/calc.ts" contains "export const add"
 
   Scenario: The machine never sees the window — status resolves the real state
     Given I run gtd next

--- a/tests/integration/support/inmem/Repo.ts
+++ b/tests/integration/support/inmem/Repo.ts
@@ -419,17 +419,6 @@ export class InMemRepo {
       else this.index.delete(key)
     }
   }
-
-  /**
-   * `git add --intent-to-add .` — register every untracked worktree file in
-   * the index with an empty placeholder, so it renders as an addition (with a
-   * content hunk) rather than an untracked `??` entry.
-   */
-  addIntentToAdd(): void {
-    for (const path of this.worktree.keys()) {
-      if (!this.index.has(path)) this.index.set(path, "")
-    }
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/support/inmem/layers.ts
+++ b/tests/integration/support/inmem/layers.ts
@@ -116,8 +116,6 @@ const makeGitWriterOps = (repo: InMemRepo): GitWriterOperations => ({
 
   restoreStagedFrom: (source: string, paths: ReadonlyArray<string>) =>
     tryCatch(() => repo.restoreStagedFrom(source, paths)),
-
-  addIntentToAdd: () => tryCatch(() => repo.addIntentToAdd()),
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Two problems traced back to the `git add --intent-to-add .` that ended `openReviewWindow`:

1. **Discarding a new file during review silently committed an empty one.** With an intent-to-add index entry, `git checkout -- <path>` — what an editor's "Discard changes" runs — truncates the file to **zero bytes** instead of removing it (verified on git 2.50). The zero-byte survivor then rides along in the next `gtd step human`'s `git add -A`. Untracked, discard deletes the file, which is the reject-this-file gesture the reviewer meant.

2. **Intermittent `index.lock` failures when entering the human review gate:**

   ```
   gtd: git add --intent-to-add . failed (exit 128): fatal: Unable to create
   '.../.git/worktrees/<wt>/index.lock': File exists.
   ```

   It was the only whole-tree index **write** in the open sequence, taken milliseconds after the `git reset --mixed` that mass-dirties the worktree and wakes every watcher on the repo (editor SCM, `gtd lsp`, git-aware shell prompts — all of which write the index to refresh their stat cache). Losing that race failed the *whole invocation* (`program.ts` surfaces a re-arm error) over a cosmetic step, which the loop driver reads as a stall.

## What changed

`openReviewWindow` now ends at the `.gtd/` index pin; new files are left in git's ordinary untracked state.

The engine is indifferent: `changedPaths` unions `git ls-files --others --exclude-standard` in, so the resting state's `on` patterns see an untracked add as `A` exactly like a staged one. The `GitWriterOperations.addIntentToAdd` member is gone along with its in-memory counterpart.

**Trade-off:** a terminal `git diff` no longer lists new files while the window is open (`git status` does), and patch-based gestures (`git stash` without `-u`, `git add -p`) skip them. The editor SCM views the window exists for show them either way.

## Tests

- `review-window.feature`: new `@inmem` scenario pins new files to `?? <path>` (and not `AM <path>`), plus a `@live` scenario asserting real git agrees and the file keeps its content.
- Full suite green: typecheck, lint, format, unit, e2e, fallow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)