### PR TITLE
fix(review-doc): stop truncating hyphenated hunk paths at go-to-definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1142,7 +1142,9 @@ the compiler's job at load time.
 per `review`-mode chunk that still has an unchecked hunk (an outline of the
 packages left to review) plus check/uncheck actions over those chunks,
 go-to-definition from a `review`-mode hunk line into the file it points at (at
-its `#line`), symbols over a `qa`-mode file's open questions plus "pick this
+its `#line` — a hunk's path is a single whitespace-delimited `./`-relative
+token, so a hyphen in a filename stays part of the path, never a note
+separator), symbols over a `qa`-mode file's open questions plus "pick this
 option"/"uncheck this option" code actions on each option — offered anywhere on
 the option's list item, including any wrapped continuation lines, not just its
 own `- [ ]` line — diagnostics for both (live as you edit), and a

--- a/src/ReviewDoc.test.ts
+++ b/src/ReviewDoc.test.ts
@@ -149,6 +149,77 @@ describe("parseReviewDoc", () => {
       "REVIEW.md has no '##' chunks",
     ])
   })
+
+  it("keeps a hyphenated path whole and its #line, instead of splitting at the first hyphen", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add budget alerts",
+      "",
+      "- [ ] ./src/server/email/budget-threshold.ts#31 — non-obvious import: uses the shared mailer",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    expect(result.errors).toEqual([])
+    expect(result.changesets[0]?.files).toEqual([
+      {
+        path: "./src/server/email/budget-threshold.ts",
+        line: 31,
+        checked: false,
+        note: "non-obvious import: uses the shared mailer",
+        sourceLine: 5,
+      },
+    ])
+  })
+
+  it("splits a single-dash note after a hyphenated path at the space, not the hyphen", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./a-b/c-d.ts#7 - note",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    expect(result.changesets[0]?.files).toEqual([
+      { path: "./a-b/c-d.ts", line: 7, checked: false, note: "note", sourceLine: 5 },
+    ])
+  })
+
+  it("keeps a # not followed by digits in the path, with no line parsed", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./a#b.ts",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    expect(result.changesets[0]?.files).toEqual([
+      { path: "./a#b.ts", checked: false, sourceLine: 5 },
+    ])
+  })
+
+  it("still refuses a bare box, a non-./ path, and a ./ with nothing after it", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [] ./x.ts",
+      "- [ ] src/no-dot-slash.ts",
+      "- [ ] ./#31",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    expect(result.changesets[0]?.files).toEqual([])
+  })
 })
 
 const reviewDoc = [
@@ -174,6 +245,21 @@ describe("untickedFiles", () => {
   it("returns an empty array when every pointer is ticked", () => {
     const allChecked = reviewDoc.replace("- [ ] ./src/calc.ts#1", "- [x] ./src/calc.ts#1")
     expect(untickedFiles(allChecked).filter((f) => f.path === "./src/calc.ts")).toEqual([])
+  })
+
+  it("reports a hyphenated path whole, not truncated at its first hyphen", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add budget alerts",
+      "",
+      "- [ ] ./src/server/email/budget-threshold.ts#31",
+      "",
+    ].join("\n")
+    expect(untickedFiles(content).map((f) => f.path)).toEqual([
+      "./src/server/email/budget-threshold.ts",
+    ])
   })
 })
 
@@ -201,6 +287,26 @@ describe("toggleFilePointer", () => {
 
   it("returns undefined for a line that isn't a file pointer", () => {
     expect(toggleFilePointer(reviewDoc, 3)).toBeUndefined()
+  })
+
+  it("flips only the box on a hyphenated pointer line, round-tripping the rest", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./src/server/email/budget-threshold.ts#31 — non-obvious import",
+      "",
+    ].join("\n")
+    const line = content.split("\n")[5]!
+    const edit = toggleFilePointer(content, 5)
+    expect(edit).toBeDefined()
+    const patched =
+      line.slice(0, edit!.range.start.character) +
+      edit!.newText +
+      line.slice(edit!.range.end.character)
+    expect(patched).toBe("- [x] ./src/server/email/budget-threshold.ts#31 — non-obvious import")
   })
 })
 
