### PR TITLE
feat(workflow): give idle a default todoFile sketch pad

### DIFF
--- a/.gtdrc.json
+++ b/.gtdrc.json
@@ -2,6 +2,7 @@
   "$schema": "https://cdn.jsdelivr.net/npm/@pmelab/gtd/schema.json",
   "vars": {
     "testCommand": "npm test",
+    "todoFile": "TODO.md",
     "requirementsFile": "REQS.md",
     "architectureFile": "ARCH.md",
     "reviewFile": "REVIEW.md"

--- a/README.md
+++ b/README.md
@@ -121,10 +121,14 @@ reads intent first, glob second.
 to the tree — a hand-edit to real code, a scratch note in some file, anything at
 all — as a sketch to be finished, never as work to be preserved: there is no
 fork on which steering file you happen to create, and `idle` has exactly one
-outgoing edge, into `unwind`. `unwind` reverts that whole diff back out of your
-working tree (`git revert --no-commit` against the commit it just landed in)
-before planning ever starts — your tree is back to exactly what it was, and your
-intent doesn't disappear, it survives in history for `design.triage` to read.
+outgoing edge, into `unwind`. `.gtd/TODO.md` (the `todoFile` var) is a good
+default place to start sketching when you'd rather write a note than touch code
+— despite living beside the workflow's own state files, that sketch is your
+input for `design.triage` to fold in, never gtd bookkeeping to preserve or
+ignore. `unwind` reverts that whole diff back out of your working tree
+(`git revert --no-commit` against the commit it just landed in) before planning
+ever starts — your tree is back to exactly what it was, and your intent doesn't
+disappear, it survives in history for `design.triage` to read.
 
 From there, `start-gate.check` runs your test suite on the tree as it now stands
 — which, thanks to the unwind, is simply your repo's own baseline. The rule is
@@ -227,11 +231,14 @@ to target a state.
 Every agent state routes its model through two `vars` tiers — `plannerModel`
 (heavier planning and review) and `coderModel` (the coding turns) — so you can
 repoint the models globally in one place (a `vars:` edit or a `GTD_PLANNERMODEL`
-override) instead of per state. Steering-file path vars (`feedbackFile`,
-`reviewFile`, …) work the same way, and propagate to the `on` patterns that
-route on them too — a repointed path var actually reroutes the machine, not just
-the templates that read/write the file. A separate `stateDir` var (default
-`.gtd`) names only where the check scripts keep their own scratch/bookkeeping,
+override) instead of per state. Steering-file path vars (`todoFile`,
+`feedbackFile`, `reviewFile`, …) work the same way, and propagate to the `on`
+patterns that route on them too — a repointed path var actually reroutes the
+machine, not just the templates that read/write the file. `todoFile` (default
+`.gtd/TODO.md`, `idle`'s own `file:` hint) is the one exception: it's the only
+per-file var gtd never writes and never reads, since it names your own sketch
+pad, not a file any state produces. A separate `stateDir` var (default `.gtd`)
+names only where the check scripts keep their own scratch/bookkeeping,
 independent of the per-file vars — relocate one steering file without touching
 it.
 
@@ -1080,11 +1087,13 @@ model, pattern grammar, load-time rules, and how to verify a change compiles.
 > `design.gate.answer`, `design.technical-author` → `architecture.author`,
 > `design.technical-answer` → `architecture.gate.answer`, `design.decompose` →
 > `architecture.decompose` (architecture is now its own sibling machine with its
-> own memory scope, not nested under `design`). The `todoFile` var and the
-> `prose` mode are both gone — there is no more free-form plan file. As with
-> every rename above, an in-flight process resting at one of the old names can
-> no longer be resumed; `gtd abandon` it (or finish it on the pre-upgrade
-> workflow version) before upgrading.
+> own memory scope, not nested under `design`). The `prose` mode is gone and
+> there is no more free-form _plan_ file — `todoFile` itself came back later
+> with a different job: `idle`'s own mode-less `file:` hint, gtd's sketch pad
+> that no state writes or reads. As with every rename above, an in-flight
+> process resting at one of the old names can no longer be resumed;
+> `gtd abandon` it (or finish it on the pre-upgrade workflow version) before
+> upgrading.
 
 ### Variables
 
