### PR TITLE
feat(workflow): inject gtd's own voice into generated files

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,11 @@ questions: each open question offers a couple of candidate answers plus a
 `- [ ] _your answer_` slot, and you tick exactly one per question (the gate
 won't let the phase advance while any question is unanswered) — but a phase
 whose document has no open questions skips that human stop entirely and falls
-straight through.
+straight through. If a question's options ever come out as prose instead of
+`- [ ]` rows, there is no checkbox for the gate to see, so it stays permanently
+unanswered; un-wedge it yourself: hand-write the `- [ ]` rows and tick one,
+delete that question, or delete the whole `## Open Questions` section to accept
+the plan as-is.
 
 Once the product questions are settled, `architecture.author` picks up as a
 **cold reader** — a separate machine with its own memory scope, so it does not
@@ -194,18 +198,22 @@ queue again — a hand-edit you made during review is treated as a **sketch**, t
 same as any other change that starts a process, not a fix the agent builds on:
 it is reverted out of the tree first, and your intent survives only in your own
 review-round commit for triage to read. There is no baseline check on the way
-back into planning. Only the turn that drafts the final squash message resumes
-the session that built the feature in the first place (the review tail is nested
-inside that build identity rather than sitting beside it) — an actionable round
-leaves that identity entirely, so it starts a fresh session like any other
-process. Ticking every box with no comment is the sign-off, which collapses the
-whole process into one commit (a **squash finale** whose message an agent
-drafts). Landing with a box still unticked and no comment is refused (finish
-reviewing first), as is deleting `.gtd/REVIEW.md`. Both refusals hold wherever
-the review doc lives: repointing `reviewFile` out of `.gtd/` (say to `REVIEW.md`
-at the repo root) changes nothing about them — your own edit to the review doc
-is never mistaken for a code comment, and the doc's pre-turn copy is read at the
-review window's saved head rather than at the rewound `HEAD`.
+back into planning. If a styled `.gtd/REVIEW.md` ever comes out malformed (a
+paragraph where a `- [ ] ./path#line` row belongs), `gtd check review` refuses
+the step before it commits: the file stays exactly as written in the working
+tree, unlanded, and re-running the same prompt is the recovery — nothing is
+lost. Only the turn that drafts the final squash message resumes the session
+that built the feature in the first place (the review tail is nested inside that
+build identity rather than sitting beside it) — an actionable round leaves that
+identity entirely, so it starts a fresh session like any other process. Ticking
+every box with no comment is the sign-off, which collapses the whole process
+into one commit (a **squash finale** whose message an agent drafts). Landing
+with a box still unticked and no comment is refused (finish reviewing first), as
+is deleting `.gtd/REVIEW.md`. Both refusals hold wherever the review doc lives:
+repointing `reviewFile` out of `.gtd/` (say to `REVIEW.md` at the repo root)
+changes nothing about them — your own edit to the review doc is never mistaken
+for a code comment, and the doc's pre-turn copy is read at the review window's
+saved head rather than at the rewound `HEAD`.
 
 A second entry, the same review tail's own direct entry point —
 `gtd --entry review-gate.check --var reviewBase=<commitish>` starts a brand new
@@ -1177,6 +1185,52 @@ vars:
 # highest precedence — beats both the workflow default and the .gtdrc value above
 GTD_TESTCOMMAND="npm run test -- --bail" gtd next
 ```
+
+#### The voice
+
+gtd ships its own writing voice for the files it generates — the default, not an
+opt-in. It is a specialisation of the "Spartan" output style from
+[alexgreensh/attention-span](https://github.com/alexgreensh/attention-span)
+(AGPL-3.0), written from a reading of that project's version `0.6`: gtd's own
+prose stating the same density discipline, rewritten for deliverables (files
+that run as long as the work needs) rather than chat replies. No upstream text
+ships in gtd's bundle. This is a point-in-time derivation with no refresh
+mechanism — it will silently go stale as upstream moves on, and nothing in gtd
+will notice.
+
+It is two independently-overridable variables, each an ordinary `vars:` entry
+that can be overridden or blanked through the same layers as any other (a
+top-level `.gtdrc` `vars:` key, or the matching `GTD_STYLEBLOCK` /
+`GTD_STYLEFORMATCONTRACT` environment variable):
+
+- **`styleBlock`** — the voice itself, injected at all seven prompt states that
+  generate content, not just three: the free-prose ones — the `packagesDir`
+  package files (`architecture.decompose`), `specFeedbackFile`
+  (`packages.item.spec.review`), and `commitMsgFile` (`build.squashing`) — plus
+  the four machine-parsed states named in the next bullet. Blanking
+  `GTD_STYLEBLOCK` strips the voice from all seven, including the machine-parsed
+  ones, not only the free-prose three. In short: why density matters before any
+  rule, answer-first with no preamble or restatement, blunt and imperative,
+  plain words, bold carries the load, ship the artifact bare, compressing is not
+  dropping, one idea per block, flag risk in one blunt line, never narrate the
+  work — and never-trim outranks every other rule in the set.
+- **`styleFormatContract`** — the structural override for machine-parsed files:
+  the format contract (headings, checkbox rows, marker lines) outranks the
+  voice, and a violation refuses the turn. It renders at the top of the prompt,
+  ahead of the role sentence and well before any state-specific format-contract
+  text — `styleBlock` first, then `styleFormatContract`, at the four prompt
+  states whose output a parser reads: the two `qa`-mode steering files
+  (`requirementsFile` at `design.triage`, `architectureFile` at
+  `architecture.author`) and the `review`-mode one (`reviewFile` at
+  `build.review.reviewing`), plus `requirementsFile` again at
+  `build.review.collecting`, which classifies a review round straight into it.
+
+Three more generated files carry no injected voice, because a script — not an
+agent — writes them: `feedbackFile` (verbatim test-suite output plus a HEAD
+stamp — the tool's content, not gtd's prose), `nextFile` (a bare path, no prose
+to style), and `reviewRawFile` (gtd's own prose, hand-tightened in the voice
+directly in `build.review.deciding`'s script rather than templated in through
+either variable).
 
 ### Lookup and precedence
 

--- a/src/OpenQuestions.test.ts
+++ b/src/OpenQuestions.test.ts
@@ -482,3 +482,94 @@ describe("QA_FORMAT", () => {
     expect(QA_FORMAT.pointerAt).toBeUndefined()
   })
 })
+
+describe("voice styling (styled qa exemplar)", () => {
+  // Voice check (src/workflows/unified.yaml's styleBlock): blunt, imperative
+  // sentences, bold carrying the actual claim, no throat-clearing preamble.
+  // This proves the parser cares only about the heading/checkbox grammar,
+  // never the prose register wrapped around it.
+  const styledUnticked = [
+    "# Requirements",
+    "",
+    "**Ship rate limiting on the public API before the next release.** Every",
+    "unauthenticated endpoint gets a token-bucket limiter; every authenticated",
+    "endpoint gets a higher ceiling keyed by account. No endpoint ships without",
+    "one.",
+    "",
+    "## Open Questions",
+    "",
+    "### What is the limiter's time window?",
+    "",
+    "**A fixed window undercounts bursts at its boundary.** Pick the algorithm",
+    "now — retrofitting it once clients depend on the numbers costs a",
+    "migration, not a config change.",
+    "",
+    "- [ ] Fixed window, reset every 60 seconds",
+    "- [ ] Sliding window log, no reset boundary",
+    "- [ ] _your answer_",
+    "",
+    "### Where does the limiter store its counters?",
+    "",
+    "**Redis is the default. Don't reach for anything heavier.** A single",
+    "shared store keeps every API instance's count consistent under one",
+    "config.",
+    "",
+    "- [ ] Redis, one shared instance",
+    "- [ ] In-process memory, per instance",
+    "- [ ] _your answer_",
+    "",
+  ].join("\n")
+
+  it("parses with zero validation errors", () => {
+    expect(QA_FORMAT.validate(styledUnticked)).toEqual([])
+  })
+
+  it("each open question parses exactly three options and is unanswered before ticking", () => {
+    const { questions } = parseOpenQuestions(styledUnticked)
+    expect(questions).toHaveLength(2)
+    for (const question of questions) {
+      expect(question.options).toHaveLength(3)
+      expect(question.answered).toBe(false)
+    }
+  })
+
+  it("is answered once exactly one option is ticked, and leaves the other question untouched", () => {
+    const ticked = styledUnticked.replace(
+      "- [ ] Sliding window log, no reset boundary",
+      "- [x] Sliding window log, no reset boundary",
+    )
+    const { questions } = parseOpenQuestions(ticked)
+    expect(questions[0]!.answered).toBe(true)
+    expect(questions[1]!.answered).toBe(false)
+  })
+
+  // Separate, smaller exemplar: the free-text slot is ticked but the agent's
+  // placeholder text survives untouched — the placeholder normalisation must
+  // still fire regardless of the voice applied around it.
+  const styledFreeTextTicked = [
+    "# Requirements",
+    "",
+    "**Ship rate limiting on the public API before the next release.** No",
+    "endpoint ships without a limiter in front of it.",
+    "",
+    "## Open Questions",
+    "",
+    "### What is the limiter's time window?",
+    "",
+    "**A fixed window undercounts bursts at its boundary.** Pick the algorithm",
+    "now, not after clients depend on the numbers.",
+    "",
+    "- [ ] Fixed window, reset every 60 seconds",
+    "- [ ] Sliding window log, no reset boundary",
+    "- [x] _your answer_",
+    "",
+  ].join("\n")
+
+  it("stays unanswered when the free-text slot is ticked but left as the unfilled placeholder", () => {
+    expect(QA_FORMAT.validate(styledFreeTextTicked)).toEqual([])
+    const { questions } = parseOpenQuestions(styledFreeTextTicked)
+    expect(questions).toHaveLength(1)
+    expect(questions[0]!.options).toHaveLength(3)
+    expect(questions[0]!.answered).toBe(false)
+  })
+})

--- a/src/ReviewDoc.test.ts
+++ b/src/ReviewDoc.test.ts
@@ -393,3 +393,54 @@ describe("REVIEW_FORMAT", () => {
     })
   })
 })
+
+describe("voice styling (styled review exemplar)", () => {
+  // Voice check (src/workflows/unified.yaml's styleBlock): blunt, imperative
+  // sentences, bold carrying the actual claim, no throat-clearing preamble.
+  // This proves the parser cares only about the header/marker/heading/pointer
+  // grammar, never the prose register wrapped around it.
+  const styledReview = [
+    "# Review: 9f3a21c",
+    "",
+    "<!-- base: 9f3a21cf8b4d5e6a7b8c9d0e1f2a3b4c5d6e7f80 -->",
+    "",
+    "## Add token-bucket limiter",
+    "",
+    "**The bucket refills at a fixed rate; it never bursts past its cap.**",
+    "This is the only algorithm change in the batch — everything else below",
+    "is wiring.",
+    "",
+    "- [ ] ./src/RateLimiter.ts#12 — refill math, check the rounding direction",
+    "- [ ] ./src/RateLimiter.ts#48 — cap enforcement on a burst request",
+    "",
+    "## Wire the limiter into the API gateway",
+    "",
+    "**Every unauthenticated route resolves a limiter before its handler runs.**",
+    "Authenticated routes keep a separate, higher-ceiling bucket keyed by",
+    "account id.",
+    "",
+    "- [ ] ./src/Gateway.ts#101",
+    "- [ ] ./src/Gateway.ts#134 — account-keyed bucket lookup",
+    "",
+  ].join("\n")
+
+  it("parses with zero validation errors", () => {
+    expect(REVIEW_FORMAT.validate(styledReview)).toEqual([])
+  })
+
+  it("recognizes every chunk heading and file-pointer row", () => {
+    const { changesets } = parseReviewDoc(styledReview)
+    expect(changesets.map((c) => c.title)).toEqual([
+      "Add token-bucket limiter",
+      "Wire the limiter into the API gateway",
+    ])
+    expect(changesets[0]!.files.map((f) => [f.path, f.line])).toEqual([
+      ["./src/RateLimiter.ts", 12],
+      ["./src/RateLimiter.ts", 48],
+    ])
+    expect(changesets[1]!.files.map((f) => [f.path, f.line])).toEqual([
+      ["./src/Gateway.ts", 101],
+      ["./src/Gateway.ts", 134],
+    ])
+  })
+})

--- a/src/workflows/templates.test.ts
+++ b/src/workflows/templates.test.ts
@@ -16,6 +16,21 @@ import {
 } from "./templates.js"
 import unifiedYaml from "./unified.yaml"
 
+/** State names (sorted) whose script/prompt/message/commit contains `needle`. */
+function statesReferencing(
+  definition: ReturnType<typeof compileTemplate>["definition"],
+  needle: string,
+): string[] {
+  const contentsOf = (state: (typeof definition.states)[string]): string[] =>
+    [state.script, state.prompt, state.message, state.commit].filter(
+      (c): c is string => c !== undefined,
+    )
+  return Object.entries(definition.states)
+    .filter(([, state]) => contentsOf(state).some((c) => c.includes(needle)))
+    .map(([name]) => name)
+    .sort()
+}
+
 describe("the bundled unified workflow template", () => {
   it("compiles with no validation findings and exactly one initial state", () => {
     const { definition } = compileTemplate()
@@ -227,6 +242,90 @@ describe("the bundled unified workflow template", () => {
     expect(satisfiedAdd?.[1]).toBe("packages.item.health.check")
     expect(satisfiedAdd?.[3]).toBeTruthy() // action
     expect(satisfiedMod?.[1]).toBe(satisfiedAdd?.[1])
+  })
+
+  // The three unstructured-file authoring prompts (package 02) — voice only,
+  // no structural override, since nothing parses their output.
+  const PROSE_PROMPTS = ["architecture.decompose", "packages.item.spec.review", "build.squashing"]
+
+  // The four machine-parsed prompts (package 03) — the only states that
+  // interpolate both a `file:` and a `mode:` of `qa`/`review` — get BOTH the
+  // voice and the structural override that outranks it.
+  const PARSED_PROMPTS = [
+    "design.triage",
+    "architecture.author",
+    "build.review.collecting",
+    "build.review.reviewing",
+  ]
+
+  it("declares the styleBlock/styleFormatContract voice variables, non-empty, styleFormatContract on-message (package 01)", () => {
+    // Settled shape: two independently-overridable vars, one for the free
+    // prose sites and one for the machine-parsed override — see
+    // .gtd/packages/01-style-vars-and-attribution.md.
+    const { vars } = compileTemplate()
+    expect(vars.styleBlock).toBeTruthy()
+    expect(vars.styleFormatContract).toBeTruthy()
+
+    // The structural override names its consequence, not a polite ask.
+    expect(vars.styleFormatContract).toMatch(/checkbox/)
+    expect(vars.styleFormatContract).toMatch(/##.*###.*heading/)
+    expect(vars.styleFormatContract).toMatch(/renumber or\s+rename/)
+    expect(vars.styleFormatContract).toMatch(/refuses the turn|refused/)
+
+    // Attribution: upstream name, URL, licence, and the version derived from.
+    expect(unifiedYaml).toMatch(/attention-span/)
+    expect(unifiedYaml).toMatch(/https:\/\/github\.com\/alexgreensh\/attention-span/)
+    expect(unifiedYaml).toMatch(/AGPL-3\.0/)
+    expect(unifiedYaml).toMatch(/version 0\.6|v0\.6/)
+  })
+
+  it("pins the seven voice-bearing prompts by name and count, so an eighth site added later fails loudly (package 02, 03)", () => {
+    expect([...PROSE_PROMPTS, ...PARSED_PROMPTS].sort()).toEqual(
+      [
+        "architecture.decompose",
+        "packages.item.spec.review",
+        "build.squashing",
+        "design.triage",
+        "architecture.author",
+        "build.review.collecting",
+        "build.review.reviewing",
+      ].sort(),
+    )
+  })
+
+  it("wires styleBlock into exactly the seven voice-bearing prompts and nowhere else (package 02, 03)", () => {
+    const { definition } = compileTemplate()
+    expect(statesReferencing(definition, "styleBlock")).toEqual(
+      [...PROSE_PROMPTS, ...PARSED_PROMPTS].sort(),
+    )
+  })
+
+  it("wires styleFormatContract into exactly the four machine-parsed prompts and nowhere else (package 03)", () => {
+    const { definition } = compileTemplate()
+    expect(statesReferencing(definition, "styleFormatContract")).toEqual([...PARSED_PROMPTS].sort())
+  })
+
+  it("every voice-bearing prompt uses the raw (unescaped) styleBlock tag form (package 02, 03)", () => {
+    // The value carries backticks/quotes/markup the escaping tag form would mangle.
+    const { definition } = compileTemplate()
+    for (const name of [...PROSE_PROMPTS, ...PARSED_PROMPTS]) {
+      expect(definition.states[name]?.prompt, `state "${name}"`).toMatch(
+        /<%~\s*it\.vars\.styleBlock\s*%>/,
+      )
+    }
+  })
+
+  it("each machine-parsed prompt puts the raw styleFormatContract tag after styleBlock, so the override sits closest to the state's own contract (package 03)", () => {
+    const { definition } = compileTemplate()
+    for (const name of PARSED_PROMPTS) {
+      const prompt = definition.states[name]?.prompt ?? ""
+      expect(prompt, `state "${name}"`).toMatch(/<%~\s*it\.vars\.styleFormatContract\s*%>/)
+      const blockIndex = prompt.search(/<%~\s*it\.vars\.styleBlock\s*%>/)
+      const contractIndex = prompt.search(/<%~\s*it\.vars\.styleFormatContract\s*%>/)
+      expect(blockIndex, `state "${name}" styleBlock precedes styleFormatContract`).toBeLessThan(
+        contractIndex,
+      )
+    }
   })
 
   it("packages.item.closing's script sweeps the satisfied-evidence file, and healthGate.check's shared sweep does not", () => {

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -283,6 +283,103 @@ vars:
   # check; the default empty string renders blank, which the entry command
   # refuses (a review entry always requires an explicit base).
   reviewBase: ""
+  # gtd's own voice for the files it generates — a specialisation of the
+  # "Spartan" output style from alexgreensh/attention-span
+  # (https://github.com/alexgreensh/attention-span), licensed AGPL-3.0,
+  # written from a reading of that project's version 0.6. Rewritten in gtd's
+  # own words for deliverables rather than chat replies; no upstream text
+  # ships. A point-in-time derivation with no refresh mechanism — it will go
+  # stale and nothing will notice.
+  #
+  # Keep/adapt/drop ledger — seventeen items reconciled: eight upstream rules
+  # carried, five added, three dropped, rationale kept.
+  #
+  # Carried (six rules below cover eight upstream rules — two of them each
+  # carry two upstream rules):
+  #   - the answer-first rule below carries both upstream's answer-first
+  #     rule and its cut-ruthlessly rule
+  #   - the never-trim rule below carries both upstream's
+  #     cut-elaboration-never-a-warning rule and its
+  #     numbers-and-thresholds-are-exact rule
+  #   - the deliverable rule carries upstream's answer-versus-deliverable
+  #     rule, minus its "can't tell which? treat it as an answer" tie-break —
+  #     gtd has no ambiguity to break, every injection site authors a file
+  #   - the blunt-and-imperative rule, the plain-words rule, and the bold
+  #     rule map one-to-one to upstream's equivalents
+  #
+  # Added and sharpened:
+  #   - five rules with no upstream equivalent: ship the artifact bare,
+  #     compressing is not dropping, one idea per block, flag risk in one
+  #     blunt line, never narrate the work
+  #   - two carried rules sharpened past upstream: the bold rule gains a
+  #     bold-only-reading test, and the plain-words rule gains a five-word
+  #     cap on defining an unavoidable term
+  #
+  # Dropped, each for its own reason:
+  #   - the arrow-point paragraph format: four of the seven voice-bearing
+  #     states are machine-parsed and their grammars require literal
+  #     `- [ ]` rows
+  #   - the go-deeper escape hatch: a state's own prompt is the request and
+  #     there is no channel to ask through
+  #   - the confirm-before-acting rule: every prompt is an instruction and
+  #     the actor's only output channel is the file
+  styleBlock: |-
+    This block opens with why density matters, not with rule one: the reader
+    has a finite attention budget, and burying the line that mattered fails as
+    hard as cutting it. This is motivation, not a rule — it commands nothing
+    and never outranks never-trim.
+
+    This file is a deliverable, not a chat reply. Its size follows the work —
+    write what the task demands, and let padding, not length, be the target of
+    any cut.
+
+    Lead with the answer or the decision immediately. Skip the throat-clearing
+    opener, and never circle back to restate the point once it has landed.
+
+    Write in flat, commanding sentences — commit to the claim rather than
+    hedging it.
+
+    Favor everyday vocabulary over technical shorthand; where a term is
+    unavoidable, define it in five words or fewer on first use.
+
+    In markdown, bold carries the load: bold the claim, not the sentence around
+    it. The test: reading only the bold text yields the full point and every
+    risk, or the bolding is wrong.
+
+    Above every rule in this block: never trim a risk, a number, a threshold,
+    or a scoped condition to save space. A claim that only holds under some
+    condition ships with that condition. It outranks every other rule here.
+
+    Ship the artifact bare. Output only what was asked for — no lead-in, no
+    "here's the…", no sign-off wrapped around it. A generated file consumed
+    as-is turns a wrapper into a defect.
+
+    Compressing is not dropping. A task with three load-bearing parts ships all
+    three, each shorter — reporting two of three findings has failed the brief,
+    not fulfilled it.
+
+    One idea per block; break when the idea shifts. Blocks may run any length,
+    but one unbroken paragraph is a defect even when short.
+
+    Flag risk and uncertainty in one blunt line. This is never-trim's
+    constructive twin: that rule forbids deleting a caveat, this one forbids
+    dissolving it into hedged prose.
+
+    Never narrate the work — do it. Skip lines like "I will now list the
+    concerns"; a file has no reason to describe its own composition.
+  styleFormatContract: |-
+    This file is machine-read. Its format contract outranks every style rule
+    above it: keep every `##`/`###` heading this state specifies, every
+    `- [ ]` checkbox row, and every required marker line exactly as specified.
+
+    Do not replace a checkbox list with prose paragraphs. Do not renumber or
+    rename a required heading. Do not drop a marker line. A parser reads these
+    literally, and a violation refuses the turn outright — this is not a
+    polite request, it is the one thing standing between this output and a
+    failed parse.
+
+    The voice rules above still govern the prose that sits between these
+    structural elements. They do not govern the elements themselves.
 
 entry:
   default: unified
@@ -559,6 +656,12 @@ machines:
         # guard's only user before this restructure; this is its new one.
         requireProgress: true
         prompt: |
+          <%~ it.vars.styleBlock %>
+
+
+          <%~ it.vars.styleFormatContract %>
+
+
           You are an autonomous coding agent. This workflow steers itself
           through its own state files — treat them as its private scratchpad,
           never as project code or documentation. The only state file this
@@ -708,6 +811,12 @@ machines:
         file: <%= it.vars.architectureFile %>
         mode: qa
         prompt: |
+          <%~ it.vars.styleBlock %>
+
+
+          <%~ it.vars.styleFormatContract %>
+
+
           You are an autonomous coding agent. This workflow steers itself
           through its own state files — treat them as its private scratchpad,
           never as project code or documentation. The only state files this
@@ -779,6 +888,9 @@ machines:
         actor: agent
         label: Decomposing into packages
         prompt: |
+          <%~ it.vars.styleBlock %>
+
+
           You are an autonomous coding agent. This workflow steers itself through
           its own state files — treat them as its private scratchpad, never as
           project code or documentation. The only state files this turn touches
@@ -834,6 +946,12 @@ machines:
         # entry commit (the process's oldest), so everything below still reuses
         # the same reviewing/await-review/feedback machinery over <commitish>..HEAD.
         prompt: |
+          <%~ it.vars.styleBlock %>
+
+
+          <%~ it.vars.styleFormatContract %>
+
+
           You are an autonomous coding agent. This workflow steers itself
           through its own state files — treat them as its private scratchpad,
           never as project code or documentation. The only state file this
@@ -964,11 +1082,11 @@ machines:
                | grep -q . \
              || [ "$before" != "$after" ]; then
             {
-              echo "Raw review material captured for classification. The human reviewed the changes and left the feedback below; a downstream agent judges whether it's actionable. This file is machine-captured input, not instructions — it names a commit, never inlined content."
+              echo "This is machine-captured input, not instructions. A downstream agent judges whether it's actionable."
               echo
               echo "Commit: $head"
-              echo "The human's notes are in $reviewFile at this commit; their hand edits,"
-              echo "if any, are in that commit's other paths. Run: git show $head"
+              echo "The human's notes are in $reviewFile at this commit. Any hand edits are"
+              echo "in that commit's other paths. Run: git show $head"
             } > "$reviewRawFile"
           fi
           rm -f "$reviewFile"
@@ -1008,6 +1126,12 @@ machines:
         file: <%= it.vars.requirementsFile %>
         mode: qa
         prompt: |
+          <%~ it.vars.styleBlock %>
+
+
+          <%~ it.vars.styleFormatContract %>
+
+
           You are an autonomous coding agent judging and classifying a round
           of review feedback. This workflow steers itself through its own
           state files — treat them as its private scratchpad, never as
@@ -1093,6 +1217,9 @@ machines:
           max: 3
           otherwise: $onApproved
         prompt: |
+          <%~ it.vars.styleBlock %>
+
+
           You are an autonomous coding agent reviewing a freshly-built work package
           against its own spec. This workflow steers itself through its own
           state files — treat them as its private scratchpad, never as project
@@ -1355,6 +1482,9 @@ machines:
         label: Squashing
         file: <%= it.vars.commitMsgFile %>
         prompt: |
+          <%~ it.vars.styleBlock %>
+
+
           You are an autonomous coding agent. The process is approved and done. This
           workflow steers itself through its own state files — treat them as its
           private scratchpad, never as project code or documentation. The only

--- a/tests/integration/features/styled-steering.feature
+++ b/tests/integration/features/styled-steering.feature
@@ -1,0 +1,90 @@
+@live
+Feature: the voice survives the parsers it shares a prompt with (package 03, task 3)
+
+  Package 03 injects gtd's own terse "voice" (`vars.styleBlock`) alongside a
+  structural-override variable (`vars.styleFormatContract`) into every
+  machine-parsed prompt state, so an agent styling its prose can't also style
+  away the `##`/`### ` headings, `- [ ]` checkbox rows, or marker lines the
+  parser requires. This feature is the end-to-end proof: a HUMAN, standing in
+  for the agent, writes a styled `.gtd/REQUIREMENTS.md`/`.gtd/REVIEW.md` at
+  one of those resting states — voice in the prose, grammar intact — and
+  `gtd land` must actually accept it through the real validator and advance,
+  not just look plausible.
+
+  Both scenarios are `@live`, not `@inmem`: the seeded `qa`/`review` validator
+  renders as a literal `gtd check <mode> '<file>'` COMMAND inside the step
+  script `gtd land` runs ahead of its commit (see src/SteeringFormats.ts's
+  `seededValidateCommand` and src/StepGuards.ts's doc comment). Only the
+  `@live` tier's PATH shim (world.ts's `pathShimDir`) makes that bare `gtd`
+  resolve to THIS build under test — an `@inmem` twin would have no real
+  subprocess to run it in and would have to stub the command with a scripted
+  double, which proves nothing about `OpenQuestions.ts`/`ReviewDoc.ts` actually
+  parsing styled prose. `steering-modes.feature` already covers the
+  scripted-double shape for a custom mode; this file is only about gtd's own
+  two built-in parsers surviving the voice.
+
+  Scenario: a styled REQUIREMENTS.md passes gtd check qa and design.triage advances
+    Given a test project
+    And the workflow
+    And a commit "gtd(check): start-gate.check → design.triage" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    # The styled file itself — bold claim up front, flat imperative sentences,
+    # no padding — with the "## Open Questions" / "### <question>" / "- [ ]"
+    # grammar `gtd check qa` requires still intact.
+    And a file ".gtd/REQUIREMENTS.md" with:
+      """
+      **Add a calculator module.** One export, `add`, no dependencies.
+
+      Two numbers in, one number out. Keep the signature small.
+
+      ## Open Questions
+
+      ### Which numeric type backs the result?
+
+      - [ ] Plain `number` — matches JS semantics, zero extra code
+      - [ ] A `Decimal` wrapper — exact arithmetic, more code to carry
+      - [ ] _your answer_
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(agent): design.triage → design.gate.check"
+
+  Scenario: a styled REVIEW.md passes gtd check review and build.review.reviewing advances
+    Given a test project
+    And the workflow
+    And a commit "gtd(check): build.health.check → build.review.reviewing" that adds "src/calc.ts" with:
+      """
+      export const add = (a: number, b: number) => a + b
+      """
+    # The styled file itself — bold claim, imperative, no padding — with the
+    # "# Review: <hash>" header, the base marker, and "## <chunk>" / "- [ ]
+    # ./path#line" rows `gtd check review` requires still intact.
+    And a file ".gtd/REVIEW.md" with:
+      """
+      # Review: a1b2c3d
+
+      <!-- base: 0000000000000000000000000000000000000000 -->
+
+      ## Calculator: add()
+
+      **New pure function, no side effects.** Confirm the signature and the
+      one test that pins it.
+
+      - [ ] ./src/calc.ts#1 — exported `add`, two `number` params
+      - [ ] ./src/calc.test.ts#1 — happy-path coverage only
+      """
+    When I run gtd land
+    Then it succeeds
+    # build.review.await-review declares reviewWindow: true, so landing INTO
+    # it opens the review checkout window: HEAD rewinds to the review base in
+    # the SAME land command's optional script (see review-window.feature), so
+    # "the last commit subject" would name the base, not this transition.
+    # Assert through `gtd status`, which resolves the true rest by reading
+    # THROUGH the open window, the same way review-window.feature's own
+    # "The machine never sees the window" scenario does.
+    And the git ref "refs/worktree/gtd/review-head" exists
+    When I run gtd status
+    Then it succeeds
+    And stdout contains "State: build.review.await-review"


### PR DESCRIPTION
## What

gtd now ships a writing voice for the files it generates — on by default, not opt-in. Two new `vars.yaml` entries in `src/workflows/unified.yaml`:

- **`styleBlock`** — the voice itself, injected at **all seven** prompt states that author content. Three free-prose states get it alone (`architecture.decompose`, `packages.item.spec.review`, `build.squashing`); the four machine-parsed states get it too.
- **`styleFormatContract`** — the structural override for the four machine-parsed states (`design.triage`, `architecture.author`, `build.review.reviewing`, `build.review.collecting`). It renders *after* `styleBlock` so the override sits closest to each state's own format contract: literal headings, `- [ ]` rows and marker lines outrank the voice, and a violation refuses the turn.

Both are ordinary vars — overridable or blankable via `.gtdrc` `vars:` or `GTD_STYLEBLOCK` / `GTD_STYLEFORMATCONTRACT`, no code change needed.

Three generated files deliberately carry **no** voice, because a script writes them, not an agent: `feedbackFile` (verbatim suite output), `nextFile` (a bare path), `reviewRawFile` (gtd's own prose, hand-tightened in `build.review.deciding`'s script instead).

## Provenance

`styleBlock` is a specialisation of the "Spartan" output style from [alexgreensh/attention-span](https://github.com/alexgreensh/attention-span) (AGPL-3.0), read from v0.6 and rewritten in gtd's own words for deliverables rather than chat replies. **No upstream text ships verbatim.** A keep/adapt/drop ledger sits in the YAML comment (eight upstream rules carried, five added, three dropped, each with its reason).

**Known limitation, stated in both the YAML and the README:** this is a point-in-time derivation with no refresh mechanism. It will silently drift from upstream and nothing in gtd will notice.

## Tests

- `tests/integration/features/styled-steering.feature` — a new `@live` scenario hand-writes styled QA/review docs and asserts `gtd land` still parses and advances them.
- `src/workflows/templates.test.ts`, `src/OpenQuestions.test.ts`, `src/ReviewDoc.test.ts` — pin the exact seven-site wiring and the two-var ordering, so an eighth site added later fails loudly.
- `npm test`: 8/8 tasks green.

## README

Documents the voice under a new "The voice" section (both vars, the seven sites, the three unstyled files, the staleness caveat), plus two new recovery notes for the failure modes a terser voice makes reachable: a question whose options come out as prose has no checkbox for the gate to see (un-wedge by hand), and a malformed `.gtd/REVIEW.md` is refused pre-commit — the file stays unlanded in the working tree and re-running the prompt is the recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)