@@ -270,5 +376,20 @@ describe("REVIEW_FORMAT", () => {
 
   it("pointerAt returns undefined when the line is not a hunk pointer", () => {
     expect(REVIEW_FORMAT.pointerAt?.(reviewDoc, 3)).toBeUndefined() // "## Add calculator"
+  })
+
+  it("pointerAt on a hyphenated hunk line returns the full path, not a truncated prefix", () => {
+    const doc = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add budget alerts",
+      "",
+      "- [ ] ./src/server/email/budget-threshold.ts#31 — non-obvious import",
+    ].join("\n")
+    expect(REVIEW_FORMAT.pointerAt?.(doc, 5)).toEqual({
+      path: "./src/server/email/budget-threshold.ts",
+      line: 30,
+    })
   })
 })

--- a/src/ReviewDoc.ts
+++ b/src/ReviewDoc.ts
@@ -20,6 +20,12 @@
  * line), the `<!-- base: <hash> -->` comment, and at least one `##` chunk
  * with a non-empty title and at least one `- [ ]` / `- [x]` file pointer.
  *
+ * A file pointer's path is ONE whitespace-delimited `./`-relative token — an
+ * optional `#<line>` suffix of that same token, then an optional
+ * whitespace-separated note. A hyphen (or em/en dash) in a filename is part of
+ * the path, never a note separator: the note separator is only recognized
+ * after whitespace has already split the note from the path.
+ *
  * **The format's single source of truth.** This module is the EXECUTABLE SPEC
  * of that format — its own unit tests (`ReviewDoc.test.ts`) are the format's
  * spec tests. Both consumers of the format run THIS parser, so there is no