@@ -1197,7 +1206,14 @@ separator), symbols over a `qa`-mode file's open questions plus "pick this
 option"/"uncheck this option" code actions on each option — offered anywhere on
 the option's list item, including any wrapped continuation lines, not just its
 own `- [ ]` line — diagnostics for both (live as you edit), and a
-`gtd.openSteeringFile` command that jumps to the current state's steering file.
+`gtd.openSteeringFile` command that jumps to the current state's steering file —
+including `idle`, whose `todoFile` hint gives the one keybinding an answer even
+before a process has started. The command only names that path — it never
+stat-checks or creates it — so on a repo that has never run gtd, `.gtd/` may not
+exist yet and editors differ on opening a file whose parent directory is missing
+(an empty buffer that creates it on save vs. refusing the path outright); this
+bites only the very first sketch in a fresh repo, since the workflow's own check
+scripts create the state directory on the first `gtd next`/`gtd land`.
 
 It is config-driven via each state's `file:`/`mode:`, and falls back to basename
 dispatch (`REVIEW.md` → `review`) with no config in sight. `qa` and `review` are

--- a/src/Lsp.test.ts
+++ b/src/Lsp.test.ts
@@ -1,4 +1,4 @@
-import type { Effect } from "effect"
+import { Effect } from "effect"
 import { describe, expect, it, vi } from "vitest"
 import {
   basenameFallbackMode,
@@ -8,6 +8,7 @@ import {
   diagnosticsFor,
   externalValidatorNotice,
   makeSteeringLanguageService,
+  resolveSteeringFile,
   resolvedModeForDocument,
   resolveWorkspaceRoot,
   startLspServer,
@@ -26,6 +27,8 @@ import { resolveBuiltInMode, resolveSteeringMode } from "./SteeringMode.js"
 import { QA_FORMAT } from "./OpenQuestions.js"
 import { REVIEW_FORMAT } from "./ReviewDoc.js"
 import type { WorkflowDefinition } from "./PatternMachine.js"
+import { InMemRepo } from "./testing/InMemRepo.js"
+import { testLayers } from "./testing/Layers.js"
 
 describe("basenameFallbackMode", () => {
   it("maps REVIEW.md to the built-in `review` mode, and anything else (including TODO.md) to undefined", () => {
@@ -576,6 +579,27 @@ describe("bindSteeringServer", () => {
     bindSteeringServer(connection, documents, service)
     expect(documents.listen).toHaveBeenCalledWith(connection)
     expect(connection.listen).toHaveBeenCalled()
+  })
+})
+
+describe("resolveSteeringFile", () => {
+  it("resolves idle's .gtd/TODO.md with no stat — gtd names the path, never checks it exists", async () => {
+    // No `.gtdrc` at all — the bundled/built-in template applies, whose
+    // `idle` state resolves `file:` to `.gtd/TODO.md` (its `todoFile` var,
+    // src/workflows/unified.yaml). One commit, nothing under `.gtd/` — the
+    // repo-relative path resolves purely from the workflow + state, never by
+    // stat-ing the worktree for it.
+    const repo = new InMemRepo()
+    repo.writeFile("README.md", "hello")
+    repo.commitAllWithPrefix("chore: initial commit")
+
+    const resolved = await Effect.runPromise(
+      resolveSteeringFile.pipe(Effect.provide(testLayers(repo))),
+    )
+
+    expect(resolved.state).toBe("idle")
+    expect(resolved.file).toBe(".gtd/TODO.md")
+    expect(repo.hasPath(".gtd/TODO.md")).toBe(false)
   })
 })
 

--- a/src/Lsp.ts
+++ b/src/Lsp.ts
@@ -31,9 +31,12 @@
  * config at all) falls back to today's basename dispatch (`REVIEW.md` →
  * `review`, via `resolveBuiltInMode`), so the server still works standalone
  * with no `.gtdrc` in sight. (`.gtd/TODO.md` is NOT dispatched by basename —
- * no bundled state writes there at all; a custom workflow that wants qa
- * validation on TODO.md declares it with `file:`+`mode: qa`, which the
- * config-driven map covers.)
+ * the bundled `idle` state NAMES it via `file:` but declares no `mode:`,
+ * deliberately: there is no format for a free-form sketch, so neither the
+ * config-driven map nor this basename fallback dispatches it, and it gets no
+ * outline, no code actions, and no live diagnostics. A custom workflow that
+ * wants qa validation on TODO.md declares it with `file:`+`mode: qa`, which
+ * the config-driven map covers.)
  *
  * A mode's `validate:` command displacing a built-in format's own parser (a
  * `modes: { qa: { validate: "…" } }` override) still gets outline + actions —
@@ -90,7 +93,7 @@ import { Cwd } from "./Cwd.js"
 import { EnvVars } from "./EnvVars.js"
 import { GitService } from "./Git.js"
 import { RepoFiles } from "./RepoFiles.js"
-import { currentRest } from "./Edge.js"
+import { currentRest, type RestRequirements } from "./Edge.js"
 import type { StateMode, WorkflowDefinition } from "./PatternMachine.js"
 import { renderStateTemplate, varsOnlyContext } from "./PatternTemplates.js"
 import {
@@ -174,7 +177,7 @@ export const diagnosticsFor = (
 
 // ── Config-driven path→mode dispatch (pure) ─────────────────────────────────
 
-/** The basename dispatch this server has always had — the fallback for any path the active workflow's `file:` map doesn't cover (or when no config resolves at all). `TODO.md` is intentionally NOT mapped: no bundled state writes there at all. */
+/** The basename dispatch this server has always had — the fallback for any path the active workflow's `file:` map doesn't cover (or when no config resolves at all). `TODO.md` is intentionally NOT mapped: the bundled `idle` state names it via `file:` but declares no `mode:` (there is no format for a free-form sketch), so no dispatch path — config-driven or basename — covers it. */
 export const basenameFallbackMode = (name: string): ResolvedMode | undefined =>
   name === "REVIEW.md" ? resolveBuiltInMode("review") : undefined
 
@@ -577,24 +580,18 @@ const runtimeFor = (root: string): RootRuntime => {
 /**
  * Resolve the CURRENT state/actor and its `file:` (rendered), exactly like
  * the CLI (`currentRest` — the same `src/Edge.ts` entry point `gtd status`/
- * `gtd next` use), scoped to `root`. `file` is `undefined` when the resolved
- * state declares none — see `steeringFileOutcome` for what that means to the
- * command.
+ * `gtd next` use). `file` is `undefined` when the resolved state declares
+ * none — see `steeringFileOutcome` for what that means to the command. Carries
+ * its requirements (`RestRequirements`, the same four services `layersForRoot`
+ * merges) rather than providing them itself — the caller runs it through
+ * `runtimeFor(root)`, the memoised runtime, instead of building fresh layers
+ * per call.
  */
-const resolveSteeringFile = (
-  root: string,
-): Effect.Effect<{ readonly state: string; readonly file: string | undefined }, Error> =>
-  currentRest.pipe(
-    Effect.map((rest) => ({ state: rest.state, file: rest.hints.file })),
-    Effect.provide(
-      Layer.mergeAll(
-        gitLayerForRoot(root),
-        configLayerForRoot(root),
-        repoFilesLayerForRoot(root),
-        EnvVars.Live,
-      ),
-    ),
-  )
+export const resolveSteeringFile: Effect.Effect<
+  { readonly state: string; readonly file: string | undefined },
+  Error,
+  RestRequirements
+> = currentRest.pipe(Effect.map((rest) => ({ state: rest.state, file: rest.hints.file })))
 
 /**
  * The Node adapter: the only place `LspEnv`'s Effects/layers get built and
@@ -618,7 +615,7 @@ const makeNodeLspEnv = (warn: (message: string) => void): LspEnv => ({
   gitTopLevel: (dir) =>
     runtimeFor(dir).runPromise(Effect.flatMap(GitService, (git) => git.topLevel())),
 
-  currentSteeringFile: (root) => Effect.runPromise(resolveSteeringFile(root)),
+  currentSteeringFile: (root) => runtimeFor(root).runPromise(resolveSteeringFile),
 })
 
 /**

--- a/src/program.ts
+++ b/src/program.ts
@@ -967,8 +967,10 @@ const runNextCommand = (
  * `mode:` selecting how) — the SAME commands `gtd land`'s capture guard now
  * embeds ahead of its own commit (see `planLanding`), rendered here for a
  * human or agent to run directly. gtd itself reads no file and executes
- * nothing: a state with no `file:`/`mode:`, or a file absent from the working
- * tree, has nothing to validate (`script: ""`, exit 0 either way) — the
+ * nothing: a state with no `file:`/`mode:` (or, like the bundled `idle`, a
+ * `file:` with no `mode:` — a mode-less sketch has no format to run), or a
+ * file absent from the working tree, has nothing to validate (`script: ""`,
+ * exit 0 either way) — the
  * verdict now lives in the emitted script's own future exit code, not this
  * command's, so this never fails on a bad file. `RepoFiles`/`FileSystem` is
  * used only to check the file's PRESENCE, never to read or judge its content.

--- a/src/workflows/templates.test.ts
+++ b/src/workflows/templates.test.ts
@@ -58,6 +58,13 @@ describe("the bundled unified workflow template", () => {
     }
   })
 
+  it("the initial state declares a non-empty file and no mode — a steering-file hint with no format/validate obligation", () => {
+    const { definition } = compileTemplate()
+    const idle = definition.states.idle!
+    expect(idle.file).toBeTruthy()
+    expect(idle.mode).toBeUndefined()
+  })
+
   it("the initial state has exactly one outgoing edge, into unwind — no filename fork", () => {
     const { definition } = compileTemplate()
     const idle = definition.states.idle!
@@ -126,10 +133,6 @@ describe("the bundled unified workflow template", () => {
       const answerPatterns = (answer.on ?? []).map(([pattern]) => pattern)
       expect(answerPatterns, prefix).not.toContain("C")
     }
-  })
-
-  it("no state, script, or var references the deleted todoFile", () => {
-    expect(unifiedYaml).not.toMatch(/todoFile/)
   })
 
   it("no state declares `mode: prose`", () => {

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -213,6 +213,10 @@ vars:
   # file, review-deciding's state-file exclusion). Independent of the per-file
   # vars below — relocating a file wholesale means setting both.
   stateDir: .gtd
+  # The only per-file var gtd never writes and never reads — the human's own
+  # sketch pad, named so the one "open steering file" keybinding has an
+  # answer at `idle` too.
+  todoFile: .gtd/TODO.md
   requirementsFile: .gtd/REQUIREMENTS.md
   architectureFile: .gtd/ARCHITECTURE.md
   # Stamped (never authored, never read for its content) by design.gate.check
@@ -508,6 +512,12 @@ machines:
           never as project code or documentation. The only state file this
           turn touches is `<%= it.vars.requirementsFile %>`; develop it. Do
           not create other files to hold notes or output.
+
+          `<%= it.vars.todoFile %>` is the likely home of the sketch that
+          started this process. Despite living beside this workflow's own
+          state files, it is the HUMAN'S INPUT — the sketch to be folded into
+          the concerns below like any other part of the start diff. It is
+          never a state file to preserve, and never gtd bookkeeping to ignore.
 
           This process started at commit `<%= it.startCommit %>`. The change
           that started it was reverted out of the working tree by the
@@ -1330,6 +1340,7 @@ machines:
       idle:
         actor: human
         label: Idle
+        file: <%= it.vars.todoFile %>
         # Every human-gate `message:` below closes with the same rendered "What
         # each change does next" list, built from `it.edges` (the resting state's
         # own `on` edges — each edge's `describe:` is the single source of truth).
@@ -1337,12 +1348,14 @@ machines:
           No active gtd process.
 
           To start one, make ANY change — a hand-edit to real code, a scratch
-          note, anything at all. gtd treats it as a SKETCH, not finished work:
-          the very next beat unwinds it out of your working tree (its intent
-          survives in history, for the triage phase to read), then checks the
-          test baseline is green, then triages the reverted diff into ordered,
-          classified concerns: product questions, then technical questions,
-          then one package per concern, built and reviewed in parallel.
+          note, anything at all. <%= it.vars.todoFile %> is a good default
+          place to start sketching. gtd treats it as a SKETCH, not finished
+          work: the very next beat unwinds it out of your working tree (its
+          intent survives in history, for the triage phase to read), then
+          checks the test baseline is green, then triages the reverted diff
+          into ordered, classified concerns: product questions, then
+          technical questions, then one package per concern, built and
+          reviewed in parallel.
 
           What each change does next (then run `gtd land`):
           <% it.edges.forEach(function (e) { if (e.describe) { %>

--- a/tests/integration/features/default-workflow.feature
+++ b/tests/integration/features/default-workflow.feature
@@ -302,6 +302,21 @@ Feature: The bundled unified workflow — one flow, end to end
     And "src/greeter.ts" exists
 
   @inmem
+  Scenario: writing the bundled sketch file alone starts a process — idle's file: hint is the same nested path its edge pattern already covers
+    Given a test project
+    And the workflow
+    # idle's edge pattern is "* **" — a lone `*` never crosses a `/`, so only
+    # the "**" half reaches into ".gtd/" at all. A future narrowing to "* *"
+    # would leave this sketch unmatched and idle would refuse it.
+    And a file ".gtd/TODO.md" with:
+      """
+      - [ ] sketch: add a greeter
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(human): idle → unwind"
+
+  @inmem
   Scenario: the design gate refuses an unanswered open question, then ticking loops back to triage
     Given a test project
     And the workflow

--- a/tests/integration/features/driver-json-status.feature
+++ b/tests/integration/features/driver-json-status.feature
@@ -616,6 +616,17 @@ Feature: Driver protocol — gtd next --json content kinds, gtd status pattern m
     And stdout does not contain "\"file\""
     And stdout does not contain "\"mode\""
 
+  Scenario: the bundled template's idle rest carries the todoFile hint in gtd next --json and gtd status --json
+    Given a test project
+    And the workflow
+    When I run gtd next with "--json"
+    Then it succeeds
+    And stdout contains "\"state\":\"idle\""
+    And stdout contains "\"file\":\".gtd/TODO.md\""
+    When I run gtd status with "--json"
+    Then it succeeds
+    And stdout contains "\"file\":\".gtd/TODO.md\""
+
   Scenario: a human gate's message renders its `on` edge descriptions as a route list, and gtd next --json carries the same edges
     Given a test project
     And a gtd config file at ".gtdrc" with:

--- a/tests/integration/features/lsp.feature
+++ b/tests/integration/features/lsp.feature
@@ -4,9 +4,10 @@ Feature: gtd lsp — the steering-file LSP server (stdio)
   Minimal protocol-level smoke for `gtd lsp` (see src/Lsp.ts and
   docs/design/steering-file-loops.md §5): the server starts over stdio, the
   `initialize` handshake succeeds and advertises the document-symbol/code-
-  action capabilities, and a `textDocument/documentSymbol` request against an
-  unmapped `.gtd/TODO.md` fixture yields NO symbols (there is no `TODO.md` → qa
-  basename fallback — no bundled state writes there at all). Two further
+  action capabilities, and a `textDocument/documentSymbol` request against a
+  `.gtd/TODO.md` fixture yields NO symbols (there is no `TODO.md` → qa
+  basename fallback — the bundled `idle` names that exact path as its `file:`
+  but declares no `mode:`, so nothing dispatches over it). Two further
   scenarios prove the config-driven half (see
   docs/design/state-file-association.md §3): documentSymbol served for a
   CUSTOM-named `qa` file mapped via a real `.gtdrc` `file:`/`mode:` pair, and
@@ -31,10 +32,11 @@ Feature: gtd lsp — the steering-file LSP server (stdio)
     And the LSP response result has a "codeActionProvider" capability
 
   Scenario: with no config, .gtd/TODO.md is NOT dispatched by basename — it yields no symbols
-    # There is no `TODO.md` → qa basename fallback: no bundled state writes
-    # there at all. With no `.gtdrc` mapping it, documentSymbol returns
-    # nothing. (Config-driven qa dispatch over any file — including TODO.md —
-    # is covered below.)
+    # There is no `TODO.md` → qa basename fallback: the bundled `idle` maps
+    # this exact path via its own `file:`, but declares no `mode:`, so nothing
+    # dispatches over it. With no `.gtdrc` mapping it either, documentSymbol
+    # returns nothing. (Config-driven qa dispatch over any file — including
+    # TODO.md — is covered below.)
     Given a test project
     And an LSP server started in the test project
     When the LSP client sends an initialize request

--- a/tests/integration/features/validate.feature
+++ b/tests/integration/features/validate.feature
@@ -108,12 +108,21 @@ Feature: gtd validate — self-validating the resolved rest's steering file
     And stderr contains ".gtd/REVIEW.md is not valid"
     And stderr contains "# Review: <hash>"
 
-  Scenario: a state with no file:/mode: has nothing to validate
+  Scenario: a state with a file: but no mode: has nothing to validate
     Given a test project
     And the workflow
     When I run gtd with args "validate"
     Then it succeeds
     And stdout contains "nothing to validate at \"idle\""
+
+  Scenario: a state with a file: but no mode: pins the file in --json output
+    Given a test project
+    And the workflow
+    When I run gtd with args "validate --json"
+    Then it succeeds
+    And stdout contains "\"state\":\"idle\""
+    And stdout contains "\"file\":\".gtd/TODO.md\""
+    And stdout contains "\"script\":\"\""
 
   Scenario: plain `gtd next` appends the self-validation instruction at a producing agent state
     Given a test project


### PR DESCRIPTION
## What

Brings back the `todoFile` var (`.gtd/TODO.md` by default) as the bundled workflow's `idle` state `file:` hint, so the "open steering file" LSP command and `gtd next`/`gtd status --json` have an answer even before a process starts.

Unlike every other per-file var, gtd never reads or writes this file's content — it's the human's own sketch pad, folded into the start diff like any other change once `design.triage` reads it back out of history after `unwind`. The `idle` prompt and `design.triage`'s prompt both say so explicitly.

## Why it needed no new engine logic

`idle` declares `file:` with **no `mode:`** — a free-form sketch has no format to validate. Both dispatch paths already treat a mode-less `file:` as nothing to run:

- `program.ts`'s steering-mode script emission → `script: ""`, exit 0
- `Lsp.ts`'s config-driven + basename dispatch → no outline, no code actions, no live diagnostics

So the change is workflow data plus doc/comment/test updates that state the mode-less case explicitly instead of the old "no bundled state writes there at all".

## Drive-by refactor

`Lsp.ts`'s `resolveSteeringFile` now takes its `RestRequirements` as an Effect requirement instead of building its own layers per call. The Node adapter runs it through the memoised `runtimeFor(root)` runtime like every other entry point, and it's directly unit-testable against the in-memory git double.

## Tests

- `src/workflows/templates.test.ts` — `idle` declares a non-empty `file:` and no `mode:` (replaces the old "no state references the deleted todoFile" invariant)
- `src/Lsp.test.ts` — `resolveSteeringFile` resolves `.gtd/TODO.md` at `idle` with no config and no such file on disk (path comes from workflow + state, never a stat)
- e2e: `default-workflow.feature`, `driver-json-status.feature`, `validate.feature`, `lsp.feature`

🤖 Generated with [Claude Code](https://claude.com/claude-code)