### PR TITLE
workflow(unified): let a package escape building via .gtd/SATISFIED.md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -204,8 +204,12 @@ look, and a box a reviewer ticks.
 file, carrying candidate answers as checkboxes plus a free-text slot. It becomes
 an **answered question** by moving under `## Answered Questions` as prose.
 
-**Package**: One independently buildable slice of an advanced-flow
-decomposition.
+**Package**: One independently buildable and independently greenable slice of an
+advanced-flow decomposition.
+
+**Satisfied package**: A package whose acceptance criteria are already met
+before its build turn runs — recorded as evidence in `.gtd/SATISFIED.md` rather
+than implemented, and reviewed and closed out like any other.
 
 **Feedback**: What a human or a check writes back to send work around again — a
 review's requested changes, or a failing suite's output.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,13 @@ for). The two steering-file entries are chosen by which file you create:
   per-package test loop, and a per-package **agentic review** that verifies the
   package against its spec. All three phases share one machine identity, so the
   agent never re-explores the codebase from scratch between them, and the
-  human's answers carry forward into decomposition.
+  human's answers carry forward into decomposition. A package whose work already
+  landed (an earlier package's fix turn pulled it in) is not a dead end: the
+  build turn records per-criterion evidence in `.gtd/SATISFIED.md` instead of
+  implementing anything, and the package still goes through the checks and the
+  spec review before closing out. If a queue item ever _does_ dead-end (a build
+  turn that authors nothing stalls), the supported recovery is to write that
+  same file yourself and `gtd land` — no hand-authored state commit.
 
 Both flows converge on the same tail: an agent hands you a `.gtd/REVIEW.md`
 checkbox review of the diff — the prompt never inlines the diff itself; it names

--- a/src/workflows/templates.test.ts
+++ b/src/workflows/templates.test.ts
@@ -173,6 +173,33 @@ describe("the bundled unified workflow template", () => {
       expect(MODES_SUGGESTION.review).not.toHaveProperty("validate")
     })
   })