@@ -64,7 +70,12 @@ export interface ReviewDoc {
 const HEADER_RE = /^#\s+Review:\s*(\S+)\s*$/
 const BASE_COMMENT_RE = /^<!--\s*base:\s*(\S+)\s*-->$/
 const CHUNK_HEADING_RE = /^##\s+(.+)$/
-const FILE_POINTER_RE = /^-\s*\[([ xX])\]\s*(\.\/\S+?)(?:#(\d+))?(?:\s*[—-]+\s*(.*))?$/
+/** One `- [ ]`/`- [x]` pointer line: the box, the whitespace-delimited pointer token, and the rest of the line. */
+const FILE_POINTER_RE = /^-\s*\[([ xX])\]\s*(\S+)(?:\s+(.*))?$/
+/** A pointer token's trailing `#<line>` (greedy, so a `#` inside the path stays in it). */
+const POINTER_LINE_RE = /^(.*)#(\d+)$/
+/** The optional dash a trailing note may lead with — em dash, en dash, or hyphens. */
+const NOTE_SEPARATOR_RE = /^[—–-]+\s*/
 
 /** The `# Review: <hash>` header, required as the document's first non-blank line. */
 const parseHeader = (lines: readonly string[]): string | undefined => {
@@ -85,11 +96,17 @@ const parseBaseComment = (lines: readonly string[]): string | undefined => {
 const parseFilePointer = (line: string, sourceLine: number): ReviewFile | undefined => {
   const match = FILE_POINTER_RE.exec(line)
   if (!match) return undefined
+  const token = match[2]!
+  if (!token.startsWith("./")) return undefined
+  const lineMatch = POINTER_LINE_RE.exec(token)
+  const path = lineMatch ? lineMatch[1]! : token
+  if (path.length <= 2) return undefined // `./` with nothing after it is not a path
+  const note = (match[3] ?? "").replace(NOTE_SEPARATOR_RE, "").trim()
   return {
     checked: match[1] !== " ",
-    path: match[2]!,
-    ...(match[3] !== undefined ? { line: Number(match[3]) } : {}),
-    ...(match[4] && match[4].trim().length > 0 ? { note: match[4].trim() } : {}),
+    path,
+    ...(lineMatch ? { line: Number(lineMatch[2]) } : {}),
+    ...(note.length > 0 ? { note } : {}),
     sourceLine,
   }
 }
@@ -206,13 +223,12 @@ export const toggleFilePointer = (content: string, line: number): SteeringEdit |
   if (raw === undefined) return undefined
   const leading = raw.length - raw.trimStart().length
   const trimmed = raw.slice(leading)
-  const match = FILE_POINTER_RE.exec(trimmed)
-  if (!match) return undefined
-  const bracketContent = match[0].indexOf("[") + 1
-  const character = leading + bracketContent
+  const pointer = parseFilePointer(trimmed, line)
+  if (pointer === undefined) return undefined
+  const character = leading + trimmed.indexOf("[") + 1
   return {
     range: { start: { line, character }, end: { line, character: character + 1 } },
-    newText: match[1] === " " ? "x" : " ",
+    newText: pointer.checked ? " " : "x",
   }
 }
 

--- a/tests/integration/features/lsp.feature
+++ b/tests/integration/features/lsp.feature
@@ -14,8 +14,10 @@ Feature: gtd lsp — the steering-file LSP server (stdio)
   hand-authored current state and asking the client to show its steering
   file (`window/showDocument`). A final scenario proves go-to-definition: a
   `textDocument/definition` on a `.gtd/REVIEW.md` hunk pointer line returns a
-  `Location` in the referenced file at its `#line` (basename fallback). One
-  more scenario proves a `qa`-mode code action is offered from a wrapped
+  `Location` in the referenced file at its `#line` (basename fallback). A
+  further scenario pins the fix for a hunk pointer whose path contains
+  hyphens: it must jump to the full file, not a truncated directory prefix.
+  One more scenario proves a `qa`-mode code action is offered from a wrapped
   option's continuation line, not just its own `- [ ]` line (see
   `QuestionOption.endLine` in src/OpenQuestions.ts). Real subprocess I/O
   (spawn + stdio JSON-RPC framing), so this runs @live.
@@ -191,6 +193,26 @@ Feature: gtd lsp — the steering-file LSP server (stdio)
       """
     Then the LSP response has no error
     And the LSP response result points to "src/calc.ts" at line 4
+
+  Scenario: a definition on a hunk whose path contains hyphens jumps to the file, not a parent folder
+    # Regression: the pointer regex's non-greedy path group split the path at
+    # its first hyphen and called the remainder a note, so the jump landed on
+    # ./src/server/email/budget (a DIRECTORY) at line 0.
+    Given a test project
+    And an LSP server started in the test project
+    When the LSP client sends an initialize request
+    Then the LSP response has no error
+    When the LSP client requests a definition at line 5 in ".gtd/REVIEW.md" containing:
+      """
+      # Review: abc1234
+      <!-- base: abc1234def5678901234567890123456789abcd -->
+
+      ## Add budget alerts
+
+      - [ ] ./src/server/email/budget-threshold.ts#31 — non-obvious import
+      """
+    Then the LSP response has no error
+    And the LSP response result points to "src/server/email/budget-threshold.ts" at line 30
 
   Scenario: a code action is offered on a wrapped option's continuation line, not just its checkbox line
     Given a test project


### PR DESCRIPTION
## Problem

The review-doc file-pointer regex used a non-greedy path group (`\.\/\S+?`) followed by an optional bare-hyphen note separator. The shortest successful parse therefore split a path at its **first hyphen** and treated the remainder as a note:

`- [ ] ./src/server/email/budget-threshold.ts#31 — note`

parsed as path `./src/server/email/budget` with **no line**, so LSP go-to-definition jumped to an existing parent directory at line 0 instead of the intended file and line.

## Fix

Replaced the single backtracking regex with tokenization:

- the path is the first whitespace-delimited token after the checkbox
- `#<line>` is a suffix of that token (matched greedily, so a `#` inside a path stays in it)
- anything after the token (space-separated) is the note

This matches the pointer grammar the bundled workflow template already documents to agents, so no prompt change is needed. A trailing note's leading dash is now optional, which only ever makes `untickedFiles` count *more* unticked pointers — the safe direction for the review sign-off guard.

`toggleFilePointer` now reuses the same `parseFilePointer` instead of re-running its own regex, so "is this line a pointer" has one answer in the module.

## Tests

- unit tests for hyphenated paths, dash-note splitting, `#` without digits, and the existing refusal cases
- a new `@live` LSP scenario pinning the go-to-definition fix end to end

## Docs

Pointer grammar documented in `ReviewDoc.ts`'s module doc comment and in the README's editor-integration section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)