### PR TITLE
build(test): run npm test through turborepo's task graph

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,12 @@ jobs:
 
       - uses: jdx/mise-action@v2
 
+      - uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-
+
       - name: Install dependencies
         run: npm install
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .eslintcache
 .cache
 *.tsbuildinfo
+.turbo/
 
 # IntelliJ based IDEs
 .idea

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,19 @@
   grows must be documented in its own Prerequisites section, and is a scenario
   failure until it is
 
+### Task graph and caching
+
+`npm test` runs through Turborepo (`turbo.json`), not a serial `&&` chain — each
+check is a task with its own `inputs`, so it's cached (skipped when its inputs
+are unchanged since the last green run) and run in parallel with the others. Two
+rules a future change must not break: adding a check means adding all three of a
+`package.json` script, a `turbo.json` task with an explicit `inputs` array, and
+that task's name to the `test` script's task list — a task missing any of the
+three fails `tests/tooling/turbo.test.ts`. And under-declared `inputs` cache a
+stale green: the canonical example is `README.md` in both e2e tasks' `inputs`,
+because `tests/integration/features/readme-driver.feature` runs it as executable
+code — omitting it would let a broken doc pass on a cached result.
+
 ## Architecture
 
 `CONTEXT.md` is the glossary — the domain language this repo uses (process,

--- a/README.md
+++ b/README.md
@@ -1126,15 +1126,20 @@ gate still format and validate it like any other mode.
 npm install
 npm run dev          # run from source, no build (node dev/run.mjs)
 npm run build        # tsdown → dist/gtd.bundle.mjs
-npm test             # format:check, typecheck, lint, unit + e2e tests, fallow
-npm run test:unit       # vitest unit tests (the pure resolver) — --project unit
-npm run test:e2e        # gherkin e2e, both tiers — test:e2e:inmem + test:e2e:live
-npm run test:e2e:inmem  # @inmem scenarios, in-process, no build — --project e2e-inmem
-npm run test:e2e:live   # @live scenarios against the built bundle — --project e2e-live
+npm test             # the whole gate, via turbo — cached and parallel
+npx turbo run test:unit         # one task, cached (add --force to bypass)
+npx turbo run test:e2e:live     # builds first (turbo dependsOn), then @live
+npm run test:changed # local pre-flight: only unit/@inmem tests git says changed
 npm run test:mutation # StrykerJS mutation testing (manual only, ~10 min)
 npm run typecheck
 npm run lint
 ```
+
+`npm test` is a turbo task graph (`turbo.json`): each check declares its own
+`inputs`, so an unchanged check is skipped, and a check that does run is run in
+parallel with the others. Caveat from the `test:e2e:live` task's `build`
+dependency: a bare `npm run test:e2e:live` skips the build, so use
+`npx turbo run test:e2e:live` to test against a fresh bundle.
 
 A pre-commit hook is installed automatically via the `prepare` script when you
 run `npm install` on a fresh clone — it runs

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "quickpickle": "1.11.2",
         "semantic-release": "^25.0.5",
         "tsdown": "^0.22.8",
+        "turbo": "^2.10.9",
         "vitest": "^3.2.0"
       },
       "engines": {
@@ -4485,6 +4486,92 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@turbo/darwin-64": {
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.10.9.tgz",
+      "integrity": "sha512-Jh+pTGXLNz8+1tkUU13TI/f+ZOI+OvC4YbHi1H+57iSpLt5DR3xgptd+4sA07RdjdRR/RX/01uQQu2OkbzIefA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/darwin-arm64": {
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.10.9.tgz",
+      "integrity": "sha512-aqtpPkiIC4IUas8Vv27oJ3aDfTuP1d5wofd01dZ7gfhHRrIKuFdqQb4imvNnVFahcOViF9Jh8Oi7feDoz8/ciA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/linux-64": {
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.10.9.tgz",
+      "integrity": "sha512-XyAneUBsS5uNOUOjBSs81zyigMVwwhVUd3u7F2JFMKGQk6F7eNAiOEBASJ+aHLldjYsOEjhfW+5gWIqwziyFFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android",
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/linux-arm64": {
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.10.9.tgz",
+      "integrity": "sha512-5jAcldLnkuWIjujGhCn2MGIeUwW8IVNOq9Sce4EEzzgLcxmhTasbV0RiW6ZkaRdOjmOCGzeNXPLkDJEOIucOLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android",
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/windows-64": {
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.10.9.tgz",
+      "integrity": "sha512-u1xGpGlefzuhBedbt/VR2nWdftfFVZwPeDg9e5uZl68sV1fL3HNYTNr5VyHkzgtPK2VTYg1x4OKZuGrh1Gvhtg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@turbo/windows-arm64": {
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.10.9.tgz",
+      "integrity": "sha512-W2Ub165Qv0iMFljbYKxxbZN+2dVSngnzEjQNEFXtnz5oJVx9XSypmNmUvMtuYMeZ3kdVC1zI7yd/rtuX+SDnbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
@@ -14828,6 +14915,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/turbo": {
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.10.9.tgz",
+      "integrity": "sha512-Yl9+ukxH+UmPtKidpDkjn82tvPoEvFNb9UACd9vUomN1Ft0cwl3rx0P8yC1D93W9EOsWRMjllvIDG8y25sFOog==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "@turbo/darwin-64": "2.10.9",
+        "@turbo/darwin-arm64": "2.10.9",
+        "@turbo/linux-64": "2.10.9",
+        "@turbo/linux-arm64": "2.10.9",
+        "@turbo/windows-64": "2.10.9",
+        "@turbo/windows-arm64": "2.10.9"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -25,15 +25,17 @@
     "node": ">=22"
   },
   "type": "module",
+  "packageManager": "npm@11.17.0",
   "scripts": {
     "prepare": "husky",
     "dev": "node dev/run.mjs",
     "build": "tsdown",
     "postbuild": "jiti scripts/generate-schema.ts && node scripts/assert-no-test-doubles.mjs",
     "watch": "tsdown --watch",
-    "test": "npm run format:check && npm run typecheck && npm run lint && npm run test:unit && npm run test:e2e && fallow --summary --quiet",
+    "test": "turbo run format:check typecheck lint test:unit test:e2e:inmem test:e2e:live deadcode",
     "test:unit": "vitest run --project unit",
     "test:watch": "vitest",
+    "test:changed": "vitest run --project unit --project e2e-inmem --changed HEAD",
     "test:e2e": "npm run test:e2e:inmem && npm run test:e2e:live",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint .",
@@ -41,8 +43,8 @@
     "format:check": "oxfmt --check .",
     "test:mutation": "stryker run",
     "test:e2e:inmem": "vitest run --project e2e-inmem",
-    "pretest:e2e:live": "tsdown --logLevel silent",
-    "test:e2e:live": "vitest run --project e2e-live"
+    "test:e2e:live": "vitest run --project e2e-live",
+    "deadcode": "fallow --summary --quiet"
   },
   "lint-staged": {
     "*": "oxfmt --no-error-on-unmatched-pattern --write"
@@ -68,6 +70,7 @@
     "quickpickle": "1.11.2",
     "semantic-release": "^25.0.5",
     "tsdown": "^0.22.8",
+    "turbo": "^2.10.9",
     "vitest": "^3.2.0"
   },
   "peerDependencies": {

--- a/tests/tooling/turbo.test.ts
+++ b/tests/tooling/turbo.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const turbo = JSON.parse(readFileSync(new URL("../../turbo.json", import.meta.url), "utf8"))
+const pkg = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8"))
+
+const taskKeys = Object.keys(turbo.tasks)
+const nonBuildTaskKeys = taskKeys.filter((key) => key !== "build")
+
+describe("turbo.json / package.json invariants", () => {
+  it("has a package.json script for every turbo task", () => {
+    for (const key of taskKeys) {
+      expect(pkg.scripts, `missing script for turbo task "${key}"`).toHaveProperty(key)
+    }
+  })
+
+  it("names exactly the non-build tasks in the test script's turbo run", () => {
+    const match = pkg.scripts.test.match(/^turbo run (.+)$/)
+    expect(match, `"test" script must start with "turbo run": ${pkg.scripts.test}`).not.toBeNull()
+    const invoked = match![1].split(/\s+/)
+    expect(new Set(invoked)).toEqual(new Set(nonBuildTaskKeys))
+  })
+
+  it("does not name itself as a turbo task (no recursion)", () => {
+    expect(taskKeys).not.toContain("test")
+  })
+
+  it("declares no pre<task> script for any task key, except the allowlisted postbuild", () => {
+    for (const key of taskKeys) {
+      expect(pkg.scripts, `"pre${key}" bypasses the turbo graph`).not.toHaveProperty(`pre${key}`)
+    }
+    // postbuild is part of the build itself (schema generation + the
+    // no-test-doubles bundle assertion), not a duplicate graph edge.
+    expect(pkg.scripts).toHaveProperty("postbuild")
+  })
+
+  it("makes test:e2e:live depend on build", () => {
+    expect(turbo.tasks["test:e2e:live"].dependsOn).toContain("build")
+  })
+
+  it("lists README.md as an input to both e2e tasks", () => {
+    expect(turbo.tasks["test:e2e:inmem"].inputs).toContain("README.md")
+    expect(turbo.tasks["test:e2e:live"].inputs).toContain("README.md")
+  })
+
+  it("declares an explicit inputs array for every task except format:check", () => {
+    for (const key of taskKeys) {
+      if (key === "format:check") continue
+      expect(
+        Array.isArray(turbo.tasks[key].inputs),
+        `task "${key}" must declare explicit inputs`,
+      ).toBe(true)
+    }
+  })
+})

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "ui": "stream",
+  "globalDependencies": ["package.json", "package-lock.json", "tsconfig.json", "mise.toml"],
+  "globalPassThroughEnv": ["CI", "TMPDIR", "TERM", "FORCE_COLOR"],
+  "tasks": {
+    "build": {
+      "inputs": ["src/**", "scripts/**", "tsdown.config.ts"],
+      "outputs": ["dist/**", "schema.json"]
+    },
+    "format:check": {
+      "outputs": []
+    },
+    "lint": {
+      "inputs": ["src/**", "tests/**", "scripts/**", "dev/**", "*.ts", "*.mjs", ".oxlintrc.json"],
+      "outputs": []
+    },
+    "typecheck": {
+      "inputs": ["src/**", "tests/**", "*.ts"],
+      "outputs": []
+    },
+    "deadcode": {
+      "inputs": ["src/**", "tests/**", "*.ts", ".fallowrc.json"],
+      "outputs": []
+    },
+    "test:unit": {
+      "inputs": [
+        "src/**",
+        "tests/tooling/**",
+        "tests/vitest.*.ts",
+        "vitest.config.ts",
+        "turbo.json"
+      ],
+      "outputs": []
+    },
+    "test:e2e:inmem": {
+      "inputs": [
+        "src/**",
+        "tests/integration/**",
+        "tests/vitest.*.ts",
+        "vitest.config.ts",
+        "README.md"
+      ],
+      "outputs": []
+    },
+    "test:e2e:live": {
+      "dependsOn": ["build"],
+      "inputs": [
+        "src/**",
+        "tests/integration/**",
+        "tests/vitest.*.ts",
+        "vitest.config.ts",
+        "README.md"
+      ],
+      "outputs": []
+    }
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
         plugins: [rawMd()],
         test: {
           name: "unit",
-          include: ["src/**/*.test.ts"],
+          include: ["src/**/*.test.ts", "tests/tooling/*.test.ts"],
           exclude: ["**/*.integration.test.ts"],
           testTimeout: 30_000,
           hookTimeout: 30_000,


### PR DESCRIPTION
`npm test` was a serial `&&` chain of seven independent checks, so every gtd check beat re-ran all of them even when a turn only touched `README.md` or a single pure module. Turborepo now fronts the chain: each check is a task with its own `inputs`, so it runs in parallel with the others and is skipped when its inputs are unchanged since the last green run.

## Key decisions

- **Single-package turbo (no workspaces).** This repo is one package, so `turbo.json`'s tasks resolve straight to root `package.json` scripts.
- **Explicit `inputs` on every task** instead of turbo's default `$TURBO_DEFAULT$`, which would hash the steering files (`TODO.md`, `REVIEW.md`, …) the loop rewrites every beat and miss the cache on every single turn. `format:check` is the one exception — kept on default inputs, since oxfmt genuinely checks markdown too.
- **`README.md` is a declared input of both e2e tasks**, because `readme-driver.feature` executes its minimal-driver block verbatim. Omitting it would let a broken doc pass on a cached green (confirmed live: breaking the block failed all 19 `@live` scenarios and busted the cache for both e2e tasks).
- **`build` became a real turbo task and `pretest:e2e:live` was deleted**, so `test:e2e:live` depends on `build` through the graph instead of an npm pre-hook that would bypass turbo's caching. Trade-off: a bare `npm run test:e2e:live` no longer builds first — documented in the README, guarded by the new tooling test. Use `npx turbo run test:e2e:live` for a fresh bundle.
- **fallow's chain tail became its own `deadcode` script** so it can be a turbo task.
- **`test:changed` ships as a documented local pre-flight only**, never wired into the gate — vitest's `--changed` heuristic doesn't model the `@live` tier at all.
- Dropped `daemon: false` from `turbo.json`: turbo 2.10.9 warns it's deprecated and unused by `turbo run`, and keeping it would only add stderr noise to a driver's captured output.
- Added the `packageManager` field turbo 2.10.9 required even for this single-package repo (it refused to resolve the workspace without one).

## Guardrails

`tests/tooling/turbo.test.ts` guards the two rules a future change must not break:

1. every turbo task needs a matching `package.json` script **and** a slot in the `test` script's task list;
2. `README.md` must stay an input of both e2e tasks.

`AGENTS.md` documents both. CI now caches `.turbo` via `actions/cache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)