### PR TITLE
fix(review): make review sign-off landable when reviewFile lives outside .gtd/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,21 @@ description, and must be preserved:
   `GitOperations` and hand it straight to `Layer.succeed` — go through
   `withIndexLockRetries`.
 
+- **Because the window un-tracks things, `changedPaths` answers by CONTENT, not
+  by the index: a path that EXISTS in the working tree is never reported `D`.**
+  The window's `git reset --mixed` leaves every file the reviewed range added
+  untracked-but-present, and `git diff --name-status <base>` compares `base` to
+  the INDEX — so the index view calls each of them deleted. That phantom `D`
+  made the review-signoff guard refuse every sign-off in a repo whose
+  `reviewFile` sits outside `.gtd/` (the one directory the window pins back into
+  the index). `src/Git.ts`'s `classifyUntracked` therefore classifies each
+  untracked path against the base tree by blob id: absent → `A`, different →
+  `M`, identical → no change. Don't "simplify" it back to the index's answer.
+  The in-memory double has always compared the base tree to the worktree
+  directly, so only the Live tier of `runGitServiceContract`'s `changedPaths`
+  base-case group can fail on this — and an @inmem e2e scenario cannot (hence
+  `@live` `review-window-untracked.feature`).
+
 ### Testing
 
 `src/testing/` is the in-memory git/config/filesystem test seam
@@ -237,13 +252,31 @@ parser, one envelope. The table is the source of truth, not prose:
   map
 - **Step-capture guards (edge, not engine):** `enforceStepGuards` in
   `src/StepGuards.ts` runs a registry of guards before a normal commit lands —
-  the steering-file guard first formats a state's `file:`+`mode:` file in place
-  and validates it per its `mode:` (over `src/SteeringMode.ts`), then the
-  review-signoff, feedback-progress, and answer-completeness guards each check
-  their own state-flavor condition. Any guard REFUSES the step when its
-  condition fires, so e.g. a malformed steering file is never committed (an
-  agent's draft or a human's gate edit alike). Each guard is a no-op when it
-  doesn't apply to the resting state (see `StepGuard.appliesTo`), and the whole
-  registry is skipped for a squash/no-op decision, or an ATTEMPT (there is
-  nothing to guard in an empty diff, and a `format:` run must not dirty an
-  attempt and break the empty-diff derivation `stalledAt` relies on)
+  the review-signoff, feedback-progress, and answer-completeness guards each
+  check their own state-flavor condition. A state's `file:`+`mode:` formatting
+  and validation is NOT a guard any more: `program.ts`'s `steeringModeSteps`
+  emits the mode's own `format:`/`validate:` commands (over
+  `src/SteeringMode.ts`) into the step script for the driver to run, ahead of
+  the commit. Any guard REFUSES the step when its condition fires, so e.g. a
+  malformed steering file is never committed (an agent's draft or a human's gate
+  edit alike). Each guard is a no-op when it doesn't apply to the resting state
+  (see `StepGuard.appliesTo`), and the whole registry is skipped for a
+  squash/no-op decision, or an ATTEMPT (there is nothing to guard in an empty
+  diff, and a `format:` run must not dirty an attempt and break the empty-diff
+  derivation `stalledAt` relies on). The emitted format/validate pair is skipped
+  for an attempt for the same reason, AND for a step whose diff DELETES that
+  `file:` (`deletesFile`, shared with the guards): deleting it is a legitimate
+  outcome — a review sign-off's whole diff is the review doc's deletion — and a
+  `format:` like `prettier --write` exits non-zero on a missing path, which
+  aborted the whole `set -euo pipefail` script before the commit and made the
+  step unlandable
+- **Two properties of a guard's INPUTS, each of which makes a guard silently
+  INERT rather than loudly wrong when broken:** the pre-turn copy of a `file:`
+  is read at `Rest.windowHead` — the open review window's saved head — never at
+  real `HEAD`, which the window has rewound to the review base, where a file the
+  process itself wrote does not exist yet; and `hasCodeChange` ("the human
+  edited something real") excludes the state's OWN `file:` by exact path, not
+  merely everything under `.gtd/`. A `reviewFile` repointed to the repo root is
+  still a steering file — the same assumption issue #128 broke in `deciding`'s
+  check script. With either one wrong, the review sign-off guard takes its
+  it-is-a-comment branch on every pass and the unticked-box check is unreachable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,10 +81,15 @@ description, and must be preserved:
   the index). `src/Git.ts`'s `classifyUntracked` therefore classifies each
   untracked path against the base tree by blob id: absent → `A`, different →
   `M`, identical → no change. Don't "simplify" it back to the index's answer.
-  The in-memory double has always compared the base tree to the worktree
-  directly, so only the Live tier of `runGitServiceContract`'s `changedPaths`
-  base-case group can fail on this — and an @inmem e2e scenario cannot (hence
-  `@live` `review-window-untracked.feature`).
+  The worktree side is hashed WITH the repo's clean filters (plain
+  `git hash-object -- <paths>`, which looks each file's attributes up from its
+  own path) — never `--no-filters`, or a `text=auto` repo reports every
+  untouched CRLF file `M`, and a spurious `M` on the review doc is a spurious
+  `hasCodeChange`, i.e. the same inert guard as above. The in-memory double has
+  always compared the base tree to the worktree directly, so only the Live tier
+  of `runGitServiceContract`'s `changedPaths` base-case group can fail on this —
+  and an @inmem e2e scenario cannot (hence `@live`
+  `review-window-untracked.feature`).
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -141,22 +141,28 @@ landing script opens a **review checkout window**: HEAD is rewound to the review
 base with the working tree untouched, so the whole reviewable change shows up as
 ordinary uncommitted changes in your editor's normal git integration (and files
 added during the process show up as ordinary untracked files, so discarding one
-deletes it). The next landing's own script closes the window before it commits.
-Tick a box as you review each hunk (ticking just records "I read this"), and
-leave a **comment** to request changes: a note on a line, an inline
-`// TODO`-style comment in the code, or a direct code edit. Any comment sends a
-build + re-review round — an agent first turns your comments into an explicit
-instruction list, then a build turn implements it (a re-review then covers only
-the follow-through, and a hand-edit is treated as your own fix the agent
-completes without reverting your lines; a comment can't be silently dropped — a
-build turn that addresses nothing is refused). For the simple flow, the build
-turn that follows through on feedback and the turn that drafts the final squash
-message both resume the same session that built the feature in the first place,
-since the review tail is nested inside that build identity rather than sitting
-beside it. Ticking every box with no comment is the sign-off, which collapses
-the whole process into one commit (a **squash finale** whose message an agent
-drafts). Landing with a box still unticked and no comment is refused (finish
-reviewing first), as is deleting `.gtd/REVIEW.md`.
+deletes it — an untracked file you leave alone is not a pending change, and only
+actually removing it from disk counts as a deletion). The next landing's own
+script closes the window before it commits. Tick a box as you review each hunk
+(ticking just records "I read this"), and leave a **comment** to request
+changes: a note on a line, an inline `// TODO`-style comment in the code, or a
+direct code edit. Any comment sends a build + re-review round — an agent first
+turns your comments into an explicit instruction list, then a build turn
+implements it (a re-review then covers only the follow-through, and a hand-edit
+is treated as your own fix the agent completes without reverting your lines; a
+comment can't be silently dropped — a build turn that addresses nothing is
+refused). For the simple flow, the build turn that follows through on feedback
+and the turn that drafts the final squash message both resume the same session
+that built the feature in the first place, since the review tail is nested
+inside that build identity rather than sitting beside it. Ticking every box with
+no comment is the sign-off, which collapses the whole process into one commit (a
+**squash finale** whose message an agent drafts). Landing with a box still
+unticked and no comment is refused (finish reviewing first), as is deleting
+`.gtd/REVIEW.md`. Both refusals hold wherever the review doc lives: repointing
+`reviewFile` out of `.gtd/` (say to `REVIEW.md` at the repo root) changes
+nothing about them — your own edit to the review doc is never mistaken for a
+code comment, and the doc's pre-turn copy is read at the review window's saved
+head rather than at the rewound `HEAD`.
 
 The same review tail also has a direct entry point —
 `gtd --entry review-gate.check --var reviewBase=<commitish>` starts a brand new
