### PR TITLE
feat: emit driver scripts instead of writing git directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,13 +227,26 @@ Commands:
   next             Print the resolved rest's rendered script/prompt/message (no mutation)
   status           Print the resolved rest's state/actor and which declared
                    pattern (if any) each pending change matches (no mutation)
-  validate         Format and validate the steering file the resolved rest
-                   declares, with its mode's commands (its file:/mode:);
-                   exits non-zero with the findings when it is invalid
+  validate         Print the script that formats (when declared) then
+                   validates the resolved rest's steering file, using its
+                   mode's commands (its file:/mode:), instead of running it —
+                   a driver runs the script and reads the findings from its
+                   own exit code/output. Always exits 0; --json emits
+                   {state, file?, mode?, script} (script is "" when there is
+                   nothing to validate; plain text prints "nothing to
+                   validate" in that case)
   lsp              Start the LSP server for .gtd/ steering files (stdio)
   visualize        Serve an interactive diagram of the active workflow on a
                    local web server (--port <n>, --no-open; --json prints the
                    model and exits)
+  check <mode> <file>
+                   Read <file> and run the built-in steering format named
+                   <mode> (see `gtd validate`'s modes: qa, review) over its
+                   contents, printing each finding one per line and exiting
+                   non-zero when there are any. Resolves no workflow state and
+                   reads no config — standalone, runnable from any directory
+                   with <mode>/<file> given explicitly. This is what a
+                   workflow's emitted validation script invokes as a leaf step
   version          Print version and exit
   help             Print this help and exit
 
@@ -468,6 +481,120 @@ Optionally,
 `herdr pane report-metadata "$HERDR_PANE_ID" --source custom:gtd-display --token summary=<text>`
 sets a value renderable as `$summary` in an Agent sidebar row, if you want more
 than the state itself.
+
+## Writing your own driver
+
+`bin/gtd` is gtd's own reference driver, not a privileged one — the engine
+itself is a supported public surface, and anything below holds for any driver
+you write against it. gtd decides and prints; it never touches git itself. The
+four commands that change anything — `gtd step [<actor>]` (including
+`--entry <state>`), `gtd abandon`, and `gtd restore` — perform no git write when
+run. Instead, under `--json`, each one's output object carries two extra string
+fields, `required` and `optional`: bash scripts for YOU to execute. (Plain-text
+output, without `--json`, never shows these — it prints only the human-facing
+result line, e.g. `committed: <subject>`, so a plain-text caller never sees a
+script at all.) A driver that only prints gtd's plain-text output is not driving
+anything; to actually land a turn, run `gtd ... --json`, pull `required`/
+`optional` out with `jq`, and execute them.
+
+- **`required`** is everything that decides what lands in git — closing an open
+  review checkout window, the resting state's own steering-mode
+  `format:`/`validate:` commands, then the commit or squash itself (`gtd step`
+  and `gtd --entry <state>`), or the ref update and reset that undo a process
+  (`gtd abandon`, `gtd restore`). Run this one. Skipping it means the turn never
+  lands.
+- **`optional`** is presentation only: re-opening the review checkout window
+  (the `<<<<<<< HEAD` diff view) after a `gtd step` lands at a
+  `reviewWindow: true` state, so an editor's diff view has something to show.
+  Skip it and you lose nothing but that view — the workflow is still driven
+  correctly. `gtd abandon`/`gtd restore` always emit `optional: ""` (there is no
+  window to reopen after either).
+
+Either field may be the empty string `""`, meaning "nothing to do here" — a
+no-op `gtd step` (a clean tree matching no `on` pattern) emits
+`required: ""`/`optional: ""` and exits zero; run nothing and move on. Both
+scripts are self-contained (each carries its own precondition assert and retry
+helper) and safe to run standalone, in sequence, or not at all — paste either
+into a terminal and it does exactly what it says.
+
+### Failure taxonomy and recovery
+
+Two different things can go wrong, and they mean different things:
+
+- **`gtd` itself exits non-zero.** Nothing was attempted — this is a refusal (a
+  guard rejected the turn) or a usage error. No script was ever produced.
+- **An emitted script exits non-zero when YOU run it.** Something may have
+  partially happened — e.g. a `gtd_retry`-wrapped git write landed but a later
+  step in the same script failed.
+
+Recovery is the same in both cases: **re-invoke `gtd`.** It re-reads the real
+repository state fresh every time — never a cached plan — and emits whatever
+still needs to happen from there. This works because every emitted script opens
+by asserting its own precondition
+(`[ "$(git rev-parse HEAD)" = <expected> ] || { ...; exit 1; }`, and the same
+shape for a review window's saved ref — see `src/Emit.ts`'s
+`headAssertion`/`reviewWindowAssertion`), so a script generated against a
+repository state that has since moved refuses loudly instead of corrupting
+anything. **Emitted scripts are re-runnable**: this is the single most important
+property for a driver's recovery logic. Re-running a script that already fully
+applied is a no-op (its git writes are `--allow-empty` commits, idempotent ref
+updates, and tolerant staged-restore calls), and re-running one that only
+partially applied resumes correctly, because the precondition either still holds
+(nothing landed yet — safe to retry verbatim) or gtd's next invocation reads the
+new real state and emits a fresh script for what remains. A driver never needs
+its own retry/resume logic beyond "if the script failed, ask gtd again."
+
+### Prerequisites
+
+- **`jq`** — to pull the `required`/`optional` strings back out of gtd's
+  `--json` output.
+- **`gtd` on `PATH`** — a mode's seeded `validate:` command (the one the
+  compiler fills in for the built-in `qa`/`review` formats) is literally the
+  string `gtd check <mode> '<file>'`, invoked by NAME from inside an emitted
+  script, not by absolute path (see `src/SteeringFormats.ts`'s
+  `seededValidateCommand`). This is a deliberate trade: a readable, overridable,
+  copy-pasteable command in exchange for depending on shell name resolution at
+  the moment the script runs. The sharp edge: if the `gtd` binary you invoked to
+  GENERATE the script differs from the `gtd` that resolves on `PATH` when the
+  script later RUNS (a locally-built dev binary vs. a globally-installed
+  release, say), you can get version skew between the two — the command that
+  validates may not be the command that decided. Keep the two in sync (one `gtd`
+  on `PATH`, consistently) if you care about that gap.
+
+### The normalization-only contract on `format:`
+
+A mode's `format:` command may reformat a steering file — whitespace, wrapping,
+reordering — but must NEVER change what a step-capture guard would decide. gtd's
+guards (the review sign-off check, the feedback-progress check, the
+answer-completeness check — `src/StepGuards.ts`) decide ONCE, against whichever
+bytes are on disk at the moment `gtd step` runs, which may be before OR after an
+emitted script's own `format:` line has run (the script runs `format:` then
+`validate:` then the commit — see `src/SteeringMode.ts`'s
+`renderSteeringCommands` — but gtd's decision and the driver's script execution
+are different processes at different times, so there's no guaranteed ordering
+between "gtd decided" and "the script formatted"). That's only safe because
+every built-in guard judges content, not incidental formatting (e.g. it
+normalizes `[ ]`/`[x]` checkboxes before comparing). If you plug in your own
+`format:` command, the same rule binds it: a formatter that also changes meaning
+— ticking a box, stripping a paragraph — makes the guard's decision and the
+file's actual content disagree, and gtd will not catch that for you.
+
+### Built-in steering formats are ordinary modes
+
+`qa` and `review` are gtd's two built-in steering-file formats (parsed and
+validated in-process because `gtd lsp` needs the same parsers for live
+diagnostics), but their `validate:` is not hardcoded or hidden: the compiler
+SEEDS every workflow's `modes:` map with `qa`/`review` entries whose `validate:`
+is the same `gtd check <mode> '<file>'` string described above
+(`src/PatternConfig.ts`, `src/SteeringFormats.ts`'s `seededValidateCommand`).
+That seeded command is visible in `gtd visualize`'s compiled model and in the
+editor JSON schema like any other mode, and it's overridable the same way any
+mode is — declare `modes: { qa: { validate: "your-own-command" } }` (in the
+workflow or in `.gtdrc`) and your command displaces the seed; declaring only a
+`format:` for `qa`/`review` composes with the seeded `validate:` rather than
+replacing it. There is no special-cased built-in behavior a driver needs to know
+about beyond the ordinary mode-resolution rules already documented under
+[The `workflow:` key](#the-workflow-key).
 
 ## Configuration
 
@@ -799,8 +926,8 @@ but `gtd lsp` never runs a shell command per keystroke, so live diagnostics
 become one `Information` notice pointing at `gtd validate` instead of the
 built-in findings. Any OTHER mode name — `prose` (used by the simple flow's plan
 file), or a project's own declared name — has no built-in format, so it gets no
-live editor support at all: `gtd validate` and the `gtd step` gate still format
-and validate it like any other mode.
+live editor support at all: `gtd validate`'s emitted script and the `gtd step`
+gate still format and validate it like any other mode.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -531,18 +531,21 @@ Recovery is the same in both cases: **re-invoke `gtd`.** It re-reads the real
 repository state fresh every time — never a cached plan — and emits whatever
 still needs to happen from there. This works because every emitted script opens
 by asserting its own precondition
-(`[ "$(git rev-parse HEAD)" = <expected> ] || { ...; exit 1; }`, and the same
-shape for a review window's saved ref — see `src/Emit.ts`'s
+(`[ "$(git rev-parse --verify --quiet HEAD 2>/dev/null)" = <expected> ] || { ...; exit 1; }`,
+and the same shape for a review window's saved ref — see `src/Emit.ts`'s
 `headAssertion`/`reviewWindowAssertion`), so a script generated against a
 repository state that has since moved refuses loudly instead of corrupting
-anything. **Emitted scripts are re-runnable**: this is the single most important
-property for a driver's recovery logic. Re-running a script that already fully
-applied is a no-op (its git writes are `--allow-empty` commits, idempotent ref
-updates, and tolerant staged-restore calls), and re-running one that only
-partially applied resumes correctly, because the precondition either still holds
-(nothing landed yet — safe to retry verbatim) or gtd's next invocation reads the
-new real state and emits a fresh script for what remains. A driver never needs
-its own retry/resume logic beyond "if the script failed, ask gtd again."
+anything. In a repository with no commits yet, `<expected>` is the empty string
+— the deciding read's own convention for "no commits yet" — so the first
+workflow commit is allowed to land instead of being blocked by an unborn `HEAD`.
+**Emitted scripts are re-runnable**: this is the single most important property
+for a driver's recovery logic. Re-running a script that already fully applied is
+a no-op (its git writes are `--allow-empty` commits, idempotent ref updates, and
+tolerant staged-restore calls), and re-running one that only partially applied
+resumes correctly, because the precondition either still holds (nothing landed
+yet — safe to retry verbatim) or gtd's next invocation reads the new real state
+and emits a fresh script for what remains. A driver never needs its own
+retry/resume logic beyond "if the script failed, ask gtd again."
 
 ### Prerequisites
 

--- a/bin/gtd
+++ b/bin/gtd
@@ -252,9 +252,18 @@ parse_subject() {
 # when it reported at least one; returns non-zero (having emitted nothing,
 # and leaving $reported_head unchanged) when there were no new commits. Global
 # rather than per-beat so the review checkout window's HEAD rewinds between
-# beats never cause an already-reported commit to replay.
+# beats never cause an already-reported commit to replay. $reported_head ==
+# "none" (the repo had no commits at all when it was last captured) can't
+# form a "none"..HEAD range — `git rev-list` would fail resolving "none" as a
+# revision — so that case walks the whole history from the root instead.
 report_commits() {
   local sha subject files reported=0
+  local range
+  if [[ "$reported_head" == none ]]; then
+    range="HEAD"
+  else
+    range="$reported_head..HEAD"
+  fi
   while IFS= read -r sha; do
     [[ -z "$sha" ]] && continue
     reported=1
@@ -265,7 +274,7 @@ report_commits() {
       transition) emit_transition "$S_FROM" "$S_TO" "$files" ;;
       capture | squash) emit_commit "$subject" "$files" ;;
     esac
-  done < <(git rev-list --reverse "$reported_head"..HEAD)
+  done < <(git rev-list --reverse "$range")
   if [[ "$reported" == 1 ]]; then
     reported_head="$(git rev-parse HEAD)"
   fi
@@ -640,7 +649,7 @@ run_agent_turn() {
 # its own comment) — a global high-water mark rather than a per-beat
 # head_before, so a review checkout window's HEAD rewind between beats never
 # causes an already-printed transition to replay.
-reported_head="$(git rev-parse HEAD 2>/dev/null || echo none)"
+reported_head="$(git rev-parse --verify --quiet HEAD || echo none)"
 
 # Opening move: capture the human's pending edit so gtd-loop is the ONLY command
 # a human runs. A human acts at a gate by editing files (a plan answer, a review
@@ -667,7 +676,7 @@ Run \`gtd status\` to inspect the repo."
 fi
 peek_kind="$(jq -r .kind <<<"$peek_json")"
 if [[ "$peek_kind" == "message" ]]; then
-  opening_head_before="$(git rev-parse HEAD 2>/dev/null || echo none)"
+  opening_head_before="$(git rev-parse --verify --quiet HEAD || echo none)"
   if ! step_out="$(run_gtd_command step human 2>&1)"; then
     emit_error "could not capture your changes at the human gate:
 $step_out
@@ -678,7 +687,7 @@ Fix the reported issue and re-run gtd-loop."
   # This branch reports nothing — advance the marker past whatever was just
   # (silently) captured so the first loop-body beat below doesn't newly
   # print it.
-  reported_head="$(git rev-parse HEAD 2>/dev/null || echo none)"
+  reported_head="$(git rev-parse --verify --quiet HEAD || echo none)"
   if [[ "$once_mode" == 1 && "$opening_head_before" != "$reported_head" ]]; then
     exit 0
   fi
@@ -755,7 +764,7 @@ Run \`gtd status\` to inspect the repo."
   # stall from a return lap back into the same state (e.g. checking ->
   # fixing): a static prompt looks identical to last time, but a commit
   # landed in between, so HEAD has moved and this isn't a stall.
-  cur_head="$(git rev-parse HEAD 2>/dev/null || echo none)"
+  cur_head="$(git rev-parse --verify --quiet HEAD || echo none)"
   if [[ "$state" == "$prev_state" && "$content" == "$prev_content" && "$cur_head" == "$prev_head" ]]; then
     next_out="$(run_gtd next 2>&1)" || true
     emit_error "no progress at '$state' — the agent's last turn changed nothing. Stopping to avoid spinning.

--- a/bin/gtd
+++ b/bin/gtd
@@ -10,8 +10,13 @@ set -euo pipefail
 #   - no arguments, or exactly `loop` with no further arguments -> fall through
 #     into the loop body below (the loop protocol comment further down).
 #   - `loop` with an unrecognised extra argument -> usage error, exit 2.
-#   - anything else -> hand off to the bundle via `run_gtd`, forwarding all
-#     arguments unchanged (e.g. `bin/gtd status`, `bin/gtd step human`).
+#   - anything else -> a WRITE subcommand (`step`, the `--entry` forms,
+#     `abandon`, `restore` — see `is_write_command`) routes through
+#     `run_gtd_command`, which actually performs the bundle's emitted
+#     `required`/`optional` scripts (the bundle itself only ever PRINTS them
+#     now); everything else (`status`, `next`, `validate`, `visualize`, `lsp`,
+#     `check`, `init`) hands off straight to the bundle via `run_gtd`,
+#     forwarding all arguments unchanged (e.g. `bin/gtd status`).
 # The loop's whole job is to drive the process until it rests at a
 # NON-AUTONOMOUS state (a human gate) or settles. Everything beyond that —
 # editors, desktop notifications, terminal-multiplexer status — is an OUTER
@@ -59,6 +64,19 @@ else
   C_CYAN=""; C_GREEN=""; C_YELLOW=""; C_RED=""
   M_TRANS="->"; M_AGENT="[agent]"; M_CHECK="[check]"; M_HUMAN="[you]"
   M_FIX="[fix]"; M_COMMIT="[commit]"; M_SETTLE="[done]"; M_ERROR="[err]"; M_WARN="[warn]"; M_ELLIPSIS="..."
+fi
+
+# `jq` used to be a loop-only dependency (the loop's own `next --json`
+# parsing); now every write subcommand's `--json` response (parsed by
+# `run_gtd_command`, below) carries the `required`/`optional` scripts this
+# script must execute for ANY invocation, not just `loop`. Checked once, up
+# front, before any dispatch below ever reaches for `jq` — a plain
+# `echo`/`exit` rather than `emit_error` since that helper (and the
+# fancy/plain markers it relies on) isn't the point; keeping the check
+# dependency-free is.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "gtd: jq is required (used to parse the bundle's --json output) — install it and retry" >&2
+  exit 1
 fi
 
 # emit_file_rows <files> — render a commit's changed files as dim, indented
@@ -254,6 +272,123 @@ report_commits() {
   [[ "$reported" == 1 ]]
 }
 
+# ── Write-command execution (is_write_command, run_gtd_command) ────────────
+# The bundle no longer performs a WRITE subcommand's git effect itself: its
+# `--json` response for `step`/the `--entry` forms/`abandon`/`restore` now
+# carries `required` (a bash script that performs the command's whole
+# effect — commit/reset/etc, including any review-window close/open
+# management) and `optional` (presentation-only, e.g. re-opening the review
+# checkout window — safe to skip), alongside whichever keys that command's
+# JSON always carried. This script is the ONE driver for every invocation
+# (not just the loop's), so it — not the bundle — must run those scripts.
+
+# is_write_command <token> — true for exactly the tokens whose command
+# mutates the repo: `step` (with or without `--entry` trailing), `abandon`,
+# `restore`, and the bare `--entry` short form (`gtd --entry <state>`, where
+# `--entry` itself is $1 since there is no subcommand token in front of it).
+# Everything else (next/status/validate/visualize/lsp/check/init, or an
+# unrecognised token) is read-only or has its own arity/usage errors and is
+# left to the existing plain `run_gtd "$@"` forwarding.
+# `--entry` takes both spellings (`--entry <state>` and `--entry=<state>`), so
+# the bare short form has to be recognised either way.
+is_write_command() {
+  case "${1:-}" in
+    step | abandon | restore | --entry | --entry=*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# run_gtd_command <subcommand-and-args...> — the ONE execution path for every
+# write subcommand, used both by the direct dispatch below and by the loop
+# body's own step calls (so there is one execution path rather than two, not
+# a loop-only one and a separate direct one). Fetches the bundle's `--json`
+# response for "$@" (forcing --json on regardless of whether the caller's own
+# arguments already carry it — repeating `--json` is harmless, see
+# `Cli.ts`'s arity-0 flag handling), runs `.required` via `bash -c` (aborting
+# — returning its exit code — before `.optional` ever runs, mirroring `set
+# -e`), then `.optional` via `bash -c` (a non-zero exit there is only ever a
+# warning: it is presentation-only, e.g. re-opening the review checkout
+# window, per its own "safe to skip" billing). On success it prints, on
+# stdout, the plain human-facing line in TODAY's exact wording — the same
+# text `runStepCommand`/`runEntryCommand`/`runAbandonCommand`/
+# `runRestoreCommand` printed themselves before this rewrite moved the git
+# write into `required`. A direct caller lets that line stream straight to
+# the terminal; the loop instead captures it (`$(... 2>&1)`, the file's
+# established idiom) and logs it, since its own on-screen presentation is
+# `report_commits`. `abandon`/`restore` have no `subject` in their JSON (never
+# did — the original handlers computed it from git AFTER writing), so this
+# recomputes it from HEAD after `.required` has run; every other field used
+# below (`state`, `from`, `head`, `to`) is one of the contract's own preserved
+# "existing keys". On failure (the JSON fetch itself — a refusal/usage error —
+# or `.required`), the combined fetch output is sent to stderr and the
+# function returns non-zero; a failing `.required`'s own output streams
+# (or is captured by the caller) exactly as it happened, unredirected here.
+run_gtd_command() {
+  local subcmd="${1:-}" json_out required optional opt_status
+  local state subject head to from
+
+  if ! json_out="$(run_gtd "$@" --json 2>&1)"; then
+    printf '%s' "$json_out" >&2
+    return 1
+  fi
+
+  # `// empty` guards a command whose JSON doesn't (yet, or ever) carry these
+  # keys for a given branch — e.g. `gtd abandon`'s "nothing to abandon" no-op
+  # reply has neither key at all — so a missing/null field reads as "" (jq's
+  # own `null` stringifies to the 4-character text "null" otherwise, which
+  # would misread as a non-empty script).
+  required="$(jq -r '.required // empty' <<<"$json_out")"
+  optional="$(jq -r '.optional // empty' <<<"$json_out")"
+
+  if [[ -n "$required" ]]; then
+    bash -c "$required" || return $?
+  fi
+
+  if [[ -n "$optional" ]]; then
+    opt_status=0
+    bash -c "$optional" || opt_status=$?
+    if ((opt_status != 0)); then
+      emit_warn "the presentation-only follow-up after '$subcmd' failed (exit $opt_status) — continuing"
+    fi
+  fi
+
+  case "$subcmd" in
+    abandon)
+      if [[ -z "$required" ]]; then
+        state="$(jq -r '.state' <<<"$json_out")"
+        printf 'no gtd process is underway (resting at "%s") — nothing to abandon\n' "$state"
+      else
+        from="$(jq -r '.from' <<<"$json_out")"
+        state="$(jq -r '.state' <<<"$json_out")"
+        head="$(jq -r '.head' <<<"$json_out")"
+        subject="$(git log -1 --format=%s HEAD)"
+        printf 'abandoned the process resting at "%s" — HEAD is back at %s ("%s"), resting at "%s".\n' \
+          "$from" "${head:0:7}" "$subject" "$state"
+        printf 'Everything the process produced is kept as uncommitted changes (`git status`); discard them with `git checkout -- . && git clean -fd .gtd` for a clean tree.\n'
+      fi
+      ;;
+    restore)
+      to="$(jq -r '.to' <<<"$json_out")"
+      state="$(jq -r '.state' <<<"$json_out")"
+      subject="$(git log -1 --format=%s HEAD)"
+      printf 'restored the retained history — HEAD is back at %s ("%s"), resting at "%s". Resume with the loop, or `git reset` to any earlier turn to restart from there.\n' \
+        "${to:0:7}" "$subject" "$state"
+      ;;
+    *)
+      # `step` (subject nullable — a no-op prints "nothing to do") and the
+      # `--entry` forms (subject never null — always "committed: ...") share
+      # this one branch: the null-check alone tells them apart.
+      subject="$(jq -r '.subject' <<<"$json_out")"
+      if [[ -n "$subject" && "$subject" != "null" ]]; then
+        printf 'committed: %s\n' "$subject"
+      else
+        state="$(jq -r '.state' <<<"$json_out")"
+        printf 'nothing to do at "%s"\n' "$state"
+      fi
+      ;;
+  esac
+}
+
 # ── Log file (resolve_log_path) ─────────────────────────────────────────────
 
 # worktree_git_dir — the git dir of the working tree gtd is operating in,
@@ -317,6 +452,10 @@ if [[ "$valid_combo" == 1 && "$n_once" == 1 ]]; then
 fi
 
 if [[ $# -gt 0 && "$1" != "loop" ]]; then
+  if is_write_command "${1:-}"; then
+    run_gtd_command "$@"
+    exit $?
+  fi
   run_gtd "$@"
   exit $?
 fi
@@ -529,7 +668,7 @@ fi
 peek_kind="$(jq -r .kind <<<"$peek_json")"
 if [[ "$peek_kind" == "message" ]]; then
   opening_head_before="$(git rev-parse HEAD 2>/dev/null || echo none)"
-  if ! step_out="$(run_gtd step human 2>&1)"; then
+  if ! step_out="$(run_gtd_command step human 2>&1)"; then
     emit_error "could not capture your changes at the human gate:
 $step_out
 Fix the reported issue and re-run gtd-loop."
@@ -590,7 +729,7 @@ Run \`gtd status\` to inspect the repo."
       emit_warn "the check script at '$state' exited $script_status — continuing; the outcome is whatever it left in the tree:"
       emit_output_since "$script_offset"
     fi
-    if ! step_out="$(run_gtd step "$actor" 2>&1)"; then
+    if ! step_out="$(run_gtd_command step "$actor" 2>&1)"; then
       printf '%s\n' "$step_out" >>"$GTD_LOOP_LOG"
       emit_error "$step_out"
       emit_log_pointer
@@ -653,12 +792,15 @@ $next_out"
   # Run the agent turn (see run_agent_turn's own comment for the adapter
   # contract). Then the self-validation gate: a producing state may declare a
   # `file:`/`mode:` pair (e.g. the default workflow's grilling/reviewing),
-  # making its output's format checkable. `gtd validate` is a no-op (exit 0)
-  # when the resolved rest has nothing to validate, so run it after EVERY agent
-  # turn; on findings, re-prompt the SAME agent session to fix them (up to a
-  # cap) before stepping — the plain-`gtd next` self-validation instruction's
-  # driver-side equivalent, so the next rest is only ever handed a well-formed
-  # file. gtd itself never validates at step time — this is the loop's job.
+  # making its output's format checkable. `gtd validate --json` always exits
+  # 0 now — it hands back the SCRIPT that formats/checks the file (`.script`,
+  # empty when the resolved rest has nothing to validate) rather than running
+  # it itself, so this driver runs that script after EVERY agent turn and
+  # re-prompts the SAME agent session on ITS non-zero exit (up to a cap)
+  # before stepping — the plain-`gtd next` self-validation instruction's
+  # driver-side equivalent, so the next rest is only ever handed a
+  # well-formed file. gtd itself never validates at step time — this is the
+  # loop's job.
   emit_action "$M_AGENT" "$label"
   turn_offset="$(log_offset)"
   agent_status=0
@@ -670,12 +812,24 @@ $next_out"
     exit 1
   fi
 
+  if ! validate_json="$(run_gtd validate --json 2>&1)"; then
+    emit_error "could not resolve the validation script at '$state':
+$validate_json
+Stopping rather than stepping with a possibly-malformed steering file."
+    emit_log_pointer
+    exit 1
+  fi
+  validate_script="$(jq -r '.script' <<<"$validate_json")"
+
   fix_attempt=0
-  while ! validate_out="$(run_gtd validate 2>&1)"; do
+  while [[ -n "$validate_script" ]]; do
+    validate_status=0
+    validate_out="$(bash -c "$validate_script" 2>&1)" || validate_status=$?
+    ((validate_status == 0)) && break
     fix_attempt=$((fix_attempt + 1))
     if ((fix_attempt > 3)); then
       printf '%s\n' "$validate_out" >>"$GTD_LOOP_LOG"
-      emit_error "'$state' still fails \`gtd validate\` after 3 fix attempts:
+      emit_error "'$state' still fails its own validation script after 3 fix attempts:
 $validate_out
 Stopping rather than stepping with a malformed steering file."
       emit_log_pointer
@@ -689,7 +843,7 @@ Stopping rather than stepping with a malformed steering file."
     [[ -n "$session_id" ]] && fix_resume=1
     turn_offset="$(log_offset)"
     agent_status=0
-    run_agent_turn "$content"$'\n\n'"Your last turn does not pass \`gtd validate\`. Fix these format violations, then finish:"$'\n'"$validate_out" "$fix_resume" || agent_status=$?
+    run_agent_turn "$content"$'\n\n'"Your last turn does not pass its own validation script. Fix these format violations, then finish:"$'\n'"$validate_out" "$fix_resume" || agent_status=$?
     if ((agent_status != 0)); then
       emit_error "the agent's fix attempt $fix_attempt at '$state' failed (exit $agent_status):"
       emit_output_since "$turn_offset"
@@ -698,7 +852,7 @@ Stopping rather than stepping with a malformed steering file."
     fi
   done
 
-  if ! step_out="$(run_gtd step "$actor" 2>&1)"; then
+  if ! step_out="$(run_gtd_command step "$actor" 2>&1)"; then
     printf '%s\n' "$step_out" >>"$GTD_LOOP_LOG"
     emit_error "$step_out"
     emit_log_pointer

--- a/src/Cli.test.ts
+++ b/src/Cli.test.ts
@@ -264,6 +264,54 @@ describe("parseArgv — the --entry selector", () => {
   })
 })
 
+describe("parseArgv — gtd check <mode> <file>", () => {
+  it("parses to a check command carrying mode and file", () => {
+    const plan = parseArgv(["node", "gtd.js", "check", "qa", ".gtd/TODO.md"])
+    expect(plan.kind).toBe("command")
+    if (plan.kind === "command") {
+      expect(plan.command).toEqual({ kind: "check", mode: "qa", file: ".gtd/TODO.md" })
+      expect(plan.json).toBe(false)
+    }
+  })
+
+  it("--json is in scope for check", () => {
+    const plan = parseArgv(["node", "gtd.js", "check", "review", "REVIEW.md", "--json"])
+    expect(plan.kind).toBe("command")
+    if (plan.kind === "command") expect(plan.json).toBe(true)
+  })
+
+  it("missing both arguments is a usage error naming mode and file", () => {
+    const plan = parseArgv(["node", "gtd.js", "check"])
+    expect(plan.kind).toBe("usage")
+    if (plan.kind === "usage") {
+      expect(plan.message).toContain("missing mode and file arguments")
+    }
+  })
+
+  it("missing the file argument (mode only) is a usage error naming file", () => {
+    const plan = parseArgv(["node", "gtd.js", "check", "qa"])
+    expect(plan.kind).toBe("usage")
+    if (plan.kind === "usage") {
+      expect(plan.message).toContain("missing file argument")
+    }
+  })
+
+  it("too many arguments is a usage error", () => {
+    const plan = parseArgv(["node", "gtd.js", "check", "qa", "TODO.md", "extra"])
+    expect(plan.kind).toBe("usage")
+    if (plan.kind === "usage") {
+      expect(plan.message).toContain("too many arguments")
+      expect(plan.message).toContain("extra")
+    }
+  })
+
+  it("a scoped-out flag (e.g. --cost) is rejected on check", () => {
+    const plan = parseArgv(["node", "gtd.js", "check", "qa", "TODO.md", "--cost=5"])
+    expect(plan.kind).toBe("usage")
+    if (plan.kind === "usage") expect(plan.message).toContain("only valid for `gtd step`")
+  })
+})
+
 describe("parseArgv — help/version short-circuits", () => {
   it("--help produces an output plan", () => {
     expect(parseArgv(["node", "gtd.js", "--help"]).kind).toBe("output")
@@ -317,12 +365,13 @@ describe("parseArgv — removed subcommands", () => {
 })
 
 describe("standaloneKinds / needsOf", () => {
-  it("pins the three standalone kinds", () => {
-    expect(standaloneKinds()).toEqual(["lsp", "init", "visualize"])
+  it("pins the four standalone kinds", () => {
+    expect(standaloneKinds()).toEqual(["lsp", "init", "visualize", "check"])
   })
 
   it("needsOf matches none/fs/config for the standalone kinds and state for everything else", () => {
     expect(needsOf("lsp")).toBe("none")
+    expect(needsOf("check")).toBe("fs")
     expect(needsOf("init")).toBe("fs")
     expect(needsOf("visualize")).toBe("config")
     for (const kind of [
@@ -354,6 +403,7 @@ describe("renderHelp", () => {
     expect(help).toContain("validate")
     expect(help).toContain("lsp")
     expect(help).toContain("visualize")
+    expect(help).toContain("check <mode> <file>")
     expect(help).toContain("version")
     expect(help).toContain("help")
     expect(help).toContain("--json")

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -50,6 +50,7 @@ export type Command =
   | { readonly kind: "next" }
   | { readonly kind: "status" }
   | { readonly kind: "validate" }
+  | { readonly kind: "check"; readonly mode: string; readonly file: string }
 
 export type CliPlan =
   | { readonly kind: "output"; readonly stdout: string }
@@ -230,7 +231,7 @@ const flagByToken = (token: string): FlagRow | undefined => {
 // Command table
 // ---------------------------------------------------------------------------
 
-type Arity = "none" | { readonly name: string }
+type Arity = "none" | { readonly name: string } | { readonly names: readonly [string, string] }
 
 interface CommandRow {
   readonly token: string
@@ -317,9 +318,14 @@ const COMMAND_ROWS: readonly CommandRow[] = [
     kind: "validate",
     arity: "none",
     details: [
-      "Format and validate the steering file the resolved rest",
-      "declares, with its mode's commands (its file:/mode:);",
-      "exits non-zero with the findings when it is invalid",
+      "Print the script that formats (when declared) then",
+      "validates the resolved rest's steering file, using its",
+      "mode's commands (its file:/mode:), instead of running it —",
+      "a driver runs the script and reads the findings from its",
+      "own exit code/output. Always exits 0; --json emits",
+      '{state, file?, mode?, script} (script is "" when there is',
+      'nothing to validate; plain text prints "nothing to',
+      'validate" in that case)',
     ],
   },
   {
@@ -336,6 +342,20 @@ const COMMAND_ROWS: readonly CommandRow[] = [
       "Serve an interactive diagram of the active workflow on a",
       "local web server (--port <n>, --no-open; --json prints the",
       "model and exits)",
+    ],
+  },
+  {
+    token: "check",
+    kind: "check",
+    arity: { names: ["mode", "file"] },
+    details: [
+      "Read <file> and run the built-in steering format named",
+      "<mode> (see `gtd validate`'s modes: qa, review) over its",
+      "contents, printing each finding one per line and exiting",
+      "non-zero when there are any. Resolves no workflow state and",
+      "reads no config — standalone, runnable from any directory",
+      "with <mode>/<file> given explicitly. This is what a",
+      "workflow's emitted validation script invokes as a leaf step",
     ],
   },
 ]
@@ -406,7 +426,12 @@ const flagHeader = (row: FlagRow): string => {
 
 export const renderHelp = (): string => {
   const commandBlocks = COMMAND_ROWS.map((row) => {
-    const header = row.arity === "none" ? row.token : `${row.token} <${row.arity.name}>`
+    const header =
+      row.arity === "none"
+        ? row.token
+        : "names" in row.arity
+          ? `${row.token} <${row.arity.names[0]}> <${row.arity.names[1]}>`
+          : `${row.token} <${row.arity.name}>`
     return renderBlock(header, row.details)
   })
   const commands =
@@ -414,7 +439,7 @@ export const renderHelp = (): string => {
     commandBlocks[0] + // init
     commandBlocks[1] + // step
     ENTRY_SHORT_FORM +
-    commandBlocks.slice(2).join("") + // abandon..visualize
+    commandBlocks.slice(2).join("") + // abandon..check
     VERSION_BLOCK +
     HELP_BLOCK
 
@@ -556,6 +581,18 @@ const arityError = (cmd: string, rest: readonly string[], arity: Arity): string 
       ? `gtd ${cmd}: too many arguments — expected none, got: ${rest.join(", ")}`
       : undefined
   }
+  if ("names" in arity) {
+    const [first, second] = arity.names
+    if (rest.length < 2) {
+      return rest.length === 0
+        ? `gtd ${cmd}: missing ${first} and ${second} arguments`
+        : `gtd ${cmd}: missing ${second} argument`
+    }
+    if (rest.length > 2) {
+      return `gtd ${cmd}: too many arguments — expected ${first} and ${second}, got: ${rest.join(", ")}`
+    }
+    return undefined
+  }
   if (rest.length === 0) return `gtd ${cmd}: missing ${arity.name} argument`
   if (rest.length > 1) {
     return `gtd ${cmd}: too many arguments — expected one ${arity.name}, got: ${rest.join(", ")}`
@@ -696,6 +733,14 @@ export const parseArgv = (argv: readonly string[]): CliPlan => {
     return {
       kind: "command",
       command: { kind: "visualize", port: bag["--port"] ?? 0, open: !(bag["--no-open"] ?? false) },
+      json,
+    }
+  }
+
+  if (kind === "check") {
+    return {
+      kind: "command",
+      command: { kind: "check", mode: restPositionals[0]!, file: restPositionals[1]! },
       json,
     }
   }

--- a/src/Config.test.ts
+++ b/src/Config.test.ts
@@ -7,6 +7,7 @@ import { NodeContext } from "@effect/platform-node"
 import { ConfigService } from "./Config.js"
 import { Cwd } from "./Cwd.js"
 import { compileTemplate } from "./workflows/templates.js"
+import { seededValidateCommand } from "./SteeringFormats.js"
 
 // ConfigService.Live only loads/validates the config — it never writes.
 // NodeContext.layer satisfies FileSystem + CommandExecutor.
@@ -99,7 +100,10 @@ describe("ConfigService", () => {
 
     // No `workflow:` -> built-in default, with the rc `modes:` merged in.
     expect(cfg.workflow.states).toEqual(compileTemplate().definition.states)
-    expect(cfg.workflow.modes?.qa).toEqual({ format: "adr-fmt <%= it.file %>" })
+    expect(cfg.workflow.modes?.qa).toEqual({
+      format: "adr-fmt <%= it.file %>",
+      validate: seededValidateCommand("qa"),
+    })
   })
 
   it("reads a custom `workflow:` from a single .gtdrc.yaml in cwd", async () => {
@@ -232,8 +236,8 @@ describe("ConfigService", () => {
     const cfg = await getConfig()
 
     expect(cfg.workflow.modes).toEqual({
-      qa: {},
-      review: {},
+      qa: { validate: seededValidateCommand("qa") },
+      review: { validate: seededValidateCommand("review") },
       adr: { format: "adr-fmt <%= it.file %>", validate: "adr-lint <%= it.file %>" },
     })
   })

--- a/src/Edge.test.ts
+++ b/src/Edge.test.ts
@@ -5,6 +5,7 @@ import {
   currentRun,
   planEntry,
   planStep,
+  renderDecision,
   reviewBaseFor,
   resolveRestFrom,
   renderRest,
@@ -13,8 +14,23 @@ import {
   type RestRequirements,
 } from "./Edge.js"
 import type { WorkflowDefinition } from "./PatternMachine.js"
+import {
+  commitAll,
+  commitAsIs,
+  discardPending,
+  shellQuote,
+  softResetTo,
+  updateRef,
+} from "./GitScript.js"
+import { HISTORY_REF, withHistoryTrailer } from "./RetainedHistory.js"
+import { fakeGitOperations } from "./testing/GitDoubles.js"
 import { InMemRepo } from "./testing/InMemRepo.js"
 import { testLayers } from "./testing/Layers.js"
+
+// The review checkout window's saved-head ref — duplicated here for the same
+// reason `Edge.ts` duplicates it from `ReviewWindow.ts` rather than importing
+// it (see `Edge.ts`'s own `REVIEW_HEAD_REF` doc comment).
+const REVIEW_HEAD_REF = "refs/worktree/gtd/review-head"
 
 /**
  * Coverage for `src/Edge.ts`'s public surface, driven through `InMemRepo` +
@@ -747,6 +763,153 @@ describe("planEntry", () => {
     const after = await provide(currentRest, repo)
     expect(after.state).toBe("fixing")
     expect(after.vars.base).toBe("custom")
+  })
+})
+
+// ── renderDecision + the plan's `scripts` field — render/perform equivalence ─
+
+describe("renderDecision + StepPlan/EntryPlan.scripts", () => {
+  it("a commit decision renders to one commitAll(withCostTrailer(...)) line, byte-identical to what perform commits", async () => {
+    const repo = seededStepRepo()
+    repo.writeFile("README.md", "edited\n")
+    const rest = await provide(currentRest, repo)
+    const plan = await provide(planStep(rest, "human", { cost: 7, model: "haiku" }), repo)
+    if (plan.kind !== "commit" || plan.decision.kind !== "commit") {
+      throw new Error("expected a commit plan")
+    }
+
+    // Direct call — `renderDecision` never reads `RestRequirements`, only the
+    // `GitOperations` it's handed, so it needs no `provide`.
+    const git = fakeGitOperations(repo)
+    const steps = await Effect.runPromise(
+      renderDecision(git, rest, plan.decision, rest.context, 7, "haiku"),
+    )
+    const expectedMessage = `${plan.decision.subject}\n\nGtd-Cost: 7 haiku`
+    expect(steps).toEqual([{ kind: "gitWrite", command: commitAll(expectedMessage) }])
+
+    // The plan's assembled `scripts.required` carries the SAME line, wrapped
+    // in the retry helper — proving Part B's assembly agrees with Part A's
+    // renderer, not just a hand-built comparison.
+    expect(plan.scripts.required).toContain(shellQuote(commitAll(expectedMessage)))
+
+    const outcome = await provide(plan.perform, repo)
+    expect(outcome).toEqual({ kind: "commit", subject: plan.decision.subject })
+    expect(repo.lastCommitMessage()).toBe(expectedMessage)
+  })
+
+  it("a squash decision's assembled script emits retain-history, soft-reset, commit-as-is, and discard-pending in order, with resolved hashes inlined, agreeing with what perform writes", async () => {
+    const repo = seededStepRepo()
+    repo.commitAllWithPrefix("gtd(human): working")
+    repo.writeFile("PLAN.md", "the plan\n")
+    const rest = await provide(currentRest, repo)
+    const plan = await provide(planStep(rest, "agent"), repo)
+    if (plan.kind !== "squash") throw new Error("expected a squash plan")
+
+    const tip = repo.resolveRef("HEAD")! // the pre-squash tip both render and perform resolve
+    const startParent = rest.run.startParentHash
+    expect(tip).not.toBe(startParent) // retain-history must fire, not be skipped
+
+    const expectedMessage = withHistoryTrailer("chore: accepted accepted", tip)
+    const script = plan.scripts.required
+    const retainIdx = script.indexOf(shellQuote(updateRef(HISTORY_REF, tip)))
+    const resetIdx = script.indexOf(shellQuote(softResetTo(startParent)))
+    const commitAsIsIdx = script.indexOf(shellQuote(commitAsIs(expectedMessage)))
+    const discardIdx = script.indexOf(shellQuote(discardPending()))
+
+    expect(retainIdx).toBeGreaterThan(-1)
+    expect(resetIdx).toBeGreaterThan(retainIdx)
+    expect(commitAsIsIdx).toBeGreaterThan(resetIdx)
+    expect(discardIdx).toBeGreaterThan(commitAsIsIdx)
+
+    const outcome = await provide(plan.perform, repo)
+    expect(outcome).toEqual({ kind: "squash", subject: "chore: accepted accepted" })
+    expect(repo.lastCommitMessage()).toBe(expectedMessage)
+  })
+
+  it("a commit-template render failure yields an EMPTY script, matching perform's own refusal", async () => {
+    const repo = seededStepRepo()
+    repo.commitAllWithPrefix("gtd(human): broken-entry") // irrelevant boundary
+    repo.hardResetTo(repo.resolveRef("HEAD~1")!) // back to a clean boundary at idle
+    repo.commitAllWithPrefix("gtd(agent): broken")
+    repo.writeFile("BROKEN.md", "x\n")
+    const rest = await provide(currentRest, repo)
+    const plan = await provide(planStep(rest, "agent"), repo)
+    expect(plan.kind).toBe("squash")
+    if (plan.kind !== "squash") throw new Error("expected a squash plan")
+
+    expect(plan.scripts.required).toBe("")
+    expect(plan.scripts.optional).toBe("")
+
+    const exit = await provideExit(plan.perform, repo)
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  it("planEntry's scripts field carries a single commitAll(message) line matching what perform commits", async () => {
+    const repo = seededStepRepo()
+    repo.writeFile("NOTES.md", "draft\n")
+    const rest = await provide(currentRest, repo)
+    const plan = await provide(
+      planEntry(rest, "human", {
+        state: "fixing",
+        commandLabel: "gtd test",
+        vars: { base: "custom" },
+      }),
+      repo,
+    )
+    if (plan.kind !== "entry") throw new Error("expected an entry plan")
+
+    const expectedMessage = "gtd(human): fixing\n\nGtd-Var: base=custom"
+    expect(plan.scripts.required).toContain(shellQuote(commitAll(expectedMessage)))
+
+    const outcome = await provide(plan.perform, repo)
+    expect(outcome).toEqual({ kind: "entry", state: "fixing", subject: "gtd(human): fixing" })
+    expect(repo.lastCommitMessage()).toBe(expectedMessage)
+  })
+})
+
+// ── restAt — window-aware read (Part C) ──────────────────────────────────────
+
+describe("restAt — the review checkout window's saved-head ref as HEAD", () => {
+  it("currentRest resolves against the window's saved head — state, trace, and startParentHash all follow it", async () => {
+    const { repo, boundary } = seededTraceRepo()
+    repo.commitAllWithPrefix("gtd(human): grilling")
+    const grilling = repo.resolveRef("HEAD")!
+    repo.commitAllWithPrefix("gtd(agent): building")
+    const building = repo.resolveRef("HEAD")!
+
+    // Simulate an OPEN review checkout window exactly as `openReviewWindow`
+    // leaves it: the saved-head ref pins the real pre-window HEAD, while real
+    // HEAD itself has been rewound (`git reset --mixed`) to an earlier commit.
+    repo.updateRef(REVIEW_HEAD_REF, building)
+    repo.mixedResetTo(grilling)
+
+    const rest = await provide(currentRest, repo)
+    expect(rest.state).toBe("building")
+    expect(rest.run.trace.map((e) => e.state)).toEqual(["grilling", "building"])
+    expect(rest.run.startParentHash).toBe(boundary)
+  })
+
+  it("falls through to today's exact behavior (real HEAD) when no window ref exists", async () => {
+    const { repo } = seededTraceRepo()
+    repo.commitAllWithPrefix("gtd(human): grilling")
+    const rest = await provide(currentRest, repo)
+    expect(rest.state).toBe("grilling")
+    expect(rest.run.trace.map((e) => e.state)).toEqual(["grilling"])
+  })
+
+  it("restAt(ref) — visualize's own call pattern — never consults the window ref", async () => {
+    const { repo, boundary } = seededTraceRepo()
+    repo.commitAllWithPrefix("gtd(human): grilling")
+    const grilling = repo.resolveRef("HEAD")!
+    repo.commitAllWithPrefix("gtd(agent): building")
+    const building = repo.resolveRef("HEAD")!
+    repo.updateRef(REVIEW_HEAD_REF, building)
+    repo.mixedResetTo(grilling)
+
+    // Even with a window ref recorded, an EXPLICIT ref resolves at that ref,
+    // exactly as before this package — this path is deliberately untouched.
+    const atBoundary = await provide(restAt(boundary), repo)
+    expect(atBoundary.state).toBe("idle")
   })
 })
 

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect"
+import { Effect, Option } from "effect"
 import { GitService, type GitOperations } from "./Git.js"
 import { ConfigService } from "./Config.js"
 import { RepoFiles, templateRead } from "./RepoFiles.js"
@@ -9,6 +9,7 @@ import {
   entryBaseTemplateOf,
   initialStateOf,
   isReviewBaseState,
+  isReviewWindowState,
   memoryScopeAt,
   parseStateSubject,
   resolveState,
@@ -31,7 +32,16 @@ import {
   type TemplateContext,
   type TemplateEdge,
 } from "./PatternTemplates.js"
-import { retainHistory, withHistoryTrailer } from "./RetainedHistory.js"
+import { HISTORY_REF, retainHistory, withHistoryTrailer } from "./RetainedHistory.js"
+import {
+  commitAll,
+  commitAsIs,
+  discardPending,
+  mixedResetTo,
+  softResetTo,
+  updateRef,
+} from "./GitScript.js"
+import { emitScripts, type EmitPreconditions, type EmitStep, type EmittedScripts } from "./Emit.js"
 
 /**
  * The v3 Effect edge. Everything git/filesystem-shaped lives here —
@@ -78,6 +88,18 @@ import { retainHistory, withHistoryTrailer } from "./RetainedHistory.js"
 // git's empty-tree object — the diff/reset base when a process (or the whole
 // repo) has no earlier commit to compare against.
 const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+/**
+ * The review checkout window's saved-head ref — duplicated from
+ * `src/ReviewWindow.ts`'s own `REVIEW_HEAD_REF` rather than imported, because
+ * `ReviewWindow.ts` already imports FROM this module (`currentRun`,
+ * `reviewBaseFor`); importing it back here would be a real circular module
+ * dependency. Mirrors `src/RetainedHistory.ts`'s own `HISTORY_REF` doc
+ * comment on the same tradeoff. Read (never written) by `restAt`'s
+ * window-aware branch and by the script preconditions below — this module
+ * never opens or closes the window itself.
+ */
+const REVIEW_HEAD_REF = "refs/worktree/gtd/review-head"
 
 const subjectOf = (message: string): string => (message.split("\n")[0] ?? "").trim()
 
@@ -307,10 +329,13 @@ export const resolveRestFrom = (def: WorkflowDefinition, headSubject: string): R
 
 // ── Pending changes ──────────────────────────────────────────────────────────
 
-/** The working tree's pending changes vs HEAD, as the pattern grammar's `{status, path}[]`. */
-const pendingChanges = (git: GitOperations): Effect.Effect<readonly PendingChange[], Error> =>
+/** The working tree's pending changes vs `base` (default HEAD), as the pattern grammar's `{status, path}[]`. */
+const pendingChanges = (
+  git: GitOperations,
+  base?: string,
+): Effect.Effect<readonly PendingChange[], Error> =>
   git
-    .changedPaths()
+    .changedPaths(base)
     .pipe(
       Effect.map((entries) =>
         entries.map((e) => ({ status: normalizeStatus(e.status), path: e.path })),
@@ -383,12 +408,20 @@ const parseEntryCommitOverrides = (
  * same shape a fresh rest at a squashed boundary has always had.
  *
  * `hasCommits` is supplied by the caller (already read once — see the module
- * doc comment's stage ordering) rather than re-read here.
+ * doc comment's stage ordering) rather than re-read here. `head` — a resolved
+ * hash, never a symbolic ref — overrides the literal `HEAD` the walk would
+ * otherwise end at: `restAt`'s window-aware branch passes the review
+ * checkout window's saved-head hash here while the window is open, so the
+ * trace still covers the commits a real `git log` would miss with HEAD
+ * rewound to the review base. `undefined` (every other caller) is today's
+ * exact behavior — an explicit trailing ref is passed to `git.commitHistory`
+ * only when `head` differs from the literal `"HEAD"` it already defaults to.
  */
 const computeProcessRun = (
   git: GitOperations,
   def: WorkflowDefinition,
   hasCommits: boolean,
+  head?: string,
 ): Effect.Effect<ProcessRun, Error> =>
   Effect.gen(function* () {
     if (!hasCommits)
@@ -402,7 +435,7 @@ const computeProcessRun = (
       }
 
     const initialState = initialStateOf(def)
-    const history = yield* git.commitHistory() // oldest -> newest, full first-parent history
+    const history = yield* git.commitHistory(undefined, head) // oldest -> newest, full first-parent history
     let i = history.length - 1
     while (i >= 0) {
       const parsed = parseStateSubject(subjectOf(history[i]!.message))
@@ -431,13 +464,20 @@ const computeProcessRun = (
  * since abandon IS the recovery command for that case) and the review
  * window's re-arm (`openReviewWindow` stays graceful there too — see its own
  * doc comment).
+ *
+ * Window-aware on exactly the same terms as `restAt`: while a review checkout
+ * window is open, real HEAD is rewound to the review base, so walking the
+ * trace from literal HEAD would see a process that has not started. Both
+ * callers need the REAL head — abandon rewinds the reviewed branch tip, the
+ * re-arm re-derives the review base — so the saved head is the walk's origin.
  */
 export const currentRun: Effect.Effect<ProcessRun, Error, GitService | ConfigService> = Effect.gen(
   function* () {
     const git = yield* GitService
     const config = yield* (yield* ConfigService).load
     const hasCommits = yield* git.hasCommits()
-    return yield* computeProcessRun(git, config.workflow, hasCommits)
+    const windowHead = Option.getOrUndefined(yield* git.readRefOption(REVIEW_HEAD_REF))
+    return yield* computeProcessRun(git, config.workflow, hasCommits, windowHead)
   },
 )
 
@@ -740,6 +780,20 @@ const omitUndefined = <T extends Record<string, unknown>>(
  * window's saved head via `REVIEW_HEAD_REF`, or `undefined` for HEAD itself —
  * see `currentRest`). Assembles every stage documented in the module doc
  * comment, threading one `hasCommits()` read through stages 3/5/11.
+ *
+ * Window-aware ONLY at `ref === undefined` (`currentRest`'s own case): when
+ * the review checkout window's saved-head ref (`REVIEW_HEAD_REF`) resolves,
+ * its hash is used as the effective head for `lastCommitSubject` AND
+ * `computeProcessRun`'s trace walk — real git HEAD has been rewound to the
+ * review base while the window is open, so reading literal `HEAD` there
+ * would resolve state/trace/memory against the wrong commit. An explicit
+ * `ref` (`gtd visualize`'s own call pattern) never triggers this branch —
+ * that path resolves exactly as it always has. Safe to land now because
+ * every existing command closes the window (`program.ts`'s
+ * `runInReviewWindowBracket`) before `restAt`/`currentRest` ever runs, so the
+ * saved-head ref is already gone by the time this branch could fire in
+ * production — see the two direct tests in `Edge.test.ts` for the only
+ * coverage today.
  */
 export const restAt = (ref: string | undefined): Effect.Effect<Rest, Error, RestRequirements> =>
   Effect.gen(function* () {
@@ -750,17 +804,30 @@ export const restAt = (ref: string | undefined): Effect.Effect<Rest, Error, Rest
     const def = config.workflow
 
     const hasCommits = yield* git.hasCommits()
-    const headSubject = hasCommits ? yield* git.lastCommitSubject(ref) : ""
+
+    let windowHead: string | undefined
+    if (ref === undefined) {
+      windowHead = Option.getOrUndefined(yield* git.readRefOption(REVIEW_HEAD_REF))
+    }
+    const effectiveRef = windowHead ?? ref
+
+    const headSubject = hasCommits ? yield* git.lastCommitSubject(effectiveRef) : ""
     const resolution = resolveRestFrom(def, headSubject)
     if (!resolution.ok) return yield* Effect.fail(resolution.error)
     const resolved = resolution.rest
 
-    const run = yield* computeProcessRun(git, def, hasCommits)
+    const run = yield* computeProcessRun(git, def, hasCommits, windowHead)
     const vars = resolveVars(config.workflowVars, config.rcVars, run.entryVars, envVars.all)
     const on = yield* renderOnEdgesOrFail(resolved.stateDef.on, vars)
     const stepDef = withRenderedOn(def, resolved.state, on)
     const reviewBase = reviewBaseFor(def, run)
-    const changes = yield* pendingChanges(git)
+    // `windowHead` (an OPEN review checkout window's saved head) is the base
+    // the reviewer's pending changes are measured against — real HEAD is
+    // rewound to the review base while the window is open, so measuring
+    // against it would report the whole reviewed diff as pending and would
+    // MISS a reviewer's deletion of a window-staged file entirely. See
+    // `GitReaderOperations.changedPaths`.
+    const changes = yield* pendingChanges(git, windowHead)
     const context = yield* buildTemplateContext(
       git,
       templateRead(files),
@@ -903,12 +970,15 @@ const formatStepRefusal = (invoker: string, refusal: StepRefusal): string =>
 
 /**
  * Build the `TemplateContext` for rendering a DIFFERENT state than `rest`'s
- * own resting one, with a step's `cost`/`model` folded in — `planStep`'s
- * squash branch is its only caller (the commit branch never reads a
- * `TemplateContext` — see `executeDecision`), so this stays unexported per
- * the module's two-caller rule.
+ * own resting one, with a step's `cost`/`model` folded in. A squash's commit
+ * template is the only thing that needs it (the commit branch never reads a
+ * `TemplateContext` at all), and it is NOT interchangeable with `rest.context`:
+ * that one is pinned to the resting state and carries `cost: 0`, so rendering
+ * `it.processCost` against it silently omits the squashing step's own
+ * `--cost`. Exported for `program.ts`'s `stepAsActor`, which assembles the
+ * same script by hand and must pick the same context.
  */
-const contextAt = (
+export const contextAt = (
   rest: Rest,
   targetState: StateName,
   invoker: string,
@@ -986,6 +1056,137 @@ const executeDecision = (
   })
 
 /**
+ * Render a `"commit"`/`"squash"` decision as the `EmitStep`s the external
+ * driver would run to produce the SAME effect `executeDecision` performs
+ * directly — same switch, same subjects, same trailers, same ordering. Every
+ * git call here is a READ (`git.resolveRef("HEAD")` for the squash branch's
+ * pre-squash tip); nothing is written. `planStep`/`planEntry`'s script
+ * assembly (`buildStepScripts`) and `Edge.test.ts`'s render/perform
+ * equivalence tests are its two callers.
+ *
+ * The squash branch renders the commit-state template against the PENDING
+ * tree — a render failure fails this Effect exactly like `executeDecision`'s
+ * own (same message), touching no git. On success it emits, in order:
+ * retain-history (`updateRef(HISTORY_REF, tip)`, OMITTED when `tip ===
+ * run.startParentHash` — an empty process retains nothing, mirroring
+ * `retainHistory`'s own no-op check, decided here since `tip` is already
+ * known), soft-reset to the process start, commit-as-is with the rendered
+ * message plus its `Gtd-History:` trailer, then discard-pending.
+ *
+ * The commit branch carries `executeDecision`'s one non-obvious case too: a
+ * commit whose target is the workflow's INITIAL state, from a process that
+ * retained nothing, is a no-op probe (`gtd --entry fix-precheck` against a
+ * green suite is the shipped example) and must leave no trace at all. It
+ * emits retain-history + a mixed reset to the process start instead of a
+ * commit, so the entry commit and the probe collapse away together rather
+ * than dirtying the log with a round trip to `idle`. Deciding it needs the
+ * whole `rest` (its definition for the initial state, its pending changes for
+ * the "retained nothing" test), which is why this takes a `Rest` rather than
+ * the `ProcessRun` alone.
+ */
+export const renderDecision = (
+  git: GitOperations,
+  rest: Rest,
+  decision: ExecutableDecision,
+  context: TemplateContext,
+  cost: number | undefined,
+  model: string | undefined,
+): Effect.Effect<readonly EmitStep[], Error> =>
+  Effect.gen(function* () {
+    const run = rest.run
+    switch (decision.kind) {
+      case "commit": {
+        const target = parseStateSubject(decision.subject)?.state
+        if (
+          target === initialStateOf(rest.def) &&
+          run.startParentHash !== EMPTY_TREE &&
+          (yield* retainsNothing(git, run, rest.changes))
+        ) {
+          const tip = yield* git.resolveRef("HEAD")
+          const steps: EmitStep[] = []
+          if (tip !== run.startParentHash) {
+            steps.push({ kind: "gitWrite", command: updateRef(HISTORY_REF, tip) })
+          }
+          steps.push({ kind: "gitWrite", command: mixedResetTo(run.startParentHash) })
+          return steps
+        }
+        const command = commitAll(withCostTrailer(decision.subject, cost, model))
+        return [{ kind: "gitWrite", command }] as const
+      }
+      case "squash": {
+        const message = yield* Effect.try({
+          try: () => renderStateTemplate(decision.template, context),
+          catch: (e) =>
+            new Error(
+              `gtd: rendering the "${decision.state}" commit template failed — nothing was committed: ${
+                e instanceof Error ? e.message : String(e)
+              }`,
+            ),
+        })
+        const tip = yield* git.resolveRef("HEAD")
+        const steps: EmitStep[] = []
+        if (tip !== run.startParentHash) {
+          steps.push({ kind: "gitWrite", command: updateRef(HISTORY_REF, tip) })
+        }
+        steps.push({ kind: "gitWrite", command: softResetTo(run.startParentHash) })
+        steps.push({ kind: "gitWrite", command: commitAsIs(withHistoryTrailer(message, tip)) })
+        steps.push({ kind: "gitWrite", command: discardPending() })
+        return steps
+      }
+    }
+  })
+
+/**
+ * The `EmitPreconditions` a step's/entry's assembled scripts assert against:
+ * `expectedHead` is the resolved HEAD hash the `Rest` snapshot was already
+ * taken at (`rest.context.currentCommit`, falling back to `EMPTY_TREE` for a
+ * commit-less repo — there is no real HEAD hash to pin to yet). When
+ * `targetState` declares `reviewWindow: true` AND a window is currently open
+ * (`REVIEW_HEAD_REF` resolves), the script also pins the window's saved-head
+ * hash — a later run whose window has since closed or moved must re-decide
+ * rather than trust a stale script. No window, or a non-review-window
+ * target, carries no `reviewWindow` precondition at all.
+ */
+const buildPreconditions = (
+  git: GitOperations,
+  rest: Rest,
+  targetState: StateName,
+): Effect.Effect<EmitPreconditions, Error> =>
+  Effect.gen(function* () {
+    const expectedHead = rest.context.currentCommit !== "" ? rest.context.currentCommit : EMPTY_TREE
+    if (!isReviewWindowState(rest.def, targetState)) {
+      return { expectedHead }
+    }
+    const windowHead = yield* git.readRefOption(REVIEW_HEAD_REF)
+    if (Option.isNone(windowHead)) return { expectedHead }
+    return { expectedHead, reviewWindow: { ref: REVIEW_HEAD_REF, expectedHash: windowHead.value } }
+  })
+
+/**
+ * The `EmittedScripts` a `"commit"`/`"squash"` `StepPlan` carries alongside
+ * `perform` — built from the SAME `renderDecision` output, but a render
+ * failure collapses to an EMPTY script (`emitScripts` with no steps) instead
+ * of failing this Effect: `perform` stays the one place a render failure is
+ * ever reported to a caller, unchanged by this addition.
+ */
+const buildStepScripts = (
+  git: GitOperations,
+  rest: Rest,
+  decision: ExecutableDecision,
+  context: TemplateContext,
+  cost: number | undefined,
+  model: string | undefined,
+): Effect.Effect<EmittedScripts, Error> =>
+  Effect.gen(function* () {
+    const targetState = decision.kind === "commit" ? decision.to : decision.state
+    const preconditions = yield* buildPreconditions(git, rest, targetState)
+    const steps = yield* renderDecision(git, rest, decision, context, cost, model).pipe(
+      Effect.catchAll(() => Effect.succeed<readonly EmitStep[]>([])),
+    )
+    return emitScripts(preconditions, steps)
+  })
+
+/**
  * Decide + perform a step. Nothing writes git until `perform` runs, so the
  * capture gates (`program.ts`'s `enforce*Gate` family) sit between `planStep`
  * and `plan.perform` by construction rather than by statement order.
@@ -999,6 +1200,14 @@ export type StepPlan =
       /** Inspectable — do not hide it behind `perform`. */
       readonly decision: StepDecision
       readonly perform: Effect.Effect<StepOutcome, Error, RestRequirements>
+      /**
+       * The `required`/`optional` bash a driver could run instead of
+       * `perform` — built alongside it by `buildStepScripts`, from the SAME
+       * `renderDecision` output `perform`'s own `executeDecision` mirrors.
+       * Nothing reads this yet; it exists so a later package's cutover has
+       * nothing left to build.
+       */
+      readonly scripts: EmittedScripts
     }
 
 /**
@@ -1019,50 +1228,57 @@ export const planStep = (
   rest: Rest,
   invoker: string,
   opts: { readonly cost?: number; readonly model?: string } = {},
-): Effect.Effect<StepPlan, Error, RestRequirements> => {
-  // Pure decision — no Effect needed to reach it, so this stays a plain
-  // function returning `Effect.succeed`/the `perform` closure rather than an
-  // `Effect.gen` with nothing to `yield*` at this level.
-  const decision = step(rest.stepDef, rest.state, invoker, {
-    changes: rest.changes,
-    // `StepPayload.processTrace` stays `readonly StateName[]` — the pure
-    // engine's retry-entry counting (`applyRetry`) only ever compares state
-    // NAMES, never commit hashes, so widening it to carry `TraceEntry`s
-    // would just churn every `step` test that builds a payload for data the
-    // engine never reads.
-    processTrace: rest.run.trace.map((entry) => entry.state),
-  })
+): Effect.Effect<StepPlan, Error, RestRequirements> =>
+  Effect.gen(function* () {
+    // Pure decision — no Effect needed to reach it.
+    const decision = step(rest.stepDef, rest.state, invoker, {
+      changes: rest.changes,
+      // `StepPayload.processTrace` stays `readonly StateName[]` — the pure
+      // engine's retry-entry counting (`applyRetry`) only ever compares state
+      // NAMES, never commit hashes, so widening it to carry `TraceEntry`s
+      // would just churn every `step` test that builds a payload for data the
+      // engine never reads.
+      processTrace: rest.run.trace.map((entry) => entry.state),
+    })
 
-  if (decision.kind === "refusal") {
-    return Effect.succeed({ kind: "refusal", message: formatStepRefusal(invoker, decision) })
-  }
-  if (decision.kind === "noop") {
-    return Effect.succeed({ kind: "noop", state: decision.state })
-  }
-
-  const { cost, model } = opts
-  const perform: Effect.Effect<StepOutcome, Error, RestRequirements> = Effect.gen(function* () {
-    const git = yield* GitService
-    if (decision.kind === "commit") {
-      const target = parseStateSubject(decision.subject)?.state
-      if (
-        target === initialStateOf(rest.def) &&
-        rest.run.startParentHash !== EMPTY_TREE &&
-        (yield* retainsNothing(git, rest.run, rest.changes))
-      ) {
-        const tip = yield* git.resolveRef("HEAD")
-        yield* retainHistory(git, tip, rest.run.startParentHash)
-        yield* git.mixedResetTo(rest.run.startParentHash)
-        return { kind: "reset", state: target }
-      }
-      return yield* executeDecision(git, rest.run, decision, rest.context, cost, model)
+    if (decision.kind === "refusal") {
+      return { kind: "refusal", message: formatStepRefusal(invoker, decision) } as const
     }
-    const context = yield* contextAt(rest, decision.state, invoker, cost, model)
-    return yield* executeDecision(git, rest.run, decision, context, cost, model)
-  })
+    if (decision.kind === "noop") {
+      return { kind: "noop", state: decision.state } as const
+    }
 
-  return Effect.succeed({ kind: decision.kind, state: rest.state, decision, perform })
-}
+    const { cost, model } = opts
+    const perform: Effect.Effect<StepOutcome, Error, RestRequirements> = Effect.gen(function* () {
+      const git = yield* GitService
+      if (decision.kind === "commit") {
+        const target = parseStateSubject(decision.subject)?.state
+        if (
+          target === initialStateOf(rest.def) &&
+          rest.run.startParentHash !== EMPTY_TREE &&
+          (yield* retainsNothing(git, rest.run, rest.changes))
+        ) {
+          const tip = yield* git.resolveRef("HEAD")
+          yield* retainHistory(git, tip, rest.run.startParentHash)
+          yield* git.mixedResetTo(rest.run.startParentHash)
+          return { kind: "reset", state: target }
+        }
+        return yield* executeDecision(git, rest.run, decision, rest.context, cost, model)
+      }
+      const context = yield* contextAt(rest, decision.state, invoker, cost, model)
+      return yield* executeDecision(git, rest.run, decision, context, cost, model)
+    })
+
+    // Built alongside `perform`, from the same inputs — see `buildStepScripts`.
+    const git = yield* GitService
+    const scriptContext =
+      decision.kind === "commit"
+        ? rest.context
+        : yield* contextAt(rest, decision.state, invoker, cost, model)
+    const scripts = yield* buildStepScripts(git, rest, decision, scriptContext, cost, model)
+
+    return { kind: decision.kind, state: rest.state, decision, perform, scripts }
+  })
 
 // ── Planning + performing an entry ───────────────────────────────────────────
 
@@ -1074,6 +1290,8 @@ export type EntryPlan =
       readonly state: StateName
       readonly subject: string
       readonly perform: Effect.Effect<StepOutcome, Error, RestRequirements>
+      /** The `required`/`optional` bash a driver could run instead of `perform` — one `commitAll(message)` line, built alongside it. Nothing reads this yet — see `StepPlan.scripts`. */
+      readonly scripts: EmittedScripts
     }
 
 /**
@@ -1201,5 +1419,11 @@ export const planEntry = (
       return { kind: "entry", state: entryState, subject }
     })
 
-    return { kind: "entry", state: entryState, subject, perform }
+    // Built alongside `perform` — a single `commitAll(message)` line mirrors
+    // `commitAllWithPrefix` exactly, no template render involved.
+    const scriptsGit = yield* GitService
+    const preconditions = yield* buildPreconditions(scriptsGit, rest, entryState)
+    const scripts = emitScripts(preconditions, [{ kind: "gitWrite", command: commitAll(message) }])
+
+    return { kind: "entry", state: entryState, subject, perform, scripts }
   })

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -1139,13 +1139,14 @@ export const renderDecision = (
 /**
  * The `EmitPreconditions` a step's/entry's assembled scripts assert against:
  * `expectedHead` is the resolved HEAD hash the `Rest` snapshot was already
- * taken at (`rest.context.currentCommit`, falling back to `EMPTY_TREE` for a
- * commit-less repo — there is no real HEAD hash to pin to yet). When
- * `targetState` declares `reviewWindow: true` AND a window is currently open
- * (`REVIEW_HEAD_REF` resolves), the script also pins the window's saved-head
- * hash — a later run whose window has since closed or moved must re-decide
- * rather than trust a stale script. No window, or a non-review-window
- * target, carries no `reviewWindow` precondition at all.
+ * taken at — `rest.context.currentCommit`, passed straight through, `""`
+ * included (its own convention for "no commits yet", which `headAssertion`
+ * now understands natively). When `targetState` declares `reviewWindow: true`
+ * AND a window is currently open (`REVIEW_HEAD_REF` resolves), the script also
+ * pins the window's saved-head hash — a later run whose window has since
+ * closed or moved must re-decide rather than trust a stale script. No window,
+ * or a non-review-window target, carries no `reviewWindow` precondition at
+ * all.
  */
 const buildPreconditions = (
   git: GitOperations,
@@ -1153,7 +1154,7 @@ const buildPreconditions = (
   targetState: StateName,
 ): Effect.Effect<EmitPreconditions, Error> =>
   Effect.gen(function* () {
-    const expectedHead = rest.context.currentCommit !== "" ? rest.context.currentCommit : EMPTY_TREE
+    const expectedHead = rest.context.currentCommit
     if (!isReviewWindowState(rest.def, targetState)) {
       return { expectedHead }
     }

--- a/src/Emit.test.ts
+++ b/src/Emit.test.ts
@@ -47,7 +47,7 @@ describe("emitScripts — required only", () => {
   })
 
   it("asserts HEAD before doing anything, naming the mismatch and telling the reader to re-run gtd", () => {
-    expect(required).toContain("git rev-parse HEAD")
+    expect(required).toContain("git rev-parse --verify --quiet HEAD")
     expect(required).toContain(HEAD)
     expect(required).toContain("re-run gtd")
   })
@@ -121,6 +121,26 @@ describe("emitScripts — a script with no gitWrite steps omits the retry helper
   })
 
   it("is still syntactically valid bash", () => {
+    expect(runBashCheckSyntax(required)).toBe(0)
+  })
+})
+
+describe("emitScripts — unborn HEAD precondition (expectedHead: '')", () => {
+  const steps: ReadonlyArray<EmitStep> = [
+    { kind: "gitWrite", command: "git commit --allow-empty -m 'gtd(agent): x'" },
+  ]
+  const { required } = emitScripts({ expectedHead: "" }, steps)
+
+  it("renders an empty-string comparison against the --verify --quiet probe", () => {
+    expect(required).toContain(`[ "$(git rev-parse --verify --quiet HEAD 2>/dev/null)" = '' ]`)
+  })
+
+  it("names 'no commits yet' rather than a hash in the failure message", () => {
+    expect(required).toContain("expected a repository with no commits yet")
+    expect(required).toContain("re-run gtd")
+  })
+
+  it("is syntactically valid bash", () => {
     expect(runBashCheckSyntax(required)).toBe(0)
   })
 })
@@ -269,6 +289,37 @@ describe("real repo — HEAD precondition and retry plumbing end to end", () => 
     const dir = initRepo()
     const before = commitCount(dir)
     const { required } = emitScripts({ expectedHead: "f".repeat(40) }, [
+      { kind: "gitWrite", command: "git commit --allow-empty -m 'gtd(agent): should-not-land'" },
+    ])
+    let status = 0
+    try {
+      execSync("bash", { input: required, cwd: dir, stdio: ["pipe", "pipe", "pipe"] })
+    } catch (error) {
+      status = (error as { status?: number }).status ?? 1
+    }
+    expect(status).not.toBe(0)
+    expect(commitCount(dir)).toBe(before)
+  })
+
+  it("an unborn HEAD (repo with no commits yet) lets the first commit land", () => {
+    const dir = mkdtempSync(join(tmpdir(), "emit-realrepo-unborn-"))
+    execFileSync("git", ["init", "-q"], { cwd: dir })
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir })
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: dir })
+    const { required } = emitScripts({ expectedHead: "" }, [
+      { kind: "gitWrite", command: "git commit --allow-empty -m 'gtd(agent): first'" },
+    ])
+    execSync("bash", { input: required, cwd: dir })
+    expect(commitCount(dir)).toBe(1)
+    expect(
+      execFileSync("git", ["log", "-1", "--pretty=%s"], { cwd: dir, encoding: "utf8" }).trim(),
+    ).toBe("gtd(agent): first")
+  })
+
+  it("an unborn-HEAD precondition run against a repo that already has a commit aborts non-zero and lands nothing", () => {
+    const dir = initRepo()
+    const before = commitCount(dir)
+    const { required } = emitScripts({ expectedHead: "" }, [
       { kind: "gitWrite", command: "git commit --allow-empty -m 'gtd(agent): should-not-land'" },
     ])
     let status = 0

--- a/src/Emit.test.ts
+++ b/src/Emit.test.ts
@@ -1,0 +1,283 @@
+import { execFileSync, execSync } from "node:child_process"
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import { REVIEW_HEAD_REF } from "./ReviewWindow.js"
+import { emitScripts, type EmitPreconditions, type EmitStep } from "./Emit.js"
+
+const runBashCheckSyntax = (script: string): number => {
+  try {
+    execFileSync("bash", ["-n"], { input: script })
+    return 0
+  } catch (error) {
+    return (error as { status?: number }).status ?? 1
+  }
+}
+
+const HEAD = "a".repeat(40)
+const basePreconditions: EmitPreconditions = { expectedHead: HEAD }
+
+describe("emitScripts — empty inputs", () => {
+  it("is the empty string when both halves are omitted", () => {
+    const { required, optional } = emitScripts(basePreconditions)
+    expect(required).toBe("")
+    expect(optional).toBe("")
+  })
+
+  it("is the empty string when both halves are explicitly []", () => {
+    const { required, optional } = emitScripts(basePreconditions, [], [])
+    expect(required).toBe("")
+    expect(optional).toBe("")
+  })
+})
+
+describe("emitScripts — required only", () => {
+  const steps: ReadonlyArray<EmitStep> = [
+    { kind: "gitWrite", command: "git commit --allow-empty -m 'gtd(agent): x'" },
+  ]
+  const { required, optional } = emitScripts(basePreconditions, steps)
+
+  it("leaves optional empty", () => {
+    expect(optional).toBe("")
+  })
+
+  it("begins with set -euo pipefail as the literal first line", () => {
+    expect(required.split("\n")[0]).toBe("set -euo pipefail")
+  })
+
+  it("asserts HEAD before doing anything, naming the mismatch and telling the reader to re-run gtd", () => {
+    expect(required).toContain("git rev-parse HEAD")
+    expect(required).toContain(HEAD)
+    expect(required).toContain("re-run gtd")
+  })
+
+  it("is syntactically valid bash", () => {
+    expect(runBashCheckSyntax(required)).toBe(0)
+  })
+})
+
+describe("emitScripts — both halves populated", () => {
+  const required: ReadonlyArray<EmitStep> = [
+    { kind: "gitWrite", command: "git commit --allow-empty -m 'gtd(agent): x'" },
+  ]
+  const optional: ReadonlyArray<EmitStep> = [
+    { kind: "command", command: "some-format-command --check FEEDBACK.md" },
+  ]
+  const preconditions: EmitPreconditions = {
+    expectedHead: HEAD,
+    reviewWindow: { ref: REVIEW_HEAD_REF, expectedHash: "b".repeat(40) },
+  }
+  const result = emitScripts(preconditions, required, optional)
+
+  it("both halves are non-empty", () => {
+    expect(result.required).not.toBe("")
+    expect(result.optional).not.toBe("")
+  })
+
+  it("both halves independently begin with set -euo pipefail", () => {
+    expect(result.required.split("\n")[0]).toBe("set -euo pipefail")
+    expect(result.optional.split("\n")[0]).toBe("set -euo pipefail")
+  })
+
+  it("both halves independently assert the review-window ref when reviewWindow is supplied", () => {
+    for (const script of [result.required, result.optional]) {
+      expect(script).toContain(REVIEW_HEAD_REF)
+      expect(script).toContain("b".repeat(40))
+      expect(script).toContain("re-run gtd")
+    }
+  })
+
+  it("both halves are syntactically valid bash", () => {
+    expect(runBashCheckSyntax(result.required)).toBe(0)
+    expect(runBashCheckSyntax(result.optional)).toBe(0)
+  })
+
+  it("a plain command step is emitted verbatim, not routed through the retry helper", () => {
+    expect(result.optional).toContain("some-format-command --check FEEDBACK.md")
+    expect(result.optional).not.toContain("gtd_retry 'some-format-command")
+  })
+
+  it("a gitWrite step is routed through the retry helper", () => {
+    expect(result.required).toMatch(/gtd_retry '.*git commit --allow-empty/)
+  })
+})
+
+describe("emitScripts — no reviewWindow means no extra ref assertion", () => {
+  const steps: ReadonlyArray<EmitStep> = [{ kind: "command", command: "echo hi" }]
+  const { required } = emitScripts(basePreconditions, steps)
+
+  it("does not mention a review-head ref at all", () => {
+    expect(required).not.toContain("refs/worktree/gtd/review-head")
+  })
+})
+
+describe("emitScripts — a script with no gitWrite steps omits the retry helper", () => {
+  const steps: ReadonlyArray<EmitStep> = [{ kind: "command", command: "echo hi" }]
+  const { required } = emitScripts(basePreconditions, steps)
+
+  it("never defines gtd_retry when nothing needs it", () => {
+    expect(required).not.toContain("gtd_retry()")
+  })
+
+  it("is still syntactically valid bash", () => {
+    expect(runBashCheckSyntax(required)).toBe(0)
+  })
+})
+
+/**
+ * A fake git-alike, invoked by ABSOLUTE PATH from within the assembled
+ * script's `gitWrite` step (never named bare `git`), behaving per invocation
+ * count (tracked in a counter file) — same technique `GitScript.test.ts`'s
+ * `withFakeGit` uses. Keeping it off `PATH` under the name `git` matters
+ * here: the assembled script's OWN precondition assertion also runs a bare
+ * `git rev-parse HEAD`, which must keep hitting the REAL git in the real
+ * throwaway repo these tests run in, not this fake.
+ */
+const withFakeGit = (
+  behaviorByAttempt: ReadonlyArray<string>,
+): { readonly binPath: string; readonly counterFile: string } => {
+  const binDir = mkdtempSync(join(tmpdir(), "emit-fakebin-"))
+  const counterFile = join(binDir, "count")
+  const binPath = join(binDir, "fake-git")
+  const cases = behaviorByAttempt.map((behavior, i) => `  ${i + 1}) ${behavior} ;;`).join("\n")
+  const last = behaviorByAttempt[behaviorByAttempt.length - 1] ?? "exit 0"
+  writeFileSync(
+    binPath,
+    [
+      "#!/bin/bash",
+      `count=$(( $(cat '${counterFile}' 2>/dev/null || echo 0) + 1 ))`,
+      `echo "$count" > '${counterFile}'`,
+      `case "$count" in`,
+      cases,
+      `  *) ${last} ;;`,
+      `esac`,
+    ].join("\n"),
+    { mode: 0o755 },
+  )
+  chmodSync(binPath, 0o755)
+  return { binPath, counterFile }
+}
+
+const runScriptInRealRepo = (script: string, cwd: string): number => {
+  try {
+    execSync("bash", { input: script, cwd, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] })
+    return 0
+  } catch (error) {
+    return (error as { status?: number }).status ?? 1
+  }
+}
+
+describe("gtd_retry — index.lock contention", () => {
+  const initRepo = (): string => {
+    const dir = mkdtempSync(join(tmpdir(), "emit-retry-repo-"))
+    execFileSync("git", ["init", "-q"], { cwd: dir })
+    execFileSync("git", ["commit", "--allow-empty", "-q", "-m", "initial"], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "Test",
+        GIT_AUTHOR_EMAIL: "test@example.com",
+        GIT_COMMITTER_NAME: "Test",
+        GIT_COMMITTER_EMAIL: "test@example.com",
+      },
+    })
+    return dir
+  }
+  const headOf = (dir: string): string =>
+    execFileSync("git", ["rev-parse", "HEAD"], { cwd: dir, encoding: "utf8" }).trim()
+  const scriptFor = (dir: string, binPath: string): string =>
+    emitScripts({ expectedHead: headOf(dir) }, [
+      { kind: "gitWrite", command: `${binPath} commit --allow-empty -m x` },
+    ]).required
+
+  it("retries on the index.lock wording and eventually succeeds", () => {
+    const dir = initRepo()
+    const { binPath, counterFile } = withFakeGit([
+      `echo "fatal: Unable to create '.git/index.lock': File exists." >&2; exit 128`,
+      `echo "fatal: Unable to create '.git/index.lock': File exists." >&2; exit 128`,
+      `exit 0`,
+    ])
+    const status = runScriptInRealRepo(scriptFor(dir, binPath), dir)
+    expect(status).toBe(0)
+    expect(execFileSync("cat", [counterFile], { encoding: "utf8" }).trim()).toBe("3")
+  })
+
+  it("retries on the 'another git process' wording too", () => {
+    const dir = initRepo()
+    const { binPath, counterFile } = withFakeGit([
+      `echo "Another git process seems to be running" >&2; exit 128`,
+      `exit 0`,
+    ])
+    const status = runScriptInRealRepo(scriptFor(dir, binPath), dir)
+    expect(status).toBe(0)
+    expect(execFileSync("cat", [counterFile], { encoding: "utf8" }).trim()).toBe("2")
+  })
+
+  it("gives up after 6 total attempts, still contending", () => {
+    const dir = initRepo()
+    const { binPath, counterFile } = withFakeGit([
+      `echo "fatal: Unable to create '.git/index.lock': File exists." >&2; exit 128`,
+    ])
+    const status = runScriptInRealRepo(scriptFor(dir, binPath), dir)
+    expect(status).not.toBe(0)
+    expect(execFileSync("cat", [counterFile], { encoding: "utf8" }).trim()).toBe("6")
+  })
+
+  it("does NOT retry a non-lock failure — fails on the first attempt", () => {
+    const dir = initRepo()
+    const { binPath, counterFile } = withFakeGit([`echo "fatal: some other failure" >&2; exit 1`])
+    const status = runScriptInRealRepo(scriptFor(dir, binPath), dir)
+    expect(status).not.toBe(0)
+    expect(execFileSync("cat", [counterFile], { encoding: "utf8" }).trim()).toBe("1")
+  })
+})
+
+describe("real repo — HEAD precondition and retry plumbing end to end", () => {
+  const initRepo = (): string => {
+    const dir = mkdtempSync(join(tmpdir(), "emit-realrepo-"))
+    execFileSync("git", ["init", "-q"], { cwd: dir })
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir })
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: dir })
+    execFileSync("git", ["commit", "--allow-empty", "-q", "-m", "initial"], { cwd: dir })
+    return dir
+  }
+
+  const headOf = (dir: string): string =>
+    execFileSync("git", ["rev-parse", "HEAD"], { cwd: dir, encoding: "utf8" }).trim()
+
+  const commitCount = (dir: string): number =>
+    Number(
+      execFileSync("git", ["rev-list", "--count", "HEAD"], { cwd: dir, encoding: "utf8" }).trim(),
+    )
+
+  it("a matching HEAD passes the precondition and the wrapped git command actually lands", () => {
+    const dir = initRepo()
+    const head = headOf(dir)
+    const before = commitCount(dir)
+    const { required } = emitScripts({ expectedHead: head }, [
+      { kind: "gitWrite", command: "git commit --allow-empty -m 'gtd(agent): landed'" },
+    ])
+    execSync("bash", { input: required, cwd: dir })
+    expect(commitCount(dir)).toBe(before + 1)
+    expect(
+      execFileSync("git", ["log", "-1", "--pretty=%s"], { cwd: dir, encoding: "utf8" }).trim(),
+    ).toBe("gtd(agent): landed")
+  })
+
+  it("a mismatched expected HEAD aborts before touching anything", () => {
+    const dir = initRepo()
+    const before = commitCount(dir)
+    const { required } = emitScripts({ expectedHead: "f".repeat(40) }, [
+      { kind: "gitWrite", command: "git commit --allow-empty -m 'gtd(agent): should-not-land'" },
+    ])
+    let status = 0
+    try {
+      execSync("bash", { input: required, cwd: dir, stdio: ["pipe", "pipe", "pipe"] })
+    } catch (error) {
+      status = (error as { status?: number }).status ?? 1
+    }
+    expect(status).not.toBe(0)
+    expect(commitCount(dir)).toBe(before)
+  })
+})

--- a/src/Emit.ts
+++ b/src/Emit.ts
@@ -24,14 +24,18 @@ export interface EmittedScripts {
 
 export interface EmitPreconditions {
   /**
-   * The HEAD the deciding read resolved. OMITTED for a script that is meant
-   * to run AFTER another one already moved HEAD — the `optional` half of a
-   * step that commits and then opens a review window is the one such case:
-   * its own expected HEAD is the commit the `required` half is about to
-   * create, a hash no one can know at decide time. Asserting the pre-commit
-   * hash there would fail the open every single time. Nothing is lost by
-   * omitting it: the open script is presentation-only, re-runnable, and
-   * resolves `HEAD` itself at run time.
+   * The HEAD the deciding read resolved. `""` means the deciding read saw a
+   * repository with NO commits yet — `rest.context.currentCommit`'s own
+   * convention for that case, passed straight through rather than translated
+   * into a hash that stands in for it (an empty tree is a tree, not a commit;
+   * there is no real HEAD to pin to). OMITTED (`undefined`) for a script that
+   * is meant to run AFTER another one already moved HEAD — the `optional`
+   * half of a step that commits and then opens a review window is the one
+   * such case: its own expected HEAD is the commit the `required` half is
+   * about to create, a hash no one can know at decide time. Asserting the
+   * pre-commit hash there would fail the open every single time. Nothing is
+   * lost by omitting it: the open script is presentation-only, re-runnable,
+   * and resolves `HEAD` itself at run time.
    */
   readonly expectedHead?: string
   readonly reviewWindow?: { readonly ref: string; readonly expectedHash: string }
@@ -63,14 +67,29 @@ export type EmitStep =
  * string-compare this exact shape, the same "call the real builder, never
  * hand-copy its template" discipline it already applies to every
  * `GitScript.ts` builder.
+ *
+ * The probe is `git rev-parse --verify --quiet HEAD 2>/dev/null`, not the
+ * bare `git rev-parse HEAD` a born repo's assertion could get away with —
+ * load-bearing, not cosmetic: against an UNBORN HEAD (a repository with no
+ * commits), the bare form prints the literal string `HEAD` to stdout (plus a
+ * `fatal:` line to stderr) and exits 128, so `"$(git rev-parse HEAD)"` reads
+ * as `"HEAD"`, never `""`, and an `expectedHead === ""` comparison could
+ * never pass. `--verify --quiet` makes an unborn HEAD read back as an empty
+ * string instead — the same idiom `reviewWindowAssertion` already uses for a
+ * missing ref — so `[ "$(…)" = '' ]` is simply the unborn case of the same
+ * comparison every born repo already runs; only the `printf` wording
+ * branches on it, to avoid naming a hash that doesn't exist.
  */
 export const headAssertion = (expectedHead: string): string => {
   const q = shellQuote(expectedHead)
-  return (
-    `[ "$(git rev-parse HEAD)" = ${q} ] || ` +
-    `{ printf 'gtd: repository changed since this script was generated ` +
-    `(expected HEAD %s) — re-run gtd\\n' ${q} >&2; exit 1; }`
-  )
+  const probe = `[ "$(git rev-parse --verify --quiet HEAD 2>/dev/null)" = ${q} ] || `
+  return expectedHead === ""
+    ? probe +
+        `{ printf 'gtd: repository changed since this script was generated ` +
+        `(expected a repository with no commits yet) — re-run gtd\\n' >&2; exit 1; }`
+    : probe +
+        `{ printf 'gtd: repository changed since this script was generated ` +
+        `(expected HEAD %s) — re-run gtd\\n' ${q} >&2; exit 1; }`
 }
 
 /**

--- a/src/Emit.ts
+++ b/src/Emit.ts
@@ -1,0 +1,176 @@
+/**
+ * Assembles the two scripts a `gtd next`-time decision hands the external
+ * driver: `required` (everything that decides what lands in git) and
+ * `optional` (presentation only — e.g. opening the review checkout window so
+ * an editor's diff view has something to show; a driver that skips it loses
+ * nothing but that view). Pure, like `src/GitScript.ts`: no git, no
+ * filesystem, no `Effect`. Every input string (a `GitScript.ts` builder's
+ * output, a steering mode's already-rendered `format:`/`validate:` command)
+ * arrives already rendered — this module only concatenates and wraps.
+ *
+ * Both halves are meant to stand alone: a driver may run either, both, or
+ * only `required`, and a person could paste either into a terminal. That's
+ * why each carries its OWN copy of the precondition asserts and the retry
+ * helper, rather than the two sharing one preamble a caller has to splice
+ * together correctly.
+ */
+
+import { shellQuote } from "./GitScript.js"
+
+export interface EmittedScripts {
+  readonly required: string
+  readonly optional: string
+}
+
+export interface EmitPreconditions {
+  /**
+   * The HEAD the deciding read resolved. OMITTED for a script that is meant
+   * to run AFTER another one already moved HEAD — the `optional` half of a
+   * step that commits and then opens a review window is the one such case:
+   * its own expected HEAD is the commit the `required` half is about to
+   * create, a hash no one can know at decide time. Asserting the pre-commit
+   * hash there would fail the open every single time. Nothing is lost by
+   * omitting it: the open script is presentation-only, re-runnable, and
+   * resolves `HEAD` itself at run time.
+   */
+  readonly expectedHead?: string
+  readonly reviewWindow?: { readonly ref: string; readonly expectedHash: string }
+}
+
+/**
+ * A step that IS a git index write (`gitWrite`, routed through the retry
+ * helper below) vs. a plain `command` (a steering mode's `format:`/
+ * `validate:` line, a `gtd check` script) that never touches git's index and
+ * must NOT be retry-wrapped — wrapping a non-git command would silently retry
+ * on any output that happens to contain the lock wording, e.g. a check whose
+ * own diff mentions "index.lock" in prose.
+ */
+export type EmitStep =
+  | { readonly kind: "gitWrite"; readonly command: string }
+  | { readonly kind: "command"; readonly command: string }
+
+/**
+ * The CLI resolves `expectedHead` (and a review window's `expectedHash`) at
+ * DECIDE time; the script may RUN later, in a process that never shared
+ * memory with the one that decided. This assertion closes that
+ * time-of-check/time-of-use gap. A plain `[ ... ] || { ...; exit 1; }`
+ * statement, not an `if`/`fi` block, so a line-oriented consumer can still
+ * recognize it, and so it stays safe under `set -e`: in an OR list, `-e`
+ * exempts every command except the LAST one, so the left-hand `[ ... ]`
+ * failing here never trips `set -e` on its own — only the explicit `exit 1`
+ * inside the right-hand group does. Exported (alongside `reviewWindowAssertion`)
+ * solely so `src/testing/EmittedScriptRecognizer.ts` can re-derive and
+ * string-compare this exact shape, the same "call the real builder, never
+ * hand-copy its template" discipline it already applies to every
+ * `GitScript.ts` builder.
+ */
+export const headAssertion = (expectedHead: string): string => {
+  const q = shellQuote(expectedHead)
+  return (
+    `[ "$(git rev-parse HEAD)" = ${q} ] || ` +
+    `{ printf 'gtd: repository changed since this script was generated ` +
+    `(expected HEAD %s) — re-run gtd\\n' ${q} >&2; exit 1; }`
+  )
+}
+
+/**
+ * Same shape as `headAssertion`, for the saved-head ref a review window
+ * pins. `--verify --quiet ... 2>/dev/null` makes a MISSING ref read as an
+ * empty string rather than erroring the substitution itself — the assertion
+ * only needs to compare, never to fail outright before the `[ ... ]` runs.
+ */
+export const reviewWindowAssertion = (ref: string, expectedHash: string): string => {
+  const refQ = shellQuote(ref)
+  const hashQ = shellQuote(expectedHash)
+  return (
+    `[ "$(git rev-parse --verify --quiet ${refQ} 2>/dev/null)" = ${hashQ} ] || ` +
+    `{ printf 'gtd: review window ref %s changed since this script was generated ` +
+    `(expected %s) — re-run gtd\\n' ${refQ} ${hashQ} >&2; exit 1; }`
+  )
+}
+
+/**
+ * `gtd_retry` takes ONE already-`shellQuote`d command string and `eval`s it,
+ * mirroring `src/Git.ts`'s `withIndexLockRetry`: retry ONLY on the same two
+ * substrings `isIndexLockError` matches, with jittered exponential backoff
+ * (~10ms doubling, capped at 6 TOTAL attempts — the initial try plus 5
+ * retries), and propagate any other failure on the very first attempt. Output
+ * is captured combined (`2>&1`) so the discrimination can inspect it exactly
+ * like `commitAllowEmpty`/`restoreStagedFrom` in `src/GitScript.ts` do for
+ * their own single-shot retries — this is the same technique, generalized
+ * into a loop. `awk` (not bash, which has no fractional `sleep` builtin)
+ * turns the millisecond backoff into the fractional-second argument `sleep`
+ * needs; `-v` passes the values in rather than interpolating them into the
+ * awk program text, so a variable's value can never be mistaken for awk
+ * syntax.
+ */
+const RETRY_HELPER = [
+  `gtd_retry() {`,
+  `  local cmd=$1 attempt=1 delay_ms=10 out total_ms jitter_ms`,
+  `  while true; do`,
+  `    if out=$(eval "$cmd" 2>&1); then`,
+  `      [ -n "$out" ] && printf '%s\\n' "$out"`,
+  `      return 0`,
+  `    fi`,
+  `    case "$out" in`,
+  `      *"index.lock"*|*"Another git process seems to be running"*) ;;`,
+  `      *) printf '%s\\n' "$out" >&2; return 1 ;;`,
+  `    esac`,
+  `    if [ "$attempt" -ge 6 ]; then`,
+  `      printf '%s\\n' "$out" >&2`,
+  `      return 1`,
+  `    fi`,
+  `    jitter_ms=$(( RANDOM % delay_ms + 1 ))`,
+  `    total_ms=$(( delay_ms + jitter_ms ))`,
+  `    sleep "$(awk -v ms="$total_ms" 'BEGIN { printf "%.3f", ms / 1000 }')"`,
+  `    delay_ms=$(( delay_ms * 2 ))`,
+  `    attempt=$(( attempt + 1 ))`,
+  `  done`,
+  `}`,
+].join("\n")
+
+const renderStep = (step: EmitStep): string =>
+  step.kind === "gitWrite" ? `gtd_retry ${shellQuote(step.command)}` : step.command
+
+const assembleScript = (
+  preconditions: EmitPreconditions,
+  steps: ReadonlyArray<EmitStep>,
+): string => {
+  if (steps.length === 0) return ""
+
+  const sections: Array<string> = ["set -euo pipefail"]
+  if (preconditions.expectedHead !== undefined) {
+    sections.push(headAssertion(preconditions.expectedHead))
+  }
+  if (preconditions.reviewWindow) {
+    sections.push(
+      reviewWindowAssertion(
+        preconditions.reviewWindow.ref,
+        preconditions.reviewWindow.expectedHash,
+      ),
+    )
+  }
+  if (steps.some((step) => step.kind === "gitWrite")) {
+    sections.push(RETRY_HELPER)
+  }
+  sections.push(...steps.map(renderStep))
+
+  return sections.join("\n\n")
+}
+
+/**
+ * Build both halves from already-rendered command strings. `required`
+ * defaults to `[]` (nothing to do), `optional` to `[]` (no review window to
+ * open) — either omitted argument, or an explicit empty array, produces the
+ * fixed empty-string result `EmittedScripts` documents: a driver checking
+ * `if [ -n "$required" ]` (or the JS equivalent) never has to special-case a
+ * bare preamble with no body.
+ */
+export const emitScripts = (
+  preconditions: EmitPreconditions,
+  required: ReadonlyArray<EmitStep> = [],
+  optional: ReadonlyArray<EmitStep> = [],
+): EmittedScripts => ({
+  required: assembleScript(preconditions, required),
+  optional: assembleScript(preconditions, optional),
+})

--- a/src/Git.test.ts
+++ b/src/Git.test.ts
@@ -6,7 +6,7 @@ import {
   withIndexLockRetries,
   type GitOperations,
 } from "./Git.js"
-import { gitTiers, runGitServiceContract } from "./testing/GitTiers.js"
+import { gitTiers, runGitServiceContract, runGitScriptContract } from "./testing/GitTiers.js"
 
 /**
  * The `GitOperations` contract, run identically against both the Live and
@@ -20,6 +20,16 @@ for (const makeTier of gitTiers) {
     runGitServiceContract(makeTier)
   })
 }
+
+/**
+ * `GitScript.ts`'s bash builders, run through real `bash` against a real git
+ * repo — the Live tier only, since the in-memory fake's root has no shell to
+ * execute against. Asserts the same 9 writer postconditions as the contract
+ * above, driven via the emitted script instead of the `GitOperations` port.
+ */
+describe("GitScript", () => {
+  runGitScriptContract()
+})
 
 // ---------------------------------------------------------------------------
 // index.lock contention retry — pure, tier-free unit assertions. The

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -16,7 +16,14 @@ export interface GitReaderOperations {
   /** `git rev-parse --show-toplevel` — the working-tree root; fails outside a repository. */
   readonly topLevel: () => Effect.Effect<string, Error>
   /**
-   * First-parent history from `base..HEAD` (or all commits if no base), oldest→newest.
+   * First-parent history from `base..head` (or all commits through `head` if
+   * no base), oldest→newest. `head` defaults to the literal `"HEAD"` when
+   * omitted — every existing call site (`commitHistory()`,
+   * `commitHistory(base)`) means exactly what it always has. Pass a resolved
+   * hash to walk through a DIFFERENT head instead — `Edge.ts`'s `restAt`
+   * does this while a review checkout window is open, since real HEAD has
+   * been rewound to the review base and a literal `HEAD` there would miss
+   * every commit between the base and the window's saved real head.
    * Each entry carries the full commit message, `removedErrors: true` iff that
    * commit's name-status diff contains a deletion (`D`) of `.gtd/ERRORS.md`
    * (or legacy root-level `ERRORS.md` from pre-namespaced history), and
@@ -26,7 +33,10 @@ export interface GitReaderOperations {
    * additional per-commit subprocess is spawned.
    * Returns `[]` for an empty repo.
    */
-  readonly commitHistory: (base?: string) => Effect.Effect<
+  readonly commitHistory: (
+    base?: string,
+    head?: string,
+  ) => Effect.Effect<
     ReadonlyArray<{
       readonly hash: string
       readonly message: string
@@ -43,16 +53,32 @@ export interface GitReaderOperations {
    */
   readonly readFileAtRef: (ref: string, path: string) => Effect.Effect<string, Error>
   /**
-   * The pending working-tree changes vs HEAD, as `{path, status}` pairs —
-   * tracked modifications (`git diff --name-status HEAD`) unioned with
-   * untracked files (reported as `status: "A"`), deduplicated by path. The
-   * v3 pattern machine's `step`/`gtd status` only need the status/path shape,
-   * never diff content, for pattern matching.
+   * The pending working-tree changes vs `base` (default `HEAD`), as
+   * `{path, status}` pairs — tracked modifications
+   * (`git diff --name-status <base>`) unioned with untracked files (reported
+   * as `status: "A"`), deduplicated by path. The v3 pattern machine's
+   * `step`/`gtd status` only need the status/path shape, never diff content,
+   * for pattern matching.
+   *
+   * `base` exists for exactly one caller: `Edge.ts`'s rest resolution while a
+   * review checkout window is OPEN. Real HEAD is rewound to the review base
+   * then, so "pending" against literal HEAD would mean "the whole reviewed
+   * diff" rather than "what the reviewer just did" — and, worse, a file the
+   * window staged back from the saved head but the reviewer DELETED shows up
+   * in neither tree and so reports no change at all (real git agrees: the
+   * index-only `AD` entry is invisible to `git diff --name-status HEAD`),
+   * which is precisely the deletion the review sign-off guard must catch.
+   * Passing the window's saved head restores the pre-window meaning.
+   *
+   * When `base` is given, an untracked path that already EXISTS at `base` is
+   * not an addition and is dropped — with the window open, every file added
+   * since the review base is untracked (the index sits at that base) while
+   * being perfectly present at the saved head. With no `base`, untracked
+   * means untracked and no filtering is paid for.
    */
-  readonly changedPaths: () => Effect.Effect<
-    ReadonlyArray<{ readonly path: string; readonly status: string }>,
-    Error
-  >
+  readonly changedPaths: (
+    base?: string,
+  ) => Effect.Effect<ReadonlyArray<{ readonly path: string; readonly status: string }>, Error>
   /**
    * `git diff --name-status <ref> HEAD` — the paths (and their status) changed
    * across the committed range `ref..HEAD`, with no content pass. The
@@ -265,12 +291,12 @@ const makeGitImpl = (executor: CommandExecutor.CommandExecutor, root: string): G
     changedPathsSince: (ref: string) =>
       exec("git", "diff", "--name-status", ref, "HEAD").pipe(Effect.map(parseNameStatus)),
 
-    changedPaths: () =>
+    changedPaths: (base?: string) =>
       Effect.gen(function* () {
         // Only the empty-repo case (no HEAD) is tolerated here — an
         // `index.lock` failure must propagate so the port-level retry
         // (`withIndexLockRetries`) sees it, not this catch.
-        const nameStatusOut = yield* exec("git", "diff", "--name-status", "HEAD").pipe(
+        const nameStatusOut = yield* exec("git", "diff", "--name-status", base ?? "HEAD").pipe(
           Effect.catchIf(
             (e) => !isIndexLockError(e),
             () => Effect.succeed(""),
@@ -279,10 +305,19 @@ const makeGitImpl = (executor: CommandExecutor.CommandExecutor, root: string): G
         const trackedPaths = parseNameStatus(nameStatusOut)
 
         const untrackedRaw = yield* exec("git", "ls-files", "--others", "--exclude-standard", "-z")
-        const untracked = untrackedRaw
+        const untrackedAll = untrackedRaw
           .split("\0")
           .filter((s) => s.length > 0)
           .map((path) => ({ path, status: "A" }))
+        const atBase =
+          base === undefined
+            ? new Set<string>()
+            : new Set(
+                (yield* exec("git", "ls-tree", "-r", "--name-only", "-z", base))
+                  .split("\0")
+                  .filter((s) => s.length > 0),
+              )
+        const untracked = untrackedAll.filter((entry) => !atBase.has(entry.path))
 
         const seen = new Set<string>()
         const all: Array<{ path: string; status: string }> = []
@@ -320,8 +355,8 @@ const makeGitImpl = (executor: CommandExecutor.CommandExecutor, root: string): G
 
     topLevel: () => exec("git", "rev-parse", "--show-toplevel").pipe(Effect.map((s) => s.trim())),
 
-    commitHistory: (base?: string) => {
-      const range = base !== undefined ? `${base}..HEAD` : undefined
+    commitHistory: (base?: string, head = "HEAD") => {
+      const range = base !== undefined ? `${base}..${head}` : head !== "HEAD" ? head : undefined
       const args: [string, ...Array<string>] = [
         "git",
         "log",

--- a/src/GitScript.test.ts
+++ b/src/GitScript.test.ts
@@ -1,0 +1,250 @@
+import { execFileSync, spawnSync } from "node:child_process"
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import fc from "fast-check"
+import {
+  commitAll,
+  commitAsIs,
+  deleteRef,
+  discardPending,
+  hardResetTo,
+  mixedResetTo,
+  restoreStagedFrom,
+  shellQuote,
+  softResetTo,
+  updateRef,
+} from "./GitScript.js"
+
+const runBashCheckSyntax = (script: string): number => {
+  try {
+    execFileSync("bash", ["-n"], { input: script })
+    return 0
+  } catch (error) {
+    return (error as { status?: number }).status ?? 1
+  }
+}
+
+/**
+ * A fake `git` on `PATH` that behaves per invocation count (tracked in a
+ * counter file), so a script's real retry/discrimination logic can be
+ * exercised against real bash without a real repo. `firstBehavior`/
+ * `secondBehavior` are shell snippets run in place of the real command.
+ */
+const withFakeGit = (
+  firstBehavior: string,
+  secondBehavior = `exit 0`,
+): { readonly binDir: string; readonly counterFile: string } => {
+  const binDir = mkdtempSync(join(tmpdir(), "gitscript-fakebin-"))
+  const counterFile = join(binDir, "count")
+  const gitPath = join(binDir, "git")
+  writeFileSync(
+    gitPath,
+    [
+      "#!/bin/bash",
+      `count=$(( $(cat '${counterFile}' 2>/dev/null || echo 0) + 1 ))`,
+      `echo "$count" > '${counterFile}'`,
+      `if [ "$count" -eq 1 ]; then`,
+      `  ${firstBehavior}`,
+      `else`,
+      `  ${secondBehavior}`,
+      `fi`,
+    ].join("\n"),
+    { mode: 0o755 },
+  )
+  chmodSync(gitPath, 0o755)
+  return { binDir, counterFile }
+}
+
+const runWithFakeGit = (script: string, binDir: string): { status: number | null } =>
+  spawnSync("bash", ["-c", script], {
+    env: { ...process.env, PATH: `${binDir}:${process.env["PATH"]}` },
+    encoding: "utf8",
+  })
+
+const allBuilders: ReadonlyArray<[string, string]> = [
+  ["commitAll", commitAll("gtd(agent): working")],
+  ["commitAsIs", commitAsIs("gtd(agent): working")],
+  ["softResetTo", softResetTo("HEAD~1")],
+  ["mixedResetTo", mixedResetTo("HEAD~1")],
+  ["hardResetTo", hardResetTo("HEAD~1")],
+  ["discardPending", discardPending()],
+  ["updateRef", updateRef("refs/worktree/gtd/review-head", "abc123")],
+  ["deleteRef", deleteRef("refs/worktree/gtd/review-head")],
+  ["restoreStagedFrom (with paths)", restoreStagedFrom("HEAD", [".gtd/TODO.md"])],
+  ["restoreStagedFrom (no paths)", restoreStagedFrom("HEAD", [])],
+]
+
+describe("commitAll", () => {
+  it("stages everything then commits with --allow-empty, retrying without hooks", () => {
+    const script = commitAll("gtd(agent): working")
+    expect(script).toContain("git add -A")
+    expect(script).toContain("git commit --allow-empty -m 'gtd(agent): working'")
+    expect(script).toContain("--no-verify")
+  })
+
+  it("short-circuits: a failed git add never reaches the commit", () => {
+    const { binDir, counterFile } = withFakeGit(`exit 1`)
+    const result = runWithFakeGit(commitAll("msg"), binDir)
+    expect(result.status).not.toBe(0)
+    // Only `git add -A` ran — the commit (which would bump the counter to 2+) never fired.
+    expect(execFileSync("cat", [counterFile], { encoding: "utf8" }).trim()).toBe("1")
+  })
+})
+
+describe("commitAsIs", () => {
+  it("commits the staged index as-is with --allow-empty, without an add", () => {
+    const script = commitAsIs("gtd(agent): working")
+    expect(script).not.toContain("git add -A")
+    expect(script).toContain("git commit --allow-empty -m 'gtd(agent): working'")
+    expect(script).toContain("--no-verify")
+  })
+})
+
+describe("commitAllowEmpty retry discrimination (via commitAsIs)", () => {
+  it("retries without hooks on the hook's own empty-git-commit rejection", () => {
+    const { binDir, counterFile } = withFakeGit(
+      `echo "fatal: rejecting an empty git commit" >&2; exit 1`,
+      `case "$*" in *--no-verify*) exit 0 ;; *) exit 1 ;; esac`,
+    )
+    const result = runWithFakeGit(commitAsIs("msg"), binDir)
+    expect(result.status).toBe(0)
+    expect(execFileSync("cat", [counterFile], { encoding: "utf8" }).trim()).toBe("2")
+  })
+
+  it("does NOT retry — and stays failed — on a non-hook commit failure", () => {
+    const { binDir, counterFile } = withFakeGit(`echo "some other failure" >&2; exit 1`)
+    const result = runWithFakeGit(commitAsIs("msg"), binDir)
+    expect(result.status).not.toBe(0)
+    // Only ran once — no retry on a failure that isn't the hook rejection.
+    expect(execFileSync("cat", [counterFile], { encoding: "utf8" }).trim()).toBe("1")
+  })
+})
+
+describe("softResetTo", () => {
+  it("emits git reset --soft <ref>", () => {
+    expect(softResetTo("HEAD~1")).toBe("git reset --soft 'HEAD~1'")
+  })
+})
+
+describe("mixedResetTo", () => {
+  it("emits git reset --mixed <ref>", () => {
+    expect(mixedResetTo("HEAD~1")).toBe("git reset --mixed 'HEAD~1'")
+  })
+})
+
+describe("hardResetTo", () => {
+  it("emits git reset --hard <ref>", () => {
+    expect(hardResetTo("HEAD~1")).toBe("git reset --hard 'HEAD~1'")
+  })
+})
+
+describe("discardPending", () => {
+  it("stages everything then hard-resets to HEAD", () => {
+    const script = discardPending()
+    expect(script).toContain("git add -A")
+    expect(script).toContain("git reset --hard HEAD")
+  })
+
+  it("short-circuits: a failed git add never reaches the hard reset", () => {
+    const { binDir, counterFile } = withFakeGit(`exit 1`)
+    const result = runWithFakeGit(discardPending(), binDir)
+    expect(result.status).not.toBe(0)
+    expect(execFileSync("cat", [counterFile], { encoding: "utf8" }).trim()).toBe("1")
+  })
+})
+
+describe("updateRef", () => {
+  it("emits git update-ref <ref> <hash>", () => {
+    expect(updateRef("refs/worktree/gtd/review-head", "abc123")).toBe(
+      "git update-ref 'refs/worktree/gtd/review-head' 'abc123'",
+    )
+  })
+})
+
+describe("deleteRef", () => {
+  it("emits git update-ref -d <ref> verbatim (tolerant of a missing ref already in real git)", () => {
+    expect(deleteRef("refs/worktree/gtd/review-head")).toBe(
+      "git update-ref -d 'refs/worktree/gtd/review-head'",
+    )
+  })
+})
+
+describe("restoreStagedFrom", () => {
+  it("emits git restore --staged --source=<source> -- <paths...>", () => {
+    const script = restoreStagedFrom("HEAD", [".gtd/TODO.md", ".gtd/REVIEW.md"])
+    expect(script).toContain("git restore --staged --source='HEAD' --")
+    expect(script).toContain("'.gtd/TODO.md'")
+    expect(script).toContain("'.gtd/REVIEW.md'")
+  })
+
+  it("emits a harmless empty script when no paths are given", () => {
+    const script = restoreStagedFrom("HEAD", [])
+    expect(script).toBe("")
+    expect(runBashCheckSyntax(script)).toBe(0)
+  })
+
+  it("tolerates a no-matching-path failure", () => {
+    const { binDir } = withFakeGit(
+      `echo "error: pathspec 'x' did not match any file(s)" >&2; exit 1`,
+    )
+    const result = runWithFakeGit(restoreStagedFrom("HEAD", [".gtd/TODO.md"]), binDir)
+    expect(result.status).toBe(0)
+  })
+
+  it("does NOT tolerate index.lock contention — it must still fail the script", () => {
+    const { binDir } = withFakeGit(
+      `echo "fatal: Unable to create '/repo/.git/index.lock': File exists." >&2; exit 128`,
+    )
+    const result = runWithFakeGit(restoreStagedFrom("HEAD", [".gtd/TODO.md"]), binDir)
+    expect(result.status).not.toBe(0)
+  })
+
+  it("does NOT tolerate the 'another git process' lock message either", () => {
+    const { binDir } = withFakeGit(`echo "Another git process seems to be running" >&2; exit 128`)
+    const result = runWithFakeGit(restoreStagedFrom("HEAD", [".gtd/TODO.md"]), binDir)
+    expect(result.status).not.toBe(0)
+  })
+})
+
+describe("shellQuote", () => {
+  it.each([
+    ["a newline", "gtd(agent): line one\nline two"],
+    ["a backtick", "gtd(agent): `echo hi`"],
+    ["a double quote", 'gtd(agent): say "hi"'],
+    ["a dollar sign", "gtd(agent): $HOME expansion"],
+    ["an arrow", "gtd(agent): design.product-author → design.product-answer"],
+    ["a single quote", "gtd(agent): it's done"],
+  ])("round-trips a message containing %s", (_label, s) => {
+    const out = execFileSync("bash", ["-c", `printf %s ${shellQuote(s)}`], { encoding: "utf8" })
+    expect(out).toBe(s)
+  })
+
+  it("round-trips arbitrary strings — including newlines and non-ASCII — through a real bash printf", () => {
+    fc.assert(
+      fc.property(
+        // `unit: "binary"` covers the full Unicode code-point range (control
+        // chars, newlines, non-ASCII) in one code point per unit, unlike the
+        // default `"grapheme-ascii"` unit fast-check 4.8 otherwise samples,
+        // which never produces a newline or a non-ASCII byte. NUL can't
+        // survive an argv round-trip (bash/exec truncate at the first NUL),
+        // so it's filtered out here deliberately rather than left to chance.
+        fc.string({ unit: "binary" }).filter((s) => !s.includes("\0")),
+        (s) => {
+          const out = execFileSync("bash", ["-c", `printf %s ${shellQuote(s)}`], {
+            encoding: "utf8",
+          })
+          expect(out).toBe(s)
+        },
+      ),
+      { numRuns: 500 },
+    )
+  })
+})
+
+describe("every builder's output", () => {
+  it.each(allBuilders)("%s is syntactically valid bash", (_name, script) => {
+    expect(runBashCheckSyntax(script)).toBe(0)
+  })
+})

--- a/src/GitScript.ts
+++ b/src/GitScript.ts
@@ -1,0 +1,107 @@
+/**
+ * Bash-script builders mirroring `GitWriterOperations` (`src/Git.ts`) — one
+ * function per writer method, each returning the equivalent bash as a
+ * `string` instead of executing it. Scaffolding for a later change that will
+ * emit these scripts rather than run git directly through the `Effect`
+ * `CommandExecutor`; nothing calls this module yet.
+ *
+ * Pure, like `src/PatternMachine.ts`: no git, no filesystem, no `Effect`, no
+ * IO of any kind. Every export is a plain, total function of its arguments.
+ * `src/Git.ts`'s doc comments on `GitWriterOperations` are the source of
+ * truth for each shape below; read them for WHY, not just WHAT.
+ */
+
+/**
+ * POSIX single-quote escaping: wrap `value` in `'...'`, replacing every
+ * embedded `'` with `'\''` (close quote, escaped literal quote, reopen
+ * quote). The only place a raw string may reach a shell command in this
+ * module — every builder below routes every interpolated value through this.
+ */
+export const shellQuote = (value: string): string => `'${value.replace(/'/g, "'\\''")}'`
+
+/**
+ * `--allow-empty` mirrors `commitAllWithPrefix`/`commitAsIs`'s load-bearing
+ * use in `src/Git.ts`: gtd's workflow commits may be empty on purpose. The
+ * retry-without-hooks behavior there keys off the specific "empty git commit"
+ * hook-rejection message, re-failing on anything else (`src/Git.ts`'s `run`
+ * doc comment records the regression a blind retry-on-any-failure would
+ * reintroduce: reporting success on a genuinely rejected commit — a lint
+ * error, a rejected commit-msg hook). Bash CAN inspect the message: capture
+ * the first attempt's combined output and discriminate on it in a `case`,
+ * exactly like `isIndexLockError`/`error.message.includes(...)` do in
+ * `src/Git.ts`, instead of retrying on the exit code alone.
+ */
+const commitAllowEmpty = (message: string): string => {
+  const m = shellQuote(message)
+  return [
+    `if ! out=$(git commit --allow-empty -m ${m} 2>&1); then`,
+    `  case "$out" in`,
+    `    *"empty git commit"*) git commit --allow-empty --no-verify -m ${m} ;;`,
+    `    *) printf '%s\\n' "$out" >&2; exit 1 ;;`,
+    `  esac`,
+    `fi`,
+  ].join("\n")
+}
+
+/**
+ * `git add -A` then `git commit --allow-empty -m <message>`, retried without
+ * hooks on the same hook rejection `commitAllowEmpty` guards against. Joined
+ * with `&&` so a failing `git add` (e.g. a quoted path breaking it) never
+ * reaches the commit — the same "lost files whose quoted paths broke a
+ * swallowed `git add`" failure mode `src/Git.ts`'s `run` doc comment records.
+ */
+export const commitAll = (message: string): string => `git add -A &&\n${commitAllowEmpty(message)}`
+
+/** `git commit --allow-empty -m <message>` — commits the index as-is, no implicit `git add`. */
+export const commitAsIs = (message: string): string => commitAllowEmpty(message)
+
+/** `git reset --soft <ref>` — HEAD moves; index and working tree untouched. */
+export const softResetTo = (ref: string): string => `git reset --soft ${shellQuote(ref)}`
+
+/** `git reset --mixed <ref>` — HEAD and index move; working tree untouched. */
+export const mixedResetTo = (ref: string): string => `git reset --mixed ${shellQuote(ref)}`
+
+/** `git reset --hard <ref>` — HEAD, index, AND working tree all move. */
+export const hardResetTo = (ref: string): string => `git reset --hard ${shellQuote(ref)}`
+
+/**
+ * `git add -A` then `git reset --hard HEAD` — discards every pending change,
+ * tracked or untracked. Joined with `&&`: a failed stage must not reach the
+ * hard reset, or untracked survivors remain — the exact outcome this builder
+ * exists to avoid.
+ */
+export const discardPending = (): string => `git add -A && git reset --hard HEAD`
+
+/** `git update-ref <ref> <hash>` — point a repo-local ref at a commit. */
+export const updateRef = (ref: string, hash: string): string =>
+  `git update-ref ${shellQuote(ref)} ${shellQuote(hash)}`
+
+/** `git update-ref -d <ref>` — idempotent: deleting a missing ref is already a no-op in real git. */
+export const deleteRef = (ref: string): string => `git update-ref -d ${shellQuote(ref)}`
+
+/**
+ * `git restore --staged --source=<source> -- <paths…>` — tolerant of the
+ * SAME two cases `src/Git.ts`'s `Effect.catchIf` tolerates (a missing ref, or
+ * no path matching at `source`), and NOT tolerant of `index.lock` contention,
+ * which must still fail the script rather than being swallowed here (see
+ * `src/Git.ts`'s `restoreStagedFrom` doc comment and `isIndexLockError`) — a
+ * lock failure silently swallowed here would mean the `.gtd/` index pin
+ * silently doesn't happen, leaking `.gtd/` plumbing into the surfaced review
+ * diff, the exact thing the pin exists to prevent. Captures the command's
+ * output and discriminates on it, mirroring `isIndexLockError`'s two
+ * substrings, exactly like `commitAllowEmpty` above. An empty `paths` emits
+ * nothing at all (a harmless, syntactically valid empty script), mirroring
+ * the Effect implementation's own `paths.length === 0` skip.
+ */
+export const restoreStagedFrom = (source: string, paths: ReadonlyArray<string>): string => {
+  if (paths.length === 0) return ""
+  const pathArgs = paths.map(shellQuote).join(" ")
+  return [
+    `if ! out=$(git restore --staged --source=${shellQuote(source)} -- ${pathArgs} 2>&1); then`,
+    `  case "$out" in`,
+    `    *"index.lock"*|*"Another git process seems to be running"*) printf '%s\\n' "$out" >&2; exit 1 ;;`,
+    `    *) : ;;`,
+    `  esac`,
+    `fi`,
+  ].join("\n")
+}

--- a/src/PatternConfig.test.ts
+++ b/src/PatternConfig.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { parse as parseYaml } from "yaml"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { Effect } from "effect"
 import { assertScopesCoverStates, compileWorkflowConfig } from "./PatternConfig.js"
+import { isSeededValidateCommand, seededValidateCommand } from "./SteeringFormats.js"
+import { resolveSteeringMode, renderSteeringCommands } from "./SteeringMode.js"
+import type { TemplateContext } from "./PatternTemplates.js"
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -148,18 +152,78 @@ describe("compileWorkflowConfig — realistic multi-state workflow", () => {
     )
     // A `./`-prefixed COMMAND is never inlined as a file reference the way a
     // content string is — it is a shell command, kept verbatim. `qa`/`review`
-    // are seeded (empty) even though this workflow never mentions them.
+    // are seeded with their own `validate:` even though this workflow never
+    // mentions them.
     expect(definition.modes).toEqual({
-      qa: {},
-      review: {},
+      qa: { validate: seededValidateCommand("qa") },
+      review: { validate: seededValidateCommand("review") },
       adr: { format: "./scripts/fmt-adr.sh <%= it.file %>", validate: "adr-lint <%= it.file %>" },
       spec: { validate: "npx ajv -s spec.schema.json -d <%= it.file %>" },
     })
   })
 
-  it("seeds the built-in registry's names (qa/review) as empty entries even when no `modes:` is declared", () => {
+  it("seeds the built-in registry's names (qa/review) with their own `validate:` command even when no `modes:` is declared", () => {
     const { definition } = compileWorkflowConfig(draftCheckRevise, "/config-dir")
-    expect(definition.modes).toEqual({ qa: {}, review: {} })
+    expect(definition.modes).toEqual({
+      qa: { validate: seededValidateCommand("qa") },
+      review: { validate: seededValidateCommand("review") },
+    })
+  })
+
+  it("keeps the seed's `validate:` when a workflow overrides only `format:` for a built-in name", () => {
+    const { definition } = compileWorkflowConfig(
+      { ...draftCheckRevise, modes: { qa: { format: "npx prettier --write <%= it.file %>" } } },
+      "/config-dir",
+    )
+    expect(definition.modes).toEqual({
+      qa: {
+        format: "npx prettier --write <%= it.file %>",
+        validate: seededValidateCommand("qa"),
+      },
+      review: { validate: seededValidateCommand("review") },
+    })
+  })
+
+  it("fully displaces the seed when a workflow declares both halves for a built-in name", () => {
+    const { definition } = compileWorkflowConfig(
+      {
+        ...draftCheckRevise,
+        modes: {
+          qa: { format: "my-fmt <%= it.file %>", validate: "my-qa-linter <%= it.file %>" },
+        },
+      },
+      "/config-dir",
+    )
+    const qa = definition.modes?.["qa"]
+    expect(qa).toEqual({ format: "my-fmt <%= it.file %>", validate: "my-qa-linter <%= it.file %>" })
+    expect(isSeededValidateCommand("qa", qa?.validate ?? "")).toBe(false)
+  })
+
+  it("seeds a usable `validate:` command that round-trips through resolveSteeringMode/renderSteeringCommands", async () => {
+    const { definition } = compileWorkflowConfig(draftCheckRevise, "/config-dir")
+    const resolved = resolveSteeringMode(definition, "qa")
+    expect(resolved?.validate).toEqual({ kind: "command", command: seededValidateCommand("qa") })
+
+    const context: TemplateContext = {
+      startCommit: "",
+      currentCommit: "",
+      previousCommit: "",
+      state: "",
+      actor: "",
+      reviewBase: "",
+      retainedBase: "",
+      processCost: 0,
+      processCostByModel: [],
+      read: () => {
+        throw new Error("must not be called")
+      },
+      vars: {},
+      edges: [],
+    }
+    const rendered = await Effect.runPromise(
+      renderSteeringCommands(resolved!, ".gtd/TODO.md", context),
+    )
+    expect(rendered).toEqual([`gtd check qa '.gtd/TODO.md'`])
   })
 
   it("rejects a non-object `modes:` value", () => {
@@ -210,8 +274,8 @@ describe("compileWorkflowConfig — realistic multi-state workflow", () => {
       { adr: { format: "project-fmt <%= it.file %>" }, spec: { validate: "spec-lint" } },
     )
     expect(definition.modes).toEqual({
-      qa: {},
-      review: {},
+      qa: { validate: seededValidateCommand("qa") },
+      review: { validate: seededValidateCommand("review") },
       adr: { format: "project-fmt <%= it.file %>", validate: "adr-lint <%= it.file %>" },
       spec: { validate: "spec-lint" },
     })
@@ -240,8 +304,8 @@ describe("compileWorkflowConfig — realistic multi-state workflow", () => {
       { adr: { validate: "adr-lint <%= it.file %>" } },
     )
     expect(definition.modes).toEqual({
-      qa: {},
-      review: {},
+      qa: { validate: seededValidateCommand("qa") },
+      review: { validate: seededValidateCommand("review") },
       adr: { validate: "adr-lint <%= it.file %>" },
     })
   })

--- a/src/PatternConfig.ts
+++ b/src/PatternConfig.ts
@@ -11,7 +11,7 @@ import {
 } from "./PatternMachine.js"
 import { CONTENT_FIELDS, STATE_FIELDS, STATE_FIELD_ENTRIES, type FieldKind } from "./StateFields.js"
 import { flattenMachines, type InstancePath, type MachineNode } from "./Machines.js"
-import { builtInModeNames } from "./SteeringFormats.js"
+import { builtInModeNames, seededValidateCommand } from "./SteeringFormats.js"
 
 /**
  * The v3 `.gtdrc` `workflow:` config compiler. This
@@ -84,11 +84,13 @@ import { builtInModeNames } from "./SteeringFormats.js"
  * `ConfigService` compiles through this module's `compileModesMap` and hands
  * back in as `rcModes`, merged per half by `mergeModes`. Underneath BOTH layers
  * this compiler seeds `src/SteeringFormats.ts`'s built-in registry names (`qa`/
- * `review`) as empty entries, so every compiled definition's `modes` map always
- * carries them and a workflow never has to declare them just to use gtd's own
- * validators — resolution of the merged map against the registry (whether a
- * declared `validate:` displaces a format's own parser) is the edge's job
- * (`src/SteeringMode.ts`), not this compiler's.
+ * `review`) with that module's own `seededValidateCommand(name)` template as
+ * their `validate:`, so every compiled definition's `modes` map always carries
+ * a usable `validate:` command for them and a workflow never has to declare
+ * them just to use gtd's own validators — a workflow (or `.gtdrc`) may still
+ * override either half per name, and `src/SteeringFormats.ts`'s
+ * `isSeededValidateCommand` lets the edge (`src/SteeringMode.ts`) tell gtd's
+ * own seeding apart from a genuine user override.
  *
  * ## File references
  *
@@ -977,7 +979,9 @@ export const compileWorkflowConfig = (
   }
 
   const vars = compileVarsMap(raw.vars, errors)
-  const seeded = Object.fromEntries(builtInModeNames().map((name) => [name, {}]))
+  const seeded = Object.fromEntries(
+    builtInModeNames().map((name) => [name, { validate: seededValidateCommand(name) }]),
+  )
   // `mergeModes` is `undefined` only when BOTH arguments are — `seeded` never
   // is, so this merge (and the one layering `rcModes` over it) always resolves.
   const modes = mergeModes(mergeModes(seeded, compileModesMap(raw.modes, errors)), rcModes)!

--- a/src/ReviewWindow.test.ts
+++ b/src/ReviewWindow.test.ts
@@ -1,32 +1,70 @@
 import { rmSync } from "node:fs"
-import { execSync } from "node:child_process"
+import { execSync, execFileSync } from "node:child_process"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { Effect } from "effect"
 import { NodeContext } from "@effect/platform-node"
 import { GitService } from "./Git.js"
 import { Cwd } from "./Cwd.js"
-import { currentRun, reviewBaseFor } from "./Edge.js"
+import { currentRun, reviewBaseFor, type ProcessRun } from "./Edge.js"
 import {
-  closeReviewWindow,
+  buildCloseWindowScript,
+  buildOpenWindowScript,
+  decideCloseWindow,
+  decideOpenWindow,
   LEGACY_REVIEW_BASE_REF,
   LEGACY_REVIEW_HEAD_REF,
-  openReviewWindow,
   REVIEW_BASE_REF,
   REVIEW_HEAD_REF,
+  type WindowRefs,
 } from "./ReviewWindow.js"
+import { deleteRef, mixedResetTo, restoreStagedFrom, updateRef } from "./GitScript.js"
 import type { WorkflowDefinition } from "./PatternMachine.js"
 import { gitTiers, type GitTier } from "./testing/GitTiers.js"
 
+// git's empty-tree object, mirrored from `src/ReviewWindow.ts`'s own private
+// constant — a pure-decision test needs to name it without reaching into the
+// module's internals.
+const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+/** Only the Live tier has a real filesystem/shell to run a generated script against. */
+const makeLiveTier = (): GitTier => {
+  const make = gitTiers.find((candidate) => {
+    const probe = candidate()
+    const isLive = probe.name === "Live"
+    probe.dispose()
+    return isLive
+  })
+  if (make === undefined) throw new Error("no Live GitTier available")
+  return make()
+}
+
+/**
+ * Runs a generated script through a REAL shell against `t.root` — the same
+ * execution model the eventual driver uses (`bash -c <script>`), mirroring
+ * `src/testing/GitTiers.ts`'s own (unexported) `execScript` helper for its
+ * `runGitScriptContract`.
+ */
+const execScript = (t: GitTier, script: string): void => {
+  execFileSync("bash", ["-c", script], { cwd: t.root, stdio: "pipe" })
+}
+
 /**
  * The review checkout window, parameterized over both `GitOperations` tiers
- * (`src/testing/GitTiers.ts`) — the mixed-reset open/close round trip and the
- * `reviewBase` base-narrowing run on Live AND InMemory alike, now that the
- * git contract (package/step 4) covers every primitive the window uses
- * (`mixedResetTo`, `restoreStagedFrom`, `isAncestor`, `updateRef`/`deleteRef`,
- * `readRefOption`). Only the linked-worktree groups
- * (`git worktree add` — `t.capabilities.linkedWorktrees`) stay Live-only; the
- * @inmem `review-window.feature` covers the same lifecycle end-to-end through
- * the program edge.
+ * (`src/testing/GitTiers.ts`) for its DECIDE-only coverage
+ * (`decideCloseWindow`/`decideOpenWindow`, both read-only through
+ * `GitService` — no write). The git contract (package/step 4) covers every
+ * reader primitive a decision uses (`isAncestor`, `readRefOption`), so a
+ * no-op/refusal decision is exercised identically on Live and InMemory.
+ *
+ * The actual WRITE — the mixed-reset open/close round trip, `reviewBase`
+ * base-narrowing observed after a real open, legacy-ref cleanup, idempotent
+ * re-entry — only makes sense against a real shell running the emitted bash
+ * (an in-memory fake root has no shell to run it against), so it lives in its
+ * own Live-only describe block below (`the emitted open/close scripts`),
+ * mirroring `runGitScriptContract`'s own scoping in `src/testing/GitTiers.ts`.
+ * The linked-worktree group (`git worktree add` — `t.capabilities.
+ * linkedWorktrees`) stays nested inside this parametrized loop, but is itself
+ * Live-only via that capability's own skip.
  */
 
 // A workflow: idle → building → gate (a reviewWindow rest), with an optional
@@ -63,95 +101,19 @@ for (const makeTier of gitTiers) {
       t.dispose()
     })
 
-    describe("openReviewWindow / closeReviewWindow — base = process start", () => {
-      it("rewinds HEAD to the process boundary, surfaces the diff, and restores on close", async () => {
-        t.seed.commit("gtd(agent): building", { "src/calc.ts": "export const add = 1\n" })
-        t.seed.commit("gtd(human): gate", { "src/other.ts": "export const x = 1\n" })
-        const realHead = t.observe.resolveRef("HEAD")
-
-        const opened = await t.provide(openReviewWindow, def)
-        expect(opened.opened).toBe(true)
-        // HEAD rewound to the process boundary (the non-gtd initial commit).
-        expect(await headSubject(t)).toBe("init: first commit")
-        expect(t.observe.refExists(REVIEW_HEAD_REF)).toBe(true)
-        expect(t.observe.refExists(REVIEW_BASE_REF)).toBe(true)
-        // The whole process diff is now uncommitted.
-        expect(t.observe.statusPorcelain()).toContain("src/calc.ts")
-        expect(t.observe.statusPorcelain()).toContain("src/other.ts")
-
-        const closed = await t.provide(closeReviewWindow, def)
-        expect(closed.closed).toBe(true)
-        expect(t.observe.resolveRef("HEAD")).toBe(realHead)
-        expect(await headSubject(t)).toBe("gtd(human): gate")
-        expect(t.observe.refExists(REVIEW_HEAD_REF)).toBe(false)
-        expect(t.observe.refExists(REVIEW_BASE_REF)).toBe(false)
-        // The working tree is clean again — the surfaced diff was re-committed.
-        expect(t.observe.statusPorcelain()).toBe("")
-      })
-
-      it("is a no-op when resting anywhere but a reviewWindow state", async () => {
+    describe("decideOpenWindow via the edge — read-only", () => {
+      it("declines to open while resting anywhere but a reviewWindow state", async () => {
         t.seed.commit("gtd(agent): building", { "src/calc.ts": "x\n" })
-        const opened = await t.provide(openReviewWindow, def)
-        expect(opened.opened).toBe(false)
-        expect(t.observe.refExists(REVIEW_HEAD_REF)).toBe(false)
+        const run = await t.provide(currentRun, def)
+        const decision = decideOpenWindow(def, "building", run, t.observe.resolveRef("HEAD"))
+        expect(decision).toEqual({ shouldOpen: false })
       })
     })
 
-    describe("reviewBase — narrowing the diff base", () => {
-      it("opens against the most-recent in-process reviewBase commit", async () => {
-        t.seed.commit("gtd(agent): building", { "src/a.ts": "a\n" })
-        t.seed.commit("gtd(human): checkpoint", {})
-        const checkpoint = t.observe.resolveRef("HEAD")
-        t.seed.commit("gtd(agent): building", { "src/b.ts": "b\n" })
-        t.seed.commit("gtd(human): gate", {})
-
-        const base = await t.provide(
-          Effect.gen(function* () {
-            const run = yield* currentRun
-            return reviewBaseFor(def, run)
-          }),
-          def,
-        )
-        expect(base).toBe(checkpoint)
-
-        await t.provide(openReviewWindow, def)
-        // HEAD rewound to the checkpoint, so only work AFTER it surfaces.
-        expect(await headSubject(t)).toBe("gtd(human): checkpoint")
-        expect(t.observe.statusPorcelain()).toContain("src/b.ts")
-        expect(t.observe.statusPorcelain()).not.toContain("src/a.ts")
-      })
-    })
-
-    describe("closeReviewWindow — safety", () => {
+    describe("decideCloseWindow — safety", () => {
       it("is a no-op when no window is open", async () => {
-        const closed = await t.provide(closeReviewWindow, def)
-        expect(closed.closed).toBe(false)
-      })
-    })
-
-    describe("closeReviewWindow — the legacy shared refs (gtd ≤ 7.1)", () => {
-      // A window an older gtd left open across the upgrade: HEAD rewound to
-      // the base, the real head parked under the SHARED refs — both tiers
-      // support this via the generic `seed.updateRef`/`seed.mixedReset`.
-      const openLegacyWindow = (tier: GitTier, base: string, head: string): void => {
-        tier.seed.updateRef(LEGACY_REVIEW_BASE_REF, base)
-        tier.seed.updateRef(LEGACY_REVIEW_HEAD_REF, head)
-        tier.seed.mixedReset(base)
-      }
-
-      it("finishes a window left behind by an older gtd in this worktree", async () => {
-        const base = t.observe.resolveRef("HEAD")
-        t.seed.commit("gtd(agent): building", { "src/calc.ts": "export const add = 1\n" })
-        t.seed.commit("gtd(human): gate", {})
-        const realHead = t.observe.resolveRef("HEAD")
-        openLegacyWindow(t, base, realHead)
-
-        const closed = await t.provide(closeReviewWindow, def)
-        expect(closed.closed).toBe(true)
-        expect(t.observe.resolveRef("HEAD")).toBe(realHead)
-        expect(t.observe.refExists(LEGACY_REVIEW_HEAD_REF)).toBe(false)
-        expect(t.observe.refExists(LEGACY_REVIEW_BASE_REF)).toBe(false)
-        expect(t.observe.statusPorcelain()).toBe("")
+        const decision = await t.provide(decideCloseWindow, def)
+        expect(decision).toEqual({ shouldClose: false })
       })
     })
 
@@ -182,8 +144,14 @@ for (const makeTier of gitTiers) {
           const sibling = addSiblingWorktree(base)
           const siblingHead = gitIn(sibling, "rev-parse", "HEAD")
 
-          const opened = await t.provide(openReviewWindow, def)
-          expect(opened.opened).toBe(true)
+          const openDecision = decideOpenWindow(
+            def,
+            "gate",
+            await t.provide(currentRun, def),
+            t.observe.resolveRef("HEAD"),
+          )
+          if (!openDecision.shouldOpen) throw new Error("expected the window to open")
+          execScript(t, buildOpenWindowScript(openDecision))
           // The window's refs live in the per-worktree namespace, so the
           // sibling sharing this `.git` cannot even see them…
           expect(t.observe.refExists(REVIEW_HEAD_REF)).toBe(true)
@@ -191,17 +159,19 @@ for (const makeTier of gitTiers) {
             gitIn(sibling, "rev-parse", "--verify", "--quiet", REVIEW_HEAD_REF),
           ).toThrow()
 
-          // …and its own gtd invocations close nothing: pre-7.2 this reset
-          // the sibling's branch onto THIS worktree's saved head.
-          const siblingClosed = await runInDir(sibling)
-          expect(siblingClosed.closed).toBe(false)
+          // …and its own gtd invocations decide to close nothing: pre-7.2
+          // this reset the sibling's branch onto THIS worktree's saved head.
+          const siblingDecision = await decideCloseWindowInDir(sibling)
+          expect(siblingDecision.shouldClose).toBe(false)
           expect(gitIn(sibling, "rev-parse", "HEAD")).toBe(siblingHead)
 
           // This worktree's window survived the sibling's invocation untouched.
           expect(await headSubject(t)).toBe("init: first commit")
           expect(t.observe.refExists(REVIEW_HEAD_REF)).toBe(true)
-          const restored = await t.provide(closeReviewWindow, def)
-          expect(restored.closed).toBe(true)
+
+          const closeDecision = await t.provide(decideCloseWindow, def)
+          if (!closeDecision.shouldClose) throw new Error("expected an open window to close")
+          execScript(t, buildCloseWindowScript(closeDecision.refs))
           expect(await headSubject(t)).toBe("gtd(human): gate")
         })
 
@@ -216,7 +186,9 @@ for (const makeTier of gitTiers) {
           t.seed.updateRef(LEGACY_REVIEW_HEAD_REF, realHead)
           t.seed.mixedReset(base)
 
-          await expect(runInDir(sibling)).rejects.toThrow(/does not belong to this worktree/)
+          await expect(decideCloseWindowInDir(sibling)).rejects.toThrow(
+            /does not belong to this worktree/,
+          )
           // Nothing moved, nothing was deleted — the owning worktree can
           // still recover with the commands the message spells out.
           expect(gitIn(sibling, "rev-parse", "HEAD")).toBe(siblingHead)
@@ -224,16 +196,17 @@ for (const makeTier of gitTiers) {
           expect(t.observe.refExists(LEGACY_REVIEW_BASE_REF)).toBe(true)
         })
 
-        // `closeReviewWindow` run against an arbitrary directory (the sibling
+        // `decideCloseWindow` run against an arbitrary directory (the sibling
         // worktree) rather than `t`'s own root — only meaningful for the Live
         // tier, where a directory maps onto a real, independently-`cwd`-able
         // git worktree, so this bypasses `GitTier.provide` (fixed to `t.root`)
         // and wires `GitService.Live` directly, mirroring the pre-tiered
-        // test's own `runIn` helper. `closeReviewWindow` needs only
-        // `GitService`, unlike `openReviewWindow` — no `ConfigService` layer.
-        function runInDir(dir: string) {
+        // test's own `runIn` helper. `decideCloseWindow` needs only
+        // `GitService`, unlike `decideOpenWindow` (a plain pure function) —
+        // no `ConfigService` layer.
+        function decideCloseWindowInDir(dir: string) {
           return Effect.runPromise(
-            closeReviewWindow.pipe(
+            decideCloseWindow.pipe(
               Effect.provide(GitService.Live),
               Effect.provide(Cwd.layer(dir)),
               Effect.provide(NodeContext.layer),
@@ -244,3 +217,303 @@ for (const makeTier of gitTiers) {
     )
   })
 }
+
+/**
+ * The pure decision/builder half of the window: a decision — "should a
+ * window open/close, and with what" — and a script builder. No git, no
+ * `Effect` — plain functions of their arguments (`buildCloseWindowScript`/
+ * `buildOpenWindowScript` take the already-decided values and never resolve
+ * anything themselves).
+ */
+describe("buildCloseWindowScript / buildOpenWindowScript — pure builders", () => {
+  it("buildCloseWindowScript emits the mixed-reset (to the resolved head HASH) then the two ref deletes, in order", () => {
+    const refs: WindowRefs = {
+      headRef: REVIEW_HEAD_REF,
+      baseRef: REVIEW_BASE_REF,
+      headHash: "deadbeef",
+      legacy: false,
+    }
+    expect(buildCloseWindowScript(refs)).toBe(
+      [mixedResetTo("deadbeef"), deleteRef(REVIEW_HEAD_REF), deleteRef(REVIEW_BASE_REF)].join(
+        " &&\n",
+      ),
+    )
+  })
+
+  it("buildCloseWindowScript names the legacy refs when handed a legacy WindowRefs", () => {
+    const refs: WindowRefs = {
+      headRef: LEGACY_REVIEW_HEAD_REF,
+      baseRef: LEGACY_REVIEW_BASE_REF,
+      headHash: "deadbeef",
+      legacy: true,
+    }
+    expect(buildCloseWindowScript(refs)).toBe(
+      [
+        mixedResetTo("deadbeef"),
+        deleteRef(LEGACY_REVIEW_HEAD_REF),
+        deleteRef(LEGACY_REVIEW_BASE_REF),
+      ].join(" &&\n"),
+    )
+  })
+
+  it("buildCloseWindowScript resets to the hash, not the ref name — the reset survives even after the ref is gone", () => {
+    // If the reset targeted the ref by NAME, re-running the emitted script
+    // after the ref delete below would fail outright ("unknown revision").
+    // Targeting the resolved hash keeps the sequence idempotent on re-entry.
+    const refs: WindowRefs = {
+      headRef: REVIEW_HEAD_REF,
+      baseRef: REVIEW_BASE_REF,
+      headHash: "cafef00d",
+      legacy: false,
+    }
+    expect(buildCloseWindowScript(refs)).toContain(mixedResetTo("cafef00d"))
+    expect(buildCloseWindowScript(refs)).not.toContain(mixedResetTo(REVIEW_HEAD_REF))
+  })
+
+  it("buildOpenWindowScript emits base-ref, head-ref, mixed-reset, then the .gtd/ pin, in order", () => {
+    expect(buildOpenWindowScript({ base: "baseHash", head: "headHash" })).toBe(
+      [
+        updateRef(REVIEW_BASE_REF, "baseHash"),
+        updateRef(REVIEW_HEAD_REF, "headHash"),
+        mixedResetTo("baseHash"),
+        restoreStagedFrom(REVIEW_HEAD_REF, [".gtd"]),
+      ].join(" &&\n"),
+    )
+  })
+
+  it("neither emitted sequence contains a whole-tree index write or an intent-to-add stage", () => {
+    const closeScript = buildCloseWindowScript({
+      headRef: REVIEW_HEAD_REF,
+      baseRef: REVIEW_BASE_REF,
+      headHash: "deadbeef",
+      legacy: false,
+    })
+    const openScript = buildOpenWindowScript({ base: "baseHash", head: "headHash" })
+    for (const script of [closeScript, openScript]) {
+      expect(script).not.toMatch(/git add (-A|--all|\.)\b/)
+      expect(script).not.toContain("intent-to-add")
+    }
+  })
+})
+
+describe("decideOpenWindow — answerable for a target state the caller names", () => {
+  const emptyRun: ProcessRun = {
+    startHash: "startHash",
+    startParentHash: "startParentHash",
+    diffBase: "startParentHash",
+    trace: [],
+    costEntries: [],
+    entryVars: {},
+  }
+
+  it("declines when the target state doesn't declare reviewWindow", () => {
+    expect(decideOpenWindow(def, "building", emptyRun, "prospectiveHead")).toEqual({
+      shouldOpen: false,
+    })
+  })
+
+  it("declines when the base is the empty tree (a whole-history process)", () => {
+    const run: ProcessRun = { ...emptyRun, startParentHash: EMPTY_TREE, diffBase: EMPTY_TREE }
+    expect(decideOpenWindow(def, "gate", run, "prospectiveHead")).toEqual({ shouldOpen: false })
+  })
+
+  it("declines when the base equals the prospective head (an empty process)", () => {
+    const run: ProcessRun = { ...emptyRun, startParentHash: "sameHash", diffBase: "sameHash" }
+    expect(decideOpenWindow(def, "gate", run, "sameHash")).toEqual({ shouldOpen: false })
+  })
+
+  it("opens against the process's diff base when no reviewBase state is in the trace", () => {
+    expect(decideOpenWindow(def, "gate", emptyRun, "prospectiveHead")).toEqual({
+      shouldOpen: true,
+      base: "startParentHash",
+      head: "prospectiveHead",
+    })
+  })
+
+  it("is answerable for an arbitrary target the caller names, independent of any currently-resolved rest", () => {
+    // The trace records a `checkpoint` (reviewBase) turn after `building` —
+    // `reviewBaseFor` narrows to it. The caller asks about `gate` directly,
+    // as the state a step is about to land ON per the matched pattern —
+    // nothing here reads HEAD's subject or resolves a "current" rest at all.
+    const run: ProcessRun = {
+      ...emptyRun,
+      trace: [
+        { state: "building", hash: "buildingHash" },
+        { state: "checkpoint", hash: "checkpointHash" },
+      ],
+    }
+    expect(decideOpenWindow(def, "gate", run, "prospectiveHead")).toEqual({
+      shouldOpen: true,
+      base: "checkpointHash",
+      head: "prospectiveHead",
+    })
+  })
+})
+
+/**
+ * The window's actual WRITE effect: real bash, real git (Live tier only — an
+ * in-memory fake root has no shell to run a script against, mirroring
+ * `runGitScriptContract`'s own scoping in `src/testing/GitTiers.ts`). Every
+ * scenario here decides with `decideCloseWindow`/`decideOpenWindow`, builds
+ * the bash with `buildCloseWindowScript`/`buildOpenWindowScript`, and executes
+ * it exactly as the external driver would (`execScript`, `bash -c <script>`),
+ * then asserts on the resulting repository state directly — there is no more
+ * separate performer Effect to compare the emitted script against; the
+ * emitted script is the only path left that writes anything.
+ */
+describe("the emitted open/close scripts — real bash, real git", () => {
+  const seedWindowFixture = (t: GitTier): void => {
+    t.seed.commit("gtd(agent): building", { "src/calc.ts": "export const add = 1\n" })
+    t.seed.commit("gtd(human): gate", { "src/other.ts": "export const x = 1\n" })
+  }
+
+  /** Decide + build + execute the open sequence against `target` (default `"gate"`, the fixture's own reviewWindow state). */
+  const openWindow = async (t: GitTier, target = "gate"): Promise<void> => {
+    const run = await t.provide(currentRun, def)
+    const head = t.observe.resolveRef("HEAD")
+    const decision = decideOpenWindow(def, target, run, head)
+    if (!decision.shouldOpen) throw new Error("expected the window to open")
+    execScript(t, buildOpenWindowScript(decision))
+  }
+
+  /** Decide + build + execute the close sequence, returning the resolved refs. */
+  const closeWindow = async (t: GitTier): Promise<WindowRefs> => {
+    const decision = await t.provide(decideCloseWindow, def)
+    if (!decision.shouldClose) throw new Error("expected an open window to close")
+    execScript(t, buildCloseWindowScript(decision.refs))
+    return decision.refs
+  }
+
+  it("base = process start: rewinds HEAD to the process boundary, surfaces the diff, and restores on close", async () => {
+    const t = makeLiveTier()
+    try {
+      seedWindowFixture(t)
+      const realHead = t.observe.resolveRef("HEAD")
+
+      await openWindow(t)
+      // HEAD rewound to the process boundary (the non-gtd initial commit).
+      expect(await headSubject(t)).toBe("init: first commit")
+      expect(t.observe.refExists(REVIEW_HEAD_REF)).toBe(true)
+      expect(t.observe.refExists(REVIEW_BASE_REF)).toBe(true)
+      // The whole process diff is now uncommitted.
+      expect(t.observe.statusPorcelain()).toContain("src/calc.ts")
+      expect(t.observe.statusPorcelain()).toContain("src/other.ts")
+
+      await closeWindow(t)
+      expect(t.observe.resolveRef("HEAD")).toBe(realHead)
+      expect(await headSubject(t)).toBe("gtd(human): gate")
+      expect(t.observe.refExists(REVIEW_HEAD_REF)).toBe(false)
+      expect(t.observe.refExists(REVIEW_BASE_REF)).toBe(false)
+      // The working tree is clean again — the surfaced diff was re-committed.
+      expect(t.observe.statusPorcelain()).toBe("")
+    } finally {
+      t.dispose()
+    }
+  })
+
+  it("reviewBase narrows the diff base to the most-recent in-process reviewBase commit", async () => {
+    const t = makeLiveTier()
+    try {
+      t.seed.commit("gtd(agent): building", { "src/a.ts": "a\n" })
+      t.seed.commit("gtd(human): checkpoint", {})
+      const checkpoint = t.observe.resolveRef("HEAD")
+      t.seed.commit("gtd(agent): building", { "src/b.ts": "b\n" })
+      t.seed.commit("gtd(human): gate", {})
+
+      const base = await t.provide(
+        Effect.gen(function* () {
+          const run = yield* currentRun
+          return reviewBaseFor(def, run)
+        }),
+        def,
+      )
+      expect(base).toBe(checkpoint)
+
+      await openWindow(t)
+      // HEAD rewound to the checkpoint, so only work AFTER it surfaces.
+      expect(await headSubject(t)).toBe("gtd(human): checkpoint")
+      expect(t.observe.statusPorcelain()).toContain("src/b.ts")
+      expect(t.observe.statusPorcelain()).not.toContain("src/a.ts")
+    } finally {
+      t.dispose()
+    }
+  })
+
+  it("legacy shared refs (gtd ≤ 7.1): finishes a window left behind by an older gtd in this worktree", async () => {
+    const t = makeLiveTier()
+    try {
+      const base = t.observe.resolveRef("HEAD")
+      t.seed.commit("gtd(agent): building", { "src/calc.ts": "export const add = 1\n" })
+      t.seed.commit("gtd(human): gate", {})
+      const realHead = t.observe.resolveRef("HEAD")
+      t.seed.updateRef(LEGACY_REVIEW_BASE_REF, base)
+      t.seed.updateRef(LEGACY_REVIEW_HEAD_REF, realHead)
+      t.seed.mixedReset(base)
+
+      const decision = await t.provide(decideCloseWindow, def)
+      if (!decision.shouldClose) throw new Error("expected the legacy window to be recognized")
+      execScript(t, buildCloseWindowScript(decision.refs))
+
+      expect(t.observe.resolveRef("HEAD")).toBe(realHead)
+      expect(t.observe.refExists(LEGACY_REVIEW_HEAD_REF)).toBe(false)
+      expect(t.observe.refExists(LEGACY_REVIEW_BASE_REF)).toBe(false)
+      expect(t.observe.statusPorcelain()).toBe("")
+    } finally {
+      t.dispose()
+    }
+  })
+
+  describe("idempotency — running the emitted script a second time changes nothing", () => {
+    it("close: the second run is a no-op", async () => {
+      const t = makeLiveTier()
+      try {
+        seedWindowFixture(t)
+        await openWindow(t)
+
+        const decision = await t.provide(decideCloseWindow, def)
+        if (!decision.shouldClose) throw new Error("expected an open window")
+        const script = buildCloseWindowScript(decision.refs)
+
+        execScript(t, script)
+        const headAfterFirst = t.observe.resolveRef("HEAD")
+        const statusAfterFirst = t.observe.statusPorcelain()
+        expect(t.observe.refExists(REVIEW_HEAD_REF)).toBe(false)
+        expect(t.observe.refExists(REVIEW_BASE_REF)).toBe(false)
+
+        execScript(t, script)
+        expect(t.observe.resolveRef("HEAD")).toBe(headAfterFirst)
+        expect(t.observe.statusPorcelain()).toBe(statusAfterFirst)
+        expect(t.observe.refExists(REVIEW_HEAD_REF)).toBe(false)
+        expect(t.observe.refExists(REVIEW_BASE_REF)).toBe(false)
+      } finally {
+        t.dispose()
+      }
+    })
+
+    it("open: the second run is a no-op", async () => {
+      const t = makeLiveTier()
+      try {
+        seedWindowFixture(t)
+        const head = t.observe.resolveRef("HEAD")
+        const run = await t.provide(currentRun, def)
+        const decision = decideOpenWindow(def, "gate", run, head)
+        if (!decision.shouldOpen) throw new Error("expected the window to open")
+        const script = buildOpenWindowScript(decision)
+
+        execScript(t, script)
+        const headRefAfterFirst = t.observe.resolveRef(REVIEW_HEAD_REF)
+        const baseRefAfterFirst = t.observe.resolveRef(REVIEW_BASE_REF)
+        const statusAfterFirst = t.observe.statusPorcelain()
+        const realHeadAfterFirst = t.observe.resolveRef("HEAD")
+
+        execScript(t, script)
+        expect(t.observe.resolveRef(REVIEW_HEAD_REF)).toBe(headRefAfterFirst)
+        expect(t.observe.resolveRef(REVIEW_BASE_REF)).toBe(baseRefAfterFirst)
+        expect(t.observe.statusPorcelain()).toBe(statusAfterFirst)
+        expect(t.observe.resolveRef("HEAD")).toBe(realHeadAfterFirst)
+      } finally {
+        t.dispose()
+      }
+    })
+  })
+})

--- a/src/ReviewWindow.ts
+++ b/src/ReviewWindow.ts
@@ -1,8 +1,8 @@
 import { Effect, Option } from "effect"
 import { GitService, type GitOperations } from "./Git.js"
-import { ConfigService } from "./Config.js"
-import { isReviewWindowState, resolveState } from "./PatternMachine.js"
-import { currentRun, reviewBaseFor } from "./Edge.js"
+import { isReviewWindowState, type StateName, type WorkflowDefinition } from "./PatternMachine.js"
+import { reviewBaseFor, type ProcessRun } from "./Edge.js"
+import { deleteRef, mixedResetTo, restoreStagedFrom, updateRef } from "./GitScript.js"
 
 /**
  * The review checkout window (v3 re-introduction).
@@ -17,24 +17,37 @@ import { currentRun, reviewBaseFor } from "./Edge.js"
  * `PatternMachine.StateDef`) — the pure engine never observes an open window,
  * exactly as before.
  *
- * Lifecycle — driven from the program edge (`src/program.ts`), bracketing
- * every state subcommand:
+ * Lifecycle — driven from the program edge (`src/program.ts`), which DECIDES
+ * with this module's pure/read-only halves and assembles the actual writes
+ * into the two scripts a `gtd` command hands the external driver:
  *
- * - `closeReviewWindow` runs BEFORE anything reads or mutates state, keyed
- *   solely on `REVIEW_HEAD_REF` existing: `git reset --mixed <that ref>`
- *   restores HEAD/index exactly, leaving only the reviewer's own edits dirty
- *   (captured by the resting state's own `on` patterns like any other pending
- *   change). The pure machine therefore never sees the window.
- * - `openReviewWindow` runs AFTER the subcommand finishes and self-guards on
- *   the resolved rest declaring `reviewWindow: true`: it saves HEAD to
- *   `REVIEW_HEAD_REF` (the base to `REVIEW_BASE_REF`), then `git reset --mixed
- *   <base>`. It re-arms after read-only commands (`gtd next` / `gtd status`)
- *   and refused invocations too, so the editor's diff view stays consistent no
- *   matter which command the loop last ran.
+ * - The CLOSE sequence (`decideCloseWindow` + `buildCloseWindowScript`) is
+ *   read-only in this module — it decides whether a window is open and safe
+ *   to close, keyed solely on `REVIEW_HEAD_REF` existing (the same
+ *   reviewed-branch/legacy-containment guards described below) — and
+ *   `program.ts`'s `buildRequiredScript` splices the resulting
+ *   `mixedResetTo`/`deleteRef`/`deleteRef` bash in as the LEAD steps of the
+ *   `required` script, ahead of the commit/squash steps themselves. Nothing
+ *   reads or mutates state until the driver actually runs that script; once
+ *   it does, HEAD/index are restored exactly, leaving only the reviewer's own
+ *   edits dirty (captured by the resting state's own `on` patterns like any
+ *   other pending change) — the pure machine never sees the window.
+ * - The OPEN sequence (`decideOpenWindow` + `buildOpenWindowScript`) is
+ *   likewise read-only — it self-guards on the STEP'S OWN target state
+ *   declaring `reviewWindow: true` — and `program.ts`'s `openWindowScript`
+ *   turns that into the `optional` script's `updateRef`/`updateRef`/
+ *   `mixedResetTo`/`restoreStagedFrom` bash: saving HEAD to `REVIEW_HEAD_REF`
+ *   (the base to `REVIEW_BASE_REF`), then rewinding to the base. The driver
+ *   runs it AFTER the required script has already landed the new commit
+ *   (`buildOpenWindowScript`'s own doc comment explains why it pins the
+ *   literal string `"HEAD"`, never a resolved hash). It re-arms after
+ *   read-only commands (`gtd next` / `gtd status`) and refused invocations
+ *   too, so the editor's diff view stays consistent no matter which command
+ *   the loop last ran.
  *
- * Every open/close step is idempotent under re-entry, so a crash at any point
- * is recovered by the next invocation's close (the saved ref also keeps the
- * real head GC-reachable for the window's whole lifetime).
+ * Every close/open sequence is idempotent under re-entry, so a crash at any
+ * point is recovered by the next invocation's close (the saved ref also keeps
+ * the real head GC-reachable for the window's whole lifetime).
  */
 
 /**
@@ -54,7 +67,7 @@ export const REVIEW_HEAD_REF = "refs/worktree/gtd/review-head"
 export const REVIEW_BASE_REF = "refs/worktree/gtd/review-base"
 
 /**
- * The pre-7.2 SHARED refs. gtd never writes them any more; `closeReviewWindow`
+ * The pre-7.2 SHARED refs. gtd never writes them any more; `decideCloseWindow`
  * only reads them to finish a window an older gtd left open across the upgrade
  * — and only when HEAD is still contained in the saved head, since a shared ref
  * may belong to a sibling worktree (see `openWindowRefs`).
@@ -67,8 +80,16 @@ export const LEGACY_REVIEW_BASE_REF = "refs/gtd/review-base"
 // commit to rewind to, so the window simply does not open in that case.
 const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
-/** The ref pair an open window is recorded under, plus whether it is the legacy shared pair. */
-interface WindowRefs {
+/**
+ * The ref pair an open window is recorded under, plus whether it is the
+ * legacy shared pair. Exported so the pure close builder below and its
+ * effectful "read + guard" counterpart (`decideCloseWindow`) can share the
+ * exact shape `openWindowRefs`'s own guards already gather — `headHash`/
+ * `legacy` are carried through even though the close SCRIPT itself (see
+ * `buildCloseWindowScript`) only needs `headRef`/`baseRef`, so a caller that
+ * received this record from the read half never has to re-derive it.
+ */
+export interface WindowRefs {
   readonly headRef: string
   readonly baseRef: string
   readonly headHash: string
@@ -107,28 +128,32 @@ const openWindowRefs = (git: GitOperations): Effect.Effect<Option.Option<WindowR
   })
 
 /**
- * Restore the real head if a review checkout window is open; no-op otherwise.
- * Keyed on the saved-head ref's existence (see `openWindowRefs`), NOT on any
- * config or machine state, so it always runs first and the machine never sees
- * the window.
- *
- * Fails loudly — refs left in place — when HEAD is no longer on the reviewed
- * branch (the base is not an ancestor of HEAD, e.g. after a branch switch): a
- * mixed reset there would rewrite the wrong branch's tip. Manual commits on
- * top of the base pass the guard: the reset keeps their content in the working
- * tree, where the next turn's capture picks it up as review feedback.
- *
- * A window found under the LEGACY shared refs gets one extra guard: a shared
- * ref may have been written by a sibling worktree, so the close only proceeds
- * when HEAD is contained in the saved head — the shape a window this worktree
- * opened itself has. Anything else refuses with the manual recovery rather
- * than resetting this branch onto another worktree's work (issue #118).
+ * Whether a caller should run the close sequence, and (when so) the resolved
+ * `WindowRefs` `buildCloseWindowScript` needs. Read-only: it reads the same
+ * refs `openWindowRefs` does and runs the same two guards a close must
+ * satisfy (the reviewed-branch containment check, and — for a legacy shared
+ * pair — the sibling-worktree containment check), keyed on the saved-head
+ * ref's existence, NOT on any config or machine state — so `program.ts`'s
+ * `buildRequiredScript` can always call it first and the pure machine never
+ * sees the window. Fails loudly — refs left in place — when HEAD is no longer
+ * on the reviewed branch (the base is not an ancestor of HEAD, e.g. after a
+ * branch switch): a mixed reset there would rewrite the wrong branch's tip.
+ * Manual commits on top of the base pass the guard: the reset keeps their
+ * content in the working tree, where the next turn's capture picks it up as
+ * review feedback. Performs no write itself — `program.ts`'s
+ * `buildRequiredScript` is the one caller, and it only splices
+ * `buildCloseWindowScript`'s bash into the assembled script when
+ * `shouldClose` comes back true.
  */
-export const closeReviewWindow: Effect.Effect<{ readonly closed: boolean }, Error, GitService> =
-  Effect.gen(function* () {
+export type CloseWindowDecision =
+  | { readonly shouldClose: false }
+  | { readonly shouldClose: true; readonly refs: WindowRefs }
+
+export const decideCloseWindow: Effect.Effect<CloseWindowDecision, Error, GitService> = Effect.gen(
+  function* () {
     const git = yield* GitService
     const open = yield* openWindowRefs(git)
-    if (Option.isNone(open)) return { closed: false }
+    if (Option.isNone(open)) return { shouldClose: false }
     const refs = open.value
 
     const base = yield* git.readRefOption(refs.baseRef)
@@ -158,80 +183,88 @@ export const closeReviewWindow: Effect.Effect<{ readonly closed: boolean }, Erro
       }
     }
 
-    yield* git.mixedResetTo(refs.headRef)
-    yield* git.deleteRef(refs.headRef)
-    yield* git.deleteRef(refs.baseRef)
-    return { closed: true }
-  })
+    return { shouldClose: true, refs }
+  },
+)
 
 /**
- * Open (or re-arm) the review checkout window. Self-guarded: a no-op unless
- * the resolved rest's state declares `reviewWindow: true` and a distinct base
- * commit exists, so the caller invokes it unconditionally after every state
- * subcommand.
+ * PURE: the close sequence's bash text — reset to the saved head, then delete
+ * both refs — built from `src/GitScript.ts`'s `mixedResetTo`/`deleteRef`.
+ * Assumes its caller's guards (the reviewed-branch check, the legacy
+ * containment check — see `decideCloseWindow`) have already passed; this
+ * builder performs none of them, only the write sequence for the case where
+ * they did.
  *
- * The base is the most-recent in-process `reviewBase` commit
- * (`reviewBaseHash`) or, absent any such state, the process's diff base
- * (`run.diffBase` — the process start, `startParentHash`, unless a
- * `gtd review <commitish>` entry commit overrode it via a `Gtd-Review-Base:`
- * trailer, see `computeProcessRun`). When that resolves to the empty tree (a
- * process with no prior commit) or to HEAD itself (an empty process), there
- * is nothing to surface and the window stays closed.
- *
- * Ordering is crash-safe: base ref → head ref → mixed reset → `.gtd/` index
- * pin. A crash before the head-ref write leaves only a stale base ref
- * (overwritten on the next open); a crash after it leaves HEAD ==
- * review-head, which the next invocation's close restores as a no-op.
+ * The reset target is `refs.headHash` — the RESOLVED hash, not `refs.headRef`
+ * by name — precisely so the sequence stays idempotent once the ref itself is
+ * gone: the very next statement deletes `headRef`, so a script naming the ref
+ * for the reset would fail on re-entry (the ref `git reset --mixed` would
+ * need is the one the script just deleted). A hash stays resolvable
+ * regardless, so a second run's reset is a true no-op (HEAD is already
+ * there) and both deletes tolerate an already-missing ref. `legacy` on `refs`
+ * goes unused here — the script only needs `headRef`/`baseRef`/`headHash` —
+ * but the parameter carries the whole `WindowRefs` record so a caller can
+ * pass `decideCloseWindow`'s resolved `refs` straight through.
  */
-export const openReviewWindow: Effect.Effect<
-  { readonly opened: boolean },
-  Error,
-  GitService | ConfigService
-> = Effect.gen(function* () {
-  const git = yield* GitService
-  const config = yield* (yield* ConfigService).load
-  const def = config.workflow
+export const buildCloseWindowScript = (refs: WindowRefs): string =>
+  [mixedResetTo(refs.headHash), deleteRef(refs.headRef), deleteRef(refs.baseRef)].join(" &&\n")
 
-  const hasCommits = yield* git.hasCommits()
-  if (!hasCommits) return { opened: false }
+/**
+ * Whether a window should open, and at what base/head — PURE, answerable for
+ * an ARBITRARY target state the caller names (not just whatever `currentRest`
+ * currently resolves to), because the caller — a step about to land a commit
+ * — knows the target from the matched pattern before that commit exists (see
+ * `program.ts`'s `openWindowScript`, which calls this then `execScript`s
+ * `buildOpenWindowScript`'s output as the `optional` script). Self-guarded,
+ * exactly the shape a caller can invoke unconditionally after every state
+ * subcommand: `isReviewWindowState` on the target, then `reviewBaseFor` (the
+ * most-recent in-process `reviewBase` commit, or absent one the process's
+ * diff base — `run.diffBase`, the process start unless a `gtd review
+ * <commitish>` entry commit overrode it via a `Gtd-Review-Base:` trailer, see
+ * `computeProcessRun`), then the same "no real base" / "empty process" no-op
+ * checks against the prospective new head hash — when that resolves to the
+ * empty tree (a process with no prior commit) or to `head` itself (an empty
+ * process), there is nothing to surface and the window stays closed.
+ */
+export type OpenWindowDecision =
+  | { readonly shouldOpen: false }
+  | { readonly shouldOpen: true; readonly base: string; readonly head: string }
 
-  const headSubject = yield* git.lastCommitSubject()
-  const state = resolveState(def, headSubject)
-  if (!isReviewWindowState(def, state)) return { opened: false }
-
-  const run = yield* currentRun
+export const decideOpenWindow = (
+  def: WorkflowDefinition,
+  target: StateName,
+  run: ProcessRun,
+  head: string,
+): OpenWindowDecision => {
+  if (!isReviewWindowState(def, target)) return { shouldOpen: false }
   const base = reviewBaseFor(def, run)
-  const headHash = yield* git.resolveRef("HEAD")
   // No real base commit to rewind to (whole-history process), or an empty
   // process with nothing committed yet — nothing to surface, so stay closed.
-  if (base === EMPTY_TREE || base === headHash) return { opened: false }
+  if (base === EMPTY_TREE || base === head) return { shouldOpen: false }
+  return { shouldOpen: true, base, head }
+}
 
-  yield* git.updateRef(REVIEW_BASE_REF, base)
-  yield* git.updateRef(REVIEW_HEAD_REF, headHash)
-  yield* git.mixedResetTo(base)
-  // `.gtd/` (REVIEW.md, plan/feedback files) is workflow plumbing, not part of
-  // the reviewable diff — pin its index entries back to the saved head so the
-  // editor's unstaged view shows only the code changes.
-  yield* git.restoreStagedFrom(REVIEW_HEAD_REF, [".gtd"])
-  // Files added since the base are left UNTRACKED, deliberately — do not
-  // "improve" this with a `git add --intent-to-add .` (gtd ≤ 8.2 did):
-  //
-  // - Discarding an intent-to-add path (`git checkout -- <path>`, i.e. an
-  //   editor's "discard changes") TRUNCATES it to zero bytes instead of
-  //   removing it, and the survivor is then committed by the next step's
-  //   `git add -A` — so rejecting a new file during review silently landed an
-  //   empty one. Untracked, discard deletes the file, which is the gesture the
-  //   reviewer meant.
-  // - It was the one whole-tree index WRITE in the open sequence, taken
-  //   milliseconds after the mixed reset above wakes every watcher on the repo
-  //   (editor SCM, `gtd lsp`, git-aware prompts — all of which write the index
-  //   to refresh their stat cache), so it lost the `index.lock` race often
-  //   enough to fail the whole invocation over a cosmetic step.
-  //
-  // The cost is that a terminal `git diff` no longer lists new files at the
-  // gate (`git status` does); the editor SCM views this window exists for show
-  // them either way, and the engine is indifferent — `changedPaths` unions
-  // `git ls-files --others` in, so the resting state's `on` patterns see an
-  // untracked add as `A` exactly like a staged one.
-  return { opened: true }
-})
+/**
+ * PURE: the open sequence's bash text — base-ref write, head-ref write,
+ * mixed-reset-to-base, then the `.gtd/` restore-staged-from pin, built from
+ * `src/GitScript.ts`'s `updateRef`/`mixedResetTo`/`restoreStagedFrom`, in the
+ * same crash-safe order `openReviewWindow` uses (base ref → head ref → mixed
+ * reset → `.gtd/` pin). Deliberately no `git add --intent-to-add` anywhere —
+ * new files stay untracked, for the exact two reasons `openReviewWindow`'s
+ * own doc comment records — and no whole-tree index write: `restoreStagedFrom`
+ * is scoped to `.gtd/` alone.
+ *
+ * Idempotent under re-entry: `updateRef`/`mixedResetTo` re-pointing at the
+ * same target is a no-op, and `restoreStagedFrom` re-pinning an already-pinned
+ * path is a no-op.
+ */
+export const buildOpenWindowScript = (decision: {
+  readonly base: string
+  readonly head: string
+}): string =>
+  [
+    updateRef(REVIEW_BASE_REF, decision.base),
+    updateRef(REVIEW_HEAD_REF, decision.head),
+    mixedResetTo(decision.base),
+    restoreStagedFrom(REVIEW_HEAD_REF, [".gtd"]),
+  ].join(" &&\n")

--- a/src/SteeringFormats.test.ts
+++ b/src/SteeringFormats.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { builtInModeNames, steeringFormatFor } from "./SteeringFormats.js"
+import fc from "fast-check"
+import {
+  builtInModeNames,
+  isSeededValidateCommand,
+  seededValidateCommand,
+  steeringFormatFor,
+} from "./SteeringFormats.js"
 import { QA_FORMAT } from "./OpenQuestions.js"
 import { REVIEW_FORMAT } from "./ReviewDoc.js"
 
@@ -18,5 +24,28 @@ describe("steeringFormatFor", () => {
   it("resolves an unknown name to undefined", () => {
     expect(steeringFormatFor("prose")).toBeUndefined()
     expect(steeringFormatFor("adr")).toBeUndefined()
+  })
+})
+
+describe("seededValidateCommand / isSeededValidateCommand", () => {
+  it("recognizes its own seeded command for every built-in mode", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...builtInModeNames()), (mode) => {
+        expect(isSeededValidateCommand(mode, seededValidateCommand(mode))).toBe(true)
+      }),
+    )
+  })
+
+  it("rejects a hand-written command", () => {
+    expect(isSeededValidateCommand("qa", "npx prettier --check <%= it.file %>")).toBe(false)
+  })
+
+  it("rejects another mode's seeded command", () => {
+    expect(isSeededValidateCommand("review", seededValidateCommand("qa"))).toBe(false)
+  })
+
+  it("rejects near-miss whitespace/quoting variants", () => {
+    expect(isSeededValidateCommand("qa", "gtd check qa  '<%= it.file %>'")).toBe(false)
+    expect(isSeededValidateCommand("qa", `gtd check qa "<%= it.file %>"`)).toBe(false)
   })
 })

--- a/src/SteeringFormats.ts
+++ b/src/SteeringFormats.ts
@@ -24,3 +24,20 @@ export const builtInModeNames = (): readonly string[] => [...STEERING_FORMATS.ke
 /** The built-in `SteeringFormat` named `mode`, or `undefined` when `mode` names no built-in. */
 export const steeringFormatFor = (mode: string): SteeringFormat | undefined =>
   STEERING_FORMATS.get(mode)
+
+/**
+ * The literal (unrendered) Eta template a workflow compiler seeds as a
+ * built-in mode's own `validate:` command — quoted so a file path containing
+ * spaces survives `renderModeCommand`'s interpolation.
+ */
+export const seededValidateCommand = (mode: string): string => `gtd check ${mode} '<%= it.file %>'`
+
+/**
+ * True when `command` is EXACTLY `mode`'s own seeded template string — a
+ * literal comparison against the declared template, never a rendered
+ * command, so recognition doesn't depend on which file the mode is applied
+ * to. Lets a later mode resolver tell gtd's own seeding apart from a user's
+ * hand-written override of the same mode.
+ */
+export const isSeededValidateCommand = (mode: string, command: string): boolean =>
+  command === seededValidateCommand(mode)

--- a/src/SteeringMode.test.ts
+++ b/src/SteeringMode.test.ts
@@ -6,6 +6,7 @@ import { Effect, Exit, type Layer } from "effect"
 import {
   formatAndValidateSteeringFile,
   formatSteeringFile,
+  renderSteeringCommands,
   resolveBuiltInMode,
   resolveSteeringMode,
   steeringCapabilities,
@@ -15,6 +16,7 @@ import {
 import { CommandRunner, type CommandOutcome } from "./CommandRunner.js"
 import { QA_FORMAT } from "./OpenQuestions.js"
 import { REVIEW_FORMAT } from "./ReviewDoc.js"
+import { seededValidateCommand } from "./SteeringFormats.js"
 import type { TemplateContext } from "./PatternTemplates.js"
 import type { WorkflowDefinition } from "./PatternMachine.js"
 
@@ -207,6 +209,51 @@ describe("steeringCapabilities", () => {
 
   it("is empty for an unresolved mode", () => {
     expect(steeringCapabilities(undefined)).toEqual({})
+  })
+
+  it("keeps liveValidate (using builtIn.validate) and drops externalValidate when a built-in mode's declared `validate:` IS its own seeded command", () => {
+    const def = commandsDef({ qa: { validate: seededValidateCommand("qa") } })
+    const resolved = resolveSteeringMode(def, "qa")
+    expect(resolved).toEqual({
+      mode: "qa",
+      builtIn: QA_FORMAT,
+      validate: { kind: "command", command: seededValidateCommand("qa") },
+    })
+    const caps = steeringCapabilities(resolved)
+    expect(caps.format).toBe(QA_FORMAT)
+    expect(caps.liveValidate).toBe(QA_FORMAT.validate)
+    expect(caps.externalValidate).toBeUndefined()
+  })
+
+  it("recognizes the seeded command for `review` too, keyed to its own mode name", () => {
+    const def = commandsDef({ review: { validate: seededValidateCommand("review") } })
+    const caps = steeringCapabilities(resolveSteeringMode(def, "review"))
+    expect(caps.format).toBe(REVIEW_FORMAT)
+    expect(caps.liveValidate).toBe(REVIEW_FORMAT.validate)
+    expect(caps.externalValidate).toBeUndefined()
+  })
+
+  it("still reports externalValidate for a genuine user override even when the command text merely resembles the seeded one", () => {
+    const def = commandsDef({ qa: { validate: `${seededValidateCommand("qa")} --extra` } })
+    const caps = steeringCapabilities(resolveSteeringMode(def, "qa"))
+    expect(caps.format).toBe(QA_FORMAT)
+    expect(caps.liveValidate).toBeUndefined()
+    expect(caps.externalValidate).toBe(true)
+  })
+
+  it("carries no format and reports externalValidate for a non-built-in mode with a `validate:` command", () => {
+    const def = commandsDef({ adr: { validate: "adr-lint <%= it.file %>" } })
+    const caps = steeringCapabilities(resolveSteeringMode(def, "adr"))
+    expect(caps.format).toBeUndefined()
+    expect(caps.liveValidate).toBeUndefined()
+    expect(caps.externalValidate).toBe(true)
+  })
+
+  it("keeps liveValidate for the LSP's definition-less basename fallback (resolveBuiltInMode)", () => {
+    const caps = steeringCapabilities(resolveBuiltInMode("review"))
+    expect(caps.format).toBe(REVIEW_FORMAT)
+    expect(caps.liveValidate).toBe(REVIEW_FORMAT.validate)
+    expect(caps.externalValidate).toBeUndefined()
   })
 })
 
@@ -475,5 +522,101 @@ describe("formatAndValidateSteeringFile", () => {
     )
     expect(Exit.isFailure(exit)).toBe(true)
     expect(calls).toHaveLength(1)
+  })
+})
+
+describe("renderSteeringCommands", () => {
+  it("returns just the rendered format command for a format-only mode", async () => {
+    const commands = await Effect.runPromise(
+      renderSteeringCommands(
+        { mode: "adr", formatCommand: "fmt <%= it.file %>" },
+        "docs/adr.md",
+        context(),
+      ),
+    )
+    expect(commands).toEqual(["fmt docs/adr.md"])
+  })
+
+  it("returns just the rendered validate command for a command-validate-only mode", async () => {
+    const commands = await Effect.runPromise(
+      renderSteeringCommands(
+        { mode: "adr", validate: { kind: "command", command: "adr-lint <%= it.file %>" } },
+        "docs/adr.md",
+        context(),
+      ),
+    )
+    expect(commands).toEqual(["adr-lint docs/adr.md"])
+  })
+
+  it("returns format then validate, in that order, when both are declared", async () => {
+    const commands = await Effect.runPromise(
+      renderSteeringCommands(
+        {
+          mode: "adr",
+          formatCommand: "fmt <%= it.file %>",
+          validate: { kind: "command", command: "adr-lint <%= it.file %>" },
+        },
+        "docs/adr.md",
+        context(),
+      ),
+    )
+    expect(commands).toEqual(["fmt docs/adr.md", "adr-lint docs/adr.md"])
+  })
+
+  it("returns nothing for a mode with no format and no command-based validator", async () => {
+    const noneCommands = await Effect.runPromise(
+      renderSteeringCommands({ mode: "adr" }, "adr.md", context()),
+    )
+    expect(noneCommands).toEqual([])
+
+    const builtInOnlyCommands = await Effect.runPromise(
+      renderSteeringCommands(
+        { mode: "qa", validate: { kind: "builtin", format: QA_FORMAT } },
+        ".gtd/TODO.md",
+        context(),
+      ),
+    )
+    expect(builtInOnlyCommands).toEqual([])
+  })
+
+  it("fails with the same message `formatSteeringFile` produces for the same malformed template", async () => {
+    const malformed = "fmt <%= it.file"
+    const renderExit = await Effect.runPromiseExit(
+      renderSteeringCommands({ mode: "adr", formatCommand: malformed }, "adr.md", context()),
+    )
+    const formatExit = await runExitWith(
+      formatSteeringFile({ mode: "adr", formatCommand: malformed }, "adr.md", context()),
+      neverRunner,
+    )
+    expect(Exit.isFailure(renderExit)).toBe(true)
+    expect(Exit.isFailure(formatExit)).toBe(true)
+    if (Exit.isFailure(renderExit) && Exit.isFailure(formatExit)) {
+      expect(String(renderExit.cause)).toBe(String(formatExit.cause))
+    }
+  })
+
+  it("fails on a malformed validate template too, without running anything", async () => {
+    const exit = await Effect.runPromiseExit(
+      renderSteeringCommands(
+        { mode: "adr", validate: { kind: "command", command: "check <%= it.file" } },
+        "docs/adr.md",
+        context(),
+      ),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      expect(String(exit.cause)).toContain('mode "adr": "validate" command failed to render')
+    }
+  })
+
+  it("has no CommandRunner requirement — runs to success with no layer provided at all", async () => {
+    const commands = await Effect.runPromise(
+      renderSteeringCommands(
+        { mode: "adr", formatCommand: "fmt <%= it.file %>" },
+        "adr.md",
+        context(),
+      ),
+    )
+    expect(commands).toEqual(["fmt adr.md"])
   })
 })

--- a/src/SteeringMode.ts
+++ b/src/SteeringMode.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
 import { CommandRunner, type CommandOutcome } from "./CommandRunner.js"
-import { steeringFormatFor } from "./SteeringFormats.js"
+import { isSeededValidateCommand, steeringFormatFor } from "./SteeringFormats.js"
 import type { SteeringFormat } from "./SteeringFormat.js"
 import { knownModes, type StateMode, type WorkflowDefinition } from "./PatternMachine.js"
 import { renderModeCommand, type TemplateContext } from "./PatternTemplates.js"
@@ -114,10 +114,16 @@ export const resolveBuiltInMode = (mode: StateMode): ResolvedMode | undefined =>
  * the sign-off/answer gates) that only cares about capability, not resolution
  * mechanics: `format` is the built-in format (outline/actions/pointer), present
  * whenever `builtIn` is; `liveValidate` is that format's own `validate`
- * function, present IFF `validate.kind === "builtin"` (a declared `validate:`
- * command displaces it); `externalValidate` is `true` IFF `validate.kind ===
- * "command"` — a shell-validated mode, which the LSP shows a notice for instead
- * of live diagnostics.
+ * function, present when `builtIn` is present AND the validator is either the
+ * built-in kind OR a command that is gtd's OWN SEEDED string for this mode
+ * (`src/SteeringFormats.ts`'s `isSeededValidateCommand` — a workflow compiler
+ * seeding `qa`/`review`'s own `gtd check <mode> '<file>'` behind the scenes
+ * changes nothing about how the file is actually validated, so the LSP must
+ * keep publishing live diagnostics rather than switch to an external notice);
+ * `externalValidate` is `true` IFF `validate.kind === "command"` AND that
+ * command is NOT the seeded string — a genuine user override of a built-in
+ * mode's `validate:`, or any command-validated non-built-in mode, which the
+ * LSP shows a notice for instead of live diagnostics.
  */
 export interface SteeringCapabilities {
   readonly format?: SteeringFormat
@@ -127,12 +133,18 @@ export interface SteeringCapabilities {
 
 export const steeringCapabilities = (resolved: ResolvedMode | undefined): SteeringCapabilities => {
   if (resolved === undefined) return {}
+  const seeded =
+    resolved.builtIn !== undefined &&
+    resolved.validate?.kind === "command" &&
+    isSeededValidateCommand(resolved.mode, resolved.validate.command)
+  const liveValidate =
+    resolved.builtIn !== undefined && (resolved.validate?.kind === "builtin" || seeded)
+      ? resolved.builtIn.validate
+      : undefined
   return {
     ...(resolved.builtIn !== undefined ? { format: resolved.builtIn } : {}),
-    ...(resolved.validate?.kind === "builtin"
-      ? { liveValidate: resolved.validate.format.validate }
-      : {}),
-    ...(resolved.validate?.kind === "command" ? { externalValidate: true } : {}),
+    ...(liveValidate !== undefined ? { liveValidate } : {}),
+    ...(resolved.validate?.kind === "command" && !seeded ? { externalValidate: true } : {}),
   }
 }
 
@@ -254,4 +266,35 @@ export const formatAndValidateSteeringFile = (
   Effect.gen(function* () {
     yield* formatSteeringFile(resolved, file, context)
     return yield* validateSteeringFile(resolved, file, content, context)
+  })
+
+/**
+ * Render a mode's `format:`/`validate:` commands as plain strings, WITHOUT
+ * running either — for a caller (an emitter that prints scripts rather than
+ * executing them) that wants the commands themselves, not their outcome.
+ * Unlike its siblings above, this needs no `CommandRunner`: it shares their
+ * `renderCommand` helper for the rendering (and its errors) but never reaches
+ * for a runner to execute the result. Order matches `formatAndValidateSteeringFile`
+ * (format then validate); a half the mode doesn't declare — no `formatCommand`,
+ * or a `validate` that is absent or `"builtin"` (an in-process parser has no
+ * shell command to render) — is OMITTED from the result, not rendered as `""`.
+ */
+export const renderSteeringCommands = (
+  resolved: ResolvedMode,
+  file: string,
+  context: TemplateContext,
+): Effect.Effect<readonly string[], Error> =>
+  Effect.gen(function* () {
+    const commands: string[] = []
+    if (resolved.formatCommand !== undefined) {
+      commands.push(
+        yield* renderCommand(resolved.mode, "format", resolved.formatCommand, file, context),
+      )
+    }
+    if (resolved.validate?.kind === "command") {
+      commands.push(
+        yield* renderCommand(resolved.mode, "validate", resolved.validate.command, file, context),
+      )
+    }
+    return commands
   })

--- a/src/StepGuards.test.ts
+++ b/src/StepGuards.test.ts
@@ -1,13 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { Effect, Exit, Layer } from "effect"
-import {
-  enforceStepGuards,
-  stepGuards,
-  checkSteeringFile,
-  type GuardContext,
-} from "./StepGuards.js"
+import { enforceStepGuards, stepGuards, type GuardContext } from "./StepGuards.js"
 import { RepoFiles, type RepoFilesOps } from "./RepoFiles.js"
-import { CommandRunner, type CommandOutcome } from "./CommandRunner.js"
 import type { ResolvedRest } from "./Edge.js"
 import type { PendingChange, StateDef, WorkflowDefinition } from "./PatternMachine.js"
 import type { TemplateContext } from "./PatternTemplates.js"
@@ -358,82 +352,47 @@ describe("answer-completeness guard", () => {
   })
 })
 
-// ── steering-file guard + enforceStepGuards runner ──────────────────────────
-
-const noopCommandRunner = Layer.succeed(CommandRunner, {
-  bash: (): Effect.Effect<CommandOutcome, Error> =>
-    Effect.fail(new Error("unscripted command in this test")),
-})
+// ── enforceStepGuards runner ─────────────────────────────────────────────────
 
 const repoFilesFrom = (files: Record<string, string>): RepoFilesOps => ({
   working: (path) => files[path],
   committed: () => Effect.succeed(undefined),
 })
 
-describe("steering-file guard", () => {
-  const draftingState = rest("drafting", {
-    actor: "agent",
-    prompt: "write",
-    file: ".gtd/TODO.md",
-    mode: "qa",
-  })
-
-  it("applies to any state that declares a mode", () => {
-    expect(guard("steering-file").appliesTo(draftingState)).toBe(true)
-    expect(
-      guard("steering-file").appliesTo(rest("drafting", { actor: "agent", prompt: "x" })),
-    ).toBe(false)
-  })
-
-  it("check reports the built-in validator's findings against post-format bytes", async () => {
-    const refusal = await checkOf(
-      "steering-file",
-      ctx({
-        rest: draftingState,
-        worktree: Effect.succeed("Plan.\n\n## Open Questions\n\n###\n\nno question text.\n"),
-      }),
-    )
-    expect(refusal).toContain("is not valid")
-    expect(refusal).toContain("has no question text")
-  })
-
-  it("check allows a valid file", async () => {
-    const refusal = await checkOf(
-      "steering-file",
-      ctx({ rest: draftingState, worktree: Effect.succeed("Just a plan, no questions.\n") }),
-    )
-    expect(refusal).toBeUndefined()
-  })
-
-  it("check no-ops when the file is absent (a deletion)", async () => {
-    const refusal = await checkOf(
-      "steering-file",
-      ctx({ rest: draftingState, worktree: Effect.succeed(undefined) }),
-    )
-    expect(refusal).toBeUndefined()
-  })
-})
-
 describe("enforceStepGuards", () => {
-  const draftingState = rest("drafting", {
-    actor: "agent",
-    prompt: "write",
-    file: ".gtd/TODO.md",
+  const answerState = rest("product-answer", {
+    actor: "human",
+    message: "answer",
+    file: ".gtd/REQUIREMENTS.md",
     mode: "qa",
+    answerGate: true,
   })
+  const unansweredDoc = [
+    "Build a thing.",
+    "",
+    "## Open Questions",
+    "",
+    "### Which API?",
+    "",
+    "- [ ] REST",
+    "- [ ] GraphQL",
+    "- [ ] _your answer_",
+    "",
+  ].join("\n")
 
-  it("no-ops for a squash or no-op decision, even with an invalid file", async () => {
+  it("no-ops for a squash or no-op decision, even with an unanswered question", async () => {
     const exit = await Effect.runPromiseExit(
       enforceStepGuards({
-        rest: draftingState,
-        file: draftingState.stateDef.file,
+        rest: answerState,
+        file: answerState.stateDef.file,
         context: templateContext,
         changes: [],
         invoker: "agent",
         kind: "squash",
       }).pipe(
-        Effect.provide(Layer.succeed(RepoFiles, repoFilesFrom({}))),
-        Effect.provide(noopCommandRunner),
+        Effect.provide(
+          Layer.succeed(RepoFiles, repoFilesFrom({ ".gtd/REQUIREMENTS.md": unansweredDoc })),
+        ),
       ),
     )
     expect(Exit.isSuccess(exit)).toBe(true)
@@ -449,31 +408,39 @@ describe("enforceStepGuards", () => {
         changes: [],
         invoker: "agent",
         kind: "commit",
-      }).pipe(
-        Effect.provide(Layer.succeed(RepoFiles, repoFilesFrom({}))),
-        Effect.provide(noopCommandRunner),
-      ),
+      }).pipe(Effect.provide(Layer.succeed(RepoFiles, repoFilesFrom({})))),
     )
     expect(Exit.isSuccess(exit)).toBe(true)
   })
 
-  it("fails with the `gtd step <invoker>: ` prefix on a refusal", async () => {
+  it("no-ops when no guard applies to the resting state", async () => {
+    const noGuard = rest("drafting", { actor: "agent", prompt: "write", file: ".gtd/TODO.md" })
     const exit = await Effect.runPromiseExit(
       enforceStepGuards({
-        rest: draftingState,
-        file: draftingState.stateDef.file,
+        rest: noGuard,
+        file: noGuard.stateDef.file,
+        context: templateContext,
+        changes: [],
+        invoker: "agent",
+        kind: "commit",
+      }).pipe(Effect.provide(Layer.succeed(RepoFiles, repoFilesFrom({})))),
+    )
+    expect(Exit.isSuccess(exit)).toBe(true)
+  })
+
+  it("fails with the `gtd step <invoker>: ` prefix on a refusal, requiring only RepoFiles", async () => {
+    const exit = await Effect.runPromiseExit(
+      enforceStepGuards({
+        rest: answerState,
+        file: answerState.stateDef.file,
         context: templateContext,
         changes: [],
         invoker: "agent",
         kind: "commit",
       }).pipe(
         Effect.provide(
-          Layer.succeed(
-            RepoFiles,
-            repoFilesFrom({ ".gtd/TODO.md": "Plan.\n\n## Open Questions\n\n###\n\nno text.\n" }),
-          ),
+          Layer.succeed(RepoFiles, repoFilesFrom({ ".gtd/REQUIREMENTS.md": unansweredDoc })),
         ),
-        Effect.provide(noopCommandRunner),
       ),
     )
     expect(Exit.isFailure(exit)).toBe(true)
@@ -483,107 +450,44 @@ describe("enforceStepGuards", () => {
     }
   })
 
-  it("runs guards in registry order — steering-file before review-signoff", () => {
+  it("runs guards in registry order — review-signoff, feedback-progress, answer-completeness", () => {
     expect(stepGuards.map((g) => g.name)).toEqual([
-      "steering-file",
       "review-signoff",
       "feedback-progress",
       "answer-completeness",
     ])
   })
 
-  it("write-before-read: a scripted format rewrite is visible to every guard's check", async () => {
-    const reviewState = rest("await-review", {
-      actor: "human",
-      prompt: "review",
-      file: ".gtd/REVIEW.md",
-      mode: "review",
-      reviewWindow: true,
-    })
-    const header = "# Review: abc1234\n<!-- base: abc1234def5678901234567890123456789abcd -->\n\n"
-    const unticked = `${header}## C\n- [ ] ./a.ts#1\n`
-    const ticked = `${header}## C\n- [x] ./a.ts#1\n`
-    const files: Record<string, string> = { ".gtd/REVIEW.md": unticked }
-    const scriptedRunner = Layer.succeed(CommandRunner, {
-      bash: (command: string): Effect.Effect<CommandOutcome, Error> => {
-        if (command.includes("normalize-review")) {
-          files[".gtd/REVIEW.md"] = ticked
-          return Effect.succeed({ status: 0, output: "" })
-        }
-        return Effect.fail(new Error(`unscripted command "${command}"`))
-      },
-    })
-    const def: WorkflowDefinition = {
-      states: { "await-review": reviewState.stateDef },
-      entries: { default: "await-review", manual: [] },
-      modes: { review: { format: "normalize-review <%= it.file %>" } },
-    }
-    const withFormat = { ...reviewState, def }
+  it("reads the CURRENT working tree as-is — no in-process formatting happens here", async () => {
+    // A step script's own `format:` command (run by an external driver) is
+    // never invoked by `enforceStepGuards` — it only samples whatever is on
+    // disk right now. An already-answered doc passes with no formatting step.
+    const answeredDoc = [
+      "Build a thing.",
+      "",
+      "## Open Questions",
+      "",
+      "### Which API?",
+      "",
+      "- [ ] REST",
+      "- [x] GraphQL",
+      "- [ ] _your answer_",
+      "",
+    ].join("\n")
     const exit = await Effect.runPromiseExit(
       enforceStepGuards({
-        rest: withFormat,
-        file: withFormat.stateDef.file,
+        rest: answerState,
+        file: answerState.stateDef.file,
         context: templateContext,
         changes: [],
         invoker: "human",
         kind: "commit",
       }).pipe(
         Effect.provide(
-          Layer.succeed(RepoFiles, {
-            working: (path: string) => files[path],
-            committed: () => Effect.succeed(unticked),
-          }),
+          Layer.succeed(RepoFiles, repoFilesFrom({ ".gtd/REQUIREMENTS.md": answeredDoc })),
         ),
-        Effect.provide(scriptedRunner),
       ),
     )
-    // The format command flips the box to ticked BEFORE review-signoff samples
-    // the worktree, so this must succeed (no unticked items survive).
     expect(Exit.isSuccess(exit)).toBe(true)
-  })
-})
-
-describe("checkSteeringFile", () => {
-  const draftingState = rest("drafting", {
-    actor: "agent",
-    prompt: "write",
-    file: ".gtd/TODO.md",
-    mode: "qa",
-  })
-
-  it("reports present: false when the state declares no file:/mode:", async () => {
-    const result = await Effect.runPromise(
-      checkSteeringFile(
-        rest("idle", { actor: "human", message: "go" }),
-        templateContext,
-        undefined,
-      ).pipe(
-        Effect.provide(Layer.succeed(RepoFiles, repoFilesFrom({}))),
-        Effect.provide(noopCommandRunner),
-      ),
-    )
-    expect(result).toEqual({ file: undefined, present: false, errors: [] })
-  })
-
-  it("reports present: false when the file is absent", async () => {
-    const result = await Effect.runPromise(
-      checkSteeringFile(draftingState, templateContext, draftingState.stateDef.file).pipe(
-        Effect.provide(Layer.succeed(RepoFiles, repoFilesFrom({}))),
-        Effect.provide(noopCommandRunner),
-      ),
-    )
-    expect(result).toEqual({ file: ".gtd/TODO.md", present: false, errors: [] })
-  })
-
-  it("formats then validates a present file", async () => {
-    const result = await Effect.runPromise(
-      checkSteeringFile(draftingState, templateContext, draftingState.stateDef.file).pipe(
-        Effect.provide(
-          Layer.succeed(RepoFiles, repoFilesFrom({ ".gtd/TODO.md": "Just a plan.\n" })),
-        ),
-        Effect.provide(noopCommandRunner),
-      ),
-    )
-    expect(result).toEqual({ file: ".gtd/TODO.md", present: true, errors: [] })
   })
 })

--- a/src/StepGuards.ts
+++ b/src/StepGuards.ts
@@ -1,12 +1,5 @@
 import { Effect } from "effect"
-import { CommandRunner } from "./CommandRunner.js"
 import { RepoFiles } from "./RepoFiles.js"
-import {
-  formatSteeringFile,
-  resolveSteeringMode,
-  unknownModeMessage,
-  validateSteeringFile,
-} from "./SteeringMode.js"
 import {
   isAnswerGateState,
   isReviewWindowState,
@@ -23,11 +16,9 @@ import type { TemplateContext } from "./PatternTemplates.js"
  * before it can commit — never engine concerns (`src/PatternMachine.ts`'s
  * `step` never sees any of this; a state's declared `on` pattern is the only
  * thing that decides WHERE a step lands, these guards only decide WHETHER it
- * may land at all). One registry (`stepGuards`) replaces four hand-copied
+ * may land at all). One registry (`stepGuards`) replaces hand-copied
  * `enforce*` blocks that used to live in `src/program.ts`:
  *
- * - **steering-file** — format then validate a state's `file:`/`mode:` pair,
- *   refusing an invalid result (`src/SteeringMode.ts`).
  * - **review-signoff** — at a review window's `mode: review` gate, refuse a
  *   deleted doc or an unfinished tick-only pass with no comment.
  * - **feedback-progress** — at a `requireProgress` state, refuse deleting the
@@ -35,20 +26,30 @@ import type { TemplateContext } from "./PatternTemplates.js"
  * - **answer-completeness** — at an `answerGate` `mode: qa` state, refuse
  *   while any open question is unanswered.
  *
- * `enforceStepGuards` runs every APPLICABLE guard's `prepare` (writes — only
- * the steering-file guard's format command has one) to completion BEFORE
- * sampling the committed/working bytes ONCE (cached), then runs every
- * `check` (reads) against that one sample — so a `format:` command's rewrite
- * is visible to every guard, including one it wasn't written for, and no
- * guard ever judges half-formatted bytes.
+ * `enforceStepGuards` samples the committed/working bytes ONCE (cached), then
+ * runs every applicable guard's `check` (reads) against that one sample.
+ * There is no write phase here anymore: a `format:` command (a mode's own
+ * whitespace/wrapping/ordering normalization) is emitted into a step's bash
+ * script for an EXTERNAL driver to run — it may run before or after this
+ * process reads the file, or not at all before the CLI decides. That is
+ * sound only because a `format:` command is NORMALIZATION-ONLY and must
+ * NEVER change what a guard would decide: this repo's guards judge whichever
+ * bytes are currently on disk (pre-format or post-format, indistinguishable
+ * to a guard that only cares about content, not incidental formatting), so
+ * the CLI's ONE decision — made here, now, against whatever the working tree
+ * currently holds — can never be invalidated by a formatter running later. A
+ * `format:` command that changes a guard's verdict (e.g. one that also
+ * mutates checkbox state, or strips content) would be a mode-author bug, not
+ * a gtd concern; gtd enforces nothing about a mode's `format:` beyond "it
+ * runs as part of the step script."
  */
 
-export type GuardRequirements = RepoFiles | CommandRunner
+export type GuardRequirements = RepoFiles
 
 /** A guard's verdict: `undefined` allows the step; a string is the refusal reason (the `gtd step <invoker>: ` prefix is added once, by `enforceStepGuards`). */
 export type Refusal = string | undefined
 
-/** Everything a guard's `check` (and the steering-file guard's `prepare`) needs — assembled once per `enforceStepGuards` call, shared by every applicable guard. */
+/** Everything a guard's `check` needs — assembled once per `enforceStepGuards` call, shared by every applicable guard. */
 export interface GuardContext {
   readonly rest: ResolvedRest
   /** The rest state's rendered `file:` — non-optional, since `enforceStepGuards` already returned early when the state declares none. */
@@ -61,7 +62,7 @@ export interface GuardContext {
   readonly template: TemplateContext
   /** `file`'s contents at HEAD (before this step), `undefined` if absent there. Cached — evaluated once per `enforceStepGuards` call. */
   readonly head: Effect.Effect<string | undefined, Error>
-  /** `file`'s WORKING-TREE contents, sampled AFTER every applicable guard's `prepare` has run — so every `check` sees post-format bytes. Cached. */
+  /** `file`'s CURRENT working-tree contents — whatever is on disk right now, pre- or post- an external driver's own `format:` run. Cached. */
   readonly worktree: Effect.Effect<string | undefined, Error>
 }
 
@@ -69,47 +70,12 @@ export interface StepGuard {
   readonly name: string
   /** Pure — decided from the definition/state alone, before any IO is paid for. */
   readonly appliesTo: (rest: ResolvedRest) => boolean
-  /** The WRITE phase (only the steering-file guard has one): runs for every applicable guard, in order, before any guard's `check`. */
-  readonly prepare?: (
-    ctx: Omit<GuardContext, "head" | "worktree">,
-  ) => Effect.Effect<void, Error, GuardRequirements>
-  /** The READ phase: decide allow (`undefined`) or refuse (a reason string). */
+  /** Decide allow (`undefined`) or refuse (a reason string). */
   readonly check: (ctx: GuardContext) => Effect.Effect<Refusal, Error, GuardRequirements>
 }
 
 /** Normalize every markdown checkbox to a single placeholder so a pure `[ ]`→`[x]` tick is invisible to a text comparison; any surviving difference is a human note. */
 const normalizeCheckboxes = (content: string): string => content.replace(/\[[ xX]\]/g, "[_]")
-
-const steeringFileGuard: StepGuard = {
-  name: "steering-file",
-  appliesTo: (rest) => rest.stateDef.mode !== undefined,
-  prepare: (ctx) =>
-    Effect.gen(function* () {
-      const mode = ctx.rest.stateDef.mode!
-      const resolved = resolveSteeringMode(ctx.rest.def, mode)
-      if (resolved === undefined) {
-        // `validateDefinition` rejects an unresolvable `mode:` at load time —
-        // defensive, not a reachable config path.
-        return yield* Effect.fail(new Error(unknownModeMessage(ctx.rest.def, ctx.rest.state, mode)))
-      }
-      const files = yield* RepoFiles
-      if (files.working(ctx.file) === undefined) return // a deletion — nothing to format
-      yield* formatSteeringFile(resolved, ctx.file, ctx.template)
-    }),
-  check: (ctx) =>
-    Effect.gen(function* () {
-      const mode = ctx.rest.stateDef.mode!
-      const resolved = resolveSteeringMode(ctx.rest.def, mode)
-      if (resolved === undefined) return undefined // `prepare` already failed this path
-      const current = yield* ctx.worktree
-      if (current === undefined) return undefined // a deletion — nothing to validate
-      const errors = yield* validateSteeringFile(resolved, ctx.file, current, ctx.template)
-      if (errors.length === 0) return undefined
-      return `${ctx.file} is not valid at "${ctx.rest.state}" — fix these before stepping:\n${errors
-        .map((e) => `  - ${e}`)
-        .join("\n")}`
-    }),
-}
 
 /** The `mode:` name of gtd's built-in REVIEW.md checkbox validator — the only mode the sign-off guard understands. */
 const REVIEW_MODE = "review"
@@ -170,9 +136,8 @@ const answerCompletenessGuard: StepGuard = {
     }),
 }
 
-/** The four step-capture guards, in EVALUATION order — message precedence when two would fire is observable, so this order is the contract (matches the old hand-copied call order). */
+/** The three step-capture guards, in EVALUATION order — message precedence when two would fire is observable, so this order is the contract (matches the old hand-copied call order, minus the now-removed steering-file guard). */
 export const stepGuards: readonly StepGuard[] = [
-  steeringFileGuard,
   reviewSignoffGuard,
   feedbackProgressGuard,
   answerCompletenessGuard,
@@ -180,7 +145,7 @@ export const stepGuards: readonly StepGuard[] = [
 
 /**
  * The `gtd step` capture gate: run every guard the resolved rest's state
- * applies to, formatting (write phase) before validating (read phase) — see
+ * applies to against ONE sample of the current committed/working bytes — see
  * the module docstring — and fail with the first refusal's reason, prefixed
  * `gtd step <invoker>: ` (the one place that prefix, and the `cliErrorLine`
  * `/^gtd[: ]/` contract, is satisfied). A no-op for a squash/no-op decision, a
@@ -214,10 +179,6 @@ export const enforceStepGuards = (input: {
       template: input.context,
     }
 
-    for (const g of applicable) {
-      if (g.prepare !== undefined) yield* g.prepare(base)
-    }
-
     const files = yield* RepoFiles
     const head = yield* Effect.cached(files.committed(file))
     const worktree = yield* Effect.cached(Effect.try(() => files.working(file)))
@@ -229,43 +190,4 @@ export const enforceStepGuards = (input: {
         return yield* Effect.fail(new Error(`gtd step ${input.invoker}: ${refusal}`))
       }
     }
-  })
-
-/** Format the resolved state's steering file (in place) then validate it — `gtd validate`'s shape. */
-export interface SteeringCheck {
-  /** The rendered `file:` path, or `undefined` when the state declares no `file:`/`mode:`. */
-  readonly file: string | undefined
-  /** True when a steering file was actually present and got formatted + validated (false when the state declares none, or the file is absent — a deletion). */
-  readonly present: boolean
-  /** The parser findings (empty when `present` is false). */
-  readonly errors: readonly string[]
-}
-
-/**
- * `gtd validate`'s shared evaluation: format the resolved rest's steering
- * file in place, then validate its formatted contents — the SAME
- * format-then-validate pair the `steering-file` guard's `prepare`/`check`
- * split runs, so both format and check the same way (an agent's fresh draft
- * and a human's edit are treated alike). `present` is false — and nothing is
- * formatted or validated — when the state declares no steering file, or the
- * file is absent (e.g. a human deleted `.gtd/REVIEW.md` to approve).
- */
-export const checkSteeringFile = (
-  rest: ResolvedRest,
-  context: TemplateContext,
-  file: string | undefined,
-): Effect.Effect<SteeringCheck, Error, GuardRequirements> =>
-  Effect.gen(function* () {
-    const mode = rest.stateDef.mode
-    if (file === undefined || mode === undefined) return { file, present: false, errors: [] }
-    const files = yield* RepoFiles
-    if (files.working(file) === undefined) return { file, present: false, errors: [] }
-    const resolved = resolveSteeringMode(rest.def, mode)
-    if (resolved === undefined) {
-      return yield* Effect.fail(new Error(unknownModeMessage(rest.def, rest.state, mode)))
-    }
-    yield* formatSteeringFile(resolved, file, context)
-    const content = files.working(file) ?? ""
-    const errors = yield* validateSteeringFile(resolved, file, content, context)
-    return { file, present: true, errors }
   })

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -18,6 +18,8 @@ import type { OnEdge, PendingChange } from "./PatternMachine.js"
 import { renderInitConfig } from "./workflows/templates.js"
 import { InMemRepo } from "./testing/InMemRepo.js"
 import { makeCapturingCliIo } from "./testing/cliIo.js"
+import { applyEmittedScript } from "./testing/EmittedScriptRecognizer.js"
+import { commitAll, shellQuote } from "./GitScript.js"
 
 /** Runs `args` through the real CLI shell (`runCli`) against an in-memory repo, returning the captured stdout/stderr/exit code — the same shape `tests/integration/support/world.ts`'s `@inmem` tier observes. */
 const run = async (
@@ -74,14 +76,29 @@ describe("gtd step <actor> --entry <state> — a custom workflow declaring `entr
     return repo
   }
 
-  it("the happy path writes one turn commit resting at the entered state", async () => {
+  it("the happy path previews the resulting subject and emits a required script — gtd itself writes nothing", async () => {
     const repo = seededRepo()
     const before = repo.commitHistory().length
     const { stdout, exitCode } = await run(repo, "step", "human", "--entry", "side-entry")
     expect(exitCode).toBe(0)
     expect(stdout).toContain("committed: gtd(human): side-entry")
-    expect(repo.commitHistory()).toHaveLength(before + 1)
-    expect(repo.lastCommitSubject()).toBe("gtd(human): side-entry")
+    // `gtd step --entry` is now a pure emitter — no commit lands until the
+    // external driver runs the printed script.
+    expect(repo.commitHistory()).toHaveLength(before)
+
+    const { stdout: jsonOut, exitCode: jsonExit } = await run(
+      repo,
+      "step",
+      "human",
+      "--entry",
+      "side-entry",
+      "--json",
+    )
+    expect(jsonExit).toBe(0)
+    const parsed = JSON.parse(jsonOut) as { subject: string; required: string }
+    expect(parsed.subject).toBe("gtd(human): side-entry")
+    expect(parsed.required).toContain(shellQuote(commitAll("gtd(human): side-entry")))
+    expect(repo.commitHistory()).toHaveLength(before)
   })
 
   it("--entry naming an undeclared state refuses, listing every enterable state", async () => {
@@ -125,9 +142,10 @@ describe("gtd step <actor> --entry <state> — a custom workflow declaring `entr
     expect(stderr).toContain("greeting")
   })
 
-  it("a declared --var override is recorded as a Gtd-Var trailer on the entry commit", async () => {
+  it("a declared --var override renders as a Gtd-Var trailer in the emitted commit script", async () => {
     const repo = seededRepo()
-    const { exitCode } = await run(
+    const before = repo.commitHistory().length
+    const { exitCode, stdout } = await run(
       repo,
       "step",
       "human",
@@ -135,27 +153,32 @@ describe("gtd step <actor> --entry <state> — a custom workflow declaring `entr
       "side-entry",
       "--var",
       "greeting=world",
+      "--json",
     )
     expect(exitCode).toBe(0)
-    const message = repo.commitHistory().at(-1)!.message
-    expect(message).toContain("Gtd-Var: greeting=world")
+    const parsed = JSON.parse(stdout) as { required: string }
+    expect(parsed.required).toContain("Gtd-Var: greeting=world")
+    expect(repo.commitHistory()).toHaveLength(before)
   })
 
-  it("a dirty working tree is CAPTURED, not refused (commitAllWithPrefix, unlike the old commitAsIs-based gtd review/gtd fix)", async () => {
+  it("a dirty working tree does not refuse entry — the emitted script would capture it (commitAll, unlike the old commitAsIs-based gtd review/gtd fix)", async () => {
     const repo = seededRepo()
     repo.writeFile("scratch.txt", "uncommitted\n")
     const before = repo.commitHistory().length
-    const { exitCode } = await run(repo, "step", "human", "--entry", "side-entry")
+    const { exitCode, stdout } = await run(repo, "step", "human", "--entry", "side-entry", "--json")
     expect(exitCode).toBe(0)
-    expect(repo.commitHistory()).toHaveLength(before + 1)
+    const parsed = JSON.parse(stdout) as { required: string }
+    expect(parsed.required.length).toBeGreaterThan(0)
+    expect(repo.commitHistory()).toHaveLength(before)
   })
 
-  it("the subcommand-less short form `gtd --entry <state>` dispatches as human", async () => {
+  it("the subcommand-less short form `gtd --entry <state>` dispatches as human, emitting the same script", async () => {
     const repo = seededRepo()
-    const { stdout, exitCode } = await run(repo, "--entry", "side-entry")
+    const { stdout, exitCode } = await run(repo, "--entry", "side-entry", "--json")
     expect(exitCode).toBe(0)
-    expect(stdout).toContain("committed: gtd(human): side-entry")
-    expect(repo.lastCommitSubject()).toBe("gtd(human): side-entry")
+    const parsed = JSON.parse(stdout) as { subject: string; required: string }
+    expect(parsed.subject).toBe("gtd(human): side-entry")
+    expect(parsed.required).toContain(shellQuote(commitAll("gtd(human): side-entry")))
   })
 })
 
@@ -172,7 +195,7 @@ describe("gtd step <actor> --entry <state> — the bundled unified template", ()
     return repo
   }
 
-  it("--entry review-gate.check --var reviewBase=<base> starts a review process anchored to that base", async () => {
+  it("--entry review-gate.check --var reviewBase=<base> emits a script that would start a review process anchored to that base", async () => {
     // review-gate.check declares a template-form `reviewBase:` (fixing the
     // whole process's diff base) — entering it requires a `--var
     // reviewBase=<commitish>` that resolves to an ancestor of HEAD distinct
@@ -191,21 +214,32 @@ describe("gtd step <actor> --entry <state> — the bundled unified template", ()
       "review-gate.check",
       "--var",
       `reviewBase=${base}`,
+      "--json",
     )
     expect(exitCode).toBe(0)
-    expect(stdout).toContain("committed: gtd(human): review-gate.check")
-    expect(repo.commitHistory()).toHaveLength(before + 1)
-    expect(repo.lastCommitSubject()).toBe("gtd(human): review-gate.check")
+    const parsed = JSON.parse(stdout) as { subject: string; required: string }
+    expect(parsed.subject).toBe("gtd(human): review-gate.check")
+    expect(parsed.required).toContain("gtd(human): review-gate.check")
+    expect(parsed.required).toContain(`Gtd-Review-Base: ${base}`)
+    expect(repo.commitHistory()).toHaveLength(before)
   })
 
-  it("--entry fix-precheck starts a fix process at the template's own fix-entry state", async () => {
+  it("--entry fix-precheck emits a script that would start a fix process at the template's own fix-entry state", async () => {
     const repo = seededRepo()
     const before = repo.commitHistory().length
-    const { stdout, exitCode } = await run(repo, "step", "human", "--entry", "fix-precheck")
+    const { stdout, exitCode } = await run(
+      repo,
+      "step",
+      "human",
+      "--entry",
+      "fix-precheck",
+      "--json",
+    )
     expect(exitCode).toBe(0)
-    expect(stdout).toContain("committed: gtd(human): fix-precheck")
-    expect(repo.commitHistory()).toHaveLength(before + 1)
-    expect(repo.lastCommitSubject()).toBe("gtd(human): fix-precheck")
+    const parsed = JSON.parse(stdout) as { subject: string; required: string }
+    expect(parsed.subject).toBe("gtd(human): fix-precheck")
+    expect(parsed.required).toContain("gtd(human): fix-precheck")
+    expect(repo.commitHistory()).toHaveLength(before)
   })
 })
 
@@ -472,9 +506,20 @@ describe("gtd next — refuses when HEAD names a state the current workflow no l
   it("`gtd abandon` itself still works for a renamed-away rest — the escape hatch it points to must not refuse right alongside everything else", async () => {
     const repo = seededRepoAt("gtd(agent): renamedAway")
     const before = repo.commitHistory().length
-    const { stdout, exitCode } = await run(repo, "abandon")
+
+    // Plain text keeps today's friendly wording (abandon now EMITS its
+    // mutation instead of performing it, so this call alone changes nothing).
+    const plain = await run(repo, "abandon")
+    expect(plain.exitCode).toBe(0)
+    expect(plain.stdout).toContain('abandoned the process resting at "renamedAway"')
+    expect(repo.commitHistory()).toHaveLength(before)
+
+    // Applying the emitted required script is what actually performs it.
+    const { stdout, exitCode } = await run(repo, "abandon", "--json")
     expect(exitCode).toBe(0)
-    expect(stdout).toContain('abandoned the process resting at "renamedAway"')
+    const { required } = JSON.parse(stdout) as { required: string }
+    const applied = applyEmittedScript(repo, new Map(), required)
+    expect(applied.ok).toBe(true)
     expect(repo.commitHistory()).toHaveLength(before - 1)
   })
 })
@@ -522,9 +567,162 @@ describe("gtd step — StepPayload.processTrace still receives plain state names
     repo.commitAllWithPrefix("gtd(human): looping")
     repo.writeFile("src/fix.ts", "export const x = 1\n")
 
-    const { exitCode } = await run(repo, "step", "agent")
+    const { stdout, exitCode } = await run(repo, "step", "agent", "--json")
     expect(exitCode).toBe(0)
+    const { required } = JSON.parse(stdout) as { required: string }
+    const applied = applyEmittedScript(repo, new Map(), required)
+    expect(applied.ok).toBe(true)
     expect(repo.lastCommitSubject()).toBe("gtd(agent): looping → idle")
+  })
+})
+
+describe("gtd check <mode> <file>", () => {
+  // Fully standalone (needsOf("check") === "none") — no config, no commit, no
+  // git state at all is required; the file just needs to exist in the
+  // in-memory worktree. Sample valid/invalid content mirrors
+  // OpenQuestions.test.ts's `questionsDoc`/`malformed` and
+  // ReviewDoc.test.ts's `reviewDoc`.
+
+  const validQaDoc = [
+    "# Plan",
+    "",
+    "## Open Questions",
+    "",
+    "### Which operations?",
+    "",
+    "add and subtract.",
+    "",
+    "## Answered Questions",
+    "",
+    "### What is the target platform?",
+    "",
+    "web only.",
+    "",
+  ].join("\n")
+
+  const invalidQaDoc = ["## Open Questions", "", "###", "", "no question text.", ""].join("\n")
+
+  const validReviewDoc = [
+    "# Review: abc1234",
+    "<!-- base: abc1234def5678901234567890123456789abcd -->",
+    "",
+    "## Add calculator",
+    "",
+    "- [x] ./src/calc.ts#1",
+    "",
+  ].join("\n")
+
+  const invalidReviewDoc = "Just some text\n"
+
+  const bareRepo = (): InMemRepo => new InMemRepo()
+
+  it("exits 0 with no output for valid qa content", async () => {
+    const repo = bareRepo()
+    repo.writeFile(".gtd/TODO.md", validQaDoc)
+    const { stdout, exitCode } = await run(repo, "check", "qa", ".gtd/TODO.md")
+    expect(exitCode).toBe(0)
+    expect(stdout).toBe("")
+  })
+
+  it("exits 0 with no output for valid review content", async () => {
+    const repo = bareRepo()
+    repo.writeFile("REVIEW.md", validReviewDoc)
+    const { stdout, exitCode } = await run(repo, "check", "review", "REVIEW.md")
+    expect(exitCode).toBe(0)
+    expect(stdout).toBe("")
+  })
+
+  it("invalid qa content prints each finding one per line and exits non-zero", async () => {
+    const repo = bareRepo()
+    repo.writeFile(".gtd/TODO.md", invalidQaDoc)
+    const { stdout, exitCode } = await run(repo, "check", "qa", ".gtd/TODO.md")
+    expect(exitCode).toBe(1)
+    expect(stdout.trim().split("\n")).toEqual([
+      "An '### ' question heading under '## Open Questions' or '## Answered Questions' has no question text",
+    ])
+  })
+
+  it("invalid review content prints each finding one per line and exits non-zero", async () => {
+    const repo = bareRepo()
+    repo.writeFile("REVIEW.md", invalidReviewDoc)
+    const { stdout, exitCode } = await run(repo, "check", "review", "REVIEW.md")
+    expect(exitCode).toBe(1)
+    const lines = stdout.trim().split("\n")
+    expect(lines).toContain(
+      "Missing or malformed '# Review: <hash>' header as the document's first line",
+    )
+    expect(lines).toContain("Missing '<!-- base: <hash> -->' comment")
+    expect(lines).toContain("REVIEW.md has no '##' chunks")
+  })
+
+  it("an absent file exits 0 with no output", async () => {
+    const repo = bareRepo()
+    const { stdout, exitCode } = await run(repo, "check", "qa", ".gtd/TODO.md")
+    expect(exitCode).toBe(0)
+    expect(stdout).toBe("")
+  })
+
+  it("an unknown mode is a usage-style error naming the known modes", async () => {
+    const repo = bareRepo()
+    repo.writeFile("TODO.md", validQaDoc)
+    const { stderr, exitCode } = await run(repo, "check", "bogus", "TODO.md")
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('unknown mode "bogus"')
+    expect(stderr).toContain("qa")
+    expect(stderr).toContain("review")
+  })
+
+  it("--json reports {valid: true, errors: []} for valid content", async () => {
+    const repo = bareRepo()
+    repo.writeFile(".gtd/TODO.md", validQaDoc)
+    const { stdout, exitCode } = await run(repo, "check", "qa", ".gtd/TODO.md", "--json")
+    expect(exitCode).toBe(0)
+    expect(JSON.parse(stdout.trim().split("\n")[0]!)).toEqual({ valid: true, errors: [] })
+  })
+
+  it("--json reports {valid: true, errors: []} for an absent file", async () => {
+    const repo = bareRepo()
+    const { stdout, exitCode } = await run(repo, "check", "qa", ".gtd/TODO.md", "--json")
+    expect(exitCode).toBe(0)
+    expect(JSON.parse(stdout.trim().split("\n")[0]!)).toEqual({ valid: true, errors: [] })
+  })
+
+  it("--json reports {valid: false, errors} for invalid content, still exiting non-zero", async () => {
+    const repo = bareRepo()
+    repo.writeFile(".gtd/TODO.md", invalidQaDoc)
+    const { stdout, exitCode } = await run(repo, "check", "qa", ".gtd/TODO.md", "--json")
+    expect(exitCode).toBe(1)
+    expect(JSON.parse(stdout.trim().split("\n")[0]!)).toEqual({
+      valid: false,
+      errors: [
+        "An '### ' question heading under '## Open Questions' or '## Answered Questions' has no question text",
+      ],
+    })
+  })
+
+  it("--json invalid content emits stdout as TWO newline-delimited JSON documents: the body, then Cli.ts's generic error envelope", async () => {
+    // `runCheckCommand` writes its own {valid,errors} body before failing the
+    // Effect; `Cli.ts`'s single envelope writer ALSO puts a {state:"error",prompt}
+    // object on stdout for any failing --json invocation — so this handler is
+    // the one command whose --json stdout is line-delimited JSON, not a single
+    // document. Pinned here because the first-line-only reads above wouldn't
+    // notice a regression on the second line.
+    const repo = bareRepo()
+    repo.writeFile(".gtd/TODO.md", invalidQaDoc)
+    const { stdout, exitCode } = await run(repo, "check", "qa", ".gtd/TODO.md", "--json")
+    expect(exitCode).toBe(1)
+    const lines = stdout.trim().split("\n")
+    expect(lines).toHaveLength(2)
+    expect(JSON.parse(lines[0]!)).toEqual({
+      valid: false,
+      errors: [
+        "An '### ' question heading under '## Open Questions' or '## Answered Questions' has no question text",
+      ],
+    })
+    expect(JSON.parse(lines[1]!)).toEqual({
+      state: "error",
+      prompt: 'gtd check: .gtd/TODO.md is not valid under mode "qa" (1 finding(s))',
+    })
   })
 })
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -10,25 +10,29 @@ import { RepoFiles } from "./RepoFiles.js"
 import { CommandRunner } from "./CommandRunner.js"
 import { GitService, type GitOperations } from "./Git.js"
 import {
+  contextAt,
   currentRest,
   currentRun,
   planEntry,
   planStep,
+  renderDecision,
   renderRest,
   restAt,
   UNATTRIBUTED_MODEL,
+  type ExecutableDecision,
   type ModelCost,
   type Rest,
   type RenderedRest,
   type RestRequirements,
 } from "./Edge.js"
-import { closeReviewWindow, openReviewWindow, REVIEW_HEAD_REF } from "./ReviewWindow.js"
 import {
-  clearRetainedHistory,
-  readRetainedHistory,
-  restorability,
-  retainHistory,
-} from "./RetainedHistory.js"
+  buildCloseWindowScript,
+  buildOpenWindowScript,
+  decideCloseWindow,
+  decideOpenWindow,
+  REVIEW_HEAD_REF,
+} from "./ReviewWindow.js"
+import { HISTORY_REF, readRetainedHistory, restorability } from "./RetainedHistory.js"
 import { startLspServer } from "./Lsp.js"
 import {
   buildCurrentStateModel,
@@ -38,15 +42,26 @@ import {
   type CurrentStateModel,
   type VizModel,
 } from "./Visualize.js"
-import { enforceStepGuards, checkSteeringFile } from "./StepGuards.js"
+import { enforceStepGuards } from "./StepGuards.js"
+import { builtInModeNames, seededValidateCommand, steeringFormatFor } from "./SteeringFormats.js"
+import { resolveSteeringMode, renderSteeringCommands, unknownModeMessage } from "./SteeringMode.js"
 import {
   initialStateOf,
   matchesPattern,
   parsePattern,
   type OnEdge,
   type PendingChange,
+  type StateMode,
+  type WorkflowDefinition,
 } from "./PatternMachine.js"
-import { type TemplateEdge } from "./PatternTemplates.js"
+import {
+  renderModeCommand,
+  renderStateTemplate,
+  type TemplateContext,
+  type TemplateEdge,
+} from "./PatternTemplates.js"
+import { deleteRef, hardResetTo, mixedResetTo, updateRef } from "./GitScript.js"
+import { emitScripts, type EmitPreconditions, type EmitStep } from "./Emit.js"
 
 export type CommandRequirements =
   | GitService
@@ -123,73 +138,224 @@ const runInitCommand = (
     }
   })
 
+/** `stepAsActor`'s result — a preview of what `gtd step` WOULD do, plus the `required`/`optional` bash the external driver runs to actually do it (see the module doc comment: `step` is now a pure read/emitter, never a git write itself). */
+interface StepResult {
+  readonly state: string
+  readonly subject: string | null
+  readonly cost: number | null
+  readonly model: string | null
+  readonly required: string
+  readonly optional: string
+}
+
+// git's empty-tree object — the precondition base for a script built against a
+// commit-less repo, where there is no real HEAD hash to pin to yet. Copied
+// here (rather than imported) exactly like `Edge.ts`/`ReviewWindow.ts` each
+// keep their own copy — see their doc comments on the same tradeoff.
+const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+/** The `EmitPreconditions` every script this file assembles asserts against: the resolved HEAD hash the snapshot driving it was taken at (falling back to `EMPTY_TREE` for a commit-less repo). */
+const headPreconditions = (currentCommit: string): EmitPreconditions => ({
+  expectedHead: currentCommit !== "" ? currentCommit : EMPTY_TREE,
+})
+
 /**
- * Authenticate `invoker` against the currently resolved rest and perform the
- * one resulting transition (commit or squash) for `gtd step`. `currentRest` →
- * `planStep` decides; the four capture gates sit between the plan and
- * `plan.perform` (nothing has written git yet), then `perform` runs. Refusals
- * fail the Effect with a formatted message; a no-op/reset returns `subject:
- * null` rather than failing (exit zero, per the plan's "clean no-op exits
- * zero").
+ * The resting state's own steering-mode commands, embedded ahead of the
+ * commit — the step script now carries its own format/validate pair instead
+ * of gtd running it in process (see `src/StepGuards.ts`'s shrunk registry).
+ * Empty for a state declaring no `file:`+`mode:` pair; an unknown mode name
+ * is a refusal, exactly as it was when gtd ran the commands itself.
+ */
+const steeringModeSteps = (
+  rest: Rest,
+): Effect.Effect<readonly EmitStep[], Error, CommandRequirements> =>
+  Effect.gen(function* () {
+    const file = rest.hints.file
+    const mode = rest.stateDef.mode
+    if (file === undefined || mode === undefined) return []
+    const resolved = resolveSteeringMode(rest.def, mode)
+    if (resolved === undefined) {
+      return yield* Effect.fail(new Error(unknownModeMessage(rest.def, rest.state, mode)))
+    }
+    const commands = yield* renderSteeringCommands(resolved, file, rest.context)
+    return commands.map((command): EmitStep => ({ kind: "command", command }))
+  })
+
+/**
+ * The `optional` half: re-open the review checkout window when the step lands
+ * at a `reviewWindow: true` state, `""` otherwise.
+ *
+ * `"HEAD"` is deliberately the literal string, not a resolved hash — git
+ * resolves it at the moment this script runs, which is after the required
+ * script has already landed the new commit (see `ReviewWindow.ts`'s
+ * `decideOpenWindow` doc comment). For the same reason it carries no
+ * `expectedHead` precondition: the HEAD it will see is a hash that does not
+ * exist yet at decide time (see `EmitPreconditions`).
+ */
+const openWindowScript = (rest: Rest, targetState: string): string => {
+  const decision = decideOpenWindow(rest.def, targetState, rest.run, "HEAD")
+  if (!decision.shouldOpen) return ""
+  return emitScripts(
+    {},
+    [],
+    [{ kind: "gitWrite", command: buildOpenWindowScript({ base: decision.base, head: "HEAD" }) }],
+  ).optional
+}
+
+/**
+ * The subject the required script WILL produce. A `"commit"` decision's is
+ * fully deterministic already; a `"squash"` decision's is only known once its
+ * template is rendered. Unreachable-on-failure: `renderDecision` already
+ * rendered the same template and refused the command if it threw, so this
+ * second render can never be the first to fail.
+ */
+const previewSubject = (
+  decision: ExecutableDecision,
+  rest: Rest,
+): Effect.Effect<string | null, never> =>
+  decision.kind === "commit"
+    ? Effect.succeed(decision.subject)
+    : Effect.try(() =>
+        renderStateTemplate(decision.template, rest.context).split("\n")[0]!.trim(),
+      ).pipe(Effect.catchAll(() => Effect.succeed(null)))
+
+/**
+ * The `required` half: everything that decides what lands in git, in order —
+ * the review-window CLOSE (when one is open), the resting state's own
+ * steering-mode format/validate commands, then the commit/squash steps
+ * themselves.
+ */
+const buildRequiredScript = (
+  rest: Rest,
+  decision: ExecutableDecision,
+  invoker: string,
+  cost: number | undefined,
+  model: string | undefined,
+): Effect.Effect<string, Error, CommandRequirements> =>
+  Effect.gen(function* () {
+    const git = yield* GitService
+    // Read-only: decides whether a review window is currently open and, when
+    // so, that it's safe to close (the same guards `closeReviewWindow` used to
+    // run) — a genuine refusal, exactly like the old `closeReviewWindow`
+    // failing, propagates as-is.
+    const closeDecision = yield* decideCloseWindow
+    // A squash renders its commit template at the TARGET commit state with
+    // this step's own `--cost`/`--model` folded in (`contextAt`) — not against
+    // `rest.context`, which is pinned to the resting state and carries
+    // `cost: 0`, so `it.processCost` would omit the squashing turn itself.
+    const commitContext =
+      decision.kind === "commit"
+        ? rest.context
+        : yield* contextAt(rest, decision.state, invoker, cost, model)
+    const steps: EmitStep[] = [
+      ...(closeDecision.shouldClose
+        ? [{ kind: "gitWrite" as const, command: buildCloseWindowScript(closeDecision.refs) }]
+        : []),
+      ...(yield* steeringModeSteps(rest)),
+      // A render failure (a squash template that fails against the pending
+      // tree) REFUSES the whole command — with the git write moved into the
+      // emitted script, this emitting path is the only place that failure can
+      // still be reported, and "nothing was committed" has to reach the caller
+      // as a non-zero exit rather than as a silently empty script.
+      ...(yield* renderDecision(git, rest, decision, commitContext, cost, model)),
+    ]
+    return emitScripts(headPreconditions(rest.context.currentCommit), steps).required
+  })
+
+/** A step's `--cost`/`--model` as `planStep` options — each key OMITTED (never `undefined`-valued) when the flag was not given. */
+const stepOptions = (
+  cost: number | undefined,
+  model: string | undefined,
+): { cost?: number; model?: string } => ({
+  ...(cost !== undefined ? { cost } : {}),
+  ...(model !== undefined ? { model } : {}),
+})
+
+/**
+ * Authenticate `invoker` against the currently resolved rest and decide the
+ * one resulting transition (commit or squash) for `gtd step` — WITHOUT
+ * performing it. `currentRest` → `planStep` decides; the step-capture guards
+ * (`src/StepGuards.ts`) then refuse before anything is emitted, exactly as
+ * before. What used to be `plan.perform` is now assembled by hand into a
+ * `required` script (the review-window CLOSE, when one is open; the resting
+ * state's steering-mode format/validate commands, when it declares
+ * `file:`+`mode:`; then the commit/squash steps themselves, via
+ * `renderDecision`) and an `optional` one (the review-window OPEN, when the
+ * target declares `reviewWindow: true`) — see the "Review-window management"
+ * recipe this mirrors. Refusals fail the Effect with a formatted message; a
+ * no-op returns `subject: null` and empty scripts (exit zero, nothing to
+ * run).
+ *
+ * `plan.scripts` (built by `Edge.ts` itself) is NOT reused here: its baked-in
+ * precondition uses `rest.context.currentCommit`, the LITERAL git HEAD at
+ * decide time — which, while a review window is open, is the window's BASE,
+ * not the real head — and it contains no window close/open steps at all. This
+ * function builds its own required/optional pair to sidestep that trap.
  */
 const stepAsActor = (
   invoker: string,
   cost?: number,
   model?: string,
-): Effect.Effect<
-  {
-    readonly state: string
-    readonly subject: string | null
-    readonly cost: number | null
-    readonly model: string | null
-  },
-  Error,
-  CommandRequirements
-> =>
+): Effect.Effect<StepResult, Error, CommandRequirements> =>
   Effect.gen(function* () {
     const rest = yield* currentRest
-    const plan = yield* planStep(rest, invoker, {
-      ...(cost !== undefined ? { cost } : {}),
-      ...(model !== undefined ? { model } : {}),
-    })
+    const plan = yield* planStep(rest, invoker, stepOptions(cost, model))
 
     if (plan.kind === "refusal") {
       return yield* Effect.fail(new Error(plan.message))
     }
     if (plan.kind === "noop") {
-      return { state: plan.state, subject: null, cost: null, model: null }
+      return {
+        state: plan.state,
+        subject: null,
+        cost: null,
+        model: null,
+        required: "",
+        optional: "",
+      }
+    }
+
+    // `StepPlan.decision`'s declared type is the full `StepDecision` union
+    // (Edge.ts never narrows it to match its own sibling `kind` field) — this
+    // re-narrows it to `ExecutableDecision`, which is always true in practice
+    // since `plan.kind` is already known to be `"commit" | "squash"` here.
+    const decision = plan.decision
+    if (decision.kind !== "commit" && decision.kind !== "squash") {
+      return yield* Effect.fail(
+        new Error(
+          `gtd: internal error — plan kind "${plan.kind}" but decision kind "${decision.kind}"`,
+        ),
+      )
     }
 
     // Step-capture guards (edge, not engine — see src/StepGuards.ts): the
     // steering-file, review-signoff, feedback-progress and answer-completeness
-    // guards, in registry order, each able to refuse before anything commits.
-    // They sit between the plan and `plan.perform`, so nothing has written git
-    // yet. `file` is the rest's already-rendered `file:` hint — rendered once
-    // when the snapshot was built, not re-rendered per guard.
+    // guards, in registry order, each able to refuse before anything is
+    // emitted. `file` is the rest's already-rendered `file:` hint — rendered
+    // once when the snapshot was built, not re-rendered per guard.
     yield* enforceStepGuards({
       rest,
       context: rest.context,
       file: rest.hints.file,
       changes: rest.changes,
       invoker,
-      kind: plan.kind,
+      kind: decision.kind,
     })
 
-    const outcome = yield* plan.perform
-    if (outcome.kind === "reset" || outcome.kind === "noop") {
-      return { state: outcome.state, subject: null, cost: null, model: null }
+    const targetState = decision.kind === "commit" ? decision.to : decision.state
+    return {
+      state: rest.state,
+      subject: yield* previewSubject(decision, rest),
+      cost: cost ?? null,
+      model: model ?? null,
+      required: yield* buildRequiredScript(rest, decision, invoker, cost, model),
+      optional: openWindowScript(rest, targetState),
     }
-    return { state: rest.state, subject: outcome.subject, cost: cost ?? null, model: model ?? null }
   })
 
-/** Renders `stepAsActor`'s result for `gtd step`. */
+/** Renders `stepAsActor`'s result for `gtd step`. Plain text names the (previewed) resulting subject exactly as before; `--json` additionally carries `required`/`optional` — the bash the external driver runs to actually land it. */
 const reportStepResult = (
-  result: {
-    readonly state: string
-    readonly subject: string | null
-    readonly cost: number | null
-    readonly model: string | null
-  },
+  result: StepResult,
   json: boolean,
   write: (chunk: string) => void,
 ): void => {
@@ -200,6 +366,8 @@ const reportStepResult = (
         subject: result.subject,
         ...(result.cost !== null ? { cost: result.cost } : {}),
         ...(result.model !== null ? { model: result.model } : {}),
+        required: result.required,
+        optional: result.optional,
       }) + "\n",
     )
   } else {
@@ -285,17 +453,26 @@ const runEntryCommand = (
     if (plan.kind === "refusal") {
       return yield* Effect.fail(new Error(plan.message))
     }
-    yield* plan.perform
+    // `plan.scripts` is safe to reuse verbatim here (unlike `stepAsActor`'s own
+    // build): an entry always lands fresh at a brand-new process's first
+    // state, which can never have an open review window and — per
+    // `enterableStates`/the bundled template — declares no `file:`/`mode:` of
+    // its own to validate ahead of the commit (that gate applies to the NEXT
+    // step away from the entered state, once its actor has produced
+    // something, not to entering it).
     if (json) {
-      write(JSON.stringify({ state: plan.state, subject: plan.subject }) + "\n")
+      write(
+        JSON.stringify({
+          state: plan.state,
+          subject: plan.subject,
+          required: plan.scripts.required,
+          optional: plan.scripts.optional,
+        }) + "\n",
+      )
     } else {
       write(`committed: ${plan.subject}\n`)
     }
   })
-
-// git's empty-tree object — `ProcessRun.startParentHash` when the process
-// covers the whole history, so there is no earlier commit to rewind to.
-const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 /**
  * `gtd abandon`: end the process currently underway WITHOUT completing it,
@@ -328,6 +505,13 @@ const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
  * that fails when there is nothing to recover is a worse tool. The one refusal
  * is a process whose first commit is the repository's own root commit: there is
  * no earlier commit to rewind to.
+ *
+ * The read-side refusal/no-op checks above stay direct `GitService` reads (the
+ * documented exception, `AGENTS.md`) — abandon must still work when a `Rest`
+ * would refuse. The actual mutation (retaining history, then the mixed reset)
+ * is no longer PERFORMED here: it's emitted as a `required` bash script for
+ * the external driver to run, built from `src/GitScript.ts`'s pure
+ * `updateRef`/`mixedResetTo` — narrowing the exception further still.
  */
 const runAbandonCommand = (
   json: boolean,
@@ -358,11 +542,36 @@ const runAbandonCommand = (
       )
     }
 
-    const tip = yield* git.resolveRef("HEAD")
-    yield* retainHistory(git, tip, run.startParentHash)
+    // An open review checkout window has rewound real HEAD to the review
+    // base, so the reviewed branch tip — the thing abandon must retain and
+    // rewind FROM — is the window's saved head, not `HEAD`. Closing it is the
+    // required script's first step, exactly as the deleted review-window
+    // bracket used to do before the command ran.
+    const closeDecision = yield* decideCloseWindow
+    const tip = closeDecision.shouldClose
+      ? closeDecision.refs.headHash
+      : yield* git.resolveRef("HEAD")
+    // A preview of the resulting HEAD's subject — read at `startParentHash`
+    // directly rather than after an actual reset, since none has happened yet.
+    const subject = yield* git.lastCommitSubject(run.startParentHash)
 
-    yield* git.mixedResetTo(run.startParentHash)
-    const subject = yield* git.lastCommitSubject()
+    const steps: EmitStep[] = [
+      ...(closeDecision.shouldClose
+        ? [
+            {
+              kind: "gitWrite" as const,
+              command: buildCloseWindowScript(closeDecision.refs),
+            },
+          ]
+        : []),
+      { kind: "gitWrite", command: updateRef(HISTORY_REF, tip) },
+      { kind: "gitWrite", command: mixedResetTo(run.startParentHash) },
+    ]
+    // The precondition is real HEAD (the rewound one, while a window is open)
+    // — that is what `git rev-parse HEAD` will actually report when the
+    // script runs, before its own close step moves it.
+    const required = emitScripts(headPreconditions(yield* git.resolveRef("HEAD")), steps).required
+
     if (json) {
       write(
         JSON.stringify({
@@ -370,6 +579,8 @@ const runAbandonCommand = (
           abandoned: true,
           from: restState,
           head: run.startParentHash,
+          required,
+          optional: "",
         }) + "\n",
       )
     } else {
@@ -392,7 +603,10 @@ const runAbandonCommand = (
  * Guarded by `restorability` so it never discards work it didn't create:
  * refuses on a dirty working tree, when there is no retained history, and
  * when HEAD has advanced past the retained tip with commits that would be
- * lost by resetting.
+ * lost by resetting. Those checks stay direct `GitService` reads (same
+ * documented exception as `gtd abandon`); the mutation itself (the hard
+ * reset, then clearing the retained-history ref) is emitted as a `required`
+ * script instead of performed here.
  */
 const runRestoreCommand = (
   json: boolean,
@@ -433,15 +647,27 @@ const runRestoreCommand = (
       )
     }
 
-    yield* git.hardResetTo(tip)
-    yield* clearRetainedHistory(git)
+    // Previews of the resulting state/subject — resolved at `tip` directly
+    // rather than after an actual reset, since none has happened yet.
+    const after = yield* restAt(tip)
+    const subject = yield* git.lastCommitSubject(tip)
 
-    const after = yield* currentRest
-    const subject = yield* git.lastCommitSubject()
+    const steps: EmitStep[] = [
+      { kind: "gitWrite", command: hardResetTo(tip) },
+      { kind: "gitWrite", command: deleteRef(HISTORY_REF) },
+    ]
+    const required = emitScripts(headPreconditions(headHash), steps).required
 
     if (json) {
       write(
-        JSON.stringify({ state: after.state, restored: true, to: tip, from: before.state }) + "\n",
+        JSON.stringify({
+          state: after.state,
+          restored: true,
+          to: tip,
+          from: before.state,
+          required,
+          optional: "",
+        }) + "\n",
       )
     } else {
       write(
@@ -453,21 +679,55 @@ const runRestoreCommand = (
   })
 
 /**
+ * The mode's own resolved VALIDATE command, rendered against `file` — the
+ * command `selfValidateInstruction` names. Resolution mirrors
+ * `renderSteeringCommands`'s own layering (`src/SteeringMode.ts`) but picks
+ * out the validate half alone: a declared `validate:` command (or, for
+ * `qa`/`review`, `PatternConfig.ts`'s own seeded `gtd check <mode> '<file>'`
+ * default — every compiled definition carries ONE of the two) renders as the
+ * LAST command `renderSteeringCommands` would emit (format, if any, always
+ * comes first); a mode resolving to a `"builtin"` validator (no shell command
+ * at all — only reachable when `resolveSteeringMode` is asked about a mode
+ * outside the active definition's own compiled `modes:`, since a real
+ * definition always seeds one) or to no mode at all names the leaf
+ * `gtd check <mode> '<file>'` invocation directly instead
+ * (`seededValidateCommand`), so there is always something concrete to name.
+ */
+const resolveSelfValidateCommand = (
+  def: WorkflowDefinition,
+  mode: StateMode,
+  file: string,
+  context: TemplateContext,
+): Effect.Effect<string, Error> =>
+  Effect.gen(function* () {
+    const resolved = resolveSteeringMode(def, mode)
+    if (resolved?.validate?.kind === "command") {
+      const rendered = yield* renderSteeringCommands(resolved, file, context)
+      const validateCommand = rendered[rendered.length - 1]
+      if (validateCommand !== undefined) return validateCommand
+    }
+    return yield* Effect.try({
+      try: () => renderModeCommand(seededValidateCommand(mode), { ...context, file }),
+      catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+    })
+  })
+
+/**
  * The self-validation instruction gtd APPENDS to a `prompt` rest that declares
  * both `file:` and `mode:` — i.e. a state whose actor hands over a steering
- * file `gtd validate` formats and checks. Appended ONLY to plain `gtd next`
- * output (for a human or a simple driver who reads the prompt and hands it to
- * an agent, so the agent self-validates); withheld from `gtd next --json`,
- * where the driving loop instead runs `gtd validate` after the turn and
- * re-prompts on findings (see the `bin/gtd` loop driver). This is
- * advisory: `gtd step` runs the same format-and-validate gate and REFUSES a
- * turn whose steering file is invalid (see `stepAsActor`), so a malformed file
- * is never captured whether or not this instruction was followed.
+ * file some command validates. Appended ONLY to plain `gtd next` output (for a
+ * human or a simple driver who reads the prompt and hands it to an agent, so
+ * the agent self-validates); withheld from `gtd next --json`, where the
+ * driving loop instead runs `gtd validate` after the turn and re-prompts on
+ * findings (see the `bin/gtd` loop driver). This is advisory: `gtd step`
+ * embeds that same command ahead of its own commit and REFUSES a turn whose
+ * steering file is invalid (see `stepAsActor`), so a malformed file is never
+ * captured whether or not this instruction was followed.
  */
-const selfValidateInstruction = (file: string): string =>
-  `\nBefore finishing your turn, run \`gtd validate\` — it formats and checks ` +
-  `${file} — and fix every violation it reports until it exits cleanly. Do not ` +
-  `finish while it still reports violations.\n`
+const selfValidateInstruction = (command: string, file: string): string =>
+  `\nBefore finishing your turn, run \`${command}\` — it checks ${file} — and fix ` +
+  `every violation it reports until it exits cleanly. Do not finish while it ` +
+  `still reports violations.\n`
 
 /** True when a rendered rest is a `prompt` turn that hands over a validatable steering file (`file:`+`mode:` both declared). */
 const emitsValidatablePrompt = (rendered: RenderedRest): boolean =>
@@ -489,10 +749,15 @@ const nextJsonOutput = (rendered: RenderedRest): string =>
     ...(rendered.edges.length > 0 ? { edges: rendered.edges } : {}),
   }) + "\n"
 
-/** `gtd next`'s plain-text output: the rendered content (newline-terminated), plus the self-validation instruction when the rest is a validatable prompt (see `emitsValidatablePrompt`). */
-const nextPlainOutput = (rendered: RenderedRest): string => {
+/** `gtd next`'s plain-text output: the rendered content (newline-terminated), plus the self-validation instruction (naming `selfValidateCommand`, when resolved) when the rest is a validatable prompt. */
+const nextPlainOutput = (
+  rendered: RenderedRest,
+  selfValidateCommand: string | undefined,
+): string => {
   const base = rendered.content.endsWith("\n") ? rendered.content : rendered.content + "\n"
-  return emitsValidatablePrompt(rendered) ? base + selfValidateInstruction(rendered.file!) : base
+  return emitsValidatablePrompt(rendered) && selfValidateCommand !== undefined
+    ? base + selfValidateInstruction(selfValidateCommand, rendered.file!)
+    : base
 }
 
 const runNextCommand = (
@@ -500,21 +765,34 @@ const runNextCommand = (
   write: (chunk: string) => void,
 ): Effect.Effect<void, Error, CommandRequirements> =>
   Effect.gen(function* () {
-    const rendered = yield* renderRest(yield* currentRest)
-    write(json ? nextJsonOutput(rendered) : nextPlainOutput(rendered))
+    const rest = yield* currentRest
+    const rendered = yield* renderRest(rest)
+    // Advisory only (see `selfValidateInstruction`'s doc comment) — a render
+    // failure here must not fail `gtd next` itself, so it degrades to omitting
+    // the instruction rather than propagating.
+    const selfValidateCommand =
+      !json && emitsValidatablePrompt(rendered)
+        ? yield* resolveSelfValidateCommand(
+            rest.def,
+            rendered.mode!,
+            rendered.file!,
+            rest.context,
+          ).pipe(Effect.catchAll(() => Effect.succeed(undefined)))
+        : undefined
+    write(json ? nextJsonOutput(rendered) : nextPlainOutput(rendered, selfValidateCommand))
   })
 
 /**
- * `gtd validate [--json]`: format (in place) then validate the steering file
- * the resolved rest declares (`file:` rendered, `mode:` selecting how), over
- * its WORKING-TREE contents. A state with no `file:`/`mode:`, or an absent
- * file, has nothing to validate (exit 0). A clean verdict exits 0; violations
- * FAIL the Effect with the findings (one per line), so the process exits
- * non-zero — the signal a producing agent (or the driver) loops on until the
- * file is valid. A built-in mode reuses the canonical `OpenQuestions`/
- * `ReviewDoc` parsers (the same the LSP publishes), so there is one source of
- * truth per format and no bash port; any `modes:`-declared command runs
- * instead (or, for `format:`, in addition).
+ * `gtd validate [--json]`: emit the script that would format (in place) then
+ * validate the steering file the resolved rest declares (`file:` rendered,
+ * `mode:` selecting how) — the SAME commands `gtd step`'s capture guard now
+ * embeds ahead of its own commit (see `stepAsActor`), rendered here for a
+ * human or agent to run directly. gtd itself reads no file and executes
+ * nothing: a state with no `file:`/`mode:`, or a file absent from the working
+ * tree, has nothing to validate (`script: ""`, exit 0 either way) — the
+ * verdict now lives in the emitted script's own future exit code, not this
+ * command's, so this never fails on a bad file. `RepoFiles`/`FileSystem` is
+ * used only to check the file's PRESENCE, never to read or judge its content.
  */
 const runValidateCommand = (
   json: boolean,
@@ -522,30 +800,121 @@ const runValidateCommand = (
 ): Effect.Effect<void, Error, CommandRequirements> =>
   Effect.gen(function* () {
     const rest = yield* currentRest
-    const { file, present, errors } = yield* checkSteeringFile(rest, rest.context, rest.hints.file)
-    if (!present) {
-      if (json) write(JSON.stringify({ state: rest.state, valid: true, errors: [] }) + "\n")
-      else write(`nothing to validate at "${rest.state}"\n`)
-      return
-    }
-    if (errors.length === 0) {
+    const file = rest.hints.file
+    const mode = rest.stateDef.mode
+
+    const emitNothingToValidate = (): void => {
       if (json) {
         write(
           JSON.stringify({
             state: rest.state,
-            file,
-            mode: rest.stateDef.mode,
-            valid: true,
-            errors: [],
+            ...(file !== undefined ? { file } : {}),
+            ...(mode !== undefined ? { mode } : {}),
+            script: "",
           }) + "\n",
         )
       } else {
-        write(`${file}: valid\n`)
+        write(`nothing to validate at "${rest.state}"\n`)
       }
+    }
+
+    if (file === undefined || mode === undefined) {
+      emitNothingToValidate()
       return
     }
+
+    const fs = yield* FileSystem.FileSystem
+    const toError = (e: unknown): Error => (e instanceof Error ? e : new Error(String(e)))
+    const present = yield* fs.exists(file).pipe(Effect.mapError(toError))
+    if (!present) {
+      emitNothingToValidate()
+      return
+    }
+
+    const resolved = resolveSteeringMode(rest.def, mode)
+    if (resolved === undefined) {
+      return yield* Effect.fail(new Error(unknownModeMessage(rest.def, rest.state, mode)))
+    }
+    const commands = yield* renderSteeringCommands(resolved, file, rest.context)
+    const script = emitScripts(
+      headPreconditions(rest.context.currentCommit),
+      commands.map((command): EmitStep => ({ kind: "command", command })),
+    ).required
+
+    if (json) {
+      write(JSON.stringify({ state: rest.state, file, mode, script }) + "\n")
+    } else {
+      write(script.length > 0 ? `${script}\n` : `nothing to validate at "${rest.state}"\n`)
+    }
+  })
+
+/**
+ * `gtd check <mode> <file>`: read `<file>` and run the BUILT-IN steering
+ * format named `<mode>`'s pure parser over its contents, printing each
+ * finding one per line and exiting non-zero when there are any. Unlike `gtd
+ * validate` (which resolves the currently resting state's own `file:`/`mode:`
+ * and formats before validating), this resolves NO workflow state and reads
+ * NO config — both `mode` and `file` are given explicitly, so it needs only
+ * `FileSystem.FileSystem` and runs from any directory. This is what a
+ * workflow's seeded `validate:` command (`SteeringFormats.ts`'s
+ * `seededValidateCommand`) invokes as a leaf step; it does no formatting
+ * in-place — an emitted script has no template context to format against.
+ *
+ * An absent file mirrors `gtd validate`'s own absent-file behavior: exit 0,
+ * no output in plain mode, `{valid: true, errors: []}` under `--json`. A
+ * clean parse is the same shape. A non-clean parse writes `--json`'s
+ * `{valid: false, errors}` body (or each finding, one per line, in plain
+ * mode) BEFORE failing the Effect. In PLAIN mode the failure then carries only
+ * a summary message, landing on stderr alone (`cliErrorLine`'s line) — the
+ * findings are already on stdout. Under `--json`, `Cli.ts`'s single envelope
+ * writer (`report`) ALSO puts its own `{state:"error",prompt}` object on
+ * stdout for any failing Effect, so a `--json` invocation with findings emits
+ * stdout as two newline-delimited JSON documents — this handler's own
+ * `{valid,errors}` body first, then the generic error envelope — rather than
+ * one; a consumer must read line-delimited JSON, not `JSON.parse(stdout)`
+ * whole. Kept as the pragmatic resolution of a real tension in this command's
+ * two governing requirements ("exits non-zero" and "`--json` reports
+ * `{valid,errors}`"): the alternative was piping a `--json` failure through a
+ * NEW exit-code channel bypassing `Cli.ts`'s shared envelope entirely, which
+ * every other command's `--json` failure goes through today.
+ */
+const runCheckCommand = (
+  mode: string,
+  file: string,
+  json: boolean,
+  write: (chunk: string) => void,
+): Effect.Effect<void, Error, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const format = steeringFormatFor(mode)
+    if (format === undefined) {
+      return yield* Effect.fail(
+        new Error(
+          `gtd check: unknown mode "${mode}" — known modes: ${builtInModeNames().join(", ")}`,
+        ),
+      )
+    }
+
+    const fs = yield* FileSystem.FileSystem
+    const toError = (e: unknown): Error => (e instanceof Error ? e : new Error(String(e)))
+    const present = yield* fs.exists(file).pipe(Effect.mapError(toError))
+    const errors = present
+      ? format.validate(yield* fs.readFileString(file).pipe(Effect.mapError(toError)))
+      : []
+
+    if (errors.length === 0) {
+      if (json) write(JSON.stringify({ valid: true, errors: [] }) + "\n")
+      return
+    }
+
+    if (json) {
+      write(JSON.stringify({ valid: false, errors }) + "\n")
+    } else {
+      write(errors.join("\n") + "\n")
+    }
     return yield* Effect.fail(
-      new Error(`${file} is not valid:\n${errors.map((e) => `  - ${e}`).join("\n")}`),
+      new Error(
+        `gtd check: ${file} is not valid under mode "${mode}" (${errors.length} finding(s))`,
+      ),
     )
   })
 
@@ -906,6 +1275,7 @@ export const needsOf = (kind: Command["kind"]): Needs => {
     case "lsp":
       return "none"
     case "init":
+    case "check":
       return "fs"
     case "visualize":
       return "config"
@@ -914,8 +1284,13 @@ export const needsOf = (kind: Command["kind"]): Needs => {
   }
 }
 
-/** The three kinds that never touch the repo-root guard / review-window bracket — pinned so a new standalone kind can't be added silently. */
-export const standaloneKinds = (): readonly Command["kind"][] => ["lsp", "init", "visualize"]
+/** The four kinds that never touch the repo-root guard / review-window bracket — pinned so a new standalone kind can't be added silently. */
+export const standaloneKinds = (): readonly Command["kind"][] => [
+  "lsp",
+  "init",
+  "visualize",
+  "check",
+]
 
 /** Dispatches to the named `run*Command` handler for every `Command.kind` — the counterpart of `Cli.ts`'s `parseArgv`, which has already validated every field a handler receives. */
 // fallow-ignore-next-line complexity
@@ -945,54 +1320,24 @@ const dispatchCommand = (
       return runStatusCommand(json, write)
     case "validate":
       return runValidateCommand(json, write)
+    case "check":
+      return runCheckCommand(command.mode, command.file, json, write)
   }
 }
 
 /**
- * Runs `command` inside the bracket every state-touching command shares: the
- * repo-root guard, then close-any-open-review-window before the command sees
- * HEAD, then re-arm it afterward whether `command` succeeded or refused (see
- * `closeReviewWindow`/`openReviewWindow`).
- */
-const runInReviewWindowBracket = (
-  git: GitOperations,
-  fs: FileSystem.FileSystem,
-  command: Effect.Effect<void, Error, CommandRequirements>,
-): Effect.Effect<void, Error, CommandRequirements> =>
-  Effect.gen(function* () {
-    yield* assertRunningFromRepoRoot(git, fs)
-    // Restore the real HEAD before anything reads or mutates workflow state:
-    // while a review checkout window is open (see src/ReviewWindow.ts), HEAD is
-    // rewound to the review base, so the pure machine would otherwise resolve
-    // against the wrong commit. Keyed on the ref alone — a no-op when no window
-    // is open.
-    //
-    // Second, independent reason this must come BEFORE the subcommand runs:
-    // the computed memory key (`memoryKeyFor`, package 05/06) is derived from
-    // `ProcessRun.trace`, which is walked back from HEAD — while the window is
-    // open, HEAD is rewound and the trace truncated, which would silently
-    // resolve the wrong `entryIndex` (and so the wrong commit-anchored token)
-    // rather than failing loudly.
-    yield* closeReviewWindow
-
-    // Re-arm the window after the subcommand — on success AND on refusal/error,
-    // and after read-only commands too (every command opts into window
-    // management), so the editor's diff view stays consistent no matter which
-    // command the loop last ran. The subcommand's own error takes priority; a
-    // re-arm failure only surfaces when the subcommand itself succeeded.
-    const outcome = yield* Effect.either(command)
-    const rearm = yield* Effect.either(openReviewWindow)
-    if (Either.isLeft(outcome)) return yield* Effect.fail(outcome.left)
-    if (Either.isLeft(rearm)) return yield* Effect.fail(rearm.left)
-  })
-
-/**
  * The one entry point `Cli.ts`'s `runCli` calls for a resolved `Command`:
  * dispatches to the matching `run*Command` handler (see `dispatchCommand`),
- * wrapped in the repo-root guard + review-window bracket exactly when
- * `needsOf(command.kind) === "state"` — `lsp`/`init`/`visualize` (the
- * `standaloneKinds`) run bare. `Cli.ts` has already validated every field on
- * `command` (arity, flag scope, decoding), so nothing here re-parses argv.
+ * wrapped in the repo-root guard exactly when `needsOf(command.kind) ===
+ * "state"` — `lsp`/`init`/`visualize`/`check` (the `standaloneKinds`) run
+ * bare. `Cli.ts` has already validated every field on `command` (arity, flag
+ * scope, decoding), so nothing here re-parses argv.
+ *
+ * No review-window close/open bracket runs here any more: every state-command
+ * handler (see `stepAsActor`) now decides for itself, off `ReviewWindow.ts`'s
+ * pure `decideCloseWindow`/`decideOpenWindow`, whether a close/open belongs in
+ * the script it emits — there is no in-process HEAD to rewind ahead of time
+ * (gtd itself no longer writes git for a state command at all).
  */
 export const runCommand = (
   command: Command,
@@ -1004,6 +1349,7 @@ export const runCommand = (
   return Effect.gen(function* () {
     const git = yield* GitService
     const fs = yield* FileSystem.FileSystem
-    yield* runInReviewWindowBracket(git, fs, dispatch)
+    yield* assertRunningFromRepoRoot(git, fs)
+    yield* dispatch
   })
 }

--- a/src/program.ts
+++ b/src/program.ts
@@ -148,15 +148,16 @@ interface StepResult {
   readonly optional: string
 }
 
-// git's empty-tree object — the precondition base for a script built against a
-// commit-less repo, where there is no real HEAD hash to pin to yet. Copied
-// here (rather than imported) exactly like `Edge.ts`/`ReviewWindow.ts` each
-// keep their own copy — see their doc comments on the same tradeoff.
+// git's empty-tree object — the abandon command's first-commit guard uses
+// this to recognize a process that starts at the repository's very first
+// commit (no earlier commit to rewind to). Copied here (rather than imported)
+// exactly like `Edge.ts`/`ReviewWindow.ts` each keep their own copy — see
+// their doc comments on the same tradeoff.
 const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
-/** The `EmitPreconditions` every script this file assembles asserts against: the resolved HEAD hash the snapshot driving it was taken at (falling back to `EMPTY_TREE` for a commit-less repo). */
+/** The `EmitPreconditions` every script this file assembles asserts against: the resolved HEAD hash the snapshot driving it was taken at — `""` when the repo has no commits yet, `headAssertion`'s own convention for that case. */
 const headPreconditions = (currentCommit: string): EmitPreconditions => ({
-  expectedHead: currentCommit !== "" ? currentCommit : EMPTY_TREE,
+  expectedHead: currentCommit,
 })
 
 /**

--- a/src/testing/EmittedScriptRecognizer.test.ts
+++ b/src/testing/EmittedScriptRecognizer.test.ts
@@ -1,0 +1,610 @@
+import { describe, expect, it } from "vitest"
+import {
+  commitAll,
+  commitAsIs,
+  deleteRef,
+  discardPending,
+  hardResetTo,
+  mixedResetTo,
+  restoreStagedFrom,
+  softResetTo,
+  updateRef,
+} from "../GitScript.js"
+import { emitScripts, headAssertion, reviewWindowAssertion, type EmitStep } from "../Emit.js"
+import {
+  buildCloseWindowScript,
+  buildOpenWindowScript,
+  REVIEW_BASE_REF,
+  REVIEW_HEAD_REF,
+} from "../ReviewWindow.js"
+import { applyEmittedScript, preconditionHeadEquals } from "./EmittedScriptRecognizer.js"
+import { InMemRepo } from "./InMemRepo.js"
+import type { ScriptedCommand } from "./Layers.js"
+
+const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+const snapshot = (repo: InMemRepo) => ({
+  head: repo.resolveRef("HEAD"),
+  message: repo.lastCommitMessage(),
+  status: repo.statusPorcelain(),
+  files: repo.pathsUnder("").map((path) => [path, repo.readFile(path)]),
+})
+
+const NO_COMMANDS: ReadonlyMap<string, ScriptedCommand> = new Map()
+
+describe("applyEmittedScript — the 9 GitScript builders", () => {
+  it("commitAll: stages the worktree and commits, like commitAllWithPrefix", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    const twin = new InMemRepo()
+    twin.writeFile("a.txt", "1")
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, commitAll("gtd(agent): building"))
+    twin.commitAllWithPrefix("gtd(agent): building")
+
+    expect(result).toEqual({ ok: true })
+    expect(snapshot(repo)).toEqual(snapshot(twin))
+  })
+
+  it("commitAsIs: commits whatever is already staged, without an implicit add", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.stageAll()
+    repo.writeFile("a.txt", "2") // pending worktree change, left OUT of the index on purpose
+    const twin = new InMemRepo()
+    twin.writeFile("a.txt", "1")
+    twin.stageAll()
+    twin.writeFile("a.txt", "2")
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, commitAsIs("gtd(agent): as-is"))
+    twin.commitAsIs("gtd(agent): as-is")
+
+    expect(result).toEqual({ ok: true })
+    expect(snapshot(repo)).toEqual(snapshot(twin))
+  })
+
+  it("softResetTo: moves HEAD only, leaving index and worktree untouched", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+    const first = repo.resolveRef("HEAD")!
+    repo.writeFile("b.txt", "2")
+    repo.commitAllWithPrefix("chore: second")
+    const twin = new InMemRepo()
+    twin.writeFile("a.txt", "1")
+    twin.commitAllWithPrefix("chore: first")
+    twin.writeFile("b.txt", "2")
+    twin.commitAllWithPrefix("chore: second")
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, softResetTo(first))
+    twin.softResetTo(first)
+
+    expect(result).toEqual({ ok: true })
+    expect(snapshot(repo)).toEqual(snapshot(twin))
+    expect(repo.resolveRef("HEAD")).toBe(first)
+  })
+
+  it("mixedResetTo: moves HEAD and index, leaving the worktree untouched", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+    const first = repo.resolveRef("HEAD")!
+    repo.writeFile("b.txt", "2")
+    repo.commitAllWithPrefix("chore: second")
+    const twin = new InMemRepo()
+    twin.writeFile("a.txt", "1")
+    twin.commitAllWithPrefix("chore: first")
+    twin.writeFile("b.txt", "2")
+    twin.commitAllWithPrefix("chore: second")
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, mixedResetTo(first))
+    twin.mixedResetTo(first)
+
+    expect(result).toEqual({ ok: true })
+    expect(snapshot(repo)).toEqual(snapshot(twin))
+  })
+
+  it("hardResetTo: moves HEAD, index, AND worktree", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+    const first = repo.resolveRef("HEAD")!
+    repo.writeFile("b.txt", "2")
+    repo.commitAllWithPrefix("chore: second")
+    const twin = new InMemRepo()
+    twin.writeFile("a.txt", "1")
+    twin.commitAllWithPrefix("chore: first")
+    twin.writeFile("b.txt", "2")
+    twin.commitAllWithPrefix("chore: second")
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, hardResetTo(first))
+    twin.hardResetTo(first)
+
+    expect(result).toEqual({ ok: true })
+    expect(snapshot(repo)).toEqual(snapshot(twin))
+    expect(repo.hasPath("b.txt")).toBe(false)
+  })
+
+  it("discardPending: drops every pending change, tracked or untracked", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+    repo.writeFile("a.txt", "changed")
+    repo.writeFile("untracked.txt", "new")
+    const twin = new InMemRepo()
+    twin.writeFile("a.txt", "1")
+    twin.commitAllWithPrefix("chore: first")
+    twin.writeFile("a.txt", "changed")
+    twin.writeFile("untracked.txt", "new")
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, discardPending())
+    twin.discardPending()
+
+    expect(result).toEqual({ ok: true })
+    expect(snapshot(repo)).toEqual(snapshot(twin))
+    expect(repo.readFile("a.txt")).toBe("1")
+    expect(repo.hasPath("untracked.txt")).toBe(false)
+  })
+
+  it("updateRef: points a repo-local ref at a commit hash", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+    const hash = repo.resolveRef("HEAD")!
+    const twin = new InMemRepo()
+    twin.writeFile("a.txt", "1")
+    twin.commitAllWithPrefix("chore: first")
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, updateRef("refs/gtd/base", hash))
+    twin.updateRef("refs/gtd/base", hash)
+
+    expect(result).toEqual({ ok: true })
+    expect(repo.resolveRef("refs/gtd/base")).toBe(hash)
+    expect(snapshot(repo)).toEqual(snapshot(twin))
+  })
+
+  it("deleteRef: removes a repo-local ref (idempotently)", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+    repo.updateRef("refs/gtd/base", repo.resolveRef("HEAD")!)
+    const twin = new InMemRepo()
+    twin.writeFile("a.txt", "1")
+    twin.commitAllWithPrefix("chore: first")
+    twin.updateRef("refs/gtd/base", twin.resolveRef("HEAD")!)
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, deleteRef("refs/gtd/base"))
+    twin.deleteRef("refs/gtd/base")
+
+    expect(result).toEqual({ ok: true })
+    expect(repo.resolveRef("refs/gtd/base")).toBeNull()
+    expect(snapshot(repo)).toEqual(snapshot(twin))
+  })
+
+  it("restoreStagedFrom: resets index entries under given paths to their content at source, leaving HEAD and worktree untouched", () => {
+    const repo = new InMemRepo()
+    repo.writeFile(".gtd/TODO.md", "base")
+    repo.commitAllWithPrefix("chore: base")
+    const base = repo.resolveRef("HEAD")!
+    repo.writeFile(".gtd/TODO.md", "changed")
+    repo.stageAll()
+    const twin = new InMemRepo()
+    twin.writeFile(".gtd/TODO.md", "base")
+    twin.commitAllWithPrefix("chore: base")
+    twin.writeFile(".gtd/TODO.md", "changed")
+    twin.stageAll()
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, restoreStagedFrom(base, [".gtd/"]))
+    twin.restoreStagedFrom(base, [".gtd/"])
+
+    expect(result).toEqual({ ok: true })
+    expect(snapshot(repo)).toEqual(snapshot(twin))
+    // Index restored to base content, worktree still holds the pending edit.
+    expect(repo.statusPorcelain()).toContain(".gtd/TODO.md")
+    expect(repo.readFile(".gtd/TODO.md")).toBe("changed")
+  })
+
+  it("restoreStagedFrom emits nothing for an empty paths list — an empty script applies cleanly as a no-op", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+    const before = snapshot(repo)
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, restoreStagedFrom("HEAD", []))
+
+    expect(result).toEqual({ ok: true })
+    expect(snapshot(repo)).toEqual(before)
+  })
+})
+
+describe("applyEmittedScript — gtd check <mode> <file>", () => {
+  it("passes on valid qa-mode content", () => {
+    const repo = new InMemRepo()
+    repo.writeFile(
+      ".gtd/TODO.md",
+      ["## Open Questions", "", "### What color?", "", "- [ ] Red", "- [ ] Blue"].join("\n"),
+    )
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, "gtd check qa '.gtd/TODO.md'")
+
+    expect(result).toEqual({ ok: true })
+  })
+
+  it("fails on invalid qa-mode content (a bare ### heading with no question text)", () => {
+    const repo = new InMemRepo()
+    repo.writeFile(".gtd/TODO.md", ["## Open Questions", "", "### "].join("\n"))
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, "gtd check qa '.gtd/TODO.md'")
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain("gtd check qa")
+  })
+})
+
+describe("applyEmittedScript — the scripted-command table", () => {
+  it("an 'exit' hit with status 0 continues", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    const commands: ReadonlyMap<string, ScriptedCommand> = new Map([
+      ["./run-check.sh", { kind: "exit", status: 0, output: "ok" }],
+    ])
+
+    const result = applyEmittedScript(repo, commands, "./run-check.sh")
+
+    expect(result).toEqual({ ok: true })
+  })
+
+  it("an 'exit' hit with a non-zero status fails the script", () => {
+    const repo = new InMemRepo()
+    const commands: ReadonlyMap<string, ScriptedCommand> = new Map([
+      ["./run-check.sh", { kind: "exit", status: 1, output: "boom" }],
+    ])
+
+    const result = applyEmittedScript(repo, commands, "./run-check.sh")
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain("./run-check.sh")
+  })
+
+  it("a 'rewrite' hit mutates the repo's file", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("FEEDBACK.md", "old")
+    const commands: ReadonlyMap<string, ScriptedCommand> = new Map([
+      ["./format-feedback.sh", { kind: "rewrite", file: "FEEDBACK.md", content: "new" }],
+    ])
+
+    const result = applyEmittedScript(repo, commands, "./format-feedback.sh")
+
+    expect(result).toEqual({ ok: true })
+    expect(repo.readFile("FEEDBACK.md")).toBe("new")
+  })
+})
+
+describe("applyEmittedScript — unrecognized blocks fail loudly", () => {
+  it("names the offending line in the error and applies nothing", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    const before = snapshot(repo)
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, "curl -X POST https://example.com/hook")
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain("curl -X POST https://example.com/hook")
+    expect(snapshot(repo)).toEqual(before)
+  })
+})
+
+describe("applyEmittedScript — a tripped precondition stops the script", () => {
+  it("fails at the precondition and never applies a subsequent recognizable block", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+    const actualHead = repo.resolveRef("HEAD")!
+    const wrongHash = "0".repeat(40)
+    expect(wrongHash).not.toBe(actualHead)
+
+    const script = [
+      preconditionHeadEquals(wrongHash),
+      commitAll("gtd(agent): should never land"),
+    ].join("\n\n")
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, script)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain("precondition failed")
+    expect(repo.resolveRef("HEAD")).toBe(actualHead)
+    expect(repo.lastCommitMessage()).toBe("chore: first")
+  })
+
+  it("a satisfied precondition is a no-op and lets the rest of the script run", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+    const actualHead = repo.resolveRef("HEAD")!
+
+    const script = [preconditionHeadEquals(actualHead), commitAll("gtd(agent): lands")].join("\n\n")
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, script)
+
+    expect(result).toEqual({ ok: true })
+    expect(repo.lastCommitMessage()).toBe("gtd(agent): lands")
+  })
+})
+
+describe("applyEmittedScript — a realistic assembled multi-block script", () => {
+  it("parses set -euo pipefail and a satisfied precondition alongside real builder blocks", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+    const first = repo.resolveRef("HEAD")!
+
+    const script = [
+      "set -euo pipefail",
+      preconditionHeadEquals(first),
+      commitAll("gtd(agent): second"),
+      updateRef("refs/gtd/base", first),
+    ].join("\n\n")
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, script)
+
+    expect(result).toEqual({ ok: true })
+    expect(repo.lastCommitMessage()).toBe("gtd(agent): second")
+    expect(repo.resolveRef("refs/gtd/base")).toBe(first)
+  })
+})
+
+describe("applyEmittedScript — src/Emit.ts's real head assertion", () => {
+  it("a satisfied assertion is a no-op and lets the rest of the script run", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+    const head = repo.resolveRef("HEAD")!
+
+    const script = [headAssertion(head), commitAll("gtd(agent): second")].join("\n\n")
+    const result = applyEmittedScript(repo, NO_COMMANDS, script)
+
+    expect(result).toEqual({ ok: true })
+    expect(repo.lastCommitMessage()).toBe("gtd(agent): second")
+  })
+
+  it("a tripped assertion stops the script before any subsequent block applies", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+    const actualHead = repo.resolveRef("HEAD")!
+    const staleHead = "0".repeat(40)
+    expect(staleHead).not.toBe(actualHead)
+
+    const script = [headAssertion(staleHead), commitAll("gtd(agent): should never land")].join(
+      "\n\n",
+    )
+    const result = applyEmittedScript(repo, NO_COMMANDS, script)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain("repository changed")
+    expect(repo.resolveRef("HEAD")).toBe(actualHead)
+    expect(repo.lastCommitMessage()).toBe("chore: first")
+  })
+
+  it("EMPTY_TREE matches a repo with no commits yet", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+
+    const script = [headAssertion(EMPTY_TREE), commitAll("gtd(agent): first")].join("\n\n")
+    const result = applyEmittedScript(repo, NO_COMMANDS, script)
+
+    expect(result).toEqual({ ok: true })
+    expect(repo.lastCommitMessage()).toBe("gtd(agent): first")
+  })
+})
+
+describe("applyEmittedScript — src/Emit.ts's review-window-ref assertion", () => {
+  it("a satisfied assertion is a no-op", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+    const head = repo.resolveRef("HEAD")!
+    repo.updateRef(REVIEW_HEAD_REF, head)
+
+    const script = [
+      headAssertion(head),
+      reviewWindowAssertion(REVIEW_HEAD_REF, head),
+      commitAll("gtd(agent): second"),
+    ].join("\n\n")
+    const result = applyEmittedScript(repo, NO_COMMANDS, script)
+
+    expect(result).toEqual({ ok: true })
+    expect(repo.lastCommitMessage()).toBe("gtd(agent): second")
+  })
+
+  it("a moved/missing ref fails the script", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+    const head = repo.resolveRef("HEAD")!
+    // REVIEW_HEAD_REF deliberately left unset — the assertion expects a hash.
+
+    const script = [
+      headAssertion(head),
+      reviewWindowAssertion(REVIEW_HEAD_REF, head),
+      commitAll("gtd(agent): should never land"),
+    ].join("\n\n")
+    const result = applyEmittedScript(repo, NO_COMMANDS, script)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain("review window ref")
+    expect(repo.lastCommitMessage()).toBe("chore: first")
+  })
+})
+
+describe("applyEmittedScript — a realistic src/Emit.ts-assembled script (gtd_retry-wrapped)", () => {
+  it("commitAll wrapped in gtd_retry applies exactly like commitAllWithPrefix", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    const twin = new InMemRepo()
+    twin.writeFile("a.txt", "1")
+
+    const steps: readonly EmitStep[] = [
+      { kind: "gitWrite", command: commitAll("gtd(agent): building") },
+    ]
+    const { required } = emitScripts({ expectedHead: EMPTY_TREE }, steps)
+    const result = applyEmittedScript(repo, NO_COMMANDS, required)
+    twin.commitAllWithPrefix("gtd(agent): building")
+
+    expect(result).toEqual({ ok: true })
+    expect(snapshot(repo)).toEqual(snapshot(twin))
+  })
+
+  it("a squash's four gitWrite steps (retain, soft-reset, commit-as-is, discard) apply in order", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("gtd(agent): building")
+    const tip = repo.resolveRef("HEAD")!
+    // Untracked, never staged — the index still matches the tip's own tree
+    // exactly, mirroring the real flow where nothing `git add`s between the
+    // last turn commit and a squash decision. `commitAsIs` commits the INDEX
+    // as-is (no implicit staging), so this file is absent from the squashed
+    // commit's tree; `discardPending`'s `git add -A && git reset --hard HEAD`
+    // then drops it from the working tree too (staged-but-not-in-HEAD).
+    repo.writeFile(".gtd/TODO.md", "leftover plumbing")
+
+    const steps: readonly EmitStep[] = [
+      { kind: "gitWrite", command: updateRef("refs/worktree/gtd/history", tip) },
+      { kind: "gitWrite", command: softResetTo(EMPTY_TREE) },
+      { kind: "gitWrite", command: commitAsIs("chore: squashed") },
+      { kind: "gitWrite", command: discardPending() },
+    ]
+    const { required } = emitScripts({ expectedHead: tip }, steps)
+    const result = applyEmittedScript(repo, NO_COMMANDS, required)
+
+    expect(result).toEqual({ ok: true })
+    expect(repo.resolveRef("refs/worktree/gtd/history")).toBe(tip)
+    expect(repo.lastCommitMessage()).toBe("chore: squashed")
+    expect(repo.hasPath(".gtd/TODO.md")).toBe(false)
+  })
+})
+
+describe("applyEmittedScript — src/ReviewWindow.ts's compound open/close scripts", () => {
+  it("buildCloseWindowScript (bare) restores HEAD and drops both refs", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: base")
+    const base = repo.resolveRef("HEAD")!
+    repo.writeFile("b.txt", "2")
+    repo.commitAllWithPrefix("chore: real head")
+    const realHead = repo.resolveRef("HEAD")!
+    repo.updateRef(REVIEW_BASE_REF, base)
+    repo.updateRef(REVIEW_HEAD_REF, realHead)
+    repo.mixedResetTo(base) // simulate an already-open window
+
+    const script = buildCloseWindowScript({
+      headRef: REVIEW_HEAD_REF,
+      baseRef: REVIEW_BASE_REF,
+      headHash: realHead,
+      legacy: false,
+    })
+    const result = applyEmittedScript(repo, NO_COMMANDS, script)
+
+    expect(result).toEqual({ ok: true })
+    expect(repo.resolveRef("HEAD")).toBe(realHead)
+    expect(repo.resolveRef(REVIEW_HEAD_REF)).toBeNull()
+    expect(repo.resolveRef(REVIEW_BASE_REF)).toBeNull()
+  })
+
+  it("buildCloseWindowScript wrapped in gtd_retry applies identically", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: base")
+    const base = repo.resolveRef("HEAD")!
+    repo.writeFile("b.txt", "2")
+    repo.commitAllWithPrefix("chore: real head")
+    const realHead = repo.resolveRef("HEAD")!
+    repo.updateRef(REVIEW_BASE_REF, base)
+    repo.updateRef(REVIEW_HEAD_REF, realHead)
+    repo.mixedResetTo(base)
+
+    const steps: readonly EmitStep[] = [
+      {
+        kind: "gitWrite",
+        command: buildCloseWindowScript({
+          headRef: REVIEW_HEAD_REF,
+          baseRef: REVIEW_BASE_REF,
+          headHash: realHead,
+          legacy: false,
+        }),
+      },
+    ]
+    const { required } = emitScripts({ expectedHead: base }, steps)
+    const result = applyEmittedScript(repo, NO_COMMANDS, required)
+
+    expect(result).toEqual({ ok: true })
+    expect(repo.resolveRef("HEAD")).toBe(realHead)
+    expect(repo.resolveRef(REVIEW_HEAD_REF)).toBeNull()
+    expect(repo.resolveRef(REVIEW_BASE_REF)).toBeNull()
+  })
+
+  it("buildOpenWindowScript (bare) with the literal 'HEAD' head resolves against the repo's own current head", () => {
+    const repo = new InMemRepo()
+    repo.writeFile(".gtd/REVIEW.md", "base copy")
+    repo.commitAllWithPrefix("chore: base")
+    const base = repo.resolveRef("HEAD")!
+    repo.writeFile("a.txt", "1")
+    repo.writeFile(".gtd/REVIEW.md", "head copy")
+    repo.commitAllWithPrefix("gtd(agent): await-review")
+    const realHead = repo.resolveRef("HEAD")!
+
+    const script = buildOpenWindowScript({ base, head: "HEAD" })
+    const result = applyEmittedScript(repo, NO_COMMANDS, script)
+
+    expect(result).toEqual({ ok: true })
+    expect(repo.resolveRef(REVIEW_BASE_REF)).toBe(base)
+    expect(repo.resolveRef(REVIEW_HEAD_REF)).toBe(realHead)
+    expect(repo.resolveRef("HEAD")).toBe(base)
+    // `.gtd/`'s index entry is pinned back to the real head's content, which
+    // still reads as staged-modified relative to the rewound (base) HEAD —
+    // exactly like `review-window.feature`'s own scenarios, this only asserts
+    // it's never UNTRACKED (an editor's default unstaged-diff view stays
+    // clean for it either way, since worktree already matches the pinned
+    // index). The new file added since the base surfaces as an ORDINARY
+    // UNTRACKED file (see `openReviewWindow`'s own doc comment on why this is
+    // deliberate).
+    expect(repo.statusPorcelain()).toContain("?? a.txt")
+    expect(repo.statusPorcelain()).not.toContain("?? .gtd/REVIEW.md")
+  })
+
+  it("buildOpenWindowScript wrapped in gtd_retry applies identically", () => {
+    const repo = new InMemRepo()
+    repo.writeFile(".gtd/REVIEW.md", "base copy")
+    repo.commitAllWithPrefix("chore: base")
+    const base = repo.resolveRef("HEAD")!
+    repo.writeFile("a.txt", "1")
+    repo.writeFile(".gtd/REVIEW.md", "head copy")
+    repo.commitAllWithPrefix("gtd(agent): await-review")
+    const realHead = repo.resolveRef("HEAD")!
+
+    const steps: readonly EmitStep[] = [
+      { kind: "gitWrite", command: buildOpenWindowScript({ base, head: "HEAD" }) },
+    ]
+    const { required } = emitScripts({ expectedHead: realHead }, steps)
+    const result = applyEmittedScript(repo, NO_COMMANDS, required)
+
+    expect(result).toEqual({ ok: true })
+    expect(repo.resolveRef(REVIEW_BASE_REF)).toBe(base)
+    expect(repo.resolveRef(REVIEW_HEAD_REF)).toBe(realHead)
+    expect(repo.resolveRef("HEAD")).toBe(base)
+  })
+})
+
+describe("applyEmittedScript — the gtd_retry function definition is an inert no-op", () => {
+  it("a bare 'gtd_retry() { ... }' block applies as a no-op", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    const before = snapshot(repo)
+
+    const script = ["gtd_retry() {", "  echo hi", "}"].join("\n")
+    const result = applyEmittedScript(repo, NO_COMMANDS, script)
+
+    expect(result).toEqual({ ok: true })
+    expect(snapshot(repo)).toEqual(before)
+  })
+})

--- a/src/testing/EmittedScriptRecognizer.test.ts
+++ b/src/testing/EmittedScriptRecognizer.test.ts
@@ -386,15 +386,28 @@ describe("applyEmittedScript — src/Emit.ts's real head assertion", () => {
     expect(repo.lastCommitMessage()).toBe("chore: first")
   })
 
-  it("EMPTY_TREE matches a repo with no commits yet", () => {
+  it("an unborn HEAD (expectedHead '') matches a repo with no commits yet", () => {
     const repo = new InMemRepo()
     repo.writeFile("a.txt", "1")
 
-    const script = [headAssertion(EMPTY_TREE), commitAll("gtd(agent): first")].join("\n\n")
+    const script = [headAssertion(""), commitAll("gtd(agent): first")].join("\n\n")
     const result = applyEmittedScript(repo, NO_COMMANDS, script)
 
     expect(result).toEqual({ ok: true })
     expect(repo.lastCommitMessage()).toBe("gtd(agent): first")
+  })
+
+  it("an unborn-HEAD assertion fails against a repo that already has commits", () => {
+    const repo = new InMemRepo()
+    repo.writeFile("a.txt", "1")
+    repo.commitAllWithPrefix("chore: first")
+
+    const script = [headAssertion(""), commitAll("gtd(agent): should never land")].join("\n\n")
+    const result = applyEmittedScript(repo, NO_COMMANDS, script)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain("repository changed")
+    expect(repo.lastCommitMessage()).toBe("chore: first")
   })
 })
 
@@ -447,7 +460,7 @@ describe("applyEmittedScript — a realistic src/Emit.ts-assembled script (gtd_r
     const steps: readonly EmitStep[] = [
       { kind: "gitWrite", command: commitAll("gtd(agent): building") },
     ]
-    const { required } = emitScripts({ expectedHead: EMPTY_TREE }, steps)
+    const { required } = emitScripts({ expectedHead: "" }, steps)
     const result = applyEmittedScript(repo, NO_COMMANDS, required)
     twin.commitAllWithPrefix("gtd(agent): building")
 

--- a/src/testing/EmittedScriptRecognizer.ts
+++ b/src/testing/EmittedScriptRecognizer.ts
@@ -59,12 +59,6 @@ import { steeringFormatFor } from "../SteeringFormats.js"
 import type { InMemRepo } from "./InMemRepo.js"
 import type { ScriptedCommand } from "./Layers.js"
 
-// git's empty-tree object — `src/Emit.ts`'s `EmitPreconditions.expectedHead`
-// falls back to this when the repo has no commits yet, mirroring every other
-// module's own local copy of the same constant (`src/Edge.ts`,
-// `src/ReviewWindow.ts`).
-const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-
 export interface AppliedScriptResult {
   readonly ok: boolean
   /** Present exactly when `ok` is `false` — names the block/line that stopped the script. */
@@ -257,16 +251,17 @@ const recognizeGitBuilders = (repo: InMemRepo, block: string): BlockOutcome | un
  * preamble every assembled script (`emitScripts`) opens with, right after
  * `set -euo pipefail`. Re-derives the block from the extracted hash and
  * compares full strings, exactly like a `GitScript.ts` builder — so this can
- * never silently drift from `headAssertion`'s actual template. A repo with no
- * commits yet resolves `HEAD` to `null` (`InMemRepo.resolveRef`); `EMPTY_TREE`
- * is the one hash value that matches that case (mirrors every write op's own
- * `ref === EMPTY_TREE` special-casing).
+ * never silently drift from `headAssertion`'s actual template. The real
+ * probe (`git rev-parse --verify --quiet HEAD 2>/dev/null`) reads an unborn
+ * HEAD back as an empty string; `InMemRepo.resolveRef` models the same
+ * repository state as `null`, so `(actual ?? "") === hash` is the fake's
+ * exact mirror of that behavior — no special-casing a hash stand-in needed.
  */
 const recognizeHeadAssertion = (repo: InMemRepo, block: string): BlockOutcome | undefined => {
   const [hash] = extractQuotedTokens(block)
   if (hash === undefined || headAssertion(hash) !== block) return undefined
   const actual = repo.resolveRef("HEAD")
-  if (actual === hash || (actual === null && hash === EMPTY_TREE)) return { kind: "noop" }
+  if ((actual ?? "") === hash) return { kind: "noop" }
   return {
     kind: "failed",
     error: `gtd: repository changed since this script was generated (expected HEAD ${hash}, got ${actual ?? "(no commits)"})`,

--- a/src/testing/EmittedScriptRecognizer.ts
+++ b/src/testing/EmittedScriptRecognizer.ts
@@ -1,0 +1,527 @@
+/**
+ * Applies an EMITTED bash script (the text `src/GitScript.ts`'s builders
+ * produce, assembled into one script by `src/Emit.ts`) onto an `InMemRepo`,
+ * so the `@inmem` e2e tier keeps observing commits once a command starts
+ * printing a script instead of writing git directly. This is `world.ts`'s
+ * ONE bridge from a `gtd`-emitted `required`/`optional` script back onto the
+ * fake repo — it exists so a scenario asserting on `gitLog()`/`gitStatus()`/
+ * etc. after a plain (non-`--json`) `gtd step`/`gtd --entry` keeps working
+ * once that command stops writing git itself and starts only PRINTING what a
+ * driver should run.
+ *
+ * The recognized vocabulary is closed and small: the 9 `GitScript.ts`
+ * builders (both bare, and wrapped in `src/Emit.ts`'s `gtd_retry` retry
+ * helper — see `recognizeRetryWrappedGitWrite`), the two compound
+ * `src/ReviewWindow.ts` open/close sequences (bare or retry-wrapped — see
+ * `recognizeReviewWindowOpen`/`Close`), `src/Emit.ts`'s real preamble
+ * (`set -euo pipefail`, the HEAD assertion, the optional review-window-ref
+ * assertion, the `gtd_retry` function definition itself), a `gtd check <mode>
+ * <file>` line, one invented placeholder precondition shape (see
+ * `preconditionHeadEquals` — kept only because some unit tests below still
+ * hand-build scripts with it; no production emitter writes it any more), and
+ * anything else must be an EXACT hit in the scripted-command table
+ * (`ScriptedCommand`, `Layers.ts`). Recognition works by SPLITTING the script
+ * into blocks on blank lines, then matching each block in turn — this is
+ * deliberately not a general bash parser, only a recognizer for gtd's own
+ * known emission shapes. A git builder block (or an `src/Emit.ts` assertion)
+ * is verified by RE-RUNNING the same builder function against the values
+ * extracted from the block and comparing strings, rather than duplicating
+ * each builder's template as a second regex — so this module can never drift
+ * from its source of truth.
+ *
+ * An unrecognized block is the safety property this module exists for: it
+ * must fail loudly (naming the offending line), never silently pass through,
+ * so "someone added a builder without teaching the recognizer" fails a test
+ * instead of producing a green run that proves nothing.
+ */
+
+import {
+  commitAll,
+  commitAsIs,
+  deleteRef,
+  discardPending,
+  hardResetTo,
+  mixedResetTo,
+  restoreStagedFrom,
+  shellQuote,
+  softResetTo,
+  updateRef,
+} from "../GitScript.js"
+import { headAssertion, reviewWindowAssertion } from "../Emit.js"
+import {
+  buildCloseWindowScript,
+  buildOpenWindowScript,
+  REVIEW_BASE_REF,
+  REVIEW_HEAD_REF,
+  type WindowRefs,
+} from "../ReviewWindow.js"
+import { steeringFormatFor } from "../SteeringFormats.js"
+import type { InMemRepo } from "./InMemRepo.js"
+import type { ScriptedCommand } from "./Layers.js"
+
+// git's empty-tree object — `src/Emit.ts`'s `EmitPreconditions.expectedHead`
+// falls back to this when the repo has no commits yet, mirroring every other
+// module's own local copy of the same constant (`src/Edge.ts`,
+// `src/ReviewWindow.ts`).
+const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+export interface AppliedScriptResult {
+  readonly ok: boolean
+  /** Present exactly when `ok` is `false` — names the block/line that stopped the script. */
+  readonly error?: string
+}
+
+/**
+ * Reverses `GitScript.ts`'s `shellQuote`: extracts every `'...'` token from
+ * `text`, in order, unescaping the `'\''` (close-literal-open) sequence back
+ * to a plain `'`. Position-agnostic on purpose — a builder's block may carry
+ * the same value quoted more than once (`commitAllowEmpty`'s retry line
+ * repeats the message), so callers take whichever index they need rather
+ * than relying on a fixed token count.
+ */
+const extractQuotedTokens = (text: string): string[] => {
+  const tokens: string[] = []
+  let i = 0
+  while (i < text.length) {
+    if (text[i] !== "'") {
+      i += 1
+      continue
+    }
+    i += 1
+    let value = ""
+    while (i < text.length) {
+      if (text[i] === "'") {
+        if (text.slice(i, i + 4) === "'\\''") {
+          value += "'"
+          i += 4
+          continue
+        }
+        i += 1
+        break
+      }
+      value += text[i]
+      i += 1
+    }
+    tokens.push(value)
+  }
+  return tokens
+}
+
+type BlockOutcome =
+  | { readonly kind: "noop" }
+  | { readonly kind: "applied" }
+  | { readonly kind: "failed"; readonly error: string }
+
+/** Bash's own no-op preamble decoration — never a failure, never applies anything. */
+const SET_FLAGS_RE = /^set\s+-\S+(\s+\S+)*$/
+
+const recognizeSetFlags = (block: string): BlockOutcome | undefined =>
+  SET_FLAGS_RE.test(block) ? { kind: "noop" } : undefined
+
+/**
+ * This module's OWN invented precondition-assertion shape — a placeholder for
+ * whatever preamble `src/Emit.ts` finalizes later, not a real gtd convention.
+ * A `[ ... ] || { ...; exit 1; }` guard on the CURRENT `HEAD`, matching
+ * `set -euo pipefail` semantics: a tripped precondition must stop the script,
+ * exactly like a failed builder line would.
+ */
+export const preconditionHeadEquals = (hash: string): string =>
+  `[ "$(git rev-parse HEAD)" = '${hash}' ] || { echo "precondition failed: HEAD moved" >&2; exit 1; }`
+
+const PRECONDITION_RE =
+  /^\[ "\$\(git rev-parse HEAD\)" = '([0-9a-f]{40})' \] \|\| \{ echo "precondition failed: HEAD moved" >&2; exit 1; \}$/
+
+const recognizePrecondition = (repo: InMemRepo, block: string): BlockOutcome | undefined => {
+  const match = PRECONDITION_RE.exec(block)
+  if (!match) return undefined
+  const expected = match[1]!
+  const actual = repo.resolveRef("HEAD")
+  if (actual === expected) return { kind: "noop" }
+  return {
+    kind: "failed",
+    error: `precondition failed: HEAD is ${actual ?? "(no commits)"}, expected ${expected}`,
+  }
+}
+
+/**
+ * The 9 `GitScript.ts` builders. Each branch checks a cheap literal PREFIX
+ * first (to pick which builder to try), then re-derives the builder's
+ * arguments from the block's quoted tokens and confirms the match by calling
+ * the SAME builder and comparing strings — so a block is only ever "applied"
+ * when it is byte-for-byte what that builder would have produced.
+ */
+/** The `if ! out=$(<git command> 2>&1); then` head of an if/case/fi builder — everything from its opening up to the terminator, however many lines its quoted argument spans. */
+const CONDITION_TERMINATOR = " 2>&1); then"
+
+const conditionStatement = (block: string): string => {
+  const start = block.indexOf("if ! out=$(")
+  if (start === -1) return block
+  const end = block.indexOf(CONDITION_TERMINATOR, start)
+  return end === -1 ? block.slice(start) : block.slice(start, end)
+}
+
+// fallow-ignore-next-line complexity
+const recognizeGitBuilders = (repo: InMemRepo, block: string): BlockOutcome | undefined => {
+  if (block === discardPending()) {
+    repo.discardPending()
+    return { kind: "applied" }
+  }
+
+  // The three multi-line if/case/fi builders below re-quote their message
+  // (and `restoreStagedFrom`'s retry `printf '%s\n'` literal) past their
+  // opening `if ! out=$(...` statement — tokens are extracted from THAT
+  // statement only, or a quoted fragment further down (e.g. `'%s\n'`) would
+  // pollute the extracted args. Sliced by its `2>&1); then` terminator rather
+  // than taken as one LINE, because a commit message is routinely multi-line
+  // (every trailer-carrying subject is) and its later lines are part of the
+  // same quoted argument.
+  const conditionLine = conditionStatement(block)
+
+  if (block.startsWith("git add -A &&\n")) {
+    const [message] = extractQuotedTokens(conditionLine)
+    if (message !== undefined && commitAll(message) === block) {
+      repo.commitAllWithPrefix(message)
+      return { kind: "applied" }
+    }
+    return undefined
+  }
+
+  if (block.startsWith("if ! out=$(git commit --allow-empty -m ")) {
+    const [message] = extractQuotedTokens(conditionLine)
+    if (message !== undefined && commitAsIs(message) === block) {
+      repo.commitAsIs(message)
+      return { kind: "applied" }
+    }
+    return undefined
+  }
+
+  if (block.startsWith("if ! out=$(git restore --staged --source=")) {
+    const [source, ...paths] = extractQuotedTokens(conditionLine)
+    if (source !== undefined && restoreStagedFrom(source, paths) === block) {
+      repo.restoreStagedFrom(source, paths)
+      return { kind: "applied" }
+    }
+    return undefined
+  }
+
+  if (block.startsWith("git reset --soft ")) {
+    const [ref] = extractQuotedTokens(block)
+    if (ref !== undefined && softResetTo(ref) === block) {
+      repo.softResetTo(ref)
+      return { kind: "applied" }
+    }
+    return undefined
+  }
+
+  if (block.startsWith("git reset --mixed ")) {
+    const [ref] = extractQuotedTokens(block)
+    if (ref !== undefined && mixedResetTo(ref) === block) {
+      repo.mixedResetTo(ref)
+      return { kind: "applied" }
+    }
+    return undefined
+  }
+
+  if (block.startsWith("git reset --hard ")) {
+    const [ref] = extractQuotedTokens(block)
+    if (ref !== undefined && hardResetTo(ref) === block) {
+      repo.hardResetTo(ref)
+      return { kind: "applied" }
+    }
+    return undefined
+  }
+
+  if (block.startsWith("git update-ref -d ")) {
+    const [ref] = extractQuotedTokens(block)
+    if (ref !== undefined && deleteRef(ref) === block) {
+      repo.deleteRef(ref)
+      return { kind: "applied" }
+    }
+    return undefined
+  }
+
+  if (block.startsWith("git update-ref ")) {
+    const [ref, hash] = extractQuotedTokens(block)
+    if (ref !== undefined && hash !== undefined && updateRef(ref, hash) === block) {
+      repo.updateRef(ref, hash)
+      return { kind: "applied" }
+    }
+    return undefined
+  }
+
+  return undefined
+}
+
+/**
+ * `src/Emit.ts`'s REAL `headAssertion` block — the current, non-placeholder
+ * preamble every assembled script (`emitScripts`) opens with, right after
+ * `set -euo pipefail`. Re-derives the block from the extracted hash and
+ * compares full strings, exactly like a `GitScript.ts` builder — so this can
+ * never silently drift from `headAssertion`'s actual template. A repo with no
+ * commits yet resolves `HEAD` to `null` (`InMemRepo.resolveRef`); `EMPTY_TREE`
+ * is the one hash value that matches that case (mirrors every write op's own
+ * `ref === EMPTY_TREE` special-casing).
+ */
+const recognizeHeadAssertion = (repo: InMemRepo, block: string): BlockOutcome | undefined => {
+  const [hash] = extractQuotedTokens(block)
+  if (hash === undefined || headAssertion(hash) !== block) return undefined
+  const actual = repo.resolveRef("HEAD")
+  if (actual === hash || (actual === null && hash === EMPTY_TREE)) return { kind: "noop" }
+  return {
+    kind: "failed",
+    error: `gtd: repository changed since this script was generated (expected HEAD ${hash}, got ${actual ?? "(no commits)"})`,
+  }
+}
+
+/**
+ * `src/Emit.ts`'s REAL `reviewWindowAssertion` block — present only when the
+ * target state declares `reviewWindow: true` AND a window is currently open.
+ * Same re-derive-and-compare discipline as `recognizeHeadAssertion`; the ref
+ * itself (never a hash) is read back via `resolveRef`, which is `null` for a
+ * missing ref exactly like the real `git rev-parse --verify --quiet ...
+ * 2>/dev/null` the block runs.
+ */
+const recognizeReviewWindowRefAssertion = (
+  repo: InMemRepo,
+  block: string,
+): BlockOutcome | undefined => {
+  const [ref, hash] = extractQuotedTokens(block)
+  if (ref === undefined || hash === undefined || reviewWindowAssertion(ref, hash) !== block) {
+    return undefined
+  }
+  const actual = repo.resolveRef(ref)
+  if (actual === hash) return { kind: "noop" }
+  return {
+    kind: "failed",
+    error: `gtd: review window ref ${ref} changed since this script was generated (expected ${hash}, got ${actual ?? "(missing)"})`,
+  }
+}
+
+/**
+ * `src/Emit.ts`'s `gtd_retry` bash FUNCTION DEFINITION (`RETRY_HELPER`) —
+ * present as its own block whenever any step is a `gitWrite`. Defining a
+ * function is inert (it does nothing until called), so this is always a
+ * no-op regardless of the helper's exact body — unlike every other
+ * recognizer here, there is nothing to re-derive-and-compare: the actual
+ * WORK happens at each `gtd_retry '<command>'` CALL site, which
+ * `recognizeRetryWrappedGitWrite` below unwraps and re-dispatches.
+ */
+const recognizeRetryHelperDefinition = (block: string): BlockOutcome | undefined =>
+  block.startsWith("gtd_retry() {") ? { kind: "noop" } : undefined
+
+/**
+ * `src/ReviewWindow.ts`'s `buildCloseWindowScript` — the compound `mixedResetTo
+ * && deleteRef && deleteRef` sequence `openReviewWindow`'s script-emitting
+ * twin writes to close a review checkout window. Its three `&&`-joined lines
+ * split cleanly on the exact `" &&\n"` separator `buildCloseWindowScript`
+ * itself joins with (no existing builder's OWN output contains that
+ * substring), so each part is handed to `extractQuotedTokens` alone —
+ * exactly like `recognizeGitBuilders`'s single-builder cases — then the whole
+ * block is re-derived via `buildCloseWindowScript` and string-compared,
+ * rather than validating each part's shape separately.
+ */
+const recognizeReviewWindowClose = (repo: InMemRepo, block: string): BlockOutcome | undefined => {
+  const parts = block.split(" &&\n")
+  if (parts.length !== 3) return undefined
+  const [headHash] = extractQuotedTokens(parts[0]!)
+  const [headRef] = extractQuotedTokens(parts[1]!)
+  const [baseRef] = extractQuotedTokens(parts[2]!)
+  if (headHash === undefined || headRef === undefined || baseRef === undefined) return undefined
+  const refs: WindowRefs = { headRef, baseRef, headHash, legacy: false }
+  if (buildCloseWindowScript(refs) !== block) return undefined
+  repo.mixedResetTo(headHash)
+  repo.deleteRef(headRef)
+  repo.deleteRef(baseRef)
+  return { kind: "applied" }
+}
+
+/**
+ * `src/ReviewWindow.ts`'s `buildOpenWindowScript` — the compound
+ * `updateRef(base) && updateRef(head) && mixedResetTo(base) &&
+ * restoreStagedFrom(.gtd)` sequence a step landing at a `reviewWindow: true`
+ * state emits alongside its commit. `program.ts` (concurrent work) always
+ * renders the HEAD ref update with the LITERAL string `'HEAD'` rather than a
+ * resolved hash — the real hash isn't known until the required script's own
+ * commit has actually landed, and real `git update-ref <ref> HEAD` resolves
+ * the symbolic name at run time — so this recognizer only ever needs to match
+ * that one literal shape (never an arbitrary resolved head). `InMemRepo.
+ * updateRef` already resolves a symbolic value itself (`resolveRef(hash) ??
+ * hash`), so passing `"HEAD"` straight through applies correctly with no
+ * special-casing here. Same split-on-`" &&\n"` + re-derive-and-compare
+ * discipline as `recognizeReviewWindowClose`; the fourth part
+ * (`restoreStagedFrom`) needs no separate extraction since
+ * `buildOpenWindowScript` hard-codes its ref/paths (`REVIEW_HEAD_REF`,
+ * `[".gtd"]`) — the whole-string comparison verifies it for free.
+ */
+const recognizeReviewWindowOpen = (repo: InMemRepo, block: string): BlockOutcome | undefined => {
+  const parts = block.split(" &&\n")
+  if (parts.length !== 4) return undefined
+  const [, base] = extractQuotedTokens(parts[0]!)
+  const [, head] = extractQuotedTokens(parts[1]!)
+  if (base === undefined || head === undefined) return undefined
+  if (buildOpenWindowScript({ base, head }) !== block) return undefined
+  repo.updateRef(REVIEW_BASE_REF, base)
+  repo.updateRef(REVIEW_HEAD_REF, head)
+  repo.mixedResetTo(base)
+  repo.restoreStagedFrom(REVIEW_HEAD_REF, [".gtd"])
+  return { kind: "applied" }
+}
+
+/**
+ * `src/Emit.ts`'s `renderStep` wraps every `"gitWrite"` step as `gtd_retry
+ * '<shellQuote-escaped whole command>'` — a SINGLE quoted argument, however
+ * many physical lines the escaped command itself spans (a compound builder's
+ * `&&`-joined lines survive as literal newlines inside the one quoted
+ * string). `extractQuotedTokens` reconstructs that one argument regardless of
+ * its internal newlines (the same property the multi-line `if`/`case`/`fi`
+ * builders already rely on), so unwrapping is: extract the one token,
+ * confirm the round trip via `shellQuote` (never hand-parse the escaping a
+ * second time), then re-dispatch the UNWRAPPED command through the ordinary
+ * git-builder/review-window recognizers — exactly as if it had never been
+ * wrapped.
+ */
+const GTD_RETRY_PREFIX = "gtd_retry "
+
+const recognizeRetryWrappedGitWrite = (
+  repo: InMemRepo,
+  block: string,
+): BlockOutcome | undefined => {
+  if (!block.startsWith(GTD_RETRY_PREFIX)) return undefined
+  const [inner] = extractQuotedTokens(block)
+  if (inner === undefined || `${GTD_RETRY_PREFIX}${shellQuote(inner)}` !== block) return undefined
+  return (
+    recognizeGitBuilders(repo, inner) ??
+    recognizeReviewWindowClose(repo, inner) ??
+    recognizeReviewWindowOpen(repo, inner)
+  )
+}
+
+const GTD_CHECK_RE = /^gtd check (\S+) (.+)$/
+
+/** `gtd check <mode> <file>` — a non-empty findings array fails the script, mirroring a real invocation's non-zero exit under `set -e`. */
+const recognizeGtdCheck = (repo: InMemRepo, block: string): BlockOutcome | undefined => {
+  const match = GTD_CHECK_RE.exec(block)
+  if (!match) return undefined
+  const mode = match[1]!
+  const [file] = extractQuotedTokens(match[2]!)
+  const format = steeringFormatFor(mode)
+  if (format === undefined || file === undefined) {
+    return { kind: "failed", error: `gtd check: no built-in steering format named "${mode}"` }
+  }
+  // An ABSENT file has nothing to check and exits 0 — `runCheckCommand`'s own
+  // documented behavior. Validating `""` instead would report every "missing
+  // header" finding the format has, turning "the reviewer deleted the file"
+  // (a case the sign-off guard owns) into a script failure.
+  const content = repo.readFile(file)
+  if (content === undefined) return { kind: "noop" }
+  const findings = format.validate(content)
+  if (findings.length > 0) {
+    return { kind: "failed", error: `gtd check ${mode} ${file}: ${findings.join("; ")}` }
+  }
+  return { kind: "noop" }
+}
+
+/** Anything left over must be an EXACT hit in the scripted-command table — mirrors `makeScriptedCommandRunner`'s two `kind`s (`Layers.ts`). */
+const recognizeScriptedCommand = (
+  repo: InMemRepo,
+  commands: ReadonlyMap<string, ScriptedCommand>,
+  block: string,
+): BlockOutcome | undefined => {
+  const scripted = commands.get(block)
+  if (scripted === undefined) return undefined
+  if (scripted.kind === "rewrite") {
+    repo.writeFile(scripted.file, scripted.content)
+    return { kind: "applied" }
+  }
+  if (scripted.status !== 0) {
+    return {
+      kind: "failed",
+      error: `scripted command "${block}" exited ${scripted.status}: ${scripted.output}`,
+    }
+  }
+  return { kind: "noop" }
+}
+
+/**
+ * Splits `script` into blocks on blank lines, IGNORING blank lines that fall
+ * inside a single-quoted string. A commit message is a quoted argument that
+ * routinely spans a blank line — every trailer-carrying subject
+ * (`gtd(human): x\n\nGtd-Cost: …`) does — so a naive `split(/\n{2,}/)` tears
+ * one `commitAll` block into fragments that recognize as nothing. POSIX
+ * single quotes have no escape sequence of their own, so quote depth is
+ * "toggle on every `'`" — with one correction that `shellQuote`'s nesting
+ * makes load-bearing: the `\` in `'\''` (close, backslash-escaped literal
+ * quote, reopen) escapes its following `'` OUTSIDE any quote, so that middle
+ * quote must not toggle. Deliberately not a bash lexer — like every other
+ * recognizer here, it only has to handle gtd's own closed emission
+ * vocabulary, where no double-quoted string ever contains a `'`.
+ */
+const trackQuoteState = (line: string, quoted: boolean): boolean => {
+  let inQuote = quoted
+  let index = 0
+  while (index < line.length) {
+    const char = line[index]
+    if (!inQuote && char === "\\") {
+      index += 2
+      continue
+    }
+    if (char === "'") inQuote = !inQuote
+    index += 1
+  }
+  return inQuote
+}
+
+const splitBlocks = (script: string): readonly string[] => {
+  const blocks: string[] = []
+  let current = ""
+  let quoted = false
+  for (const line of script.trim().split("\n")) {
+    if (!quoted && line.trim().length === 0) {
+      if (current.trim().length > 0) blocks.push(current.trim())
+      current = ""
+      continue
+    }
+    current += (current.length > 0 ? "\n" : "") + line
+    quoted = trackQuoteState(line, quoted)
+  }
+  if (current.trim().length > 0) blocks.push(current.trim())
+  return blocks
+}
+
+/**
+ * Applies `script` to `repo` block by block, stopping at the first failure —
+ * an unrecognized block, a tripped precondition, a failing `gtd check`, or a
+ * non-zero scripted-command exit — exactly like `set -euo pipefail` stops a
+ * real script. No block after the failing one is applied.
+ */
+export const applyEmittedScript = (
+  repo: InMemRepo,
+  commands: ReadonlyMap<string, ScriptedCommand>,
+  script: string,
+): AppliedScriptResult => {
+  const blocks = splitBlocks(script)
+
+  for (const block of blocks) {
+    const outcome =
+      recognizeSetFlags(block) ??
+      recognizePrecondition(repo, block) ??
+      recognizeHeadAssertion(repo, block) ??
+      recognizeReviewWindowRefAssertion(repo, block) ??
+      recognizeRetryHelperDefinition(block) ??
+      recognizeGitBuilders(repo, block) ??
+      recognizeReviewWindowClose(repo, block) ??
+      recognizeReviewWindowOpen(repo, block) ??
+      recognizeRetryWrappedGitWrite(repo, block) ??
+      recognizeGtdCheck(repo, block) ??
+      recognizeScriptedCommand(repo, commands, block)
+
+    if (outcome === undefined) {
+      return { ok: false, error: `unrecognized script block: ${block.split("\n")[0]}` }
+    }
+    if (outcome.kind === "failed") {
+      return { ok: false, error: outcome.error }
+    }
+  }
+
+  return { ok: true }
+}

--- a/src/testing/GitDoubles.ts
+++ b/src/testing/GitDoubles.ts
@@ -58,9 +58,9 @@ const makeGitReaderOps = (repo: InMemRepo): GitReaderOperations => ({
 
   topLevel: () => Effect.succeed("/repo"),
 
-  commitHistory: (base?: string) => Effect.succeed(repo.commitHistory(base)),
+  commitHistory: (base?: string, head?: string) => Effect.succeed(repo.commitHistory(base, head)),
 
-  changedPaths: () => Effect.succeed(repo.changedPathsWorktree()),
+  changedPaths: (base?: string) => Effect.succeed(repo.changedPathsWorktree(base)),
 
   changedPathsSince: (ref: string) =>
     tryCatch(() => {

--- a/src/testing/GitTiers.ts
+++ b/src/testing/GitTiers.ts
@@ -21,11 +21,22 @@ import {
 } from "node:fs"
 import { join, dirname } from "node:path"
 import { tmpdir } from "node:os"
-import { execSync } from "node:child_process"
+import { execSync, execFileSync } from "node:child_process"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { Effect, Exit, Layer } from "effect"
 import { NodeContext } from "@effect/platform-node"
 import { GitService, type GitOperations } from "../Git.js"
+import {
+  commitAll,
+  commitAsIs,
+  softResetTo,
+  mixedResetTo,
+  hardResetTo,
+  discardPending,
+  updateRef,
+  deleteRef,
+  restoreStagedFrom,
+} from "../GitScript.js"
 import { ConfigService } from "../Config.js"
 import { Cwd } from "../Cwd.js"
 import type { WorkflowDefinition } from "../PatternMachine.js"
@@ -507,6 +518,17 @@ export const runGitServiceContract = (makeTier: () => GitTier): void => {
       expect(addTwo?.touched).toEqual(expect.arrayContaining(["a.txt", "b.txt"]))
       expect(removeA?.touched).toEqual(["a.txt"])
     })
+
+    it("reads through an explicit head ref instead of literal HEAD when given one", async () => {
+      t.seed.commit("feat: second", { "b.txt": "b" })
+      const earlierHead = t.observe.resolveRef("HEAD")
+      // Moves real HEAD forward — a `head` argument must stop the walk at
+      // `earlierHead` instead, proving the read goes through the given ref
+      // rather than the literal `HEAD` the git CLI would default to.
+      t.seed.commit("feat: third", { "c.txt": "c" })
+      const result = await runGit(t, (g) => g.commitHistory(undefined, earlierHead))
+      expect(result.map((c) => c.message)).toEqual(["init: first commit", "feat: second"])
+    })
   })
 
   describe("commitAllWithPrefix", () => {
@@ -733,6 +755,165 @@ export const runGitServiceContract = (makeTier: () => GitTier): void => {
       const result = await runGitExit(t, (g) => g.commitAllWithPrefix("gtd(test): capture"))
       expect(Exit.isSuccess(result)).toBe(true)
       expect(t.observe.resolveRef("HEAD")).not.toBe(undefined)
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// The GitScript contract — real bash, real git, no GitOperations port at all
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs a `GitScript.ts` builder's output through a REAL shell against `t.root`
+ * — the same execution model the eventual driver uses (`bash -c <script>`),
+ * so a builder that's syntactically fine but semantically wrong (a missing
+ * `&&`, a misquoted path) fails here exactly as it would in production.
+ */
+const execScript = (t: GitTier, script: string): void => {
+  execFileSync("bash", ["-c", script], { cwd: t.root, stdio: "pipe" })
+}
+
+/** Names touched by HEAD's own commit — `git show`'s diff against its parent, not the whole tree. */
+const headTouchedPaths = (t: GitTier): ReadonlyArray<string> =>
+  gitExecIn(t.root, "show", "--name-only", "--pretty=format:", "HEAD")
+    .split("\n")
+    .filter((line) => line.length > 0)
+
+const headSubject = (t: GitTier): string => gitExecIn(t.root, "log", "-1", "--pretty=%s")
+
+/**
+ * The SAME 9 writer postconditions `runGitServiceContract` asserts against
+ * `GitOperations`, asserted here against `GitScript.ts`'s bash builders
+ * instead — driven through real `bash` against a real repo (`makeLiveTier`),
+ * never the in-memory fake, since a fake root (`/repo`) has no shell to run
+ * against. Proves the script translation preserves every edge case the doc
+ * comments in `GitScript.ts` call out, not just the happy path.
+ */
+export const runGitScriptContract = (): void => {
+  let t: GitTier
+
+  beforeEach(() => {
+    t = makeLiveTier()
+  })
+
+  afterEach(() => {
+    t.dispose()
+  })
+
+  describe("commitAll", () => {
+    it("stages (git add -A) before committing — a new untracked file lands in the commit", () => {
+      t.seed.writeFile("new.ts", "export const x = 1")
+      const headBefore = t.observe.resolveRef("HEAD")
+      execScript(t, commitAll("gtd: building"))
+      expect(t.observe.resolveRef("HEAD")).not.toBe(headBefore)
+      expect(headSubject(t)).toBe("gtd: building")
+      expect(headTouchedPaths(t)).toEqual(["new.ts"])
+      expect(t.observe.statusPorcelain().trim()).toBe("")
+    })
+
+    it("commits even on a clean tree (--allow-empty), never 'nothing to commit'", () => {
+      const headBefore = t.observe.resolveRef("HEAD")
+      execScript(t, commitAll("gtd: grilled"))
+      expect(t.observe.resolveRef("HEAD")).not.toBe(headBefore)
+      expect(headSubject(t)).toBe("gtd: grilled")
+    })
+  })
+
+  describe("commitAsIs", () => {
+    it("does NOT stage — a worktree write after staging is excluded (the squash mechanic)", () => {
+      t.seed.writeFile("a.txt", "a")
+      t.seed.stageAll()
+      t.seed.writeFile("b.txt", "b")
+      execScript(t, commitAsIs("feat: squash"))
+      expect(headSubject(t)).toBe("feat: squash")
+      expect(headTouchedPaths(t)).toEqual(["a.txt"])
+    })
+
+    it("commits even on a clean index (--allow-empty), never 'nothing to commit'", () => {
+      const headBefore = t.observe.resolveRef("HEAD")
+      execScript(t, commitAsIs("gtd: empty squash"))
+      expect(t.observe.resolveRef("HEAD")).not.toBe(headBefore)
+      expect(headSubject(t)).toBe("gtd: empty squash")
+    })
+  })
+
+  describe("softResetTo", () => {
+    it("moves HEAD back but keeps worktree changes from the second commit", () => {
+      const firstHash = t.observe.resolveRef("HEAD")
+      t.seed.commit("feat: second", { "second.txt": "second content" })
+      execScript(t, softResetTo(firstHash))
+      expect(t.observe.resolveRef("HEAD")).toBe(firstHash)
+      expect(t.observe.statusPorcelain()).toContain("second.txt")
+    })
+  })
+
+  describe("hardResetTo", () => {
+    it("moves HEAD, index, and working tree content back to the target ref", () => {
+      const firstHash = t.observe.resolveRef("HEAD")
+      t.seed.commit("feat: second", { "readme.txt": "modified content" })
+      execScript(t, hardResetTo(firstHash))
+      expect(t.observe.resolveRef("HEAD")).toBe(firstHash)
+      expect(t.observe.statusPorcelain()).toBe("")
+      expect(t.observe.readWorktreeFile("readme.txt")).toBe("hello")
+    })
+  })
+
+  describe("mixedResetTo", () => {
+    it("moves HEAD and index, leaving the working tree untouched", () => {
+      const firstHash = t.observe.resolveRef("HEAD")
+      t.seed.commit("feat: second", { "second.txt": "second content" })
+      execScript(t, mixedResetTo(firstHash))
+      expect(t.observe.resolveRef("HEAD")).toBe(firstHash)
+      expect(t.observe.statusPorcelain()).toContain("second.txt")
+    })
+  })
+
+  describe("discardPending", () => {
+    it("drops both tracked modifications and untracked files", () => {
+      t.seed.writeFile("readme.txt", "modified")
+      t.seed.writeFile("untracked.txt", "new")
+      execScript(t, discardPending())
+      expect(t.observe.statusPorcelain()).toBe("")
+    })
+  })
+
+  describe("updateRef / deleteRef", () => {
+    it("updateRef points a ref at a commit", () => {
+      const head = t.observe.resolveRef("HEAD")
+      execScript(t, updateRef("refs/gtd/marker", head))
+      expect(t.observe.refExists("refs/gtd/marker")).toBe(true)
+      expect(t.observe.resolveRef("refs/gtd/marker")).toBe(head)
+    })
+
+    it("deleteRef removes an existing ref, and tolerates deleting it again", () => {
+      const head = t.observe.resolveRef("HEAD")
+      execScript(t, updateRef("refs/gtd/marker", head))
+      execScript(t, deleteRef("refs/gtd/marker"))
+      execScript(t, deleteRef("refs/gtd/marker"))
+      expect(t.observe.refExists("refs/gtd/marker")).toBe(false)
+    })
+
+    it("deleteRef tolerates a ref that was never created", () => {
+      expect(() => execScript(t, deleteRef("refs/gtd/never-created"))).not.toThrow()
+      expect(t.observe.refExists("refs/gtd/never-created")).toBe(false)
+    })
+  })
+
+  describe("restoreStagedFrom", () => {
+    it("pins the index for the given paths back to source, leaving HEAD/worktree untouched", () => {
+      const base = t.observe.resolveRef("HEAD")
+      t.seed.commit("feat: touch plumbing", { ".gtd/TODO.md": "sketch" })
+      const beforeHead = t.observe.resolveRef("HEAD")
+      execScript(t, restoreStagedFrom(base, [".gtd"]))
+      expect(t.observe.resolveRef("HEAD")).toBe(beforeHead)
+      // Present at HEAD, absent from `base` — pinning to `base` surfaces as a
+      // staged deletion, mirroring `restoreStagedFrom`'s existing port test.
+      expect(t.observe.statusPorcelain()).toContain(".gtd/TODO.md")
+    })
+
+    it("is tolerant of a path absent at source (best-effort plumbing pin)", () => {
+      const base = t.observe.resolveRef("HEAD")
+      expect(() => execScript(t, restoreStagedFrom(base, [".gtd/never-existed"]))).not.toThrow()
     })
   })
 }

--- a/src/testing/InMemRepo.ts
+++ b/src/testing/InMemRepo.ts
@@ -62,6 +62,13 @@ export class InMemRepo {
     return this.headCommit()?.files ?? new Map()
   }
 
+  /** The tree at `ref` (HEAD's own when `ref` is omitted), empty when it resolves to nothing. */
+  private treeAt(ref: string | undefined): Map<string, string> {
+    if (ref === undefined) return this.headTree()
+    const hash = this.resolveRef(ref)
+    return hash === null ? new Map() : (this.getCommit(hash)?.files ?? new Map())
+  }
+
   // ---------------------------------------------------------------------------
   // Read methods
   // ---------------------------------------------------------------------------
@@ -161,17 +168,28 @@ export class InMemRepo {
     return c.message
   }
 
-  commitHistory(base?: string): Array<{
+  /**
+   * `head` (default `this.head`, mirroring production's `"HEAD"` default) is
+   * resolved through the SAME `resolveRef` logic as any other ref — so a
+   * symbolic name, a hash, or a `~N` expression all work exactly as they
+   * would for `head === undefined`. `Edge.ts`'s `restAt` passes the review
+   * checkout window's saved-head hash here while the window is open.
+   */
+  commitHistory(
+    base?: string,
+    head?: string,
+  ): Array<{
     hash: string
     message: string
     removedErrors: boolean
     touched: ReadonlyArray<string>
   }> {
-    if (this.head === null) return []
+    const headHash = head !== undefined ? this.resolveRef(head) : this.head
+    if (headHash === null) return []
 
     // Collect first-parent chain newest→oldest
     const chain: Commit[] = []
-    let cur: string | null = this.head
+    let cur: string | null = headHash
     while (cur !== null) {
       const c = this.getCommit(cur)
       if (!c) break
@@ -221,23 +239,17 @@ export class InMemRepo {
     return diffTrees(treeA, treeB)
   }
 
-  changedPathsWorktree(): Array<{ path: string; status: string }> {
-    const headTree = this.headTree()
-    // Worktree vs HEAD: untracked → "A"
-    const allPaths = new Set([...headTree.keys(), ...this.worktree.keys()])
-    const result: Array<{ path: string; status: string }> = []
-    for (const path of allPaths) {
-      const inHead = headTree.has(path)
-      const inWorktree = this.worktree.has(path)
-      if (!inHead && inWorktree) {
-        result.push({ path, status: "A" })
-      } else if (inHead && !inWorktree) {
-        result.push({ path, status: "D" })
-      } else if (inHead && inWorktree && headTree.get(path) !== this.worktree.get(path)) {
-        result.push({ path, status: "M" })
-      }
-    }
-    return result.sort((a, b) => a.path.localeCompare(b.path))
+  /**
+   * `base` (default HEAD) mirrors the port's own optional base — see
+   * `GitReaderOperations.changedPaths`. Tree-vs-worktree comparison already
+   * subsumes production's untracked-file filtering: a path present at `base`
+   * with identical content is simply not a difference.
+   */
+  changedPathsWorktree(base?: string): Array<{ path: string; status: string }> {
+    // Worktree vs the base tree: untracked → "A"
+    const baseTree = this.treeAt(base)
+    const worktreeTree = new Map(this.worktree)
+    return diffTrees(baseTree, worktreeTree)
   }
 
   /** The worktree content of `path`, or `undefined` when absent. A LIVE read — never a snapshot. */

--- a/src/workflows/templates.test.ts
+++ b/src/workflows/templates.test.ts
@@ -1,6 +1,7 @@
 import { parse as parseYaml } from "yaml"
 import { describe, expect, it } from "vitest"
 import { validateDefinition } from "../PatternMachine.js"
+import { seededValidateCommand } from "../SteeringFormats.js"
 import type { MachineNode } from "../Machines.js"
 import {
   compileTemplate,
@@ -23,11 +24,11 @@ describe("the bundled unified workflow template", () => {
     expect(definition.states[definition.entries.default]).toBeDefined()
   })
 
-  it("declares its own `modes.prose` entry, plus the built-in registry's `qa`/`review` seeded as empty entries", () => {
+  it("declares its own `modes.prose` entry, plus the built-in registry's `qa`/`review` seeded with their validate command", () => {
     const { definition } = compileTemplate()
     expect(definition.modes?.["prose"]).toEqual({})
-    expect(definition.modes?.["qa"]).toEqual({})
-    expect(definition.modes?.["review"]).toEqual({})
+    expect(definition.modes?.["qa"]).toEqual({ validate: seededValidateCommand("qa") })
+    expect(definition.modes?.["review"]).toEqual({ validate: seededValidateCommand("review") })
   })
 
   it("declares exactly one review checkout window and one review entry", () => {

--- a/tests/integration/features/check.feature
+++ b/tests/integration/features/check.feature
@@ -1,0 +1,135 @@
+Feature: gtd check <mode> <file> — the standalone leaf validator
+
+  `gtd check <mode> <file>` (see src/program.ts's runCheckCommand) reads
+  <file> and runs the named BUILT-IN steering format's pure parser over its
+  contents — the same qa/review parsers gtd validate and the LSP use. Unlike
+  every other gtd subcommand, both arguments are given explicitly: it resolves
+  no workflow state and reads no config, so it needs neither a git repository
+  nor a .gtdrc — the standalone command an emitted validation script (a later
+  package) invokes as a leaf step, from any directory. A clean parse exits 0
+  with no output; findings print one per line and it exits non-zero; an
+  absent file mirrors gtd validate's own absent-file behavior (exit 0,
+  nothing to check); an unrecognized <mode> is a usage error naming the modes
+  that do exist.
+
+  @inmem
+  Scenario: a well-formed qa file validates cleanly and exits 0 silently
+    Given a file "NOTES.md" with:
+      """
+      Build a thing. Plan: add src/thing.ts exporting `thing`.
+
+      ## Open Questions
+
+      ### Should thing export a default too?
+
+      No, named export only.
+      """
+    When I run gtd with args "check qa NOTES.md"
+    Then it succeeds
+    And stdout is empty
+
+  @inmem
+  Scenario: a malformed qa file prints the parser's findings, one per line, and fails
+    Given a file "NOTES.md" with:
+      """
+      Build a thing.
+
+      ## Open Questions
+
+      ###
+
+      A question heading with no question text.
+      """
+    When I run gtd with args "check qa NOTES.md"
+    Then it fails
+    And stdout contains "has no question text"
+
+  @inmem
+  Scenario: a well-formed review file validates cleanly and exits 0 silently
+    Given a file "REVIEW.md" with:
+      """
+      # Review: abc1234
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add thing.ts
+
+      - [ ] ./src/thing.ts#1 — new export
+      """
+    When I run gtd with args "check review REVIEW.md"
+    Then it succeeds
+    And stdout is empty
+
+  @inmem
+  Scenario: a malformed review file prints the parser's findings and fails
+    Given a file "REVIEW.md" with:
+      """
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add thing.ts
+
+      - [ ] ./src/thing.ts#1 — new export
+      """
+    When I run gtd with args "check review REVIEW.md"
+    Then it fails
+    And stdout contains "# Review: <hash>"
+
+  @inmem
+  Scenario: a file that does not exist has nothing to check — exits 0 silently
+    When I run gtd with args "check qa MISSING.md"
+    Then it succeeds
+    And stdout is empty
+
+  @inmem
+  Scenario: an unrecognized mode is a usage error naming the modes that do exist
+    Given a file "whatever.md" with:
+      """
+      anything
+      """
+    When I run gtd with args "check bogus-mode whatever.md"
+    Then it fails
+    And stderr contains "unknown mode"
+    And stderr contains "qa, review"
+
+  @inmem
+  Scenario: --json reports the clean verdict structurally
+    Given a file "NOTES.md" with:
+      """
+      Build a thing. Plan: add src/thing.ts.
+      """
+    When I run gtd with args "check qa NOTES.md --json"
+    Then it succeeds
+    And stdout contains "{\"valid\":true,\"errors\":[]}"
+
+  @inmem
+  Scenario: --json reports findings structurally and still fails
+    Given a file "NOTES.md" with:
+      """
+      Build a thing.
+
+      ## Open Questions
+
+      ###
+
+      A question heading with no question text.
+      """
+    When I run gtd with args "check qa NOTES.md --json"
+    Then it fails
+    And stdout contains "\"valid\":false"
+    And stdout contains "has no question text"
+
+  @inmem
+  Scenario: --json reports the clean verdict for an absent file too
+    When I run gtd with args "check qa MISSING.md --json"
+    Then it succeeds
+    And stdout contains "{\"valid\":true,\"errors\":[]}"
+
+  @live
+  Scenario: gtd check runs standalone outside any git repository
+    Given a plain directory that is not a git repository
+    And a file "NOTES.md" with:
+      """
+      Build a thing. Plan: add src/thing.ts.
+      """
+    When I run gtd with args "check qa NOTES.md"
+    Then it succeeds
+    And stdout is empty

--- a/tests/integration/features/command-surface.feature
+++ b/tests/integration/features/command-surface.feature
@@ -2,11 +2,11 @@
 Feature: Command surface — bare gtd, unknown subcommands, --help, --version
 
   gtd v3 exposes `init`, `step <actor>` (with `--entry <state>`), `abandon`,
-  `restore`, `next`, `status`, `validate`, `lsp`, `visualize`, `version`, and
-  `help` as its subcommands. Bare `gtd` (no subcommand) is a usage error unless
-  `--entry <state>` is given. `--help`/`help` and `--version`/`version`
-  short-circuit before any repo-state work and exit 0 everywhere, including
-  outside a workflow state.
+  `restore`, `next`, `status`, `validate`, `check <mode> <file>`, `lsp`,
+  `visualize`, `version`, and `help` as its subcommands. Bare `gtd` (no
+  subcommand) is a usage error unless `--entry <state>` is given. `--help`/
+  `help` and `--version`/`version` short-circuit before any repo-state work
+  and exit 0 everywhere, including outside a workflow state.
 
   Scenario: Bare gtd fails with usage help and authors nothing
     Given a test project
@@ -53,6 +53,7 @@ Feature: Command surface — bare gtd, unknown subcommands, --help, --version
     And stdout contains "abandon"
     And stdout contains "next"
     And stdout contains "visualize"
+    And stdout contains "check <mode> <file>"
     And stdout does not contain "review <commitish>"
 
   Scenario: --version prints the version and exits 0

--- a/tests/integration/features/default-workflow.feature
+++ b/tests/integration/features/default-workflow.feature
@@ -340,13 +340,16 @@ Feature: The bundled unified workflow — simple-flow full-process journeys
 
       - [ ] ./src/thing.ts#1
       """
-    Given the file ".gtd/REVIEW.md" is deleted
+    Given I record the commit count
+    And the file ".gtd/REVIEW.md" is deleted
     When I run gtd step human
     Then it fails
     And stderr contains "was deleted"
-    # Nothing committed — the refusal re-arms the review window, so the process
-    # stays at the gate for the reviewer to restore + tick.
-    And the git ref "refs/worktree/gtd/review-head" exists
+    # Nothing committed, and a refusal emits no script at all — the process
+    # stays at the gate for the reviewer to restore + tick. (What a refusal
+    # does to an OPEN review window is review-window.feature's subject; no
+    # step has landed at the gate here, so there is none.)
+    And the commit count is unchanged
 
   Scenario: stepping at await-review with a box still unticked and no comment is refused — finish reviewing first
     Given a test project
@@ -372,11 +375,12 @@ Feature: The bundled unified workflow — simple-flow full-process journeys
       - [x] ./src/a.ts#1
       - [ ] ./src/b.ts#1
       """
+    And I record the commit count
     When I run gtd step human
     Then it fails
     And stderr contains "still unticked and no comment"
-    # Nothing committed — the window re-arms, keeping the reviewer at the gate.
-    And the git ref "refs/worktree/gtd/review-head" exists
+    # Nothing committed — the reviewer stays at the gate.
+    And the commit count is unchanged
 
   Scenario: at await-review, gtd next surfaces the sign-off vs. feedback contract in its human-gate message
     Given a test project

--- a/tests/integration/features/empty-repository.feature
+++ b/tests/integration/features/empty-repository.feature
@@ -1,0 +1,33 @@
+Feature: gtd in a repository with no commits yet
+
+  The unborn-HEAD precondition case: `rest.context.currentCommit` is `""` for
+  a repository with no commits, and `src/Emit.ts`'s `headAssertion` treats
+  `""` as its own first-class value for "no commits yet" rather than a hash
+  standing in for it — so the very first `gtd step` in a freshly `git init`'d
+  project is allowed to land. Covered on both tiers: the @live scenario is
+  what would have caught the original bug (a bare `git rev-parse HEAD` prints
+  the literal string `HEAD` plus a `fatal:` line against an unborn HEAD, never
+  an empty string), and the @inmem twin keeps `EmittedScriptRecognizer.ts`
+  honest about modelling that same behavior.
+
+  @live
+  Scenario: the first gtd step lands in a repository with no commits
+    Given a git repository with no commits
+    And a file ".gtd/TODO.md" with:
+      """
+      build a thing
+      """
+    When I run gtd step human
+    Then it succeeds
+    And the last commit subject is "gtd(human): idle → plan-gate.check"
+
+  @inmem
+  Scenario: the first gtd step lands in a repository with no commits (scripted)
+    Given a git repository with no commits
+    And a file ".gtd/TODO.md" with:
+      """
+      build a thing
+      """
+    When I run gtd step human
+    Then it succeeds
+    And the last commit subject is "gtd(human): idle → plan-gate.check"

--- a/tests/integration/features/lsp.feature
+++ b/tests/integration/features/lsp.feature
@@ -284,3 +284,54 @@ Feature: gtd lsp — the steering-file LSP server (stdio)
     Then the LSP response has no error
     And the LSP response result contains a symbol named "[unanswered] Which operations?"
     And the LSP client received a textDocument/publishDiagnostics notification for ".gtd/PLAN.md" with exactly one Information diagnostic containing "exit 1"
+
+  Scenario: a modes: qa validate: entry carrying gtd's own SEEDED command keeps live diagnostics, not the external notice
+    # A later package's workflow compiler will seed `qa`/`review`'s own
+    # `validate:` with the literal string `gtd check <mode> '<%= it.file %>'`
+    # (src/SteeringFormats.ts's seededValidateCommand) — a shell-out that just
+    # calls back into gtd's own parser, changing nothing about how the file is
+    # actually validated. steeringCapabilities must recognize that string
+    # (isSeededValidateCommand) and keep publishing the built-in parser's live
+    # findings, never the "validated by an external command" notice a genuine
+    # user override gets (see the scenario above, which uses "exit 1").
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        modes:
+          qa:
+            validate: "gtd check qa '<%= it.file %>'"
+        entry:
+          default: root
+        machines:
+          root:
+            entry: idle
+            states:
+              idle:
+                actor: human
+                message: "go"
+                on:
+                  "* **": working
+              working:
+                actor: agent
+                file: ".gtd/PLAN.md"
+                mode: qa
+                prompt: "develop the plan"
+                on:
+                  "* **": idle
+      """
+    And an LSP server started in the test project
+    When the LSP client sends an initialize request
+    Then the LSP response has no error
+    When the LSP client requests document symbols for ".gtd/PLAN.md" containing:
+      """
+      Plan.
+
+      ## Open Questions
+
+      ###
+
+      no question text.
+      """
+    Then the LSP response has no error
+    And the LSP client received a textDocument/publishDiagnostics notification for ".gtd/PLAN.md" with exactly one Warning diagnostic containing "has no question text"

--- a/tests/integration/features/review-window.feature
+++ b/tests/integration/features/review-window.feature
@@ -1,25 +1,34 @@
 Feature: Review checkout window — the pending review diff surfaces in the editor
 
   A state may declare `reviewWindow: true` (see STATES.md §11). While the
-  workflow RESTS at such a state, gtd rewinds HEAD and the index to the review
-  base (the process start, unless a `reviewBase` state narrows it) with the
-  working tree untouched, so the whole reviewable diff shows up as ordinary
-  uncommitted changes in any editor's standard git integration. The real head
-  is preserved under `refs/worktree/gtd/review-head` (the base under
+  workflow RESTS at such a state, HEAD and the index sit at the review base
+  (the process start, unless a `reviewBase` state narrows it) with the working
+  tree untouched, so the whole reviewable diff shows up as ordinary uncommitted
+  changes in any editor's standard git integration. The real head is preserved
+  under `refs/worktree/gtd/review-head` (the base under
   `refs/worktree/gtd/review-base`) — git's PER-WORKTREE ref namespace, so
-  linked worktrees sharing one `.git` each get their own window; every gtd
-  invocation restores it BEFORE reading or mutating state, so the pure machine
-  never sees the window and the reviewer's own edits are captured by the
-  resting state's own `on` patterns like any other pending change. Files added
-  since the base surface as ORDINARY UNTRACKED files (see the scenario below);
-  the step decision is indifferent, since `changedPaths` unions
-  `git ls-files --others` in and reports them as `A` either way.
+  linked worktrees sharing one `.git` each get their own window. Rest
+  resolution READS THROUGH an open window, so the pure machine never sees it
+  and the reviewer's own edits are captured by the resting state's own `on`
+  patterns like any other pending change. Files added since the base surface as
+  ORDINARY UNTRACKED files (see the scenario below); the step decision is
+  indifferent, since `changedPaths` unions `git ls-files --others` in and
+  reports them as `A` either way.
+
+  The window is WRITE-COMMAND territory, and that is what these scenarios
+  exercise. The step that LANDS at the gate opens it (in that command's
+  `optional` script — presentation only, which is exactly what the window is);
+  the next step AWAY from the gate closes it (in that command's `required`
+  script, ahead of its own commit). A read command — `gtd next`, `gtd status` —
+  neither opens nor closes it: it resolves through the window and leaves it
+  exactly as it found it.
 
   The bundled unified workflow declares `reviewWindow: true` on
-  `await-review`. Each scenario builds a process that rests there: the
-  `chore: init gtd workflow` config commit is the process boundary (the diff
-  base), two `building` commits carry the reviewable code, and a final
-  `await-review` commit carries the committed review doc.
+  `await-review`. Each scenario builds a process resting one state earlier, at
+  `build.review.reviewing`, with the review doc pending in the working tree:
+  the `chore: init gtd workflow` config commit is the process boundary (the
+  diff base) and two `building` commits carry the reviewable code, so
+  `gtd step agent` commits the doc, lands at the gate, and opens the window.
 
   Background:
     Given a test project
@@ -32,7 +41,8 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
       """
       export const untouched = () => true
       """
-    And a commit "gtd(check): build.review.await-review" that adds ".gtd/REVIEW.md" with:
+    And an empty commit "gtd(check): build.review.reviewing"
+    And a file ".gtd/REVIEW.md" with:
       """
       # Review: abc1234
 
@@ -43,8 +53,8 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
       """
 
   @inmem
-  Scenario: Resting at the gate opens the window — HEAD at the base, the diff dirty
-    When I run gtd next
+  Scenario: The step that lands at the gate opens the window — HEAD at the base, the diff dirty
+    When I run gtd step agent
     Then it succeeds
     And the git ref "refs/worktree/gtd/review-head" exists
     And the git ref "refs/worktree/gtd/review-base" exists
@@ -58,7 +68,7 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
 
   @inmem
   Scenario: Files added since the base stay untracked — never intent-to-add index entries
-    When I run gtd next
+    When I run gtd step agent
     Then it succeeds
     # git's ordinary new-file state, deliberately: an editor's "discard changes"
     # then DELETES the file — the reject-this-file gesture a reviewer means —
@@ -70,35 +80,37 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
 
   @live
   Scenario: Real git agrees — the new file is untracked and keeps its content
-    When I run gtd next
+    When I run gtd step agent
     Then it succeeds
     And the git status contains "?? src/calc.ts"
     And "src/calc.ts" contains "export const add"
 
   @inmem
   Scenario: The machine never sees the window — status resolves the real state
-    Given I run gtd next
+    Given I run gtd step agent
     When I run gtd status
     Then it succeeds
-    # `gtd status` closed the window, resolved the true rest, then re-armed it:
+    # `gtd status` resolved the true rest by reading THROUGH the open window —
+    # it neither closed nor re-armed anything:
     And stdout contains "State: build.review.await-review"
     And the git ref "refs/worktree/gtd/review-head" exists
     And the last commit subject is "chore: init gtd workflow"
 
   @inmem
   Scenario: Deleting the review doc is refused — the window stays open, nothing commits
-    Given I run gtd next
+    Given I run gtd step agent
     And the file ".gtd/REVIEW.md" is deleted
     When I run gtd step human
     Then it fails
     And stderr contains "was deleted"
-    # Nothing committed; the window re-arms so the reviewer can restore + tick.
+    # A refusal emits no script at all, so the window stays exactly as it was —
+    # the reviewer can restore the file and tick.
     And the git ref "refs/worktree/gtd/review-head" exists
     And the last commit subject is "chore: init gtd workflow"
 
   @inmem
   Scenario: Ticking every box with no comment signs off — the window closes and routes to build.review.deciding
-    Given I run gtd next
+    Given I run gtd step agent
     And ".gtd/REVIEW.md" is modified to:
       """
       # Review: abc1234
@@ -117,7 +129,7 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
 
   @inmem
   Scenario: Reviewer code edits are feedback — the window closes and routes to build.review.deciding
-    Given I run gtd next
+    Given I run gtd step agent
     And "src/calc.ts" is modified to:
       """
       export const add = (a: number, b: number) => a + b
@@ -131,9 +143,19 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
     And the git ref "refs/worktree/gtd/review-head" does not exist
 
   @inmem
-  Scenario: Read-only commands re-arm the window on their way out
-    Given I run gtd next
+  Scenario: Read-only commands leave an open window exactly as they found it
+    # Neither command touches git at all now — no close, no re-arm, no reset.
+    # The window they resolve through survives both invocations untouched, and
+    # the second one still sees exactly what the first did.
+    Given I run gtd step agent
     When I run gtd status
     Then it succeeds
     And the git ref "refs/worktree/gtd/review-head" exists
+    And the git ref "refs/worktree/gtd/review-base" exists
     And the last commit subject is "chore: init gtd workflow"
+    When I run gtd next
+    Then it succeeds
+    And the git ref "refs/worktree/gtd/review-head" exists
+    And the git ref "refs/worktree/gtd/review-base" exists
+    And the last commit subject is "chore: init gtd workflow"
+    And the git status contains "src/calc.ts"

--- a/tests/integration/features/steering-modes.feature
+++ b/tests/integration/features/steering-modes.feature
@@ -344,7 +344,9 @@ Feature: Pluggable steering-file modes — a mode is a format command plus a val
       """
     When I run gtd step agent
     Then it fails
-    And stderr contains "docs/adr.md is not valid at \"drafting\""
+    # The step's own required script runs the mode's validate command ahead of
+    # its commit, so the refusal IS that command's non-zero exit and output —
+    # nothing is committed.
     And stderr contains "an ADR needs a '## Decision' section"
     And the last commit subject is "gtd(human): drafting"
 
@@ -394,7 +396,9 @@ Feature: Pluggable steering-file modes — a mode is a format command plus a val
       """
     When I run gtd step agent
     Then it fails
-    And stderr contains "docs/adr.md is not valid at \"drafting\""
+    # The step's own required script runs the mode's validate command ahead of
+    # its commit, so the refusal IS that command's non-zero exit and output —
+    # nothing is committed.
     And stderr contains "an ADR needs a '## Decision' section"
     And the last commit subject is "gtd(human): drafting"
 
@@ -483,7 +487,10 @@ Feature: Pluggable steering-file modes — a mode is a format command plus a val
       """
     When I run gtd step agent
     Then it fails
-    And stderr contains "format command exited with status 3"
+    # `format:` comes first in the emitted script and the script runs under
+    # `set -e`, so a non-zero format exit stops it before the validate command
+    # or the commit is ever reached — and its status is the script's own.
+    And the exit code is 3
     And stderr contains "adr-fmt: cannot parse docs/adr.md"
     And the last commit subject is "gtd(human): drafting"
 
@@ -530,8 +537,12 @@ Feature: Pluggable steering-file modes — a mode is a format command plus a val
       """
     When I run gtd step agent
     Then it fails
-    And stderr contains "format command exited with status 3"
+    # `format:` comes first in the emitted script and the script runs under
+    # `set -e`, so a non-zero format exit stops it before the validate command
+    # or the commit is ever reached.
+    And stderr contains "exited 3"
     And stderr contains "adr-fmt: cannot parse docs/adr.md"
+    And stderr does not contain "adr-validate-never-runs"
     And the last commit subject is "gtd(human): drafting"
 
   @live
@@ -810,3 +821,49 @@ Feature: Pluggable steering-file modes — a mode is a format command plus a val
     And stderr contains "1 open question(s)"
     And stderr contains "not answered at \"answering\""
     And the last commit subject is "gtd(agent): answering"
+
+  @live
+  Scenario: a seeded validate: command's bare "gtd" resolves to the build under test
+    # SteeringFormats.ts's seededValidateCommand renders as the literal
+    # `gtd check <mode> '<file>'` — resolving `gtd` BY NAME off $PATH rather
+    # than by absolute path, trading PATH independence for readability. This
+    # proves the @live tier's PATH shim (world.ts's pathShimDir, wired up by
+    # hooks.ts's Before/After) makes that bare `gtd` resolve to THIS build
+    # under test, never a stray globally-installed gtd.
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        modes:
+          adr:
+            validate: |
+              v=$(gtd version)
+              echo "path-shim: $v"
+              exit 1
+        entry:
+          default: root
+        machines:
+          root:
+            entry: idle
+            states:
+              idle:
+                actor: human
+                message: "start a decision record"
+                on:
+                  "* **": drafting
+              drafting:
+                actor: agent
+                prompt: "Write the ADR."
+                file: docs/adr.md
+                mode: adr
+                on:
+                  "* **": idle
+      """
+    And a commit "gtd(human): drafting" that adds "docs/adr.md" with:
+      """
+      # ADR 1: use gtd
+      """
+    When I run gtd with args "validate"
+    Then it fails
+    And stderr contains "path-shim:"
+    And stderr contains the gtd version under test

--- a/tests/integration/features/validate.feature
+++ b/tests/integration/features/validate.feature
@@ -60,7 +60,11 @@ Feature: gtd validate — self-validating the resolved rest's steering file
     And stderr contains ".gtd/REQUIREMENTS.md is not valid"
     And stderr contains "has no question text"
 
-  Scenario: --json reports the valid verdict structurally
+  Scenario: --json reports the emitted script structurally
+    # `--json` is the raw engine response: the resolved state, its file and
+    # mode, and the `script` a driver runs to get the verdict. There is no
+    # `valid` key — the verdict lives in that script's exit code, not this
+    # command's, which is why `validate` itself always succeeds now.
     Given a test project
     And the workflow
     And a commit "gtd(human): design.product-author" that adds ".gtd/REQUIREMENTS.md" with:
@@ -69,8 +73,9 @@ Feature: gtd validate — self-validating the resolved rest's steering file
       """
     When I run gtd with args "validate --json"
     Then it succeeds
-    And stdout contains "\"valid\":true"
     And stdout contains "\"mode\":\"qa\""
+    And stdout contains "\"file\":\".gtd/REQUIREMENTS.md\""
+    And stdout contains "gtd check qa"
 
   Scenario: a well-formed REVIEW.md at build.review.reviewing validates cleanly
     Given a test project
@@ -111,10 +116,11 @@ Feature: gtd validate — self-validating the resolved rest's steering file
     Then it succeeds
     And stdout contains "nothing to validate at \"idle\""
 
-  Scenario: the simple flow's TODO.md is `prose`-moded — it validates cleanly with no findings to check
+  Scenario: the simple flow's TODO.md is `prose`-moded — there is nothing to emit
     # The SIMPLE flow iterates on a free-form plan; planning declares `file:`
-    # + `mode: prose`, a format-only built-in with no validator, so any
-    # content validates cleanly.
+    # + `mode: prose`, an EMPTY modes: entry — no `format:`, no `validate:`.
+    # A mode with no commands emits no script at all, which is exactly the
+    # "nothing to validate" case: any content is acceptable.
     Given a test project
     And the workflow
     And a commit "gtd(human): plan.planning" that adds ".gtd/TODO.md" with:
@@ -123,7 +129,7 @@ Feature: gtd validate — self-validating the resolved rest's steering file
       """
     When I run gtd with args "validate"
     Then it succeeds
-    And stdout contains ".gtd/TODO.md: valid"
+    And stdout contains "nothing to validate at \"plan.planning\""
 
   Scenario: plain `gtd next` appends the self-validation instruction at a producing agent state
     Given a test project
@@ -134,7 +140,10 @@ Feature: gtd validate — self-validating the resolved rest's steering file
       """
     When I run gtd next
     Then it succeeds
-    And stdout contains "run `gtd validate`"
+    # The instruction names the MODE's own resolved validation command — for a
+    # built-in format that is the leaf `gtd check` invocation the compiler
+    # seeds — not `gtd validate`, which now only prints a script.
+    And stdout contains "run `gtd check qa '.gtd/REQUIREMENTS.md'`"
     And stdout contains "fix every violation"
 
   Scenario: `gtd next --json` withholds the instruction — the driving loop owns the validate-and-retry step
@@ -187,7 +196,10 @@ Feature: gtd validate — self-validating the resolved rest's steering file
       """
     When I run gtd step human
     Then it fails
-    And stderr contains "is not valid"
+    # The step's own required script runs the same validation ahead of its
+    # commit, so the refusal is the checker's findings and a non-zero exit —
+    # nothing is committed.
+    And stderr contains "has no question text"
     And the last commit subject is "gtd(human): design.product-answer"
 
   Scenario: the step gate captures a human's valid edit (routing it back to design.product-author)

--- a/tests/integration/support/hooks.ts
+++ b/tests/integration/support/hooks.ts
@@ -1,6 +1,8 @@
 import { Before, After } from "quickpickle"
-import { rmSync } from "node:fs"
-import type { GtdWorld } from "./world.js"
+import { rmSync, mkdtempSync, writeFileSync, chmodSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { GTD_BIN, type GtdWorld } from "./world.js"
 import { InMemRepo } from "../../../src/testing/InMemRepo.js"
 
 // Scrub every inherited GIT_* and GTD_LOOP_* var from the test process's
@@ -33,6 +35,25 @@ for (const key of Object.keys(process.env)) {
   if (key.startsWith("GIT_") || key.startsWith("GTD_LOOP_")) delete process.env[key]
 }
 
+// A seeded steering-mode validate: command (`SteeringFormats.ts`'s
+// `seededValidateCommand`) is the literal template `gtd check <mode> <file>`
+// — readable at the cost of resolving `gtd` by NAME off `$PATH`, rather than
+// by an absolute path. Nothing guarantees a `gtd` on the host's PATH at all
+// (a dev machine may have none), and even if one exists it may be a stale
+// global install — either way, running the seeded command for real against
+// whatever `bin/gtd`/`gtd.bundle.mjs` happens to be on PATH would silently
+// test the wrong binary. This shim makes `gtd` resolve to THIS build's own
+// bundle for the whole live-tier subprocess tree (the spawned gtd process
+// itself, and anything IT shells out to, e.g. CommandRunner.Live's `bash -c`
+// running a mode's validate: command).
+function createPathShim(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gtd-path-shim-"))
+  const shim = join(dir, "gtd")
+  writeFileSync(shim, `#!/usr/bin/env bash\nexec node "${GTD_BIN}" "$@"\n`)
+  chmodSync(shim, 0o755)
+  return dir
+}
+
 /**
  * Detect tier from scenario tags. Exactly one of `@live`/`@inmem` is required
  * on every scenario (directly or inherited from its feature) — the tier tag
@@ -55,24 +76,33 @@ Before(async (world: GtdWorld) => {
   if (live) {
     world.tier = "live"
     world.repo = undefined
+    world.pathShimDir = createPathShim()
   } else {
     world.tier = "inmem"
     world.repo = new InMemRepo()
   }
 })
 
-After(async (world: GtdWorld) => {
-  // In-memory tier: just drop the reference — no temp dir to clean up.
-  if (world.tier === "inmem") {
-    world.repo = undefined
-    return
-  }
-
-  // Live tier: remove the temp repo dir (and any purpose-built ancestor dir).
+// Live tier: remove the temp repo dir (and any purpose-built ancestor dir),
+// honoring KEEP_TEST_REPO — then always remove the PATH shim dir regardless
+// (it's harness scaffolding, not part of the test repo KEEP_TEST_REPO is for).
+function cleanupLiveTier(world: GtdWorld): void {
   const keep = process.env["KEEP_TEST_REPO"] === "1"
   const dirs = [world.repoDir, world.extraCleanupDir].filter(Boolean) as string[]
   for (const dir of dirs) {
     if (keep) process.stderr.write(`Test repo preserved at: ${dir}\n`)
     else rmSync(dir, { recursive: true, force: true })
   }
+  if (world.pathShimDir !== undefined) {
+    rmSync(world.pathShimDir, { recursive: true, force: true })
+    world.pathShimDir = undefined
+  }
+}
+
+After(async (world: GtdWorld) => {
+  if (world.tier === "inmem") {
+    world.repo = undefined
+    return
+  }
+  cleanupLiveTier(world)
 })

--- a/tests/integration/support/steps/common.steps.ts
+++ b/tests/integration/support/steps/common.steps.ts
@@ -1,7 +1,8 @@
 import { Given, Then, When } from "quickpickle"
 import { execFileSync } from "node:child_process"
-import { writeFileSync, mkdirSync } from "node:fs"
+import { writeFileSync, mkdirSync, mkdtempSync } from "node:fs"
 import { createRequire } from "node:module"
+import { tmpdir } from "node:os"
 import { join } from "node:path"
 import assert from "node:assert"
 import type { GtdWorld } from "../world.js"
@@ -24,6 +25,24 @@ Given("a test project", (world: GtdWorld) => {
   } else {
     world.repoDir = createTestProject()
   }
+})
+
+// The unborn-HEAD case "a test project" deliberately doesn't cover: no
+// initial commit at all, so `git rev-parse HEAD` has nothing to resolve.
+// Inmem: the Before hook's `new InMemRepo()` is already commit-less — nothing
+// to seed. Live: `git init` plus the author identity `commit --allow-empty`
+// needs, and nothing else.
+Given("a git repository with no commits", (world: GtdWorld) => {
+  if (world.tier === "inmem") {
+    world.repoDir = "/inmem"
+    return
+  }
+  const dir = mkdtempSync(join(tmpdir(), "gtd-test-unborn-"))
+  execFileSync("git", ["init", "-q"], { cwd: dir })
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: dir })
+  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: dir })
+  execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: dir })
+  world.repoDir = dir
 })
 
 // ── Working-tree file edits (uncommitted) ────────────────────────────────────

--- a/tests/integration/support/steps/common.steps.ts
+++ b/tests/integration/support/steps/common.steps.ts
@@ -1,10 +1,13 @@
 import { Given, Then, When } from "quickpickle"
 import { execFileSync } from "node:child_process"
 import { writeFileSync, mkdirSync } from "node:fs"
+import { createRequire } from "node:module"
 import { join } from "node:path"
 import assert from "node:assert"
 import type { GtdWorld } from "../world.js"
 import { createTestProject } from "../../helpers/project-setup.js"
+
+const _require = createRequire(import.meta.url)
 
 // ── Repo / branch setup ──────────────────────────────────────────────────────
 
@@ -250,6 +253,17 @@ Then("stderr contains {string}", (world: GtdWorld, text: string) => {
   assert.ok(
     world.lastResult.stderr.includes(text),
     `Expected stderr to contain "${text}". Got:\n${world.lastResult.stderr}`,
+  )
+})
+
+// Reads package.json's own `version` at run time (same technique as
+// Cli.ts's GTD_VERSION) rather than a literal string, so this assertion
+// doesn't go stale across semantic-release bumps.
+Then("stderr contains the gtd version under test", (world: GtdWorld) => {
+  const { version } = _require("../../../../package.json") as { version: string }
+  assert.ok(
+    world.lastResult.stderr.includes(version),
+    `Expected stderr to contain the gtd version under test (${version}). Got:\n${world.lastResult.stderr}`,
   )
 })
 

--- a/tests/integration/support/steps/gtd-loop.steps.ts
+++ b/tests/integration/support/steps/gtd-loop.steps.ts
@@ -36,19 +36,41 @@ function scrubInheritedLoopEnv(env: NodeJS.ProcessEnv, world: GtdWorld): void {
   }
 }
 
+// Prepend the PATH shim dir (see hooks.ts's Before / world.ts's spawnEnv,
+// same rationale) so a `gtd` invoked BY NAME resolves to this build's own
+// bundle. bin/gtd itself needs no shim (it self-locates dist/gtd.bundle.mjs
+// relative to its own script path), but a WRITE subcommand's `required`/
+// `.script` bash — e.g. a seeded steering-mode validate: command
+// (`SteeringFormats.ts`'s literal `gtd check <mode> <file>`) that
+// `run_gtd_command`/the validate gate execute via `bash -c` — shells out to
+// `gtd` by name, and would otherwise resolve to whatever (if anything) is
+// globally installed on the host.
+function prependPathShim(env: NodeJS.ProcessEnv, shimDir: string | undefined): void {
+  if (shimDir === undefined) return
+  env["PATH"] = `${shimDir}:${env["PATH"] ?? ""}`
+}
+
+/** Sets each override whose value the scenario actually supplied; an absent one leaves the inherited value alone. */
+function applyEnvOverrides(
+  env: NodeJS.ProcessEnv,
+  overrides: Record<string, string | undefined>,
+): void {
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value !== undefined) env[key] = value
+  }
+}
+
 function gtdLoopEnv(world: GtdWorld): NodeJS.ProcessEnv {
   const env = { ...process.env }
   scrubInheritedLoopEnv(env, world)
-  const overrides: Record<string, string | undefined> = {
+  prependPathShim(env, world.pathShimDir)
+  applyEnvOverrides(env, {
     GTD_LOOP_AGENT_CMD: world.stubAgentPath ? `bash "${world.stubAgentPath}"` : undefined,
     GTD_LOOP_LOG: world.gtdLoopLogOverride,
     GIT_DIR: world.gitDirOverride,
     NO_COLOR: world.noColorOverride,
     GTD_TESTCOMMAND: world.gtdTestCommandOverride,
-  }
-  for (const [key, value] of Object.entries(overrides)) {
-    if (value !== undefined) env[key] = value
-  }
+  })
   return env
 }
 

--- a/tests/integration/support/steps/lsp.steps.ts
+++ b/tests/integration/support/steps/lsp.steps.ts
@@ -173,14 +173,22 @@ When("the LSP client sends an initialize request", async (world: GtdWorld) => {
   notify(client, "initialized", {})
 })
 
+// Shared by every "requests X for/in {file} containing:" step below: opens
+// `content` as `path` over `textDocument/didOpen` and returns its URI, so
+// each step only supplies the request that differs.
+function openDocument(client: LspClient, world: GtdWorld, path: string, content: string): string {
+  const uri = pathToFileURL(join(world.repoDir, path)).toString()
+  notify(client, "textDocument/didOpen", {
+    textDocument: { uri, languageId: "markdown", version: 1, text: content },
+  })
+  return uri
+}
+
 When(
   "the LSP client requests document symbols for {string} containing:",
   async (world: GtdWorld, path: string, content: string) => {
     const client = clients.get(world)!
-    const uri = pathToFileURL(join(world.repoDir, path)).toString()
-    notify(client, "textDocument/didOpen", {
-      textDocument: { uri, languageId: "markdown", version: 1, text: content },
-    })
+    const uri = openDocument(client, world, path, content)
     const response = await request(client, "textDocument/documentSymbol", {
       textDocument: { uri },
     })
@@ -192,10 +200,7 @@ When(
   "the LSP client requests a definition at line {int} in {string} containing:",
   async (world: GtdWorld, line: number, path: string, content: string) => {
     const client = clients.get(world)!
-    const uri = pathToFileURL(join(world.repoDir, path)).toString()
-    notify(client, "textDocument/didOpen", {
-      textDocument: { uri, languageId: "markdown", version: 1, text: content },
-    })
+    const uri = openDocument(client, world, path, content)
     const response = await request(client, "textDocument/definition", {
       textDocument: { uri },
       position: { line, character: 0 },
@@ -208,10 +213,7 @@ When(
   "the LSP client requests code actions at line {int} in {string} containing:",
   async (world: GtdWorld, line: number, path: string, content: string) => {
     const client = clients.get(world)!
-    const uri = pathToFileURL(join(world.repoDir, path)).toString()
-    notify(client, "textDocument/didOpen", {
-      textDocument: { uri, languageId: "markdown", version: 1, text: content },
-    })
+    const uri = openDocument(client, world, path, content)
     const response = await request(client, "textDocument/codeAction", {
       textDocument: { uri },
       range: {
@@ -313,11 +315,26 @@ Then(
   },
 )
 
+/** LSP `DiagnosticSeverity` values, named the way a scenario names them — `Warning` is what a built-in format's own live `validate` publishes (see `src/Lsp.ts`'s `toDiagnostic`); `Information` is the external-validator notice (`externalValidatorNotice`). */
+const DIAGNOSTIC_SEVERITY_BY_NAME: Readonly<Record<string, number>> = {
+  Error: 1,
+  Warning: 2,
+  Information: 3,
+  Hint: 4,
+}
+
 Then(
-  "the LSP client received a textDocument\\/publishDiagnostics notification for {string} with exactly one Information diagnostic containing {string}",
-  async (world: GtdWorld, path: string, substring: string) => {
+  "the LSP client received a textDocument\\/publishDiagnostics notification for {string} with exactly one {word} diagnostic containing {string}",
+  async (world: GtdWorld, path: string, severityName: string, substring: string) => {
     const client = clients.get(world)!
     const expectedUri = pathToFileURL(join(world.repoDir, path)).toString()
+    const expectedSeverity = DIAGNOSTIC_SEVERITY_BY_NAME[severityName]
+    assert.ok(
+      expectedSeverity !== undefined,
+      `Unknown diagnostic severity name "${severityName}" — expected one of ${Object.keys(
+        DIAGNOSTIC_SEVERITY_BY_NAME,
+      ).join(", ")}`,
+    )
     const notification = await waitForServerRequest(
       client,
       "textDocument/publishDiagnostics",
@@ -331,7 +348,7 @@ Then(
       1,
       `Expected exactly one diagnostic for "${path}". Got: ${JSON.stringify(diagnostics)}`,
     )
-    assert.strictEqual(diagnostics[0]!.severity, 3 /* DiagnosticSeverity.Information */)
+    assert.strictEqual(diagnostics[0]!.severity, expectedSeverity)
     assert.ok(
       diagnostics[0]!.message.includes(substring),
       `Expected the diagnostic message to contain "${substring}". Got: ${diagnostics[0]!.message}`,

--- a/tests/integration/support/world.ts
+++ b/tests/integration/support/world.ts
@@ -12,11 +12,100 @@ import { runCli } from "../../../src/Cli.js"
 import { makeCapturingCliIo } from "../../../src/testing/cliIo.js"
 import { type ScriptedCommand } from "../../../src/testing/Layers.js"
 import { InMemRepo } from "../../../src/testing/InMemRepo.js"
+import { applyEmittedScript } from "../../../src/testing/EmittedScriptRecognizer.js"
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "../../..")
-const GTD_BIN = join(PROJECT_ROOT, "dist/gtd.bundle.mjs")
+// Exported so `hooks.ts`'s PATH shim (a `gtd` shell script on the live tier's
+// PATH, for anything the spawned process itself shells out to by name — see
+// `pathShimDir` below) execs this SAME bundle, never a globally-installed gtd.
+export const GTD_BIN = join(PROJECT_ROOT, "dist/gtd.bundle.mjs")
 
 export type Tier = "live" | "inmem"
+
+/**
+ * Mirrors `bin/gtd`'s own `is_write_command`: the tokens whose command no
+ * longer performs its git effect itself but PRINTS it as a `required`/
+ * `optional` script pair for a driver to run (`step`, `abandon`, `restore`,
+ * and the bare `gtd --entry <state>` short form). `--entry`'s long form
+ * (`gtd step --entry <state>`) is already covered by the `step` token in
+ * front of it. Everything else is a read command with nothing to drive.
+ */
+const WRITE_COMMAND_TOKENS: ReadonlySet<string> = new Set(["step", "abandon", "restore", "--entry"])
+
+/** `--entry` takes both spellings (`--entry <state>` and `--entry=<state>`), so the bare short form has to be recognized either way. */
+const isWriteCommand = (args: readonly string[]): boolean => {
+  const first = args[0] ?? ""
+  return WRITE_COMMAND_TOKENS.has(first) || first.startsWith("--entry=")
+}
+
+/** The one line of a possibly multi-document stdout that parses as a JSON object (`gtd check --json`'s failing shape emits two). */
+const firstJsonObject = (stdout: string): Record<string, unknown> | undefined => {
+  for (const line of stdout.split("\n")) {
+    if (!line.startsWith("{")) continue
+    try {
+      return JSON.parse(line) as Record<string, unknown>
+    } catch {
+      continue
+    }
+  }
+  return undefined
+}
+
+const stringField = (json: Record<string, unknown>, key: string): string =>
+  typeof json[key] === "string" ? json[key] : ""
+
+/** What running one emitted script produced — a real `bash` exit + combined output on the live tier, the recognizer's verdict on the in-memory one. */
+interface EmittedRun {
+  readonly exitCode: number
+  readonly output: string
+}
+
+/** A rejected `execFile` promise, read back as an `EmittedRun`. */
+const execFailure = (err: unknown): EmittedRun => {
+  const e = err as { code?: unknown; stdout?: string; stderr?: string }
+  return {
+    exitCode: typeof e.code === "number" ? e.code : 1,
+    output: (e.stdout ?? "") + (e.stderr ?? ""),
+  }
+}
+
+/**
+ * In-memory tier: apply an emitted script to the fake through
+ * `EmittedScriptRecognizer`. Its refusal on a block it does not know is
+ * THROWN rather than returned as an exit code — that refusal is the property
+ * keeping the fake honest (a builder added without teaching the recognizer
+ * must fail the suite loudly, never masquerade as a script that legitimately
+ * failed).
+ */
+const applyScriptToFake = (
+  repo: InMemRepo,
+  commands: ReadonlyMap<string, ScriptedCommand>,
+  script: string,
+): EmittedRun => {
+  const applied = applyEmittedScript(repo, commands, script)
+  if (applied.ok) return { exitCode: 0, output: "" }
+  const error = applied.error ?? ""
+  if (error.startsWith("unrecognized script block:")) {
+    throw new Error(
+      `the in-memory tier could not apply an emitted script — ${error}\n` +
+        `Teach src/testing/EmittedScriptRecognizer.ts about it.\nScript:\n${script}`,
+    )
+  }
+  return { exitCode: 1, output: `${error}\n` }
+}
+
+/** How a driver reports `gtd validate`'s emitted script once it has run: `<file>: valid`, or the script's own output as findings. */
+const validateVerdict = (
+  file: string,
+  run: EmittedRun,
+): { exitCode: number; stdout: string; stderr: string } =>
+  run.exitCode === 0
+    ? { exitCode: 0, stdout: `${file}: valid\n`, stderr: "" }
+    : {
+        exitCode: run.exitCode,
+        stdout: "",
+        stderr: `gtd validate: ${file} is not valid\n${run.output}`,
+      }
 
 export class GtdWorld extends QuickPickleWorld {
   // Under `moduleResolution: nodenext`, a bare subclass of `QuickPickleWorld`
@@ -57,6 +146,8 @@ export class GtdWorld extends QuickPickleWorld {
   noColorOverride: string | undefined = undefined
   /** Explicit `$GTD_TESTCOMMAND` value a scenario wants exported — overrides the bundled template's `vars.testCommand` for a real `checking`/`fix-precheck` script run (`gtd-loop` @live scenarios only). */
   gtdTestCommandOverride: string | undefined = undefined
+  /** A scenario-scoped temp dir holding a `gtd` shim (see hooks.ts's `Before`) so a bare `gtd` invoked BY NAME — e.g. a seeded steering-mode `validate:` command (`gtd check <mode> <file>`) — resolves to this build, not a globally-installed gtd. Set by the Before hook, live tier only. */
+  pathShimDir: string | undefined = undefined
 
   /** Environment variables the in-memory tier's `EnvVars` layer exposes (`it.vars`'s highest-precedence `GTD_<UPPERCASE-name>` layer) — never mutates the real `process.env`. Set by `Given an environment variable "..." set to "..."`. */
   envVars: Record<string, string> = {}
@@ -64,13 +155,137 @@ export class GtdWorld extends QuickPickleWorld {
   /** Canned `bash` command behaviors for the in-memory tier's `CommandRunner` — real subprocess execution is unreachable against an in-memory worktree. Keyed by the rendered command string; set by `Given the shell command "..." ...` (@inmem steering-mode scenarios only). */
   scriptedCommands: Map<string, ScriptedCommand> = new Map()
 
-  /** Dispatch: routes to the live or in-process implementation based on this.tier. */
+  /**
+   * The e2e DRIVER — the test-suite counterpart of `bin/gtd`. gtd's write
+   * commands no longer perform their own git effect: they print a `required`
+   * (and sometimes `optional`) bash script for a driver to run, and `gtd
+   * validate` likewise prints the script that formats-then-validates rather
+   * than doing it. Every scenario's assertions are about what those scripts
+   * DO — the resulting commits, the reformatted file, the findings — so the
+   * world has to be the thing that runs them.
+   *
+   * Invoke the command exactly as the scenario asked (so `lastResult` carries
+   * gtd's own wording and exit code verbatim), then drive whatever it
+   * emitted. A read command (`next`, `status`, `visualize`, `lsp`, `check`,
+   * `init`) emits nothing and falls straight through.
+   */
   async runGtd(...args: string[]): Promise<void> {
+    await this.invokeGtd(...args)
+    if (this.lastResult.exitCode !== 0) return
+    if (isWriteCommand(args)) await this.driveWriteCommand(args)
+    else if (args[0] === "validate") await this.driveValidateCommand(args)
+  }
+
+  /** Raw invocation: routes to the live or in-process implementation based on this.tier, with no script driving. */
+  private async invokeGtd(...args: string[]): Promise<void> {
     if (this.tier === "inmem") {
       await this.runGtdInMem(...args)
     } else {
       await this.runGtdLive(...args)
     }
+  }
+
+  /**
+   * The emitted scripts for `args`, read off the command's own `--json`
+   * response. A scenario that already asked for `--json` has them in
+   * `lastResult` already; otherwise this re-invokes with `--json` appended
+   * and restores `lastResult` afterwards. Re-invoking is sound precisely
+   * because of the property this whole change establishes: every command is
+   * now a pure read, so asking twice against an unchanged repo answers
+   * identically. Returns `undefined` when the probe itself failed (a refusal
+   * the first invocation already reported) — there is nothing to drive then.
+   */
+  private async emittedJson(args: string[]): Promise<Record<string, unknown> | undefined> {
+    if (args.includes("--json")) return firstJsonObject(this.lastResult.stdout)
+    const reported = this.lastResult
+    await this.invokeGtd(...args, "--json")
+    const probe = this.lastResult
+    this.lastResult = reported
+    return probe.exitCode === 0 ? firstJsonObject(probe.stdout) : undefined
+  }
+
+  /**
+   * `step`/`--entry`/`abandon`/`restore`: run `required` (the commit, reset,
+   * ref update, review-window close/open — everything that decides what lands
+   * in git), then `optional` (presentation only, so a non-zero exit there is
+   * ignored exactly as `bin/gtd` ignores it). gtd's own plain-text line stays
+   * as `lastResult`; only a FAILING required script overrides it, since a
+   * scenario asserting "it succeeds" must not pass when the work never landed.
+   */
+  private async driveWriteCommand(args: string[]): Promise<void> {
+    const json = await this.emittedJson(args)
+    if (json === undefined) return
+    if (!(await this.runRequiredScript(stringField(json, "required")))) return
+    const optional = stringField(json, "optional")
+    if (optional.length > 0) await this.runEmittedScript(optional)
+  }
+
+  /** Runs a write command's `required` half; `false` (with `lastResult` already rewritten to say so) when it failed, so the caller skips `optional`. */
+  private async runRequiredScript(required: string): Promise<boolean> {
+    if (required.length === 0) return true
+    const run = await this.runEmittedScript(required)
+    if (run.exitCode === 0) return true
+    this.lastResult = {
+      exitCode: run.exitCode,
+      stdout: this.lastResult.stdout,
+      stderr: this.lastResult.stderr + run.output,
+    }
+    return false
+  }
+
+  /**
+   * `validate`: gtd prints the format-then-validate script; the verdict lives
+   * in that script's exit code, not the command's. Run it and report the
+   * verdict the way a driver does (`validateVerdict`). Under `--json` the
+   * scenario asked for the engine's raw response (the `script` field itself),
+   * so the script still runs — a mode's `format:` half rewrites the file in
+   * place, which a scenario may then assert on — but `lastResult` is left as
+   * the JSON gtd wrote. An empty `script` ("nothing to validate") leaves gtd's
+   * own line alone in both cases.
+   */
+  private async driveValidateCommand(args: string[]): Promise<void> {
+    const json = await this.emittedJson(args)
+    if (json === undefined) return
+    const script = stringField(json, "script")
+    if (script.length === 0) return
+    const run = await this.runEmittedScript(script)
+    if (args.includes("--json")) return
+    this.lastResult = validateVerdict(stringField(json, "file"), run)
+  }
+
+  /** Executes one emitted script against whichever repo the tier owns. */
+  private async runEmittedScript(script: string): Promise<EmittedRun> {
+    return this.repo !== undefined
+      ? applyScriptToFake(this.repo, this.scriptedCommands, script)
+      : this.runScriptWithBash(script)
+  }
+
+  /** Live tier: real `bash`, in the real worktree, with the PATH shim in scope so a script's bare `gtd` resolves to this build. */
+  private async runScriptWithBash(script: string): Promise<EmittedRun> {
+    try {
+      const { stdout, stderr } = await execFile("bash", ["-c", script], {
+        cwd: this.repoDir,
+        env: this.spawnEnv(),
+        encoding: "utf-8",
+        timeout: 30_000,
+      })
+      return { exitCode: 0, output: stdout + stderr }
+    } catch (err: unknown) {
+      return execFailure(err)
+    }
+  }
+
+  /**
+   * The environment every live-tier subprocess gets. Prepends the PATH shim
+   * dir (see hooks.ts's Before) so a bare `gtd` invoked BY NAME — by the
+   * process spawned here, or by anything IT spawns — resolves to this same
+   * build under test rather than a stray global install.
+   */
+  private spawnEnv(): NodeJS.ProcessEnv {
+    const pathEnv = this.pathShimDir
+      ? { PATH: `${this.pathShimDir}:${process.env["PATH"] ?? ""}` }
+      : {}
+    return { ...process.env, ...pathEnv, NODE_OPTIONS: undefined }
   }
 
   /** Async execFile implementation — used for the live tier. */
@@ -80,7 +295,7 @@ export class GtdWorld extends QuickPickleWorld {
     try {
       const { stdout, stderr } = await execFile(process.execPath, [GTD_BIN, ...args], {
         cwd: this.repoDir,
-        env: { ...process.env, NODE_OPTIONS: undefined },
+        env: this.spawnEnv(),
         encoding: "utf-8",
         timeout: 30_000,
       })


### PR DESCRIPTION
Moves every git-mutating action (`gtd step`, `--entry`, `abandon`, `restore`, and steering-file validation) out of in-process execution and into **emitted shell scripts a driver runs itself**.

Each command's `--json` output now carries:

- **`required`** — everything that decides what lands in git: closing the review window, `format:`/`validate:` commands, the commit/squash, or the `abandon`/`restore` ref update + reset
- **`optional`** — presentation only (reopening the review checkout window)

Scripts are built by two new pure modules, `src/Emit.ts` and `src/GitScript.ts`, sitting alongside `src/PatternMachine.ts`.

## Key decisions

- **Self-contained and re-runnable.** Each script opens with a precondition assert (expected HEAD, or a review window's saved ref), so a script generated against stale repository state refuses loudly instead of corrupting anything. A driver's whole recovery story collapses to "re-invoke gtd."
- **`index.lock` tolerance is preserved.** `gitWrite` steps are wrapped in a shared `gtd_retry` helper mirroring `src/Git.ts`'s `withIndexLockRetry`, so contention from an editor/LSP/git-aware prompt is tolerated. Non-git command steps (`format:`/`validate:`/check scripts) are deliberately *not* retry-wrapped — wrapping them would silently retry on unrelated output that happens to mention `index.lock`.
- **`gtd validate` no longer executes anything.** It prints the script for a driver to run and always exits 0. `gtd check <mode> <file>` is a new standalone leaf command (no workflow/config resolution) that the emitted validate script invokes by name on `PATH` — trading a readable/overridable command for a small version-skew risk between the gtd that generated a script and the gtd that later runs it.
- **`src/testing/EmittedScriptRecognizer.ts` re-derives each script shape from the real builders** rather than hand-copying templates, so fake-vs-real drift in the test doubles is caught the same way `GitTiers`' contract test already catches it for `GitOperations`.

## Docs

README gains a **"Writing your own driver"** section documenting the `required`/`optional` contract, the failure taxonomy, and the normalization-only contract on `format:` commands — any driver, not just `bin/gtd`, now depends on these guarantees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)