+
+  it("packages.item.building declares an escape hatch for a package whose work already landed (issue #152)", () => {
+    // A package whose acceptance criteria are already met (an earlier
+    // package's fix turn pulled the work in) must have a legal, non-empty way
+    // to say so, rather than dead-ending in an empty attempt + stall.
+    const { definition } = compileTemplate()
+    const building = definition.states["packages.item.building"]!
+    const edges = building.on ?? []
+    const satisfiedAdd = edges.find(([pattern]) => pattern.includes("A "))
+    const satisfiedMod = edges.find(([pattern]) => pattern.includes("M "))
+    expect(satisfiedAdd?.[1]).toBe("packages.item.health.check")
+    expect(satisfiedAdd?.[3]).toBeTruthy() // action
+    expect(satisfiedMod?.[1]).toBe(satisfiedAdd?.[1])
+  })
+
+  it("packages.item.closing's script sweeps the satisfied-evidence file, and healthGate.check's shared sweep does not", () => {
+    // closing is the single owner of that cleanup: sweeping it earlier (in the
+    // shared healthGate.check) would delete the evidence before spec.review
+    // reads it.
+    const { definition } = compileTemplate()
+    const closing = definition.states["packages.item.closing"]!
+    expect(closing.script).toContain("it.vars.satisfiedFile")
+    const buildHealthCheck = definition.states["build.health.check"]!
+    const packagesHealthCheck = definition.states["packages.item.health.check"]!
+    expect(buildHealthCheck.script).not.toContain("it.vars.satisfiedFile")
+    expect(packagesHealthCheck.script).not.toContain("it.vars.satisfiedFile")
+  })
 })
 
 describe("the bundled template's machine boundaries line up with conversational identity (package 08)", () => {

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -173,6 +173,11 @@ vars:
   architectureFile: .gtd/ARCHITECTURE.md
   packagesDir: .gtd/packages
   nextFile: .gtd/NEXT.md
+  # Written by packages.item.building when a package's acceptance criteria are
+  # already met (an earlier package's fix turn pulled the work in); read by
+  # the spec reviewer as the evidence a clean turn there is a real approval,
+  # not a lazy/crashed one; removed by packages.item.closing.
+  satisfiedFile: .gtd/SATISFIED.md
   reviewFile: .gtd/REVIEW.md
   reviewRawFile: .gtd/REVIEW_RAW.md
   reviewFeedbackFile: .gtd/REVIEW_FEEDBACK.md
@@ -574,8 +579,14 @@ machines:
           (the converged technical plan) yourself. Decompose it into an ordered
           set of WORK PACKAGES, one file each under
           `<%= it.vars.packagesDir %>/` (e.g. `<%= it.vars.packagesDir %>/01-name.md`,
-          `<%= it.vars.packagesDir %>/02-name.md`, ...). Order the packages so the
-          test suite can pass again after each one lands.
+          `<%= it.vars.packagesDir %>/02-name.md`, ...).
+
+          Every package must leave the test suite GREEN on its own, in the order
+          you write them. If a package's change would red-light tests that a
+          later package is meant to fix, that is not a valid split: MERGE the
+          two into one package. Never annotate a package with "expected
+          sequencing" or "this will fail until package N" — an expected-red
+          window is a decomposition error, not a note.
 
           Each package file describes a set of INDEPENDENT tasks that can be
           implemented concurrently without ordering constraints between them — a
@@ -996,12 +1007,22 @@ machines:
         prompt: |
           You are an autonomous coding agent. This workflow steers itself
           through its own state files — treat them as its private scratchpad,
-          never as project code or documentation. This turn writes no state
-          file: do NOT delete the package file (the spec-review gate reads
-          it after you) and never touch `<%= it.vars.nextFile %>` — the
-          `picking` state owns it.
+          never as project code or documentation. The only state file this
+          turn may write is `<%= it.vars.satisfiedFile %>` (see below); do NOT
+          delete the package file (the spec-review gate reads it after you)
+          and never touch `<%= it.vars.nextFile %>` — the `picking` state owns
+          it.
 
           The package to implement is: <%~ it.read(it.vars.nextFile) %>
+
+          Before implementing anything, check the package's acceptance criteria
+          against the current tree — an earlier package's fix turn may already
+          have satisfied them. If **every** criterion is already met, implement
+          nothing: write `<%= it.vars.satisfiedFile %>` recording each criterion
+          and the concrete evidence it is already satisfied (the commit, file,
+          or symbol that proves it), change nothing else, and finish your turn.
+          If any criterion is outstanding, implement the package normally and
+          do not write that file.
 
           That file describes a set of INDEPENDENT tasks. Implement ALL of them in
           this one turn, fanning the independent tasks out to parallel subagents
@@ -1013,13 +1034,22 @@ machines:
           Leave the package file in place and everything else uncommitted, then
           finish your turn.
         on:
+          "A <%= it.vars.satisfiedFile %>": &satisfied
+            to: health.check
+            action: Close as already satisfied
+            describe: >-
+              record per-criterion evidence in .gtd/SATISFIED.md when this
+              package's work already landed (an earlier package's fix turn
+              pulled it in) — the package still runs the checks and the spec
+              review, then closes out.
+          "M <%= it.vars.satisfiedFile %>": *satisfied
           "* **": health.check
 
       fix-suite:
         actor: agent
         label: Fixing the check
         file: <%= it.vars.feedbackFile %>
-        prompt: &suiteFixPrompt |
+        prompt: |
           You are an autonomous coding agent. This workflow steers itself
           through its own state files — treat them as its private scratchpad,
           never as project code or documentation. The only state file this
@@ -1030,7 +1060,11 @@ machines:
           Read `<%= it.vars.feedbackFile %>` (the failing test output) and fix the
           code so the suite passes. Keep the change focused — do not refactor
           unrelated code. If the feedback is wrong, empty or delete
-          `<%= it.vars.feedbackFile %>` instead of "fixing" a non-issue.
+          `<%= it.vars.feedbackFile %>` instead of "fixing" a non-issue. If the
+          only way to green the suite is to implement work that another
+          package file describes, make the smallest change that gets there and
+          do it — that later package will then legitimately report itself
+          already satisfied when its turn comes.
 
           Leave everything uncommitted and finish your turn — do not commit.
         retry:
@@ -1065,14 +1099,15 @@ machines:
         script: |
           #!/usr/bin/env bash
           # gtd check turn (the package closer) — remove the just-reviewed package
-          # file (its path is in NEXT.md) plus any leftover spec feedback, so
-          # `picking` selects the NEXT package (or falls through to review when the
-          # queue is empty). Reached on approval (spec review clean) and on the
-          # spec review retry cap (force-close, deferring the concern to the tail).
+          # file (its path is in NEXT.md) plus any leftover spec feedback and
+          # already-satisfied evidence, so `picking` selects the NEXT package (or
+          # falls through to review when the queue is empty). Reached on approval
+          # (spec review clean) and on the spec review retry cap (force-close,
+          # deferring the concern to the tail).
           set +e
           pkg=$(cat <%~ it.vars.nextFile %> 2>/dev/null)
           [ -n "$pkg" ] && rm -f "$pkg"