@@ -771,6 +777,13 @@ normalizes `[ ]`/`[x]` checkboxes before comparing). If you plug in your own
 — ticking a box, stripping a paragraph — makes the guard's decision and the
 file's actual content disagree, and gtd will not catch that for you.
 
+One case never runs your `format:` (or `validate:`) at all: a step whose diff
+DELETES the state's own `file:`. Deleting it is a legitimate outcome — a review
+sign-off's whole diff is the review doc's deletion — and there is nothing left
+to format. Emitting the command anyway would make such a step unlandable, since
+`format:` is the first line of a `set -euo pipefail` script and a formatter like
+`prettier --write` exits non-zero on a path that is not there.
+
 ### Built-in steering formats are ordinary modes
 
 `qa` and `review` are gtd's two built-in steering-file formats (parsed and
@@ -1076,12 +1089,14 @@ the compiler's job at load time.
 - **Test/build artifacts must be gitignored.** This is **load-bearing**, not a
   style preference: every land decision detects "clean" via
   `git diff --name-status HEAD` (tracked changes) unioned with
-  `git ls-files --others --exclude-standard` (untracked files), which silently
-  omits anything matched by `.gitignore`. If a `script` state's command (or the
-  build it triggers) writes output — a `dist/`, a coverage report, a log file —
-  into the working tree, the tree never goes clean after a green run, and the
-  check's `"C"` pattern never fires. Gitignore every path your scripts write
-  before wiring gtd into a repo.
+  `git ls-files --others --exclude-standard` (untracked files, classified by
+  content against the base — one that is already there with the same bytes is
+  not a change, and a file that exists on disk is never reported as a deletion,
+  however the index sees it), which silently omits anything matched by
+  `.gitignore`. If a `script` state's command (or the build it triggers) writes
+  output — a `dist/`, a coverage report, a log file — into the working tree, the
+  tree never goes clean after a green run, and the check's `"C"` pattern never
+  fires. Gitignore every path your scripts write before wiring gtd into a repo.
 - **Repository root invocation.** Every state subcommand must run from the git
   repository root. `--help`/`--version` (and the `help`/`version` subcommands),
   `lsp`, `init`, `visualize`, `check`, and `install` skip this guard entirely

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -841,6 +841,21 @@ export interface Rest extends ResolvedRest {
   /** `def` with `on` patched onto the resting state — what `PatternMachine.step` must be fed. The one deliberate exception to this module's two-caller rule (see the module doc comment). */
   readonly stepDef: WorkflowDefinition
   readonly changes: readonly PendingChange[]
+  /**
+   * The open review checkout window's SAVED HEAD (`REVIEW_HEAD_REF`), when one
+   * is open — the commit this snapshot's state, trace and `changes` were all
+   * resolved against, because real git HEAD is rewound to the review base while
+   * the window is open. `undefined` when no window is open (then real `HEAD` is
+   * that commit) or when the rest was resolved at an explicit `ref`.
+   *
+   * Carried on the snapshot rather than re-read per caller: it is the PRE-TURN
+   * head, so anything that needs a file's committed, pre-turn copy — the step
+   * guards' own `readFileAtRef` reads (`src/StepGuards.ts`) — must resolve it
+   * here, not at `HEAD`. Reading `HEAD` under an open window reports every file
+   * the process itself added as absent, which silently turned the review
+   * sign-off's tick-completeness check into a no-op.
+   */
+  readonly windowHead: string | undefined
   readonly memory: string | undefined
   /** `memoryResumedFor`'s verdict — `false` for a non-`prompt` rest or one whose scope doesn't resolve, exactly like `memory` but never `undefined` (there is always an answer, even when there is no key to answer about). */
   readonly memoryResumed: boolean
@@ -927,7 +942,19 @@ export const restAt = (ref: string | undefined): Effect.Effect<Rest, Error, Rest
     const memoryResumed = memoryResumedFor(def, config.stateScopes, resolved, run)
     const hints = yield* renderHints(resolved.stateDef, context)
 
-    return { ...resolved, run, vars, on, stepDef, changes, memory, memoryResumed, hints, context }
+    return {
+      ...resolved,
+      run,
+      vars,
+      on,
+      stepDef,
+      changes,
+      windowHead,
+      memory,
+      memoryResumed,
+      hints,
+      context,
+    }
   })
 
 /** THE call. No parens, no options — an Effect value, like `openReviewWindow`. */

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -229,16 +229,26 @@ const blobsAtRef = (
   )
 
 /**
- * `git hash-object` each path's CURRENT bytes → `path → object id` (git prints
- * one id per path, in argument order). An empty map when hashing fails at all
- * (an unreadable file): every candidate then reads as "differs", which is the
- * safe direction — a file that EXISTS must never be reported deleted.
+ * `git hash-object` every path's CURRENT bytes in ONE call → `path → object id`
+ * (git prints one id per path, in argument order). An empty map when the call
+ * fails at all (an unreadable file): every candidate then reads as "differs",
+ * which is the safe direction — a file that EXISTS must never be reported
+ * deleted.
  *
- * Deliberately no `--path`, so clean filters/`core.autocrlf` are NOT applied.
- * In a repo that rewrites content on checkout an unmodified file can therefore
- * read as `M`; that is a cosmetic over-report of a change that did happen to
- * the bytes on disk, never a phantom deletion, and no pattern gains a `D` it
- * should not have.
+ * These ids are directly comparable with the ones `git ls-tree` reports because
+ * hash-object applies the repo's own CLEAN FILTERS, looking each file's
+ * attributes up from its own path — so in a `text=auto`/`core.autocrlf` repo an
+ * untouched CRLF working-tree file hashes to the same LF-normalized blob git
+ * stored, and is correctly read as unchanged. Never add `--no-filters` (nor
+ * `--path=<other>`) here: that would report every such file `M`, i.e. a
+ * spurious "the human edited something real" (`StepGuards`'s `hasCodeChange`),
+ * which walks the review-signoff guard past its unticked-box check, plus a
+ * spurious change for any `on` pattern to match. Both tiers of the
+ * `changedPaths` contract pin this (`src/testing/GitTiers.ts`).
+ *
+ * A symlink is the one residual inexactness: hash-object reads through it, so it
+ * hashes the target's content rather than the link text git stores, and reads as
+ * `M`. Still never `D`.
  */
 const hashObjects = (
   exec: GitExec,
@@ -274,6 +284,14 @@ const hashObjects = (
  * from the worktree rather than the index, this is the same tree-vs-worktree
  * comparison the in-memory double has always done (`InMemRepo`'s
  * `changedPathsWorktree`) — production used to disagree with it here.
+ *
+ * "Different bytes" is decided the way GIT decides it — `hashObjects` hashes
+ * through the repo's own clean filters, so a `text=auto` repo's untouched CRLF
+ * file matches the LF blob it was stored as. Over-reporting `M` for an untouched
+ * file would not be cosmetic: it is a spurious "the human edited something real"
+ * (`StepGuards`'s `hasCodeChange`), which sends the review-signoff guard down
+ * its it-is-a-comment branch and past the unticked-box check, plus a spurious
+ * change for any `on` pattern to match.
  */
 const classifyUntracked = (
   exec: GitExec,

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -78,11 +78,21 @@ export interface GitReaderOperations {
    * which is precisely the deletion the review sign-off guard must catch.
    * Passing the window's saved head restores the pre-window meaning.
    *
-   * When `base` is given, an untracked path that already EXISTS at `base` is
-   * not an addition and is dropped — with the window open, every file added
-   * since the review base is untracked (the index sits at that base) while
-   * being perfectly present at the saved head. With no `base`, untracked
-   * means untracked and no filtering is paid for.
+   * An untracked path is classified by CONTENT against `base`, not by the
+   * index: absent there → `A`, present with different bytes → `M`, present
+   * with identical bytes → no entry (see `classifyUntracked`). "Untracked"
+   * does not mean "new" — with the window open, every file the reviewed range
+   * added is untracked (the index sits at the review base) while being
+   * perfectly present at the saved head. Reporting the index's view instead
+   * would report each of them DELETED (`git diff --name-status <base>`
+   * compares `base` to the INDEX) though the file sits right there on disk —
+   * a phantom deletion that made the review sign-off guard refuse every
+   * sign-off in a repo whose `reviewFile` is not under `.gtd/` (the one
+   * directory the window pins back into the index).
+   *
+   * A REAL deletion (the reviewer removed the file from disk) still reports
+   * `D`: it is not in the untracked list, so the tracked diff's own `D`
+   * stands. That is the deletion the sign-off guard must catch.
    */
   readonly changedPaths: (
     base?: string,
@@ -182,6 +192,105 @@ const parseNameStatus = (out: string): Array<{ path: string; status: string }> =
   }
   return result
 }
+
+/** Split a `-z` git output into its entries, dropping the trailing empty one. */
+const splitNul = (out: string): Array<string> => out.split("\0").filter((s) => s.length > 0)
+
+/** A `git exec` bound to one repo root — `makeGitImpl`'s own local `exec`, named so the module-level helpers below can take it. */
+type GitExec = (...args: [string, ...Array<string>]) => Effect.Effect<string, Error>
+
+/**
+ * `git ls-tree` the given paths at `ref` → `path → blob object id`; a path
+ * absent from the map does not exist at `ref`. Pathspec-limited, so the cost
+ * tracks the candidate list rather than the size of the tree. An unresolvable
+ * `ref` (an empty repo has no `HEAD`) yields an empty map — every candidate
+ * then reads as "not at `ref`", exactly the pre-`base` behaviour.
+ */
+const blobsAtRef = (
+  exec: GitExec,
+  ref: string,
+  paths: ReadonlyArray<string>,
+): Effect.Effect<Map<string, string>, Error> =>
+  exec("git", "ls-tree", "-r", "-z", ref, "--", ...paths).pipe(
+    Effect.catchIf(
+      (e) => !isIndexLockError(e),
+      () => Effect.succeed(""),
+    ),
+    Effect.map((out) => {
+      const blobs = new Map<string, string>()
+      for (const entry of splitNul(out)) {
+        const tab = entry.indexOf("\t")
+        if (tab === -1) continue
+        const [, type, oid] = entry.slice(0, tab).split(" ")
+        if (type === "blob" && oid !== undefined) blobs.set(entry.slice(tab + 1), oid)
+      }
+      return blobs
+    }),
+  )
+
+/**
+ * `git hash-object` each path's CURRENT bytes → `path → object id` (git prints
+ * one id per path, in argument order). An empty map when hashing fails at all
+ * (an unreadable file): every candidate then reads as "differs", which is the
+ * safe direction — a file that EXISTS must never be reported deleted.
+ *
+ * Deliberately no `--path`, so clean filters/`core.autocrlf` are NOT applied.
+ * In a repo that rewrites content on checkout an unmodified file can therefore
+ * read as `M`; that is a cosmetic over-report of a change that did happen to
+ * the bytes on disk, never a phantom deletion, and no pattern gains a `D` it
+ * should not have.
+ */
+const hashObjects = (
+  exec: GitExec,
+  paths: ReadonlyArray<string>,
+): Effect.Effect<Map<string, string>, Error> =>
+  exec("git", "hash-object", "--", ...paths).pipe(
+    Effect.map(
+      (out) =>
+        new Map(
+          out
+            .trim()
+            .split("\n")
+            .map((oid, i) => [paths[i] ?? "", oid.trim()] as const),
+        ),
+    ),
+    Effect.catchIf(
+      (e) => !isIndexLockError(e),
+      () => Effect.succeed(new Map<string, string>()),
+    ),
+  )
+
+/**
+ * Classify every untracked path against `ref`'s tree, by CONTENT:
+ *
+ * - not at `ref` → `A`, an ordinary untracked addition
+ * - at `ref` with different bytes → `M`
+ * - at `ref` with identical bytes → no entry at all
+ *
+ * The last two exist because "untracked" does not mean "new": the review
+ * checkout window's `git reset --mixed <base>` moves the index to the review
+ * base, so every file the reviewed range ADDED is untracked while being
+ * perfectly present (and usually unchanged) at the window's saved head. Read
+ * from the worktree rather than the index, this is the same tree-vs-worktree
+ * comparison the in-memory double has always done (`InMemRepo`'s
+ * `changedPathsWorktree`) — production used to disagree with it here.
+ */
+const classifyUntracked = (
+  exec: GitExec,
+  ref: string,
+  untrackedPaths: ReadonlyArray<string>,
+): Effect.Effect<Array<{ path: string; status: string }>, Error> =>
+  Effect.gen(function* () {
+    const atRef = yield* blobsAtRef(exec, ref, untrackedPaths)
+    const candidates = untrackedPaths.filter((path) => atRef.has(path))
+    const onDisk =
+      candidates.length === 0 ? new Map<string, string>() : yield* hashObjects(exec, candidates)
+    return untrackedPaths.flatMap((path) => {
+      const at = atRef.get(path)
+      if (at === undefined) return [{ path, status: "A" }]
+      return onDisk.get(path) === at ? [] : [{ path, status: "M" }]
+    })
+  })
 
 /**
  * True when `error` is git's `index.lock` contention failure — another process
@@ -301,10 +410,11 @@ const makeGitImpl = (executor: CommandExecutor.CommandExecutor, root: string): G
 
     changedPaths: (base?: string) =>
       Effect.gen(function* () {
+        const ref = base ?? "HEAD"
         // Only the empty-repo case (no HEAD) is tolerated here — an
         // `index.lock` failure must propagate so the port-level retry
         // (`withIndexLockRetries`) sees it, not this catch.
-        const nameStatusOut = yield* exec("git", "diff", "--name-status", base ?? "HEAD").pipe(
+        const nameStatusOut = yield* exec("git", "diff", "--name-status", ref).pipe(
           Effect.catchIf(
             (e) => !isIndexLockError(e),
             () => Effect.succeed(""),
@@ -313,23 +423,24 @@ const makeGitImpl = (executor: CommandExecutor.CommandExecutor, root: string): G
         const trackedPaths = parseNameStatus(nameStatusOut)
 
         const untrackedRaw = yield* exec("git", "ls-files", "--others", "--exclude-standard", "-z")
-        const untrackedAll = untrackedRaw
-          .split("\0")
-          .filter((s) => s.length > 0)
-          .map((path) => ({ path, status: "A" }))
-        const atBase =
-          base === undefined
-            ? new Set<string>()
-            : new Set(
-                (yield* exec("git", "ls-tree", "-r", "--name-only", "-z", base))
-                  .split("\0")
-                  .filter((s) => s.length > 0),
-              )
-        const untracked = untrackedAll.filter((entry) => !atBase.has(entry.path))
+        const untrackedPaths = splitNul(untrackedRaw)
+        // Nothing untracked: the index-based diff above already IS the answer,
+        // and the two classification reads below are not paid for at all.
+        if (untrackedPaths.length === 0) return trackedPaths
 
+        const untrackedChanges = yield* classifyUntracked(exec, ref, untrackedPaths)
+
+        // The untracked classification OVERRIDES the tracked diff for its own
+        // paths: `git diff --name-status <ref>` compares `ref` to the INDEX, so
+        // a path the index no longer carries reports `D` even while sitting
+        // right there on disk — a phantom deletion, not a real one.
+        const untrackedSet = new Set(untrackedPaths)
         const seen = new Set<string>()
         const all: Array<{ path: string; status: string }> = []
-        for (const entry of [...trackedPaths, ...untracked]) {
+        for (const entry of [
+          ...trackedPaths.filter((e) => !untrackedSet.has(e.path)),
+          ...untrackedChanges,
+        ]) {
           if (!seen.has(entry.path)) {
             seen.add(entry.path)
             all.push(entry)

--- a/src/ReviewWindow.ts
+++ b/src/ReviewWindow.ts
@@ -257,6 +257,20 @@ export const decideOpenWindow = (
  * Idempotent under re-entry: `updateRef`/`mixedResetTo` re-pointing at the
  * same target is a no-op, and `restoreStagedFrom` re-pinning an already-pinned
  * path is a no-op.
+ *
+ * `".gtd"` stays a LITERAL, deliberately, rather than being derived from the
+ * workflow's own `stateDir`/`file:` declarations. The pin exists to keep gtd's
+ * PLUMBING out of the reviewer's editor, and `.gtd/` is the conventional
+ * directory it lives in — including the parts no state declares (a check
+ * script's temp output), which a `file:`-derived list would miss. A steering
+ * file a workflow repoints outside it (`vars: { reviewFile: REVIEW.md }`)
+ * simply stays untracked in the window, which is harmless: `changedPaths`
+ * classifies untracked paths by content (`src/Git.ts`), so an unedited one is
+ * not a pending change and never a phantom deletion. Making the list dynamic
+ * would also cost the in-memory tier its trust property — the recognizer
+ * (`src/testing/EmittedScriptRecognizer.ts`'s `recognizeReviewWindowOpen`)
+ * re-derives this exact string and compares, which only works while the paths
+ * are fixed. Don't trade that for cosmetics.
  */
 export const buildOpenWindowScript = (decision: {
   readonly base: string

--- a/src/StepGuards.test.ts
+++ b/src/StepGuards.test.ts
@@ -354,9 +354,16 @@ describe("answer-completeness guard", () => {
 
 // ── enforceStepGuards runner ─────────────────────────────────────────────────
 
-const repoFilesFrom = (files: Record<string, string>): RepoFilesOps => ({
+const repoFilesFrom = (
+  files: Record<string, string>,
+  committedByRef: Record<string, Record<string, string>> = {},
+): RepoFilesOps => ({
   working: (path) => files[path],
-  committed: () => Effect.succeed(undefined),
+  // Keyed by the REF the guard asked for ("HEAD" when it passed none): the
+  // review window's saved head is a different ref, and which of the two a
+  // guard reads its "before this step" copy at is exactly what the
+  // open-window scenarios below pin.
+  committed: (path, ref = "HEAD") => Effect.succeed(committedByRef[ref]?.[path]),
 })
 
 describe("enforceStepGuards", () => {
@@ -387,6 +394,7 @@ describe("enforceStepGuards", () => {
         file: answerState.stateDef.file,
         context: templateContext,
         changes: [],
+        windowHead: undefined,
         kind: "squash",
         attempt: false,
       }).pipe(
@@ -406,6 +414,7 @@ describe("enforceStepGuards", () => {
         file: noFile.stateDef.file,
         context: templateContext,
         changes: [],
+        windowHead: undefined,
         kind: "commit",
         attempt: false,
       }).pipe(Effect.provide(Layer.succeed(RepoFiles, repoFilesFrom({})))),
@@ -421,6 +430,7 @@ describe("enforceStepGuards", () => {
         file: noGuard.stateDef.file,
         context: templateContext,
         changes: [],
+        windowHead: undefined,
         kind: "commit",
         attempt: false,
       }).pipe(Effect.provide(Layer.succeed(RepoFiles, repoFilesFrom({})))),
@@ -435,6 +445,7 @@ describe("enforceStepGuards", () => {
         file: answerState.stateDef.file,
         context: templateContext,
         changes: [],
+        windowHead: undefined,
         kind: "commit",
         attempt: false,
       }).pipe(
@@ -456,6 +467,84 @@ describe("enforceStepGuards", () => {
       "feedback-progress",
       "answer-completeness",
     ])
+  })
+
+  // While the review checkout window is open, real HEAD sits at the REVIEW
+  // BASE — the review doc the process itself wrote does not exist there. The
+  // pre-turn copy every guard compares against therefore has to be read at the
+  // window's SAVED HEAD (`Rest.windowHead`), or `original` comes back empty,
+  // the sign-off guard sees "the doc differs beyond a checkbox flip", takes the
+  // it-is-a-comment branch, and the unticked count is never reached.
+  describe("with a review checkout window open", () => {
+    const WINDOW_HEAD = "refs/worktree/gtd/review-head"
+    const reviewState = rest("await-review", {
+      actor: "human",
+      message: "review",
+      file: "REVIEW.md",
+      mode: "review",
+      reviewWindow: true,
+    })
+    // A real review doc: `untickedFiles` only counts file pointers inside a
+    // chunk heading, so the header/base/chunk shape is load-bearing here.
+    const doc = (a: string, b: string): string =>
+      [
+        "# Review: abc1234",
+        "<!-- base: abc1234def5678901234567890123456789abcd -->",
+        "",
+        "## Chunk",
+        "",
+        `- [${a}] ./src/a.ts#1 — first hunk`,
+        `- [${b}] ./src/b.ts#1 — second hunk`,
+        "",
+      ].join("\n")
+    const agentsDoc = doc(" ", " ")
+    const oneTicked = doc("x", " ")
+    const allTicked = doc("x", "x")
+
+    const runGuards = (worktreeDoc: string, windowHead: string | undefined) =>
+      Effect.runPromiseExit(
+        enforceStepGuards({
+          rest: reviewState,
+          file: reviewState.stateDef.file,
+          context: templateContext,
+          changes: [{ path: "REVIEW.md", status: "M" }],
+          windowHead,
+          kind: "commit",
+          attempt: false,
+        }).pipe(
+          Effect.provide(
+            Layer.succeed(
+              RepoFiles,
+              // The doc exists at the window's saved head and NOT at real HEAD
+              // (the review base) — the window's whole shape, in one double.
+              repoFilesFrom(
+                { "REVIEW.md": worktreeDoc },
+                { [WINDOW_HEAD]: { "REVIEW.md": agentsDoc } },
+              ),
+            ),
+          ),
+        ),
+      )
+
+    it("refuses a tick-only pass that still leaves a box unticked", async () => {
+      const exit = await runGuards(oneTicked, WINDOW_HEAD)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(String(exit.cause)).toContain("still unticked and no comment")
+      }
+    })
+
+    it("allows the same pass once every box is ticked — a sign-off", async () => {
+      const exit = await runGuards(allTicked, WINDOW_HEAD)
+      expect(Exit.isSuccess(exit)).toBe(true)
+    })
+
+    it("reading real HEAD instead is what made the gate inert — the unticked pass would pass", async () => {
+      // Pins the regression itself: with no saved head to read, the pre-turn
+      // copy is absent, every tick reads as a note, and nothing is enforced.
+      const exit = await runGuards(oneTicked, undefined)
+      expect(Exit.isSuccess(exit)).toBe(true)
+    })
   })
 
   it("reads the CURRENT working tree as-is — no in-process formatting happens here", async () => {
@@ -480,6 +569,7 @@ describe("enforceStepGuards", () => {
         file: answerState.stateDef.file,
         context: templateContext,
         changes: [],
+        windowHead: undefined,
         kind: "commit",
         attempt: false,
       }).pipe(

--- a/src/StepGuards.ts
+++ b/src/StepGuards.ts
@@ -57,10 +57,34 @@ export interface GuardContext {
   readonly changes: readonly PendingChange[]
   /** True when this step's changes delete `file`. */
   readonly fileDeleted: boolean
-  /** True when this step touches a path outside `.gtd/`. */
+  /**
+   * True when this step touches a path that is neither gtd plumbing (`.gtd/`)
+   * nor the state's OWN `file:` — i.e. the human edited something real, which
+   * every guard here reads as "a comment"/"the work was done".
+   *
+   * Excluding `file` by exact path is load-bearing for a state whose `file:` is
+   * repointed OUTSIDE `.gtd/` (an ordinary `vars:` override, e.g. `REVIEW.md`
+   * at the repo root): the reviewer's own edit to the review doc would
+   * otherwise count as a code edit, so the sign-off guard took the
+   * it-is-a-comment branch on every pass and its unticked check was
+   * unreachable. Same shape as the bug in `deciding`'s check script (issue
+   * #128), which also assumed every steering file lives under `.gtd/`.
+   */
   readonly hasCodeChange: boolean
   readonly template: TemplateContext
-  /** `file`'s contents at HEAD (before this step), `undefined` if absent there. Cached — evaluated once per `enforceStepGuards` call. */
+  /**
+   * `file`'s contents at the PRE-TURN head (before this step), `undefined` if
+   * absent there. Cached — evaluated once per `enforceStepGuards` call.
+   *
+   * That head is real `HEAD` normally, but the review checkout window's saved
+   * head (`Rest.windowHead`) while a window is open: the window has rewound
+   * real HEAD to the review base, where a file the process itself added does
+   * not exist yet. Reading `HEAD` there made `original` empty for every review
+   * doc, so the sign-off guard's "only checkbox flips" comparison always found
+   * a difference, took the it's-a-comment branch, and never reached the
+   * unticked count — the tick-completeness gate was inert for exactly the
+   * situation it exists for.
+   */
   readonly head: Effect.Effect<string | undefined, Error>
   /** `file`'s CURRENT working-tree contents — whatever is on disk right now, pre- or post- an external driver's own `format:` run. Cached. */
   readonly worktree: Effect.Effect<string | undefined, Error>
@@ -73,6 +97,17 @@ export interface StepGuard {
   /** Decide allow (`undefined`) or refuse (a reason string). */
   readonly check: (ctx: GuardContext) => Effect.Effect<Refusal, Error, GuardRequirements>
 }
+
+/**
+ * True when `changes` deletes `file` — the one question BOTH this registry's
+ * `GuardContext.fileDeleted` and `program.ts`'s `steeringModeSteps` ask about a
+ * state's `file:`, so they ask it in exactly one place. A deletion is a
+ * legitimate step outcome at some states (a review sign-off's bare REVIEW.md
+ * deletion) and a refusal at others (see `reviewSignoffGuard`), but either way
+ * there is no file left to format or validate.
+ */
+export const deletesFile = (changes: readonly PendingChange[], file: string): boolean =>
+  changes.some((c) => c.path === file && c.status === "D")
 
 /** Normalize every markdown checkbox to a single placeholder so a pure `[ ]`→`[x]` tick is invisible to a text comparison; any surviving difference is a human note. */
 const normalizeCheckboxes = (content: string): string => content.replace(/\[[ xX]\]/g, "[_]")
@@ -158,6 +193,8 @@ export const enforceStepGuards = (input: {
   /** The state's ALREADY-RENDERED `file:` — `Rest.hints.file`, rendered once when the snapshot was built rather than re-rendered per guard. */
   readonly file: string | undefined
   readonly changes: readonly PendingChange[]
+  /** `Rest.windowHead` — the open review window's saved head, the ref `head` reads `file` at. `undefined` (real `HEAD`) when no window is open. */
+  readonly windowHead: string | undefined
   readonly kind: ExecutableDecision["kind"]
   /**
    * True for an ATTEMPT commit (`PatternMachine.StepCommit.attempt`) — a
@@ -178,8 +215,8 @@ export const enforceStepGuards = (input: {
     const applicable = stepGuards.filter((g) => g.appliesTo(input.rest))
     if (applicable.length === 0) return
 
-    const fileDeleted = input.changes.some((c) => c.path === file && c.status === "D")
-    const hasCodeChange = input.changes.some((c) => !c.path.startsWith(".gtd/"))
+    const fileDeleted = deletesFile(input.changes, file)
+    const hasCodeChange = input.changes.some((c) => !c.path.startsWith(".gtd/") && c.path !== file)
 
     const base = {
       rest: input.rest,
@@ -191,7 +228,7 @@ export const enforceStepGuards = (input: {
     }
 
     const files = yield* RepoFiles
-    const head = yield* Effect.cached(files.committed(file))
+    const head = yield* Effect.cached(files.committed(file, input.windowHead))
     const worktree = yield* Effect.cached(Effect.try(() => files.working(file)))
     const ctx: GuardContext = { ...base, head, worktree }
 

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -1436,3 +1436,70 @@ describe("gtd land --json — the settled signal", () => {
     expect(parsed.required).toContain("git commit")
   })
 })
+
+describe("a step that DELETES its state's own steering file", () => {
+  // The `format:`/`validate:` pair a state's `mode:` declares is emitted into
+  // the step script ahead of the commit. When the step's own diff is that
+  // file's DELETION — a legitimate outcome, e.g. the bundled template's review
+  // sign-off, whose whole diff is a bare REVIEW.md deletion — there is nothing
+  // left to format, and emitting the command anyway made the step UNLANDABLE:
+  // it is the script's first command under `set -euo pipefail`, and a real
+  // formatter (`prettier --write`) exits non-zero on a path that is not there.
+
+  const NOTES_WORKFLOW = [
+    "workflow:",
+    "  modes:",
+    "    notes:",
+    "      format: fmt-notes <%= it.file %>",
+    "  entry:",
+    "    default: root",
+    "  machines:",
+    "    root:",
+    "      entry: idle",
+    "      states:",
+    "        idle:",
+    "          actor: human",
+    "          message: hi",
+    "          on:",
+    '            "* **": drafting',
+    "        drafting:",
+    "          actor: agent",
+    "          prompt: write the notes",
+    "          file: NOTES.md",
+    "          mode: notes",
+    "          on:",
+    '            "D NOTES.md": idle',
+    '            "* **": drafting',
+    "",
+  ].join("\n")
+
+  const restingAtDrafting = (): InMemRepo => {
+    const repo = new InMemRepo()
+    repo.writeFile(".gtdrc.yaml", NOTES_WORKFLOW)
+    repo.commitAllWithPrefix("chore: add custom workflow")
+    repo.writeFile("NOTES.md", "# notes\n\nfirst draft\n")
+    repo.commitAllWithPrefix("gtd(agent): drafting")
+    return repo
+  }
+
+  it("emits no format command, and still lands the commit", async () => {
+    const repo = restingAtDrafting()
+    repo.deleteFile("NOTES.md")
+    const { stdout, exitCode } = await run(repo, "land", "--json")
+    expect(exitCode).toBe(0)
+    const { required } = JSON.parse(stdout) as { required: string }
+    expect(required).not.toContain("fmt-notes")
+    // And the emitted script is what actually performs the step.
+    expect(applyEmittedScript(repo, new Map(), required).ok).toBe(true)
+    expect(repo.lastCommitSubject()).toBe("gtd(agent): drafting → idle")
+  })
+
+  it("still emits it when the same step MODIFIES that file — the skip is the deletion, not the state", async () => {
+    const repo = restingAtDrafting()
+    repo.writeFile("NOTES.md", "# notes\n\nsecond draft\n")
+    const { stdout, exitCode } = await run(repo, "land", "--json")
+    expect(exitCode).toBe(0)
+    const { required } = JSON.parse(stdout) as { required: string }
+    expect(required).toContain("fmt-notes NOTES.md")
+  })
+})

--- a/src/program.ts
+++ b/src/program.ts
@@ -45,7 +45,7 @@ import {
   type CurrentStateModel,
   type VizModel,
 } from "./Visualize.js"
-import { enforceStepGuards } from "./StepGuards.js"
+import { deletesFile, enforceStepGuards } from "./StepGuards.js"
 import { builtInModeNames, seededValidateCommand, steeringFormatFor } from "./SteeringFormats.js"
 import { resolveSteeringMode, renderSteeringCommands, unknownModeMessage } from "./SteeringMode.js"
 import {
@@ -218,6 +218,16 @@ const headPreconditions = (currentCommit: string): EmitPreconditions => ({
  * of gtd running it in process (see `src/StepGuards.ts`'s shrunk registry).
  * Empty for a state declaring no `file:`+`mode:` pair; an unknown mode name
  * is a refusal, exactly as it was when gtd ran the commands itself.
+ *
+ * Also empty when the step DELETES that file (`deletesFile`). A deletion is a
+ * legitimate outcome at some states — `build.review.deciding`'s sign-off diff
+ * is a bare REVIEW.md deletion — and there is nothing left to format or
+ * validate either way. Emitting the mode's `format:` anyway made the step
+ * UNLANDABLE for any formatter that treats a missing path as an error
+ * (`prettier --write` exits non-zero with "No files matching the pattern were
+ * found"): it is the first command in a `set -euo pipefail` script, so it
+ * aborted the whole thing — window close, commit and all — before anything
+ * could land, and a driver saw only a non-zero exit.
  */
 const steeringModeSteps = (
   rest: Rest,
@@ -226,6 +236,7 @@ const steeringModeSteps = (
     const file = rest.hints.file
     const mode = rest.stateDef.mode
     if (file === undefined || mode === undefined) return []
+    if (deletesFile(rest.changes, file)) return []
     const resolved = resolveSteeringMode(rest.def, mode)
     if (resolved === undefined) {
       return yield* Effect.fail(new Error(unknownModeMessage(rest.def, rest.state, mode)))
@@ -284,8 +295,10 @@ const previewSubject = (
  * (decision 6): there is nothing to format/validate in an empty diff, and a
  * `format:` command running ahead of the commit could dirty the tree and
  * turn an "empty" attempt non-empty, breaking the derivation `stalledAt`
- * relies on (`Edge.ts`). The review-window close still runs regardless —
- * committing with a window open would land the attempt on the review base.
+ * relies on (`Edge.ts`). It is skipped for a step that DELETES the state's
+ * own `file:` too — see `steeringModeSteps`. The review-window close still
+ * runs regardless — committing with a window open would land the attempt on
+ * the review base.
  */
 const buildRequiredScript = (
   rest: Rest,
@@ -402,6 +415,7 @@ const planLanding = (
       context: rest.context,
       file: rest.hints.file,
       changes: rest.changes,
+      windowHead: rest.windowHead,
       kind: decision.kind,
       attempt: isAttemptDecision(decision),
     })

--- a/src/testing/GitTiers.ts
+++ b/src/testing/GitTiers.ts
@@ -192,7 +192,12 @@ const makeLiveTier = (initialCommit = true): GitTier => {
         mkdirSync(dirname(join(root, path)), { recursive: true })
         writeFileSync(join(root, path), content)
       },
-      deleteFile: (path) => gitExec("rm", "-f", path),
+      // A plain unlink, NOT `git rm` — the index is left exactly as it stood,
+      // which is the only way to model a reviewer deleting a file the review
+      // window left untracked (`git rm` refuses an untracked pathspec), and
+      // matches what the in-memory tier's worktree-only delete has always
+      // done. Callers that want the deletion staged say `stageAll()`.
+      deleteFile: (path) => rmSync(join(root, path), { force: true }),
       commitDeletion: (path, message) => {
         gitExec("rm", path)
         gitExec(`commit -m "${message}"`)
@@ -719,6 +724,54 @@ export const runGitServiceContract = (makeTier: () => GitTier): void => {
 
     it("returns [] on a clean tree", async () => {
       expect(await runGit(t, (g) => g.changedPaths())).toEqual([])
+    })
+
+    // The review checkout window's own shape: `git reset --mixed <base>` drops
+    // every path the reviewed range ADDED out of the index, leaving it
+    // untracked but present on disk. An index-based answer calls each of those
+    // a deletion (`git diff --name-status <base>` compares base to the INDEX),
+    // which made the review sign-off guard refuse every sign-off whose
+    // `reviewFile` the window does not pin back. The port answers by CONTENT
+    // instead — these four cases are that contract.
+    describe("with a base, over paths the index no longer carries", () => {
+      /** Commit `REVIEW.md` on top of a seed commit, then rewind the index to that seed — the window's own state. Returns the saved head the window would measure against. */
+      const openWindowOver = (content: string): string => {
+        t.seed.commit("chore: seed", { "kept.txt": "seed" })
+        const base = t.observe.resolveRef("HEAD")
+        t.seed.commit("gtd(agent): reviewing", { "REVIEW.md": content })
+        const head = t.observe.resolveRef("HEAD")
+        t.seed.mixedReset(base)
+        return head
+      }
+
+      it("omits an untracked path whose bytes match the base — present and unchanged is not a change", async () => {
+        const head = openWindowOver("- [ ] one\n")
+        expect(await runGit(t, (g) => g.changedPaths(head))).toEqual([])
+      })
+
+      it("reports an untracked path edited since the base as M, never D", async () => {
+        const head = openWindowOver("- [ ] one\n")
+        t.seed.writeFile("REVIEW.md", "- [x] one\n")
+        expect(await runGit(t, (g) => g.changedPaths(head))).toEqual([
+          { path: "REVIEW.md", status: "M" },
+        ])
+      })
+
+      it("reports an untracked path REMOVED from disk as D — the deletion the sign-off guard must catch", async () => {
+        const head = openWindowOver("- [ ] one\n")
+        t.seed.deleteFile("REVIEW.md")
+        expect(await runGit(t, (g) => g.changedPaths(head))).toEqual([
+          { path: "REVIEW.md", status: "D" },
+        ])
+      })
+
+      it("still reports a genuinely new untracked path as A", async () => {
+        const head = openWindowOver("- [ ] one\n")
+        t.seed.writeFile("NOTE.md", "a reviewer's note\n")
+        expect(await runGit(t, (g) => g.changedPaths(head))).toEqual([
+          { path: "NOTE.md", status: "A" },
+        ])
+      })
     })
   })
 

--- a/src/testing/GitTiers.ts
+++ b/src/testing/GitTiers.ts
@@ -772,6 +772,41 @@ export const runGitServiceContract = (makeTier: () => GitTier): void => {
           { path: "NOTE.md", status: "A" },
         ])
       })
+
+      // "Different bytes" has to mean what GIT means by it. Under
+      // `text=auto` the committed blob is normalized to LF while the working
+      // tree legitimately holds CRLF, so a RAW byte comparison calls an
+      // untouched file modified — and a spurious `M` on the review doc is a
+      // spurious "the human edited something real" (`StepGuards`'s
+      // `hasCodeChange`), which walks the sign-off guard straight past its
+      // unticked-box check. The fake has no filters at all, so it answers
+      // "unchanged" by construction; this pins real git to the same answer.
+      it("omits an untracked path that only differs by a clean filter's normalization", async () => {
+        t.seed.writeFile(".gitattributes", "* text=auto\n")
+        t.seed.commit("chore: normalize line endings", {})
+        const base = t.observe.resolveRef("HEAD")
+        // Committed through `git add`, so the blob is normalized to LF while
+        // the file on disk keeps its CRLF bytes.
+        t.seed.writeFile("REVIEW.md", "- [ ] one\r\n- [ ] two\r\n")
+        t.seed.commit("gtd(agent): reviewing", {})
+        const head = t.observe.resolveRef("HEAD")
+        t.seed.mixedReset(base)
+        expect(await runGit(t, (g) => g.changedPaths(head))).toEqual([])
+      })
+
+      it("still reports a real edit to such a path as M", async () => {
+        t.seed.writeFile(".gitattributes", "* text=auto\n")
+        t.seed.commit("chore: normalize line endings", {})
+        const base = t.observe.resolveRef("HEAD")
+        t.seed.writeFile("REVIEW.md", "- [ ] one\r\n- [ ] two\r\n")
+        t.seed.commit("gtd(agent): reviewing", {})
+        const head = t.observe.resolveRef("HEAD")
+        t.seed.mixedReset(base)
+        t.seed.writeFile("REVIEW.md", "- [x] one\r\n- [ ] two\r\n")
+        expect(await runGit(t, (g) => g.changedPaths(head))).toEqual([
+          { path: "REVIEW.md", status: "M" },
+        ])
+      })
     })
   })
 

--- a/tests/integration/features/review-signoff-outside-gtd.feature
+++ b/tests/integration/features/review-signoff-outside-gtd.feature
@@ -48,3 +48,50 @@ Feature: Review sign-off reaches build.squashing even when reviewFile lives outs
     And I run gtd land
     Then it succeeds
     And the last commit subject is "gtd(check): build.review.deciding → build.squashing"
+
+  # The same sign-off, in a project whose `review` mode declares a `format:`
+  # command. A mode's format/validate pair is emitted into the step script ahead
+  # of the commit — but this step's whole diff IS the reviewFile's deletion, so
+  # there is nothing left to format, and running the formatter anyway made the
+  # sign-off UNLANDABLE: `format:` is the first command in a `set -euo pipefail`
+  # script, and a real formatter (`prettier --write`, modelled below) exits
+  # non-zero on a path that is not there, aborting the script before the commit.
+  # A driver saw only a non-zero exit with the failure buried in its log.
+  Scenario: the sign-off still lands when the review mode declares a format command that fails on a missing file
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      vars:
+        reviewFile: REVIEW.md
+      modes:
+        review:
+          format: |
+            test -f <%= it.file %> || {
+              echo "No files matching the pattern were found: <%= it.file %>" >&2
+              exit 2
+            }
+      """
+    And a commit "gtd(agent): build.health.check → build.review.reviewing" that adds "REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: 0000000 -->
+
+      ## calc
+      - [ ] ./src/calc.ts#1 — new add function
+      """
+    And a commit "gtd(human): build.review.await-review → build.review.deciding" that adds "REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: 0000000 -->
+
+      ## calc
+      - [x] ./src/calc.ts#1 — new add function
+      """
+    When I run gtd next with "--json"
+    And I execute the printed check script
+    And I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(check): build.review.deciding → build.squashing"
+    And "REVIEW.md" does not exist

--- a/tests/integration/features/review-window-untracked.feature
+++ b/tests/integration/features/review-window-untracked.feature
@@ -1,0 +1,126 @@
+@live
+Feature: An open review window reports untracked-but-present files by content, never as deletions
+
+  The review checkout window rewinds HEAD and the INDEX to the review base
+  (`git reset --mixed`) and leaves the working tree untouched, so every file the
+  reviewed range ADDED sits on disk while being absent from the index — git's
+  ordinary untracked state, deliberately (see review-window.feature). Pending
+  changes are measured against the window's saved head, and
+  `git diff --name-status <saved-head>` compares that commit to the INDEX: it
+  therefore reports each of those files DELETED, though they are right there on
+  disk. `changedPaths` classifies untracked paths by CONTENT instead (see
+  `src/Git.ts`) — absent at the base is `A`, different bytes are `M`, identical
+  bytes are no change at all.
+
+  Without that, the review-signoff guard (`src/StepGuards.ts`) saw a phantom
+  `D <reviewFile>` and refused EVERY sign-off with "was deleted — restore it and
+  tick the boxes", with the file sitting untouched in the working tree. The
+  bundled `.gtd/REVIEW.md` hid it: `.gtd` is the one directory the window pins
+  back into the index (`buildOpenWindowScript`'s `restoreStagedFrom`), so the
+  doc stays TRACKED there. A `reviewFile` repointed to the repo root — an
+  ordinary `vars:` override — is not pinned, and so was unlandable.
+
+  Every scenario here is live, because the phantom deletion is real git's index
+  behaviour: the in-memory double compares the base tree to the worktree
+  directly and has always answered by content
+  (`InMemRepo.changedPathsWorktree`), so an @inmem scenario cannot fail on this.
+  The contract test that pins the two tiers together on it lives in
+  `src/testing/GitTiers.ts`.
+
+  Background:
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      vars:
+        reviewFile: REVIEW.md
+      """
+    And a commit "gtd(agent): building" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    And an empty commit "gtd(check): build.review.reviewing"
+    And a file "REVIEW.md" with:
+      """
+      # Review: abc1234
+
+      <!-- base: 0000000 -->
+
+      ## calc
+      - [ ] ./src/calc.ts#1 — new add function
+      """
+
+  Scenario: the review doc the window left untracked is not pending at all — it is present and unchanged
+    # The step that lands at the gate commits REVIEW.md and opens the window,
+    # which un-tracks it again (the index moves to the review base).
+    Given I run gtd land
+    When I run gtd status
+    Then it succeeds
+    And stdout contains "State: build.review.await-review"
+    # Present on disk with the bytes it was committed with: no change, and
+    # above all not a deletion.
+    And stdout does not contain "D REVIEW.md"
+    And the git status contains "?? REVIEW.md"
+
+  Scenario: ticking every box signs off — the reviewer's edit reads as a modification
+    Given I run gtd land
+    And "REVIEW.md" is modified to:
+      """
+      # Review: abc1234
+
+      <!-- base: 0000000 -->
+
+      ## calc
+      - [x] ./src/calc.ts#1 — new add function
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(human): build.review.await-review → build.review.deciding"
+    And the git ref "refs/worktree/gtd/review-head" does not exist
+
+  Scenario: a REAL deletion is still refused — the guard keeps its teeth through real git
+    Given I run gtd land
+    And the file "REVIEW.md" is deleted
+    When I run gtd land
+    Then it fails
+    And stderr contains "was deleted"
+    # A refusal emits no script, so the window stays open for the reviewer to
+    # restore the file and tick.
+    And the git ref "refs/worktree/gtd/review-head" exists
+
+  # The tick-completeness half of the same guard, through an OPEN window and a
+  # root-level reviewFile — the two things that each independently made it
+  # unreachable. It compares the doc on disk against its PRE-TURN committed copy,
+  # which lives at the window's saved head, not at real HEAD (rewound to the
+  # review base, where the doc does not exist yet); and "did the human edit
+  # something other than gtd's own files" must not count the reviewFile itself
+  # just because it sits outside `.gtd/`.
+  Scenario: a box left unticked with no comment is refused — finish reviewing first
+    # Two hunks to review, so ticking one still leaves the pass unfinished.
+    Given "REVIEW.md" is modified to:
+      """
+      # Review: abc1234
+
+      <!-- base: 0000000 -->
+
+      ## calc
+      - [ ] ./src/calc.ts#1 — new add function
+      - [ ] ./src/calc.ts#2 — its export
+      """
+    And I run gtd land
+    # Tick the first hunk only, leave the second, add no note and no code edit.
+    And "REVIEW.md" is modified to:
+      """
+      # Review: abc1234
+
+      <!-- base: 0000000 -->
+
+      ## calc
+      - [x] ./src/calc.ts#1 — new add function
+      - [ ] ./src/calc.ts#2 — its export
+      """
+    And I record the commit count
+    When I run gtd land
+    Then it fails
+    And stderr contains "still unticked and no comment"
+    And the commit count is unchanged
+    And the git ref "refs/worktree/gtd/review-head" exists


### PR DESCRIPTION
Found while debugging a real `gtd-loop` run that hard-stopped at
`build.review.await-review` with

```
gtd land: REVIEW.md was deleted at "build.review.await-review" — restore it and
tick the boxes to sign off, or leave a note (or edit code) to request changes.
```

while `REVIEW.md` sat untouched in the working tree. Four separate defects were
behind it, all of them masked by the bundled `.gtd/REVIEW.md` layout and
therefore invisible to the suite. This repo's own `.gtdrc` repoints `reviewFile`
to the repo root, which is what exposed them.

## 1. A file on disk reported as deleted

`changedPaths` answered from the **index**. The review checkout window's
`git reset --mixed <base>` leaves every path the reviewed range added
untracked-but-present, and `git diff --name-status <saved-head>` compares that
commit to the index — so each of them reports `D` while sitting on disk. The
sign-off guard saw a phantom `D REVIEW.md` and refused.

`src/Git.ts` now classifies untracked paths by **content** against the base tree
(`classifyUntracked`): absent → `A`, different blob → `M`, identical → no change.
A real removal still reports `D`, so the deletion the guard exists to catch is
untouched.

This is also a fake-vs-production disagreement: `InMemRepo.changedPathsWorktree`
has always compared the base tree to the worktree directly, i.e. it was already
right. The new `changedPaths` base-case group in `runGitServiceContract` pins
both tiers — 3 of its 4 cases were red on Live before this change, all 4 green on
the fake.

## 2. `format:` emitted for a deleted steering file

A sign-off's whole diff *is* the review doc's deletion, but `steeringModeSteps`
emitted the mode's `format:` regardless — so `npx prettier --write REVIEW.md` ran
as the first command of a `set -euo pipefail` script, exited non-zero on the
missing path, and aborted the script before the commit. The step could never
land, and a driver saw only a non-zero exit (the failure lands in its log, not
the terminal). Skipped now when the step deletes that `file:`.

## 3. The guards read the wrong head

`GuardContext.head` read the pre-turn copy at real `HEAD` — which the window has
rewound to the review base, where a doc the process itself wrote does not exist.
`original` came back empty, so the sign-off guard always found "a difference
beyond a checkbox flip", took its it-is-a-comment branch, and never reached the
unticked count: **the tick-completeness gate was inert whenever a window was
open**, for the default layout too. `Rest.windowHead` now carries the window's
saved head, and the guards read there.

## 4. `hasCodeChange` counted the review doc as a code edit

Any path outside `.gtd/` counted as "the human edited something real", so a
root-level review doc counted as one and the sign-off guard was inert for that
layout regardless of the window. Same assumption issue #128 broke in
`deciding`'s check script. It now excludes the state's own `file:` by exact path.

## Tests

- `src/testing/GitTiers.ts` — new `changedPaths` base-case contract group
  (unchanged / edited / removed / genuinely new), run against both tiers. Live
  `seed.deleteFile` is now a plain unlink rather than `git rm`, the only way to
  model deleting a file the window left untracked.
- `src/StepGuards.test.ts` — open-window group: an unticked pass is refused, an
  all-ticked pass signs off, and a third case pins the regression itself (read
  real HEAD instead and the unticked pass sails through).
- `src/program.test.ts` — a `D <file>` step emits no format command and still
  lands, plus a control proving a *modification* still emits it.
- `tests/integration/features/review-window-untracked.feature` (`@live`, new) —
  four scenarios over an open window with a root-level `reviewFile`. Live only:
  the phantom `D` is real git's index behaviour, so an `@inmem` scenario cannot
  fail on it.
- `review-signoff-outside-gtd.feature` — sign-off still lands with a `review`
  mode whose `format:` fails on a missing file.

Every new test was verified red against the unfixed code. Full `npm test`
(format, typecheck, lint, unit, e2e inmem + live, fallow) is green.

## Deliberately not changed

The window's index pin stays the literal `".gtd"` rather than being derived from
the workflow's `stateDir`/`file:` vars. The pin hides gtd's *plumbing*, and
`.gtd/` is the conventional home for it — including parts no state declares (a
check script's temp output), which a `file:`-derived list would miss. A relocated
steering file staying untracked is harmless now that (1) is fixed, and a dynamic
path list would cost the in-memory tier its trust property:
`recognizeReviewWindowOpen` re-derives the emitted script and compares, which
works only while the paths are fixed. The reasoning is recorded at
`buildOpenWindowScript`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