-          rm -f <%~ it.vars.specFeedbackFile %> <%~ it.vars.nextFile %>
+          rm -f <%~ it.vars.specFeedbackFile %> <%~ it.vars.nextFile %> <%~ it.vars.satisfiedFile %>
         on:
           "* **": $onNext
 
@@ -1217,7 +1252,20 @@ machines:
         actor: agent
         label: Fixing the check
         file: <%= it.vars.feedbackFile %>
-        prompt: *suiteFixPrompt
+        prompt: |
+          You are an autonomous coding agent. This workflow steers itself
+          through its own state files — treat them as its private scratchpad,
+          never as project code or documentation. The only state file this
+          turn touches is `<%= it.vars.feedbackFile %>`; fix it per its
+          contents, or delete it if the feedback turns out to be wrong. Do not
+          create other files to hold notes or output.
+
+          Read `<%= it.vars.feedbackFile %>` (the failing test output) and fix the
+          code so the suite passes. Keep the change focused — do not refactor
+          unrelated code. If the feedback is wrong, empty or delete
+          `<%= it.vars.feedbackFile %>` instead of "fixing" a non-issue.
+
+          Leave everything uncommitted and finish your turn — do not commit.
         retry:
           max: 3
           otherwise: health.escalate

--- a/tests/integration/features/unified-advanced-flow.feature
+++ b/tests/integration/features/unified-advanced-flow.feature
@@ -25,6 +25,15 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
   simulated by writing their verdict files directly and running
   `gtd land` — @inmem never executes the scripts themselves.
 
+  A package whose work already landed (an earlier package's fix turn pulled it
+  in) is not a dead end: at packages.item.building the agent records
+  per-criterion evidence in `.gtd/SATISFIED.md` instead of implementing
+  anything, and the package still runs the checks and the spec review before
+  closing out (issue #152). If a build turn authors nothing at all instead, the
+  turn lands an empty attempt and `gtd next` reports the queue as stalled — the
+  supported recovery is a human writing that same `.gtd/SATISFIED.md` file and
+  running `gtd land`, no hand-authored state commit.
+
   Scenario: idle forks on the entry file — REQUIREMENTS.md starts the advanced flow gate
     Given a test project
     And the workflow
@@ -283,6 +292,184 @@ Feature: The bundled unified workflow — advanced-flow entry and per-package lo
     When I run gtd status
     Then it succeeds
     And stdout contains "State: build.review.await-review"
+
+  Scenario: a package whose work already landed closes out via .gtd/SATISFIED.md
+    Given a test project
+    And the workflow
+    And a file ".gtd/REQUIREMENTS.md" with:
+      """
+      Build a widget.
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(human): idle → spec-gate.check"
+
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(check): spec-gate.check → design.product-author"
+
+    Given ".gtd/REQUIREMENTS.md" is modified to:
+      """
+      Build a widget. Product plan: it exposes a `widget()` factory.
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(agent): design.product-author → design.product-answer"
+
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(human): design.product-answer → design.technical-author"
+
+    Given the file ".gtd/REQUIREMENTS.md" is deleted
+    And a file ".gtd/ARCHITECTURE.md" with:
+      """
+      Technical plan: src/widget.ts with a factory function.
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(agent): design.technical-author → design.technical-answer"
+
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(human): design.technical-answer → design.decompose"
+
+    Given the file ".gtd/ARCHITECTURE.md" is deleted
+    And a file ".gtd/packages/01-widget.md" with:
+      """
+      Package: the widget factory. Independent tasks:
+      - [ ] add src/widget.ts
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(agent): design.decompose → packages.picking"
+
+    Given a file ".gtd/NEXT.md" with:
+      """
+      .gtd/packages/01-widget.md
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(check): packages.picking → packages.item.building"
+
+    # packages.item.building: an earlier package's fix turn already implemented
+    # the widget factory — the agent records evidence instead of implementing
+    # anything
+    Given a file ".gtd/SATISFIED.md" with:
+      """
+      - [x] add src/widget.ts — already present, see commit
+        "gtd(agent): design.decompose → packages.picking"
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(agent): packages.item.building → packages.item.health.check"
+
+    # packages.item.health.check (green) -> packages.item.spec.review
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(check): packages.item.health.check → packages.item.spec.review"
+
+    # packages.item.spec.review (clean = approval — the reviewer's own range is
+    # process-wide, so it can see the earlier package's commit that satisfied
+    # this spec) -> packages.item.closing
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(agent): packages.item.spec.review → packages.item.closing"
+
+    # packages.item.closing: removes the package file, NEXT.md, and the
+    # satisfied evidence -> packages.picking
+    Given the file ".gtd/packages/01-widget.md" is deleted
+    And the file ".gtd/NEXT.md" is deleted
+    And the file ".gtd/SATISFIED.md" is deleted
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(check): packages.item.closing → packages.picking"
+
+    # packages.picking: the queue is now empty — a clean step closes out to the
+    # shared review tail
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(check): packages.picking → build.review.reviewing"
+
+  Scenario: a dead-ended package stalls, then a human's .gtd/SATISFIED.md unsticks it
+    Given a test project
+    And the workflow
+    And a file ".gtd/REQUIREMENTS.md" with:
+      """
+      Build a widget.
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(human): idle → spec-gate.check"
+
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(check): spec-gate.check → design.product-author"
+
+    Given ".gtd/REQUIREMENTS.md" is modified to:
+      """
+      Build a widget. Product plan: it exposes a `widget()` factory.
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(agent): design.product-author → design.product-answer"
+
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(human): design.product-answer → design.technical-author"
+
+    Given the file ".gtd/REQUIREMENTS.md" is deleted
+    And a file ".gtd/ARCHITECTURE.md" with:
+      """
+      Technical plan: src/widget.ts with a factory function.
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(agent): design.technical-author → design.technical-answer"
+
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(human): design.technical-answer → design.decompose"
+
+    Given the file ".gtd/ARCHITECTURE.md" is deleted
+    And a file ".gtd/packages/01-widget.md" with:
+      """
+      Package: the widget factory. Independent tasks:
+      - [ ] add src/widget.ts
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(agent): design.decompose → packages.picking"
+
+    Given a file ".gtd/NEXT.md" with:
+      """
+      .gtd/packages/01-widget.md
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(check): packages.picking → packages.item.building"
+
+    # packages.item.building: the agent's turn changes nothing (the issue's
+    # regression case) — a clean tree at a prompt rest with no "C" row lands an
+    # empty attempt instead of implementing anything
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(agent): packages.item.building"
+    And the git status is clean
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"kind\":\"stalled\""
+    And the json field "content" contains "stalled at \"packages.item.building\""
+
+    # the supported recovery: a human writes the satisfied evidence themselves
+    # and runs gtd land — no hand-authored state commit
+    Given a file ".gtd/SATISFIED.md" with:
+      """
+      - [x] add src/widget.ts — already present, see commit
+        "gtd(agent): design.decompose → packages.picking"
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(agent): packages.item.building → packages.item.health.check"
 
   Scenario: a custom two-level nested machine reference resolves $param bindings and qualified names across both levels
     Given a test project


### PR DESCRIPTION
Fixes #152.

## Problem

`packages.item.building` had no legal way to say "this package's work already
landed" (pulled in by an earlier package's fix-suite turn). Its only outcome was
the catch-all edge to `health.check`, so a clean turn there produced an empty
attempt and the queue dead-ended — recoverable only by hand-authoring history.

## Approach

Rejected the issue's own suggestion of a `C` (clean-tree) row: an empty diff
meaning success is indistinguishable from a lazy or crashed agent, and destroys
the stall signal this state most needs.

Instead the agent must author **evidence** — `.gtd/SATISFIED.md`, recording each
criterion and the concrete proof it's already met — so the outcome is a real,
auditable commit. That evidence still routes through `health.check` and
`packages.item.spec.review` before closing, so the package's own reviewer (whose
range is process-wide) confirms the claim against the spec rather than taking the
coder's word for it.

A genuinely fruitless turn still lands an empty attempt and stalls, exactly as
before; the supported recovery is a human writing the same file and running
`gtd land`, no new CLI command.

## Also in here

- `design.decompose` tightened: a package split that would red-light tests a
  later package is meant to fix is now a decomposition error to merge, not a
  sequencing note to annotate — the upstream cause of the dead end.
- `fix-suite`'s prompt names the resulting borrow scenario so it isn't a surprise.
- `packages.item.closing` sweeps the new file;
  `build.health.check` / `packages.item.health.check`'s shared sweep deliberately
  does **not**, so the evidence survives to the reviewer.

## Coverage

Two new `@inmem` scenarios (satisfied close-out, and the stall-then-recover
regression) plus template invariants pinning the new edges and the sweep
boundary. README and CONTEXT.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)