### PR TITLE
feat(review): stop gating sign-off on checkbox completion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,20 +92,21 @@ description, and must be preserved:
   The window's `git reset --mixed` leaves every file the reviewed range added
   untracked-but-present, and `git diff --name-status <base>` compares `base` to
   the INDEX — so the index view calls each of them deleted. That phantom `D`
-  made the review-signoff guard refuse every sign-off in a repo whose
-  `reviewFile` sits outside `.gtd/` (the one directory the window pins back into
-  the index). `src/Git.ts`'s `classifyUntracked` therefore classifies each
-  untracked path against the base tree by blob id: absent → `A`, different →
-  `M`, identical → no change. Don't "simplify" it back to the index's answer.
-  The worktree side is hashed WITH the repo's clean filters (plain
-  `git hash-object -- <paths>`, which looks each file's attributes up from its
-  own path) — never `--no-filters`, or a `text=auto` repo reports every
-  untouched CRLF file `M`, and a spurious `M` on the review doc is a spurious
-  `hasCodeChange`, i.e. the same inert guard as above. The in-memory double has
-  always compared the base tree to the worktree directly, so only the Live tier
-  of `runGitServiceContract`'s `changedPaths` base-case group can fail on this —
-  and an @inmem e2e scenario cannot (hence `@live`
-  `review-window-untracked.feature`).
+  made the review-doc guard refuse every sign-off in a repo whose `reviewFile`
+  sits outside `.gtd/` (the one directory the window pins back into the index).
+  `src/Git.ts`'s `classifyUntracked` therefore classifies each untracked path
+  against the base tree by blob id: absent → `A`, different → `M`, identical →
+  no change. Don't "simplify" it back to the index's answer. The worktree side
+  is hashed WITH the repo's clean filters (plain `git hash-object -- <paths>`,
+  which looks each file's attributes up from its own path) — never
+  `--no-filters`, or a `text=auto` repo reports every untouched CRLF file `M`,
+  and a spurious `M` on such a file (never the review doc itself, which
+  `hasCodeChange` excludes by exact path) flips a clean sign-off onto the
+  feedback edge in `deciding`'s classification script and the feedback-progress
+  guard. The in-memory double has always compared the base tree to the worktree
+  directly, so only the Live tier of `runGitServiceContract`'s `changedPaths`
+  base-case group can fail on this — and an @inmem e2e scenario cannot (hence
+  `@live` `review-window-untracked.feature`).
 
 - **No emitted script moves HEAD.** `unified.yaml`'s `unwind` state reverts the
   entry commit's diff (`git revert --no-commit`) before planning ever starts, so
@@ -290,7 +291,7 @@ parser, one envelope. The table is the source of truth, not prose:
   map
 - **Step-capture guards (edge, not engine):** `enforceStepGuards` in
   `src/StepGuards.ts` runs a registry of four guards before a normal commit
-  lands — the review-signoff, feedback-progress, answer-completeness, and
+  lands — the review-doc, feedback-progress, answer-completeness, and
   require-revert guards each check their own state-flavor condition. A state's
   `file:`+`mode:` formatting and validation is NOT a guard any more:
   `program.ts`'s `steeringModeSteps` emits the mode's own `format:`/`validate:`
@@ -319,8 +320,10 @@ parser, one envelope. The table is the source of truth, not prose:
   prefix check. A `reviewFile` repointed to the repo root is still a steering
   file — the same assumption issue #128 broke in `deciding`'s check script — and
   a plumbing directory relocated via `vars.stateDir` is still plumbing. With
-  either exemption wrong, the review sign-off guard takes its it-is-a-comment
-  branch on every pass and the unticked-box check is unreachable
+  either exemption wrong, a spurious `hasCodeChange` flips a clean sign-off onto
+  the feedback edge — a full re-plan nobody asked for — in both of its live
+  consumers, `deciding`'s own classification script and the feedback-progress
+  guard
 - The require-revert guard's own version of the same INPUTS risk: it compares
   the current tree against `reviewBase~1` intersected with the human's own
   review-round commit's touched paths, and it exempts the state's own `file:` by

--- a/README.md
+++ b/README.md
@@ -179,41 +179,57 @@ file yourself and `gtd land` — no hand-authored state commit.
 The process converges on that same shared tail: an agent hands you a
 `.gtd/REVIEW.md` checkbox review of the diff — the prompt never inlines the diff
 itself; it names the commit the changes are based at and the agent runs
-`git diff` to read the range before writing the review. While the process rests
-at that gate, the landing script opens a **review checkout window**: HEAD is
-rewound to the review base with the working tree untouched, so the whole
-reviewable change shows up as ordinary uncommitted changes in your editor's
-normal git integration (and files added during the process show up as ordinary
-untracked files, so discarding one deletes it — an untracked file you leave
-alone is not a pending change, and only actually removing it from disk counts as
-a deletion). The next landing's own script closes the window before it commits.
-Tick a box as you review each hunk (ticking just records "I read this"), and
-leave a **comment** to request changes: a note on a line, an inline
-`// TODO`-style comment in the code, or a direct code edit. A comment sends a
-FULL development lap, not a quick fix-and-re-review: an agent first judges
-whether your comment is actually actionable (a genuinely approving remark with
-no code edit short-circuits straight to sign-off instead), and an actionable
-round is re-planned from scratch through triage, architecture, and the package
-queue again — a hand-edit you made during review is treated as a **sketch**, the
-same as any other change that starts a process, not a fix the agent builds on:
-it is reverted out of the tree first, and your intent survives only in your own
-review-round commit for triage to read. There is no baseline check on the way
-back into planning. If a styled `.gtd/REVIEW.md` ever comes out malformed (a
-paragraph where a `- [ ] ./path#line` row belongs), `gtd check review` refuses
-the step before it commits: the file stays exactly as written in the working
-tree, unlanded, and re-running the same prompt is the recovery — nothing is
-lost. Only the turn that drafts the final squash message resumes the session
-that built the feature in the first place (the review tail is nested inside that
-build identity rather than sitting beside it) — an actionable round leaves that
-identity entirely, so it starts a fresh session like any other process. Ticking
-every box with no comment is the sign-off, which collapses the whole process
-into one commit (a **squash finale** whose message an agent drafts). Landing
-with a box still unticked and no comment is refused (finish reviewing first), as
-is deleting `.gtd/REVIEW.md`. Both refusals hold wherever the review doc lives:
-repointing `reviewFile` out of `.gtd/` (say to `REVIEW.md` at the repo root)
-changes nothing about them — your own edit to the review doc is never mistaken
-for a code comment, and the doc's pre-turn copy is read at the review window's
-saved head rather than at the rewound `HEAD`.
+`git diff` to read the range before writing the review. Each hunk is a
+`- [ ] ./path/to/file.ts#42` pointer with its explanation on the line(s) BELOW
+it, not trailing the pointer on the same line:
+
+```
+- [ ] ./path/to/file.ts#42
+  what this hunk does, with room to run to several lines
+```
+
+Text after the pointer token on the pointer's own line is a validation error —
+`gtd check`/`gtd validate`/the LSP all reject it — and, because the review
+gate's own emitted script runs that same check ahead of every commit, upgrading
+gtd mid-review leaves an already-open `.gtd/REVIEW.md` written in the old
+same-line form UNLANDABLE until every pointer in it is hand-edited into the new
+shape; there is no migration tool. If a styled `.gtd/REVIEW.md` ever comes out
+malformed some other way (a paragraph where a `- [ ] ./path#line` row belongs),
+`gtd check review` refuses the step the same way: the file stays exactly as
+written in the working tree, unlanded, and re-running the same prompt is the
+recovery — nothing is lost. While the process rests at that gate, the landing
+script opens a **review checkout window**: HEAD is rewound to the review base
+with the working tree untouched, so the whole reviewable change shows up as
+ordinary uncommitted changes in your editor's normal git integration (and files
+added during the process show up as ordinary untracked files, so discarding one
+deletes it — an untracked file you leave alone is not a pending change, and only
+actually removing it from disk counts as a deletion). The next landing's own
+script closes the window before it commits. Tick a box as you review each hunk
+(ticking just records "I read this"), and leave a **comment** to request
+changes: a note on a line, an inline `// TODO`-style comment in the code, or a
+direct code edit. A comment sends a FULL development lap, not a quick
+fix-and-re-review: an agent first judges whether your comment is actually
+actionable (a genuinely approving remark with no code edit short-circuits
+straight to sign-off instead), and an actionable round is re-planned from
+scratch through triage, architecture, and the package queue again — a hand-edit
+you made during review is treated as a **sketch**, the same as any other change
+that starts a process, not a fix the agent builds on: it is reverted out of the
+tree first, and your intent survives only in your own review-round commit for
+triage to read. There is no baseline check on the way back into planning. Only
+the turn that drafts the final squash message resumes the session that built the
+feature in the first place (the review tail is nested inside that build identity
+rather than sitting beside it) — an actionable round leaves that identity
+entirely, so it starts a fresh session like any other process. A comment is what
+asks for changes; landing with no comment signs off, whatever the boxes say,
+which collapses the whole process into one commit (a **squash finale** whose
+message an agent drafts). Deleting `.gtd/REVIEW.md` is refused, wherever the
+review doc lives: repointing `reviewFile` out of `.gtd/` (say to `REVIEW.md` at
+the repo root) changes nothing about that refusal, since it only asks whether
+the step's diff deletes the file. The exact-path exemption issue #128 fixed
+still matters elsewhere, though: the `deciding` state's own classification and
+the feedback-progress guard both exclude the state's own `file:` by exact path,
+not merely a `.gtd/` prefix, so your own edit to a relocated steering file is
+never mistaken for a code comment.
 
 A second entry, the same review tail's own direct entry point —
 `gtd --entry review-gate.check --var reviewBase=<commitish>` starts a brand new
@@ -859,7 +875,7 @@ its own retry/resume logic beyond "if the script failed, ask gtd again."
 
 A mode's `format:` command may reformat a steering file — whitespace, wrapping,
 reordering — but must NEVER change what a land-capture guard would decide. gtd's
-guards (the review sign-off check, the feedback-progress check, the
+guards (the review-doc check, the feedback-progress check, the
 answer-completeness check, the require-revert check — `src/StepGuards.ts`)
 decide ONCE, against whichever bytes are on disk at the moment `gtd land` runs,
 which may be before OR after an emitted script's own `format:` line has run (the
@@ -867,12 +883,14 @@ script runs `format:` then `validate:` then the commit — see
 `src/SteeringMode.ts`'s `renderSteeringCommands` — but gtd's decision and the
 driver's script execution are different processes at different times, so there's
 no guaranteed ordering between "gtd decided" and "the script formatted"). That's
-only safe because every built-in guard judges content, not incidental formatting
-(e.g. it normalizes `[ ]`/`[x]` checkboxes before comparing). If you plug in
-your own `format:` command, the same rule binds it: a formatter that also
-changes meaning — ticking a box, stripping a paragraph — makes the guard's
-decision and the file's actual content disagree, and gtd will not catch that for
-you.
+only safe because every built-in guard judges only the content it explicitly
+cares about, not incidental formatting around it — the feedback-progress guard,
+for instance, only checks whether a deleted file's trimmed first line is the
+`NOTHING ACTIONABLE` sentinel, so reindenting the rest of it changes nothing the
+guard reads. If you plug in your own `format:` command, the same rule binds it:
+a formatter that also changes meaning — stripping a paragraph a guard reads —
+makes the guard's decision and the file's actual content disagree, and gtd will
+not catch that for you.
 
 One case never runs your `format:` (or `validate:`) at all: a step whose diff
 DELETES the state's own `file:`. Deleting it is a legitimate outcome — a review

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -882,9 +882,10 @@ export interface Rest extends ResolvedRest {
    * Carried on the snapshot rather than re-read per caller: it is the PRE-TURN
    * head, so anything that needs a file's committed, pre-turn copy — the step
    * guards' own `readFileAtRef` reads (`src/StepGuards.ts`) — must resolve it
-   * here, not at `HEAD`. Reading `HEAD` under an open window reports every file
-   * the process itself added as absent, which silently turned the review
-   * sign-off's tick-completeness check into a no-op.
+   * here, not at `HEAD`. Any guard running at a `reviewWindow: true` state must
+   * read the pre-turn copy at this saved head: real `HEAD` is rewound to the
+   * review base there, where a file the process itself wrote does not exist
+   * yet.
    */
   readonly windowHead: string | undefined
   readonly memory: string | undefined

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -75,7 +75,7 @@ export interface GitReaderOperations {
    * window staged back from the saved head but the reviewer DELETED shows up
    * in neither tree and so reports no change at all (real git agrees: the
    * index-only `AD` entry is invisible to `git diff --name-status HEAD`),
-   * which is precisely the deletion the review sign-off guard must catch.
+   * which is precisely the deletion the review-doc guard must catch.
    * Passing the window's saved head restores the pre-window meaning.
    *
    * An untracked path is classified by CONTENT against `base`, not by the
@@ -86,13 +86,13 @@ export interface GitReaderOperations {
    * perfectly present at the saved head. Reporting the index's view instead
    * would report each of them DELETED (`git diff --name-status <base>`
    * compares `base` to the INDEX) though the file sits right there on disk —
-   * a phantom deletion that made the review sign-off guard refuse every
-   * sign-off in a repo whose `reviewFile` is not under `.gtd/` (the one
-   * directory the window pins back into the index).
+   * a phantom deletion that made the review-doc guard refuse every sign-off
+   * in a repo whose `reviewFile` is not under `.gtd/` (the one directory the
+   * window pins back into the index).
    *
    * A REAL deletion (the reviewer removed the file from disk) still reports
    * `D`: it is not in the untracked list, so the tracked diff's own `D`
-   * stands. That is the deletion the sign-off guard must catch.
+   * stands. That is the deletion the review-doc guard must catch.
    */
   readonly changedPaths: (
     base?: string,
@@ -251,9 +251,9 @@ const blobsAtRef = (
  * stored, and is correctly read as unchanged. Never add `--no-filters` (nor
  * `--path=<other>`) here: that would report every such file `M`, i.e. a
  * spurious "the human edited something real" (`StepGuards`'s `hasCodeChange`),
- * which walks the review-signoff guard past its unticked-box check, plus a
- * spurious change for any `on` pattern to match. Both tiers of the
- * `changedPaths` contract pin this (`src/testing/GitTiers.ts`).
+ * which flips a clean sign-off onto the feedback edge — a full re-plan nobody
+ * asked for — and still fabricates a change for any `on` pattern to match.
+ * Both tiers of the `changedPaths` contract pin this (`src/testing/GitTiers.ts`).
  *
  * A symlink is the one residual inexactness: hash-object reads through it, so it
  * hashes the target's content rather than the link text git stores, and reads as
@@ -298,8 +298,8 @@ const hashObjects = (
  * through the repo's own clean filters, so a `text=auto` repo's untouched CRLF
  * file matches the LF blob it was stored as. Over-reporting `M` for an untouched
  * file would not be cosmetic: it is a spurious "the human edited something real"
- * (`StepGuards`'s `hasCodeChange`), which sends the review-signoff guard down
- * its it-is-a-comment branch and past the unticked-box check, plus a spurious
+ * (`StepGuards`'s `hasCodeChange`), which flips a clean sign-off onto the
+ * feedback edge — a full re-plan nobody asked for — and still fabricates a
  * change for any `on` pattern to match.
  */
 const classifyUntracked = (

--- a/src/Lsp.test.ts
+++ b/src/Lsp.test.ts
@@ -268,6 +268,43 @@ describe("diagnosticsFor", () => {
   it("publishes nothing for an unresolved mode", () => {
     expect(diagnosticsFor(undefined, "anything")).toEqual([])
   })
+
+  it("underlines exactly one line for a positioned review finding (a trailing-text pointer)", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add thing.ts",
+      "",
+      "- [ ] ./src/thing.ts#1 — legacy trailing note",
+      "",
+    ].join("\n")
+    const diagnostics = diagnosticsFor(resolveBuiltInMode("review"), content)
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]?.message).toContain("has text on the pointer line")
+    expect(diagnostics[0]?.range).toEqual({
+      start: { line: 5, character: 0 },
+      end: { line: 5, character: content.split("\n")[5]!.length },
+    })
+  })
+
+  it("spans the whole document for a positionless review finding (a missing header)", () => {
+    const content = [
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add thing.ts",
+      "",
+      "- [ ] ./src/thing.ts#1",
+      "",
+    ].join("\n")
+    const lines = content.split("\n")
+    const diagnostics = diagnosticsFor(resolveBuiltInMode("review"), content)
+    const headerFinding = diagnostics.find((d) => String(d.message).includes("# Review: <hash>"))
+    expect(headerFinding?.range).toEqual({
+      start: { line: 0, character: 0 },
+      end: { line: lines.length - 1, character: lines[lines.length - 1]!.length },
+    })
+  })
 })
 
 const fakeEnv = (overrides: Partial<LspEnv> = {}): LspEnv => ({

--- a/src/Lsp.ts
+++ b/src/Lsp.ts
@@ -102,7 +102,12 @@ import {
   steeringCapabilities,
   type ResolvedMode,
 } from "./SteeringMode.js"
-import type { SteeringAction, SteeringOutlineNode, SteeringPointer } from "./SteeringFormat.js"
+import type {
+  SteeringAction,
+  SteeringFinding,
+  SteeringOutlineNode,
+  SteeringPointer,
+} from "./SteeringFormat.js"
 
 // ── Domain → protocol translation (pure) ────────────────────────────────────
 
@@ -141,12 +146,15 @@ export const toLocation =
     },
   })
 
-/** One bare finding string → a whole-document `Diagnostic` (a built-in format's `validate` errors carry no per-line position). Not exported on its own — `diagnosticsFor`'s tests cover it in context. */
+/** One `SteeringFinding` → a `Diagnostic`: a positioned finding underlines exactly its own line, a positionless one spans the whole document. Not exported on its own — `diagnosticsFor`'s tests cover it in context. */
 const toDiagnostic =
   (lines: readonly string[]) =>
-  (message: string): Diagnostic => ({
-    range: spanRange(lines, 0, Math.max(0, lines.length - 1)),
-    message,
+  (finding: SteeringFinding): Diagnostic => ({
+    range:
+      finding.line !== undefined
+        ? spanRange(lines, finding.line, finding.line)
+        : spanRange(lines, 0, Math.max(0, lines.length - 1)),
+    message: finding.message,
     severity: DiagnosticSeverity.Warning,
     source: "gtd",
   })

--- a/src/OpenQuestions.test.ts
+++ b/src/OpenQuestions.test.ts
@@ -396,10 +396,13 @@ describe("QA_FORMAT", () => {
     "",
   ].join("\n")
 
-  it("validate delegates to parseOpenQuestions's errors", () => {
+  it("validate delegates to parseOpenQuestions's errors, each wrapped as a positionless finding", () => {
     const malformed = ["## Open Questions", "", "###", "", "no question text.", ""].join("\n")
     expect(QA_FORMAT.validate(malformed)).toEqual([
-      "An '### ' question heading under '## Open Questions' or '## Answered Questions' has no question text",
+      {
+        message:
+          "An '### ' question heading under '## Open Questions' or '## Answered Questions' has no question text",
+      },
     ])
     expect(QA_FORMAT.validate(questionsDoc)).toEqual([])
   })

--- a/src/OpenQuestions.ts
+++ b/src/OpenQuestions.ts
@@ -418,9 +418,9 @@ const questionActions: SteeringFormat["actions"] = (content, range) => {
   return actions
 }
 
-/** The `qa` steering format: gtd's own in-process open-questions checkbox format — validation, outline, and code actions, no `pointerAt` (an open question's options have nothing to jump to). */
+/** The `qa` steering format: gtd's own in-process open-questions checkbox format — validation, outline, and code actions, no `pointerAt` (an open question's options have nothing to jump to). Its one finding is always positionless — this format has no notion of a per-line problem. */
 export const QA_FORMAT: SteeringFormat = {
-  validate: (content) => parseOpenQuestions(content).errors,
+  validate: (content) => parseOpenQuestions(content).errors.map((message) => ({ message })),
   outline: questionsOutline,
   actions: questionActions,
 }

--- a/src/ReviewDoc.test.ts
+++ b/src/ReviewDoc.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest"
-import { parseReviewDoc, untickedFiles, toggleFilePointer, REVIEW_FORMAT } from "./ReviewDoc.js"
+import { parseReviewDoc, toggleFilePointer, REVIEW_FORMAT } from "./ReviewDoc.js"
 
 describe("parseReviewDoc", () => {
-  it("parses a well-formed review with one chunk", () => {
+  it("parses a well-formed review with one chunk, no explanations", () => {
     const content = [
       "# Review: abc1234",
       "",
@@ -26,8 +26,8 @@ describe("parseReviewDoc", () => {
           headingLine: 4,
           description: "New add function for the calculator.",
           files: [
-            { path: "./src/calc.ts", line: 1, checked: false, sourceLine: 8 },
-            { path: "./src/calc.ts", line: 5, checked: false, sourceLine: 9 },
+            { path: "./src/calc.ts", line: 1, checked: false, sourceLine: 8, endLine: 8 },
+            { path: "./src/calc.ts", line: 5, checked: false, sourceLine: 9, endLine: 9 },
           ],
         },
       ],
@@ -35,14 +35,15 @@ describe("parseReviewDoc", () => {
     })
   })
 
-  it("parses multiple chunks, checked boxes, and trailing notes", () => {
+  it("parses multiple chunks, checked boxes, and below-the-pointer explanations", () => {
     const content = [
       "# Review: abc1234",
       "<!-- base: abc1234def5678901234567890123456789abcd -->",
       "",
       "## Add calculator",
       "",
-      "- [x] ./src/calc.ts#1 — new add function",
+      "- [x] ./src/calc.ts#1",
+      "  new add function",
       "",
       "## Wire it up",
       "",
@@ -64,16 +65,143 @@ describe("parseReviewDoc", () => {
             checked: true,
             note: "new add function",
             sourceLine: 5,
+            endLine: 6,
           },
         ],
       },
       {
         title: "Wire it up",
-        headingLine: 7,
+        headingLine: 8,
         description: "",
-        files: [{ path: "./src/index.ts", line: 10, checked: false, sourceLine: 9 }],
+        files: [{ path: "./src/index.ts", line: 10, checked: false, sourceLine: 10, endLine: 10 }],
       },
     ])
+  })
+
+  it("gathers a multi-line explanation, joined with a single space", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./src/calc.ts#1",
+      "  first line of the explanation",
+      "  second line of the explanation",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    expect(result.changesets[0]?.files[0]).toEqual({
+      path: "./src/calc.ts",
+      line: 1,
+      checked: false,
+      note: "first line of the explanation second line of the explanation",
+      sourceLine: 5,
+      endLine: 7,
+    })
+  })
+
+  it("parses the same note whether the continuation is indented or flush", () => {
+    const indented = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./src/calc.ts#1",
+      "  what this hunk does",
+      "",
+    ].join("\n")
+    const flush = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./src/calc.ts#1",
+      "what this hunk does",
+      "",
+    ].join("\n")
+    expect(parseReviewDoc(indented).changesets[0]?.files[0]?.note).toBe("what this hunk does")
+    expect(parseReviewDoc(flush).changesets[0]?.files[0]?.note).toBe("what this hunk does")
+  })
+
+  it("keeps a blank line between two continuation paragraphs inside the pointer's span, joining both", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./src/calc.ts#1",
+      "  first paragraph",
+      "",
+      "  second paragraph",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    const file = result.changesets[0]?.files[0]!
+    expect(file.note).toBe("first paragraph second paragraph")
+    expect(file.endLine).toBe(8)
+  })
+
+  it("a pointer with no explanation has endLine === sourceLine", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./src/calc.ts#1",
+      "- [ ] ./src/calc.ts#2",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    const [first, second] = result.changesets[0]!.files
+    expect(first?.sourceLine).toBe(first?.endLine)
+    expect(second?.sourceLine).toBe(second?.endLine)
+  })
+
+  it("trims trailing blank lines before the next '##' heading out of the last pointer's span", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./src/calc.ts#1",
+      "  the note",
+      "",
+      "",
+      "## Next chunk",
+      "",
+      "- [ ] ./src/index.ts#1",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    expect(result.changesets[0]?.files[0]?.endLine).toBe(6)
+  })
+
+  it("puts lines before a chunk's first pointer into its description, and lines after a pointer into that pointer's note, not the description", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "Chunk-level prose, describing why the group exists.",
+      "",
+      "- [ ] ./src/calc.ts#1",
+      "  This is the hunk's own note, not chunk prose.",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    expect(result.changesets[0]?.description).toBe(
+      "Chunk-level prose, describing why the group exists.",
+    )
+    expect(result.changesets[0]?.files[0]?.note).toBe(
+      "This is the hunk's own note, not chunk prose.",
+    )
   })
 
   it("errors when the header is missing", () => {
@@ -157,7 +285,8 @@ describe("parseReviewDoc", () => {
       "",
       "## Add budget alerts",
       "",
-      "- [ ] ./src/server/email/budget-threshold.ts#31 — non-obvious import: uses the shared mailer",
+      "- [ ] ./src/server/email/budget-threshold.ts#31",
+      "  non-obvious import: uses the shared mailer",
       "",
     ].join("\n")
     const result = parseReviewDoc(content)
@@ -169,23 +298,8 @@ describe("parseReviewDoc", () => {
         checked: false,
         note: "non-obvious import: uses the shared mailer",
         sourceLine: 5,
+        endLine: 6,
       },
-    ])
-  })
-
-  it("splits a single-dash note after a hyphenated path at the space, not the hyphen", () => {
-    const content = [
-      "# Review: abc1234",
-      "<!-- base: abc1234def5678901234567890123456789abcd -->",
-      "",
-      "## Chunk",
-      "",
-      "- [ ] ./a-b/c-d.ts#7 - note",
-      "",
-    ].join("\n")
-    const result = parseReviewDoc(content)
-    expect(result.changesets[0]?.files).toEqual([
-      { path: "./a-b/c-d.ts", line: 7, checked: false, note: "note", sourceLine: 5 },
     ])
   })
 
@@ -201,7 +315,7 @@ describe("parseReviewDoc", () => {
     ].join("\n")
     const result = parseReviewDoc(content)
     expect(result.changesets[0]?.files).toEqual([
-      { path: "./a#b.ts", checked: false, sourceLine: 5 },
+      { path: "./a#b.ts", checked: false, sourceLine: 5, endLine: 5 },
     ])
   })
 
@@ -222,6 +336,122 @@ describe("parseReviewDoc", () => {
   })
 })
 
+describe("parseReviewDoc — trailing text on the pointer's own line (invalid legacy form)", () => {
+  it("still parses as a pointer, with path, #line, and checked state intact", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add thing.ts",
+      "",
+      "- [x] ./src/Edge.ts#42 — what this hunk does",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    expect(result.changesets[0]?.files[0]).toMatchObject({
+      path: "./src/Edge.ts",
+      line: 42,
+      checked: true,
+      sourceLine: 5,
+    })
+  })
+
+  it("produces exactly one error, naming the chunk and the pointer, and carrying the pointer's sourceLine", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add thing.ts",
+      "",
+      "- [ ] ./src/Edge.ts#42 — what this hunk does",
+      "",
+    ].join("\n")
+    expect(REVIEW_FORMAT.validate(content)).toEqual([
+      {
+        message:
+          'Chunk "Add thing.ts" hunk ./src/Edge.ts#42 has text on the pointer line — move the explanation to the line(s) below it',
+        line: 5,
+      },
+    ])
+  })
+
+  it("does not also report 'no file pointers' for a chunk whose only pointer carries trailing text", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add thing.ts",
+      "",
+      "- [ ] ./src/Edge.ts#42 — what this hunk does",
+      "",
+    ].join("\n")
+    const errors = parseReviewDoc(content).errors
+    expect(errors.some((e) => e.includes("no file pointers"))).toBe(false)
+  })
+
+  it("a hyphen inside a filename is never read as a separator — the separator is only recognized after whitespace splits it from the path", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./a-b/c-d.ts#7",
+      "",
+    ].join("\n")
+    expect(REVIEW_FORMAT.validate(content)).toEqual([])
+    expect(parseReviewDoc(content).changesets[0]?.files[0]?.path).toBe("./a-b/c-d.ts")
+  })
+
+  it("the clean below-the-pointer form produces no errors", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./src/Edge.ts#42",
+      "  what this hunk does",
+      "",
+    ].join("\n")
+    expect(REVIEW_FORMAT.validate(content)).toEqual([])
+  })
+})
+
+describe("parseReviewDoc — continuation-line dash stripping", () => {
+  it("strips a leading em dash, en dash, or hyphen run from a continuation line", () => {
+    for (const dash of ["—", "–", "-", "---"]) {
+      const content = [
+        "# Review: abc1234",
+        "<!-- base: abc1234def5678901234567890123456789abcd -->",
+        "",
+        "## Chunk",
+        "",
+        "- [ ] ./src/calc.ts#1",
+        `  ${dash} the note`,
+        "",
+      ].join("\n")
+      expect(parseReviewDoc(content).changesets[0]?.files[0]?.note).toBe("the note")
+    }
+  })
+
+  it("keeps a dash mid-sentence on a continuation line", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./src/calc.ts#1",
+      "  a note with a mid-sentence dash — kept",
+      "",
+    ].join("\n")
+    expect(parseReviewDoc(content).changesets[0]?.files[0]?.note).toBe(
+      "a note with a mid-sentence dash — kept",
+    )
+  })
+})
+
 const reviewDoc = [
   "# Review: abc1234",
   "<!-- base: abc1234def5678901234567890123456789abcd -->",
@@ -229,39 +459,15 @@ const reviewDoc = [
   "## Add calculator",
   "",
   "- [ ] ./src/calc.ts#1",
-  "- [x] ./src/calc.ts#5 — subtract",
+  "  add",
+  "- [x] ./src/calc.ts#5",
+  "  subtract",
   "",
   "## Wire it up",
   "",
   "- [ ] ./src/index.ts#10",
   "",
 ].join("\n")
-
-describe("untickedFiles", () => {
-  it("returns every unticked pointer across all chunks", () => {
-    expect(untickedFiles(reviewDoc).map((f) => f.path)).toEqual(["./src/calc.ts", "./src/index.ts"])
-  })
-
-  it("returns an empty array when every pointer is ticked", () => {
-    const allChecked = reviewDoc.replace("- [ ] ./src/calc.ts#1", "- [x] ./src/calc.ts#1")
-    expect(untickedFiles(allChecked).filter((f) => f.path === "./src/calc.ts")).toEqual([])
-  })
-
-  it("reports a hyphenated path whole, not truncated at its first hyphen", () => {
-    const content = [
-      "# Review: abc1234",
-      "<!-- base: abc1234def5678901234567890123456789abcd -->",
-      "",
-      "## Add budget alerts",
-      "",
-      "- [ ] ./src/server/email/budget-threshold.ts#31",
-      "",
-    ].join("\n")
-    expect(untickedFiles(content).map((f) => f.path)).toEqual([
-      "./src/server/email/budget-threshold.ts",
-    ])
-  })
-})
 
 describe("toggleFilePointer", () => {
   it("flips an unchecked box to checked without touching the rest of the line", () => {
@@ -272,24 +478,24 @@ describe("toggleFilePointer", () => {
     expect(edit!.newText).toBe("x")
   })
 
-  it("flips a checked box back to unchecked, preserving the trailing note", () => {
-    const edit = toggleFilePointer(reviewDoc, 6)
+  it("flips a checked box back to unchecked, preserving the pointer line exactly", () => {
+    const edit = toggleFilePointer(reviewDoc, 7)
     expect(edit).toBeDefined()
     expect(edit!.newText).toBe(" ")
     const lines = reviewDoc.split("\n")
-    const line = lines[6]!
+    const line = lines[7]!
     const patched =
       line.slice(0, edit!.range.start.character) +
       edit!.newText +
       line.slice(edit!.range.end.character)
-    expect(patched).toBe("- [ ] ./src/calc.ts#5 — subtract")
+    expect(patched).toBe("- [ ] ./src/calc.ts#5")
   })
 
   it("returns undefined for a line that isn't a file pointer", () => {
     expect(toggleFilePointer(reviewDoc, 3)).toBeUndefined()
   })
 
-  it("flips only the box on a hyphenated pointer line, round-tripping the rest", () => {
+  it("still toggles a legacy trailing-note pointer line, round-tripping the rest", () => {
     const content = [
       "# Review: abc1234",
       "<!-- base: abc1234def5678901234567890123456789abcd -->",
@@ -311,12 +517,29 @@ describe("toggleFilePointer", () => {
 })
 
 describe("REVIEW_FORMAT", () => {
-  it("validate delegates to parseReviewDoc's errors", () => {
+  it("validate delegates to the review findings, header/base-comment/no-chunks findings carrying no line", () => {
     expect(REVIEW_FORMAT.validate(reviewDoc)).toEqual([])
     expect(REVIEW_FORMAT.validate("Just some text\n")).toEqual([
-      "Missing or malformed '# Review: <hash>' header as the document's first line",
-      "Missing '<!-- base: <hash> -->' comment",
-      "REVIEW.md has no '##' chunks",
+      {
+        message: "Missing or malformed '# Review: <hash>' header as the document's first line",
+      },
+      { message: "Missing '<!-- base: <hash> -->' comment" },
+      { message: "REVIEW.md has no '##' chunks" },
+    ])
+  })
+
+  it("no-file-pointers finding also carries no line", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add calculator",
+      "",
+      "Just prose, no pointers.",
+      "",
+    ].join("\n")
+    expect(REVIEW_FORMAT.validate(content)).toEqual([
+      { message: 'Chunk "Add calculator" has no file pointers' },
     ])
   })
 
@@ -345,9 +568,36 @@ describe("REVIEW_FORMAT", () => {
     expect(REVIEW_FORMAT.outline(doc).map((n) => n.name)).toEqual(["Still open (0/1)"])
   })
 
-  it("actions offer a single-hunk toggle when the range sits on a hunk line", () => {
+  it("actions offer a single-hunk toggle when the range sits on a hunk's pointer line", () => {
     const at = (line: number) => ({ start: { line, character: 0 }, end: { line, character: 0 } })
     const actions = REVIEW_FORMAT.actions(reviewDoc, at(5))
+    expect(actions.map((a) => a.title)).toContain("gtd: check this hunk")
+  })
+
+  it("actions offer the SAME single-hunk toggle when the range sits on a continuation line below the pointer, and its edit targets the pointer line's own box", () => {
+    const at = (line: number) => ({ start: { line, character: 0 }, end: { line, character: 0 } })
+    const onPointer = REVIEW_FORMAT.actions(reviewDoc, at(5))
+    const onContinuation = REVIEW_FORMAT.actions(reviewDoc, at(6))
+    expect(onContinuation.map((a) => a.title)).toContain("gtd: check this hunk")
+    const pointerEdit = onPointer.find((a) => a.title === "gtd: check this hunk")!.edits[0]!
+    const continuationEdit = onContinuation.find((a) => a.title === "gtd: check this hunk")!
+      .edits[0]!
+    expect(continuationEdit).toEqual(pointerEdit)
+    expect(continuationEdit.range.start.line).toBe(5)
+  })
+
+  it("actions still offer the toggle on a legacy trailing-note pointer line", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./src/calc.ts#1 — legacy note",
+      "",
+    ].join("\n")
+    const at = (line: number) => ({ start: { line, character: 0 }, end: { line, character: 0 } })
+    const actions = REVIEW_FORMAT.actions(content, at(5))
     expect(actions.map((a) => a.title)).toContain("gtd: check this hunk")
   })
 
@@ -358,7 +608,7 @@ describe("REVIEW_FORMAT", () => {
   })
 
   it("pointerAt jumps to the hunk's file at its 1-based #line, mapped to a 0-based position", () => {
-    const pointer = REVIEW_FORMAT.pointerAt?.(reviewDoc, 6)
+    const pointer = REVIEW_FORMAT.pointerAt?.(reviewDoc, 7)
     expect(pointer).toEqual({ path: "./src/calc.ts", line: 4 })
   })
 
@@ -378,6 +628,15 @@ describe("REVIEW_FORMAT", () => {
     expect(REVIEW_FORMAT.pointerAt?.(reviewDoc, 3)).toBeUndefined() // "## Add calculator"
   })
 
+  it("go-to-definition and the check/uncheck action DISAGREE at a continuation line: the action fires, go-to-definition does not — asserted at the SAME cursor position", () => {
+    const at = (line: number) => ({ start: { line, character: 0 }, end: { line, character: 0 } })
+    const continuationLine = 6 // "  add" — below "- [ ] ./src/calc.ts#1" at line 5
+    expect(REVIEW_FORMAT.actions(reviewDoc, at(continuationLine)).map((a) => a.title)).toContain(
+      "gtd: check this hunk",
+    )
+    expect(REVIEW_FORMAT.pointerAt?.(reviewDoc, continuationLine)).toBeUndefined()
+  })
+
   it("pointerAt on a hyphenated hunk line returns the full path, not a truncated prefix", () => {
     const doc = [
       "# Review: abc1234",
@@ -385,7 +644,8 @@ describe("REVIEW_FORMAT", () => {
       "",
       "## Add budget alerts",
       "",
-      "- [ ] ./src/server/email/budget-threshold.ts#31 — non-obvious import",
+      "- [ ] ./src/server/email/budget-threshold.ts#31",
+      "  non-obvious import",
     ].join("\n")
     expect(REVIEW_FORMAT.pointerAt?.(doc, 5)).toEqual({
       path: "./src/server/email/budget-threshold.ts",
@@ -410,8 +670,10 @@ describe("voice styling (styled review exemplar)", () => {
     "This is the only algorithm change in the batch — everything else below",
     "is wiring.",
     "",
-    "- [ ] ./src/RateLimiter.ts#12 — refill math, check the rounding direction",
-    "- [ ] ./src/RateLimiter.ts#48 — cap enforcement on a burst request",
+    "- [ ] ./src/RateLimiter.ts#12",
+    "  Refill math. Check the rounding direction.",
+    "- [ ] ./src/RateLimiter.ts#48",
+    "  Cap enforcement on a burst request.",
     "",
     "## Wire the limiter into the API gateway",
     "",
@@ -420,7 +682,8 @@ describe("voice styling (styled review exemplar)", () => {
     "account id.",
     "",
     "- [ ] ./src/Gateway.ts#101",
-    "- [ ] ./src/Gateway.ts#134 — account-keyed bucket lookup",
+    "- [ ] ./src/Gateway.ts#134",
+    "  Account-keyed bucket lookup.",
     "",
   ].join("\n")
 

--- a/src/ReviewDoc.ts
+++ b/src/ReviewDoc.ts
@@ -13,6 +13,7 @@
  * <What this chunk changes and why>
  *
  * - [ ] ./path/to/file.ts#42
+ *   what this hunk does, with room to run to several lines
  * - [ ] ./path/to/file.ts#99
  * ```
  *
@@ -20,11 +21,16 @@
  * line), the `<!-- base: <hash> -->` comment, and at least one `##` chunk
  * with a non-empty title and at least one `- [ ]` / `- [x]` file pointer.
  *
- * A file pointer's path is ONE whitespace-delimited `./`-relative token — an
- * optional `#<line>` suffix of that same token, then an optional
- * whitespace-separated note. A hyphen (or em/en dash) in a filename is part of
- * the path, never a note separator: the note separator is only recognized
- * after whitespace has already split the note from the path.
+ * A file pointer's path is ONE whitespace-delimited `./`-relative token, with
+ * an optional `#<line>` suffix of that same token — nothing else may follow on
+ * the pointer's own line; a hyphen (or em/en dash) in a filename is part of the
+ * path, never a separator. **Text after the pointer token on the pointer's own
+ * line is a validation error** — the explanation belongs on the line(s) below
+ * it instead. Every line after a pointer belongs to that pointer as its
+ * explanation (`note`), until the next pointer or the next `##` heading;
+ * indentation is optional, and a blank line between two continuation
+ * paragraphs stays inside the span. Only lines before a chunk's FIRST pointer
+ * are chunk-level description.
  *
  * **The format's single source of truth.** This module is the EXECUTABLE SPEC
  * of that format — its own unit tests (`ReviewDoc.test.ts`) are the format's
@@ -32,7 +38,7 @@
  * second implementation to keep in sync: the `gtd validate` CLI command
  * (`src/program.ts`) parses the resolved state's `review`-mode file and exits
  * non-zero with the `errors` below, and the LSP (`src/Lsp.ts`) publishes the
- * same `errors` as live diagnostics. The engine (`PatternMachine`/`Edge`/the
+ * same findings as live diagnostics. The engine (`PatternMachine`/`Edge`/the
  * bundled workflow) itself stays git/filesystem/Effect-dependency-free of this
  * module, and this module stays independent of any particular workflow's shape.
  *
@@ -41,15 +47,25 @@
  * wants to read/validate `.gtd/REVIEW.md`.
  */
 
-import type { SteeringEdit, SteeringFormat, SteeringOutlineNode } from "./SteeringFormat.js"
+import type {
+  SteeringEdit,
+  SteeringFinding,
+  SteeringFormat,
+  SteeringOutlineNode,
+} from "./SteeringFormat.js"
 
 export interface ReviewFile {
   readonly path: string
   readonly line?: number
   readonly checked: boolean
+  /** The pointer's explanation, gathered from the lines BELOW it, joined with " ". */
   readonly note?: string
   /** 0-based line index of this file pointer's own `- [ ]`/`- [x]` line in REVIEW.md, for editor tooling. */
   readonly sourceLine: number
+  /** 0-based index of the last NON-BLANK line of this pointer's span; equals `sourceLine` when it has no explanation. */
+  readonly endLine: number
+  /** Text found after the pointer token on the pointer's OWN line — the invalid legacy form. Absent when the line is clean. */
+  readonly trailingText?: string
 }
 
 export interface Changeset {
@@ -70,11 +86,11 @@ export interface ReviewDoc {
 const HEADER_RE = /^#\s+Review:\s*(\S+)\s*$/
 const BASE_COMMENT_RE = /^<!--\s*base:\s*(\S+)\s*-->$/
 const CHUNK_HEADING_RE = /^##\s+(.+)$/
-/** One `- [ ]`/`- [x]` pointer line: the box, the whitespace-delimited pointer token, and the rest of the line. */
+/** One `- [ ]`/`- [x]` pointer line: the box, the whitespace-delimited pointer token, and (invalidly) whatever trails it. */
 const FILE_POINTER_RE = /^-\s*\[([ xX])\]\s*(\S+)(?:\s+(.*))?$/
 /** A pointer token's trailing `#<line>` (greedy, so a `#` inside the path stays in it). */
 const POINTER_LINE_RE = /^(.*)#(\d+)$/
-/** The optional dash a trailing note may lead with — em dash, en dash, or hyphens. */
+/** The optional dash a continuation line may lead with — em dash, en dash, or hyphens. */
 const NOTE_SEPARATOR_RE = /^[—–-]+\s*/
 
 /** The `# Review: <hash>` header, required as the document's first non-blank line. */
@@ -92,8 +108,18 @@ const parseBaseComment = (lines: readonly string[]): string | undefined => {
   return undefined
 }
 
-/** One `- [ ]` / `- [x]` file-pointer line, or `undefined` if `line` isn't one. */
-const parseFilePointer = (line: string, sourceLine: number): ReviewFile | undefined => {
+/** A pointer line's own fields — everything `FILE_POINTER_RE` can tell without looking at surrounding lines. */
+interface ParsedPointer {
+  readonly path: string
+  readonly line?: number
+  readonly checked: boolean
+  readonly sourceLine: number
+  /** Whatever trailed the pointer token on its own line, trimmed — present exactly when that line is invalid (Task 2). */
+  readonly trailingText?: string
+}
+
+/** One `- [ ]` / `- [x]` file-pointer line, or `undefined` if `line` isn't one. The regex is unchanged from the legacy same-line-note form — a line WITH trailing text still parses, so the resulting error can point at it precisely (see the module docstring). */
+const parseFilePointer = (line: string, sourceLine: number): ParsedPointer | undefined => {
   const match = FILE_POINTER_RE.exec(line)
   if (!match) return undefined
   const token = match[2]!
@@ -101,13 +127,13 @@ const parseFilePointer = (line: string, sourceLine: number): ReviewFile | undefi
   const lineMatch = POINTER_LINE_RE.exec(token)
   const path = lineMatch ? lineMatch[1]! : token
   if (path.length <= 2) return undefined // `./` with nothing after it is not a path
-  const note = (match[3] ?? "").replace(NOTE_SEPARATOR_RE, "").trim()
+  const trailingText = (match[3] ?? "").trim()
   return {
     checked: match[1] !== " ",
     path,
     ...(lineMatch ? { line: Number(lineMatch[2]) } : {}),
-    ...(note.length > 0 ? { note } : {}),
     sourceLine,
+    ...(trailingText.length > 0 ? { trailingText } : {}),
   }
 }
 
@@ -117,23 +143,100 @@ interface BodyLine {
   readonly line: number
 }
 
-/** Splits one chunk's body lines (up to the next `##` heading) into its file pointers and description prose. */
-const parseChunkBody = (
-  body: readonly BodyLine[],
-): { readonly description: string; readonly files: readonly ReviewFile[] } => {
-  const files: ReviewFile[] = []
-  const descriptionLines: string[] = []
-  for (const raw of body) {
-    const trimmed = raw.text.trim()
+/**
+ * Index (into `body`) of the last NON-BLANK line belonging to the pointer that
+ * starts at `index`: every following line up to (but excluding) the next
+ * pointer line belongs to this pointer's span. Unlike `OpenQuestions.ts`'s
+ * `itemEndIndex`, a blank line does NOT end the span — the review format
+ * admits multi-paragraph explanations, so a blank line between two
+ * continuation paragraphs stays inside the span; the returned index is just
+ * trimmed back to the last non-blank line so a trailing blank run before the
+ * next pointer/heading isn't absorbed.
+ */
+const pointerEndIndex = (body: readonly BodyLine[], index: number): number => {
+  let end = index
+  for (let i = index + 1; i < body.length; i += 1) {
+    const trimmed = body[i]!.text.trim()
     if (trimmed.length === 0) continue
-    const file = parseFilePointer(trimmed, raw.line)
-    if (file) {
-      files.push(file)
-    } else {
-      descriptionLines.push(trimmed)
-    }
+    if (parseFilePointer(trimmed, body[i]!.line)) break
+    end = i
   }
-  return { description: descriptionLines.join(" "), files }
+  return end
+}
+
+/** The trailing-text validation error for one pointer whose own line carries text after the pointer token. */
+const trailingTextError = (title: string, pointer: ParsedPointer): SteeringFinding => {
+  const target = pointer.line !== undefined ? `${pointer.path}#${pointer.line}` : pointer.path
+  return {
+    message: `Chunk "${title}" hunk ${target} has text on the pointer line — move the explanation to the line(s) below it`,
+    line: pointer.sourceLine,
+  }
+}
+
+/** Joins a pointer's gathered explanation: every non-blank line strictly between `startIndex` and `endIndex` (inclusive), each stripped of a leading dash, joined with a single space. */
+const gatherNote = (body: readonly BodyLine[], startIndex: number, endIndex: number): string => {
+  const noteLines: string[] = []
+  for (let j = startIndex + 1; j <= endIndex; j += 1) {
+    const t = body[j]!.text.trim()
+    if (t.length > 0) noteLines.push(t.replace(NOTE_SEPARATOR_RE, ""))
+  }
+  return noteLines.join(" ").trim()
+}
+
+/** One pointer's parsed `ReviewFile` (span + gathered note), its trailing-text error when its own line carried one, and the body index just past its span for the caller to resume from. */
+const parsePointerSpan = (
+  title: string,
+  body: readonly BodyLine[],
+  index: number,
+  pointer: ParsedPointer,
+): { readonly file: ReviewFile; readonly error?: SteeringFinding; readonly nextIndex: number } => {
+  const endIndex = pointerEndIndex(body, index)
+  const note = gatherNote(body, index, endIndex)
+  const { trailingText, ...pointerFields } = pointer
+  const file: ReviewFile = {
+    ...pointerFields,
+    endLine: body[endIndex]!.line,
+    ...(note.length > 0 ? { note } : {}),
+    ...(trailingText !== undefined ? { trailingText } : {}),
+  }
+  return {
+    file,
+    ...(trailingText !== undefined ? { error: trailingTextError(title, pointer) } : {}),
+    nextIndex: endIndex + 1,
+  }
+}
+
+/** Splits one chunk's body lines (up to the next `##` heading) into its file pointers (each with its gathered below-the-pointer note and span) and description prose — only the lines before the chunk's FIRST pointer. */
+const parseChunkBody = (
+  title: string,
+  body: readonly BodyLine[],
+): {
+  readonly description: string
+  readonly files: readonly ReviewFile[]
+  readonly errors: readonly SteeringFinding[]
+} => {
+  const files: ReviewFile[] = []
+  const errors: SteeringFinding[] = []
+  const descriptionLines: string[] = []
+  let i = 0
+  while (i < body.length) {
+    const trimmed = body[i]!.text.trim()
+    if (trimmed.length === 0) {
+      i += 1
+      continue
+    }
+    const pointer = parseFilePointer(trimmed, body[i]!.line)
+    if (!pointer) {
+      descriptionLines.push(trimmed)
+      i += 1
+      continue
+    }
+    const { file, error, nextIndex } = parsePointerSpan(title, body, i, pointer)
+    files.push(file)
+    if (error) errors.push(error)
+    i = nextIndex
+  }
+  return { description: descriptionLines.join(" "), files, errors }
 }
 
 /** Splits the document into `##` chunks, each with its title, heading line, and body lines. */
@@ -161,19 +264,54 @@ const splitChunks = (
   return chunks
 }
 
-/** Parses every `##` chunk into a `Changeset`, collecting one error per chunk with no file pointers. */
+/** Parses every `##` chunk into a `Changeset`, collecting one error per chunk with no file pointers plus each chunk body's own trailing-text errors. */
 const parseChangesets = (
   lines: readonly string[],
-): { readonly changesets: readonly Changeset[]; readonly errors: readonly string[] } => {
+): { readonly changesets: readonly Changeset[]; readonly errors: readonly SteeringFinding[] } => {
   const changesets: Changeset[] = []
-  const errors: string[] = []
+  const errors: SteeringFinding[] = []
   for (const { title, headingLine, body } of splitChunks(lines)) {
-    const { description, files } = parseChunkBody(body)
-    if (files.length === 0) errors.push(`Chunk "${title}" has no file pointers`)
+    const { description, files, errors: bodyErrors } = parseChunkBody(title, body)
+    errors.push(...bodyErrors)
+    if (files.length === 0) errors.push({ message: `Chunk "${title}" has no file pointers` })
     changesets.push({ title, description, files, headingLine })
   }
-  if (changesets.length === 0) errors.push("REVIEW.md has no '##' chunks")
+  if (changesets.length === 0) errors.push({ message: "REVIEW.md has no '##' chunks" })
   return { changesets, errors }
+}
+
+/** Shared by `parseReviewDoc` and `REVIEW_FORMAT.validate` — the latter needs each finding's `line` (Task 3), which `ReviewDoc.errors` (plain strings, for backward-compatible callers) drops. */
+const parseReviewFindings = (
+  content: string,
+): {
+  readonly shortHash?: string
+  readonly fullHash?: string
+  readonly changesets: readonly Changeset[]
+  readonly findings: readonly SteeringFinding[]
+} => {
+  const lines = content.split(/\r?\n/)
+  const shortHash = parseHeader(lines)
+  const fullHash = parseBaseComment(lines)
+  const { changesets, errors: chunkFindings } = parseChangesets(lines)
+
+  const findings: SteeringFinding[] = [
+    ...(shortHash
+      ? []
+      : [
+          {
+            message: "Missing or malformed '# Review: <hash>' header as the document's first line",
+          },
+        ]),
+    ...(fullHash ? [] : [{ message: "Missing '<!-- base: <hash> -->' comment" }]),
+    ...chunkFindings,
+  ]
+
+  return {
+    ...(shortHash ? { shortHash } : {}),
+    ...(fullHash ? { fullHash } : {}),
+    changesets,
+    findings,
+  }
 }
 
 /**
@@ -184,38 +322,14 @@ const parseChangesets = (
  * exits non-zero with them; the LSP publishes them as diagnostics).
  */
 export const parseReviewDoc = (content: string): ReviewDoc => {
-  const lines = content.split(/\r?\n/)
-  const shortHash = parseHeader(lines)
-  const fullHash = parseBaseComment(lines)
-  const { changesets, errors: chunkErrors } = parseChangesets(lines)
-
-  const errors = [
-    ...(shortHash
-      ? []
-      : ["Missing or malformed '# Review: <hash>' header as the document's first line"]),
-    ...(fullHash ? [] : ["Missing '<!-- base: <hash> -->' comment"]),
-    ...chunkErrors,
-  ]
-
+  const { shortHash, fullHash, changesets, findings } = parseReviewFindings(content)
   return {
     ...(shortHash ? { shortHash } : {}),
     ...(fullHash ? { fullHash } : {}),
     changesets,
-    errors,
+    errors: findings.map((f) => f.message),
   }
 }
-
-/**
- * Every file pointer in every chunk that is not ticked, over a freshly-parsed
- * document — the structured narrowing the review sign-off guard
- * (`src/StepGuards.ts`) counts instead of a raw `- [ ]` regex over the whole
- * document: a bare `- []`, an indented note, or a non-`./` path outside a
- * chunk's file pointers no longer counts.
- */
-export const untickedFiles = (content: string): readonly ReviewFile[] =>
-  parseReviewDoc(content)
-    .changesets.flatMap((chunk) => chunk.files)
-    .filter((file) => !file.checked)
 
 /** Flips the `[ ]`/`[x]` box of the hunk line at `line`, preserving path/note text exactly. */
 export const toggleFilePointer = (content: string, line: number): SteeringEdit | undefined => {
@@ -297,7 +411,9 @@ const reviewActions: SteeringFormat["actions"] = (content, range) => {
 
   // fallow-ignore-next-line complexity
   changesets.forEach((chunk, i) => {
-    const hunk = chunk.files.find((file) => file.sourceLine === cursorLine)
+    const hunk = chunk.files.find(
+      (file) => cursorLine >= file.sourceLine && cursorLine <= file.endLine,
+    )
     if (hunk) {
       const edit = toggleFilePointer(content, hunk.sourceLine)
       if (edit) {
@@ -352,7 +468,7 @@ const reviewPointerAt = (
 
 /** The `review` steering format: gtd's own in-process review-checkbox format — validation, outline, code actions, and `pointerAt` (a hunk pointer's go-to-definition target). */
 export const REVIEW_FORMAT: SteeringFormat = {
-  validate: (content) => parseReviewDoc(content).errors,
+  validate: (content) => parseReviewFindings(content).findings,
   outline: reviewOutline,
   actions: reviewActions,
   pointerAt: reviewPointerAt,

--- a/src/SteeringFormat.ts
+++ b/src/SteeringFormat.ts
@@ -56,16 +56,22 @@ export interface SteeringPointer {
   readonly line: number
 }
 
+/** One validation finding. `line` is 0-based; absent when the finding is about the document as a whole. */
+export interface SteeringFinding {
+  readonly message: string
+  readonly line?: number
+}
+
 /**
  * One steering-file FORMAT's whole behavior: how to validate it in process,
  * build its outline, offer code actions at a range, and (optionally) resolve
  * a cursor position to a pointer elsewhere. `validate` returns the same
- * `errors` shape `gtd validate` and the capture gate both consume (empty =
+ * `findings` shape `gtd validate` and the capture gate both consume (empty =
  * valid). `pointerAt` is absent for a format with nothing to jump to (`qa`
  * has none; `review` does).
  */
 export interface SteeringFormat {
-  readonly validate: (content: string) => readonly string[]
+  readonly validate: (content: string) => readonly SteeringFinding[]
   readonly outline: (content: string) => readonly SteeringOutlineNode[]
   readonly actions: (
     content: string,

--- a/src/SteeringMode.test.ts
+++ b/src/SteeringMode.test.ts
@@ -270,7 +270,7 @@ describe("validateSteeringFile — built-in modes", () => {
       ),
       neverRunner,
     )
-    expect(errors.join("\n")).toContain("has no question text")
+    expect(errors.map((e) => e.message).join("\n")).toContain("has no question text")
   })
 
   it("`review` reports the review-doc parser's findings", async () => {
@@ -283,7 +283,7 @@ describe("validateSteeringFile — built-in modes", () => {
       ),
       neverRunner,
     )
-    expect(errors.join("\n")).toContain("# Review: <hash>")
+    expect(errors.map((e) => e.message).join("\n")).toContain("# Review: <hash>")
   })
 
   it("reports no findings for a valid file", async () => {
@@ -335,7 +335,10 @@ describe("validateSteeringFile — a workflow-declared command", () => {
       ),
       layer,
     )
-    expect(errors).toEqual(["docs/adr.md: missing Status section", "on stderr"])
+    expect(errors).toEqual([
+      { message: "docs/adr.md: missing Status section" },
+      { message: "on stderr" },
+    ])
     expect(calls).toEqual([
       { command: 'echo "docs/adr.md: missing Status section"; echo "on stderr" >&2; exit 3' },
     ])
@@ -352,7 +355,9 @@ describe("validateSteeringFile — a workflow-declared command", () => {
       ),
       layer,
     )
-    expect(errors).toEqual(['mode "adr": validate command exited with status 2 and no output'])
+    expect(errors).toEqual([
+      { message: 'mode "adr": validate command exited with status 2 and no output' },
+    ])
   })
 
   it("renders the command as an Eta template over `it.file` and `it.vars` before running it", async () => {
@@ -373,7 +378,7 @@ describe("validateSteeringFile — a workflow-declared command", () => {
       layer,
     )
     expect(calls[0]?.command).toBe('echo "adr-lint saw docs/adr.md"; exit 1')
-    expect(errors).toEqual(["adr-lint saw docs/adr.md"])
+    expect(errors).toEqual([{ message: "adr-lint saw docs/adr.md" }])
   })
 
   it("fails (rather than running anything) when the command template is malformed", async () => {

--- a/src/SteeringMode.ts
+++ b/src/SteeringMode.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect"
 import { CommandRunner, type CommandOutcome } from "./CommandRunner.js"
 import { isSeededValidateCommand, steeringFormatFor } from "./SteeringFormats.js"
-import type { SteeringFormat } from "./SteeringFormat.js"
+import type { SteeringFinding, SteeringFormat } from "./SteeringFormat.js"
 import { knownModes, type StateMode, type WorkflowDefinition } from "./PatternMachine.js"
 import { renderModeCommand, type TemplateContext } from "./PatternTemplates.js"
 
@@ -127,7 +127,7 @@ export const resolveBuiltInMode = (mode: StateMode): ResolvedMode | undefined =>
  */
 export interface SteeringCapabilities {
   readonly format?: SteeringFormat
-  readonly liveValidate?: (content: string) => readonly string[]
+  readonly liveValidate?: (content: string) => readonly SteeringFinding[]
   readonly externalValidate?: boolean
 }
 
@@ -175,14 +175,18 @@ const renderCommand = (
     catch: (e) => new Error(`mode "${mode}": "${key}" command failed to render — ${errorText(e)}`),
   })
 
-/** The findings a non-zero `validate` exit reports: its output lines, or a synthesized line when it said nothing. */
-const findingsFrom = (mode: StateMode, outcome: CommandOutcome): readonly string[] => {
+/** The findings a non-zero `validate` exit reports: its output lines, or a synthesized line when it said nothing. A shell command's findings can never carry a line — gtd sees only its stdout/stderr text, so each output line maps to a positionless finding. */
+const findingsFrom = (mode: StateMode, outcome: CommandOutcome): readonly SteeringFinding[] => {
   const lines = outcome.output
     .split("\n")
     .map((line) => line.trimEnd())
     .filter((line) => line.length > 0)
-  if (lines.length > 0) return lines
-  return [`mode "${mode}": validate command exited with ${exitText(outcome.status)} and no output`]
+  if (lines.length > 0) return lines.map((message) => ({ message }))
+  return [
+    {
+      message: `mode "${mode}": validate command exited with ${exitText(outcome.status)} and no output`,
+    },
+  ]
 }
 
 /**
@@ -227,7 +231,7 @@ export const validateSteeringFile = (
   file: string,
   content: string,
   context: TemplateContext,
-): Effect.Effect<readonly string[], Error, CommandRunner> =>
+): Effect.Effect<readonly SteeringFinding[], Error, CommandRunner> =>
   Effect.gen(function* () {
     const validator = resolved.validate
     if (validator === undefined) return []
@@ -262,7 +266,7 @@ export const formatAndValidateSteeringFile = (
   file: string,
   content: string,
   context: TemplateContext,
-): Effect.Effect<readonly string[], Error, CommandRunner> =>
+): Effect.Effect<readonly SteeringFinding[], Error, CommandRunner> =>
   Effect.gen(function* () {
     yield* formatSteeringFile(resolved, file, context)
     return yield* validateSteeringFile(resolved, file, content, context)

--- a/src/StepGuards.test.ts
+++ b/src/StepGuards.test.ts
@@ -59,9 +59,9 @@ const guard = (name: string) => {
 const checkOf = async (name: string, context: GuardContext): Promise<string | undefined> =>
   Effect.runPromise(guard(name).check(context) as Effect.Effect<string | undefined, never, never>)
 
-// ── review-signoff ───────────────────────────────────────────────────────────
+// ── review-doc ───────────────────────────────────────────────────────────────
 
-describe("review-signoff guard", () => {
+describe("review-doc guard", () => {
   const reviewState = rest("await-review", {
     actor: "human",
     prompt: "review",
@@ -69,18 +69,16 @@ describe("review-signoff guard", () => {
     mode: "review",
     reviewWindow: true,
   })
-  const twoUnticked = "## C\n- [ ] ./a.ts#1\n- [ ] ./b.ts#1\n"
-  const allTicked = "## C\n- [x] ./a.ts#1\n- [x] ./b.ts#1\n"
 
   it("applies only to a review-window state with mode: review", () => {
-    expect(guard("review-signoff").appliesTo(reviewState)).toBe(true)
+    expect(guard("review-doc").appliesTo(reviewState)).toBe(true)
     expect(
-      guard("review-signoff").appliesTo(
+      guard("review-doc").appliesTo(
         rest("await-review", { actor: "human", prompt: "x", reviewWindow: true }),
       ),
     ).toBe(false)
     expect(
-      guard("review-signoff").appliesTo(
+      guard("review-doc").appliesTo(
         rest("drafting", { actor: "human", prompt: "x", mode: "review" }),
       ),
     ).toBe(false)
@@ -88,70 +86,19 @@ describe("review-signoff guard", () => {
 
   it("refuses a deleted review doc", async () => {
     const refusal = await checkOf(
-      "review-signoff",
+      "review-doc",
       ctx({ rest: reviewState, fileDeleted: true, file: ".gtd/REVIEW.md" }),
     )
     expect(refusal).toContain("was deleted")
   })
 
-  it("allows a code edit (a comment) even with boxes unticked", async () => {
+  it("allows a sign-off with boxes still unticked — a tick only records that the hunk was read", async () => {
     const refusal = await checkOf(
-      "review-signoff",
+      "review-doc",
       ctx({
         rest: reviewState,
-        hasCodeChange: true,
-        head: Effect.succeed(twoUnticked),
-        worktree: Effect.succeed(twoUnticked),
-      }),
-    )
-    expect(refusal).toBeUndefined()
-  })
-
-  it("allows a note — the doc differs beyond a tick — even with a box left unticked", async () => {
-    const refusal = await checkOf(
-      "review-signoff",
-      ctx({
-        rest: reviewState,
-        head: Effect.succeed(twoUnticked),
-        worktree: Effect.succeed("## C\n- [x] ./a.ts#1\n- [ ] ./b.ts#1 — please rename\n"),
-      }),
-    )
-    expect(refusal).toBeUndefined()
-  })
-
-  it("allows a clean sign-off: every box ticked, no note, no code", async () => {
-    const refusal = await checkOf(
-      "review-signoff",
-      ctx({
-        rest: reviewState,
-        head: Effect.succeed(twoUnticked),
-        worktree: Effect.succeed(allTicked),
-      }),
-    )
-    expect(refusal).toBeUndefined()
-  })
-
-  it("refuses an unfinished review: only tick-flips, a box still unticked, no comment", async () => {
-    const refusal = await checkOf(
-      "review-signoff",
-      ctx({
-        rest: reviewState,
-        head: Effect.succeed(twoUnticked),
-        worktree: Effect.succeed("## C\n- [x] ./a.ts#1\n- [ ] ./b.ts#1\n"),
-      }),
-    )
-    expect(refusal).toContain("1 review item(s) still unticked")
-  })
-
-  it("narrows unticked to `./`-prefixed hunk pointers inside `##` chunks (deliberate behavior change)", async () => {
-    // An indented note-only `- [ ]` outside any recognized file-pointer shape
-    // (no `./` prefix) must NOT block sign-off, unlike the old raw-regex count.
-    const refusal = await checkOf(
-      "review-signoff",
-      ctx({
-        rest: reviewState,
-        head: Effect.succeed("## C\n- [ ] ./a.ts#1\n"),
-        worktree: Effect.succeed("## C\n- [x] ./a.ts#1\n\nNotes:\n- [ ] not a file pointer\n"),
+        head: Effect.succeed("## C\n- [ ] ./a.ts#1\n- [ ] ./b.ts#1\n"),
+        worktree: Effect.succeed("## C\n- [ ] ./a.ts#1\n- [ ] ./b.ts#1\n"),
       }),
     )
     expect(refusal).toBeUndefined()
@@ -780,22 +727,21 @@ describe("enforceStepGuards", () => {
     }
   })
 
-  it("runs guards in registry order — review-signoff, feedback-progress, answer-completeness, require-revert", () => {
+  it("runs guards in registry order — review-doc, feedback-progress, answer-completeness, require-revert", () => {
     expect(stepGuards.map((g) => g.name)).toEqual([
-      "review-signoff",
+      "review-doc",
       "feedback-progress",
       "answer-completeness",
       "require-revert",
     ])
   })
 
-  // While the review checkout window is open, real HEAD sits at the REVIEW
-  // BASE — the review doc the process itself wrote does not exist there. The
-  // pre-turn copy every guard compares against therefore has to be read at the
-  // window's SAVED HEAD (`Rest.windowHead`), or `original` comes back empty,
-  // the sign-off guard sees "the doc differs beyond a checkbox flip", takes the
-  // it-is-a-comment branch, and the unticked count is never reached.
-  describe("with a review checkout window open", () => {
+  it("refuses a deleted review doc while a review checkout window is open, reading the pre-turn copy at windowHead", async () => {
+    // While the review checkout window is open, real HEAD sits at the review
+    // base — a file the process itself wrote does not exist there. The
+    // review-doc guard's `fileDeleted` branch doesn't need to read `head` at
+    // all, but `windowHead` is still threaded through so a future guard that
+    // does can rely on it.
     const WINDOW_HEAD = "refs/worktree/gtd/review-head"
     const reviewState = rest("await-review", {
       actor: "human",
@@ -804,108 +750,27 @@ describe("enforceStepGuards", () => {
       mode: "review",
       reviewWindow: true,
     })
-    // A real review doc: `untickedFiles` only counts file pointers inside a
-    // chunk heading, so the header/base/chunk shape is load-bearing here.
-    const doc = (a: string, b: string): string =>
-      [
-        "# Review: abc1234",
-        "<!-- base: abc1234def5678901234567890123456789abcd -->",
-        "",
-        "## Chunk",
-        "",
-        `- [${a}] ./src/a.ts#1 — first hunk`,
-        `- [${b}] ./src/b.ts#1 — second hunk`,
-        "",
-      ].join("\n")
-    const agentsDoc = doc(" ", " ")
-    const oneTicked = doc("x", " ")
-    const allTicked = doc("x", "x")
-
-    const runGuards = (worktreeDoc: string, windowHead: string | undefined) =>
-      Effect.runPromiseExit(
-        enforceStepGuards({
-          rest: reviewState,
-          file: reviewState.stateDef.file,
-          context: templateContext,
-          changes: [{ path: "REVIEW.md", status: "M" }],
-          windowHead,
-          kind: "commit",
-          attempt: false,
-        }).pipe(
-          Effect.provide(
-            Layer.merge(
-              unusedGitService,
-              Layer.succeed(
-                RepoFiles,
-                // The doc exists at the window's saved head and NOT at real HEAD
-                // (the review base) — the window's whole shape, in one double.
-                repoFilesFrom(
-                  { "REVIEW.md": worktreeDoc },
-                  { [WINDOW_HEAD]: { "REVIEW.md": agentsDoc } },
-                ),
-              ),
-            ),
-          ),
-        ),
-      )
-
-    it("refuses a tick-only pass that still leaves a box unticked", async () => {
-      const exit = await runGuards(oneTicked, WINDOW_HEAD)
-      expect(Exit.isFailure(exit)).toBe(true)
-      if (Exit.isFailure(exit)) {
-        expect(String(exit.cause)).toContain("still unticked and no comment")
-      }
-    })
-
-    it("allows the same pass once every box is ticked — a sign-off", async () => {
-      const exit = await runGuards(allTicked, WINDOW_HEAD)
-      expect(Exit.isSuccess(exit)).toBe(true)
-    })
-
-    it("reading real HEAD instead is what made the gate inert — the unticked pass would pass", async () => {
-      // Pins the regression itself: with no saved head to read, the pre-turn
-      // copy is absent, every tick reads as a note, and nothing is enforced.
-      const exit = await runGuards(oneTicked, undefined)
-      expect(Exit.isSuccess(exit)).toBe(true)
-    })
-  })
-
-  it("a plumbing-only edit under a relocated stateDir is not a code change — the unticked-box check stays reachable", async () => {
-    const reviewState = rest("await-review", {
-      actor: "human",
-      message: "review",
-      file: ".gtd/REVIEW.md",
-      mode: "review",
-      reviewWindow: true,
-    })
-    const twoUnticked = "## C\n- [ ] ./a.ts#1\n- [ ] ./b.ts#1\n"
     const exit = await Effect.runPromiseExit(
       enforceStepGuards({
         rest: reviewState,
         file: reviewState.stateDef.file,
-        context: { ...templateContext, stateDir: "workflow-state" },
-        changes: [{ path: "workflow-state/notes.md", status: "M" }],
-        windowHead: undefined,
+        context: templateContext,
+        changes: [{ path: "REVIEW.md", status: "D" }],
+        windowHead: WINDOW_HEAD,
         kind: "commit",
         attempt: false,
       }).pipe(
         Effect.provide(
           Layer.merge(
             unusedGitService,
-            Layer.succeed(
-              RepoFiles,
-              repoFilesFrom(
-                { ".gtd/REVIEW.md": twoUnticked },
-                { HEAD: { ".gtd/REVIEW.md": twoUnticked } },
-              ),
-            ),
+            Layer.succeed(RepoFiles, repoFilesFrom({}, { [WINDOW_HEAD]: { "REVIEW.md": "doc" } })),
           ),
         ),
       ),
     )
     expect(Exit.isFailure(exit)).toBe(true)
     if (Exit.isFailure(exit)) {
-      expect(String(exit.cause)).toContain("still unticked and no comment")
+      expect(String(exit.cause)).toContain("was deleted")
     }
   })
 

--- a/src/StepGuards.ts
+++ b/src/StepGuards.ts
@@ -10,7 +10,6 @@ import {
   type PendingChange,
 } from "./PatternMachine.js"
 import { unansweredQuestions } from "./OpenQuestions.js"
-import { untickedFiles } from "./ReviewDoc.js"
 import type { ExecutableDecision, ResolvedRest } from "./Edge.js"
 import type { TemplateContext } from "./PatternTemplates.js"
 
@@ -22,8 +21,11 @@ import type { TemplateContext } from "./PatternTemplates.js"
  * may land at all). One registry (`stepGuards`) replaces hand-copied
  * `enforce*` blocks that used to live in `src/program.ts`:
  *
- * - **review-signoff** — at a review window's `mode: review` gate, refuse a
- *   deleted doc or an unfinished tick-only pass with no comment.
+ * - **review-doc** — at a review window's `mode: review` gate, refuse a
+ *   deleted review doc — the review record must survive the step. A tick only
+ *   records that the reviewer has read a hunk; it never gates a land. (Sign-off
+ *   itself is decided elsewhere, by `unified.yaml`'s `deciding` script — no
+ *   guard in this registry has anything to do with it.)
  * - **feedback-progress** — at a `requireProgress` state, refuse deleting the
  *   instructions file without doing (or explicitly declining) the work.
  * - **answer-completeness** — at an `answerGate` `mode: qa` state, refuse
@@ -70,12 +72,12 @@ export interface GuardContext {
    * every guard here reads as "a comment"/"the work was done".
    *
    * Excluding `file` by exact path is load-bearing for a state whose `file:` is
-   * repointed OUTSIDE `stateDir` (an ordinary `vars:` override, e.g. `REVIEW.md`
-   * at the repo root): the reviewer's own edit to the review doc would
-   * otherwise count as a code edit, so the sign-off guard took the
-   * it-is-a-comment branch on every pass and its unticked check was
-   * unreachable. Same shape as the bug in `deciding`'s check script (issue
-   * #128), which also assumed every steering file lives under `.gtd/`.
+   * repointed OUTSIDE `stateDir` (an ordinary `vars:` override, e.g.
+   * `REQUIREMENTS.md` at the repo root): the human's own edit to that file
+   * would otherwise count as a code edit, so the feedback-progress guard's
+   * "was this deletion actually addressed" check could never see the deletion
+   * as bare. Same shape as the bug in `deciding`'s check script (issue #128),
+   * which also assumed every steering file lives under `.gtd/`.
    */
   readonly hasCodeChange: boolean
   readonly template: TemplateContext
@@ -86,11 +88,10 @@ export interface GuardContext {
    * That head is real `HEAD` normally, but the review checkout window's saved
    * head (`Rest.windowHead`) while a window is open: the window has rewound
    * real HEAD to the review base, where a file the process itself added does
-   * not exist yet. Reading `HEAD` there made `original` empty for every review
-   * doc, so the sign-off guard's "only checkbox flips" comparison always found
-   * a difference, took the it's-a-comment branch, and never reached the
-   * unticked count — the tick-completeness gate was inert for exactly the
-   * situation it exists for.
+   * not exist yet. Any guard that runs at a `reviewWindow: true` state MUST
+   * read this field rather than reach for real `HEAD` some other way, or its
+   * "pre-turn copy" would come back empty for every file the review turn
+   * itself wrote.
    */
   readonly head: Effect.Effect<string | undefined, Error>
   /** `file`'s CURRENT working-tree contents — whatever is on disk right now, pre- or post- an external driver's own `format:` run. Cached. */
@@ -110,7 +111,7 @@ export interface StepGuard {
  * `GuardContext.fileDeleted` and `program.ts`'s `steeringModeSteps` ask about a
  * state's `file:`, so they ask it in exactly one place. A deletion is a
  * legitimate step outcome at some states (a review sign-off's bare REVIEW.md
- * deletion) and a refusal at others (see `reviewSignoffGuard`), but either way
+ * deletion) and a refusal at others (see `reviewDocGuard`), but either way
  * there is no file left to format or validate. `steeringModeSteps` widens this
  * same "nothing to format" idea one step further, to a file that was never
  * written at all (not deleted this step, just absent) — that's a separate
@@ -142,34 +143,19 @@ const isPlumbingPath = (path: string, dir: string): boolean =>
 const isCodePath = (path: string, file: string, stateDir: string): boolean =>
   !isPlumbingPath(path, stateDir) && path !== file
 
-/** Normalize every markdown checkbox to a single placeholder so a pure `[ ]`→`[x]` tick is invisible to a text comparison; any surviving difference is a human note. */
-const normalizeCheckboxes = (content: string): string => content.replace(/\[[ xX]\]/g, "[_]")
-
-/** The `mode:` name of gtd's built-in REVIEW.md checkbox validator — the only mode the sign-off guard understands. */
+/** The `mode:` name of gtd's built-in REVIEW.md checkbox format — the only mode the review-doc guard understands. */
 const REVIEW_MODE = "review"
 
-const reviewSignoffGuard: StepGuard = {
-  name: "review-signoff",
+const reviewDocGuard: StepGuard = {
+  name: "review-doc",
   appliesTo: (rest) =>
     isReviewWindowState(rest.def, rest.state) && rest.stateDef.mode === REVIEW_MODE,
   check: (ctx) =>
-    Effect.gen(function* () {
-      if (ctx.fileDeleted) {
-        return `${ctx.file} was deleted at "${ctx.rest.state}" — restore it and tick the boxes to sign off, or leave a note (or edit code) to request changes.`
-      }
-      // A comment — a code edit, or a note (the doc differs beyond a checkbox
-      // flip) — is always a feedback round; let it commit.
-      if (ctx.hasCodeChange) return undefined
-      const original = (yield* ctx.head) ?? ""
-      const current = (yield* ctx.worktree) ?? ""
-      if (normalizeCheckboxes(original) !== normalizeCheckboxes(current)) return undefined
-      // Only checkbox flips, no comment: a sign-off needs EVERY file pointer ticked.
-      const unticked = untickedFiles(current).length
-      if (unticked > 0) {
-        return `${unticked} review item(s) still unticked and no comment at "${ctx.rest.state}" — finish reviewing (tick every box), or leave a note (or edit code) to request a change.`
-      }
-      return undefined
-    }),
+    Effect.succeed(
+      ctx.fileDeleted
+        ? `${ctx.file} was deleted at "${ctx.rest.state}" — restore it, or leave a note (or edit code) to request changes.`
+        : undefined,
+    ),
 }
 
 /** The one-line marker `feedback-collecting` writes when a review round left nothing actionable — the ONLY content that lets a `requireProgress` state's instructions file be deleted without a code change. */
@@ -254,7 +240,7 @@ const requireRevertGuard: StepGuard = {
 
 /** The four step-capture guards, in EVALUATION order — message precedence when two would fire is observable, so this order is the contract (matches the old hand-copied call order, minus the now-removed steering-file guard). */
 export const stepGuards: readonly StepGuard[] = [
-  reviewSignoffGuard,
+  reviewDocGuard,
   feedbackProgressGuard,
   answerCompletenessGuard,
   requireRevertGuard,

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -1098,6 +1098,26 @@ describe("gtd check <mode> <file>", () => {
     expect(lines).toContain("REVIEW.md has no '##' chunks")
   })
 
+  it("a positioned finding prints '<file>:<line>: <message>' with a 1-based line number", async () => {
+    const repo = bareRepo()
+    const trailingTextDoc = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add calculator",
+      "",
+      "- [ ] ./src/calc.ts#1 — legacy trailing note",
+      "",
+    ].join("\n")
+    repo.writeFile("REVIEW.md", trailingTextDoc)
+    const { stdout, exitCode } = await run(repo, "check", "review", "REVIEW.md")
+    expect(exitCode).toBe(1)
+    // The trailing-text pointer is the 0-based 6th line (index 5) — printed 1-based as 6.
+    expect(stdout.trim().split("\n")).toContain(
+      'REVIEW.md:6: Chunk "Add calculator" hunk ./src/calc.ts#1 has text on the pointer line — move the explanation to the line(s) below it',
+    )
+  })
+
   it("an absent file exits 0 with no output", async () => {
     const repo = bareRepo()
     const { stdout, exitCode } = await run(repo, "check", "qa", ".gtd/TODO.md")

--- a/src/program.ts
+++ b/src/program.ts
@@ -48,6 +48,7 @@ import {
 import { deletesFile, enforceStepGuards } from "./StepGuards.js"
 import { unansweredQuestions } from "./OpenQuestions.js"
 import { builtInModeNames, seededValidateCommand, steeringFormatFor } from "./SteeringFormats.js"
+import type { SteeringFinding } from "./SteeringFormat.js"
 import { resolveSteeringMode, renderSteeringCommands, unknownModeMessage } from "./SteeringMode.js"
 import {
   initialStateOf,
@@ -411,11 +412,10 @@ const planLanding = (
     }
 
     // Step-capture guards (edge, not engine — see src/StepGuards.ts): the
-    // review-signoff, feedback-progress, answer-completeness and
-    // require-revert guards, in registry order, each able to refuse before
-    // anything is emitted. `file` is the rest's already-rendered `file:`
-    // hint — rendered once when the snapshot was built, not re-rendered per
-    // guard.
+    // review-doc, feedback-progress, answer-completeness and require-revert
+    // guards, in registry order, each able to refuse before anything is
+    // emitted. `file` is the rest's already-rendered `file:` hint — rendered
+    // once when the snapshot was built, not re-rendered per guard.
     yield* enforceStepGuards({
       rest,
       context: rest.context,
@@ -1067,6 +1067,10 @@ const runValidateCommand = (
  * takes two, but `"review"` there is a distinct, equally wrong, silent
  * mismatch this rejects explicitly rather than accepting).
  */
+/** One `SteeringFinding` printed the way plain-mode `gtd check`/`gtd validate` show it: `<file>:<line+1>: <message>` for a positioned finding (1-based, editors and humans both count from 1), bare `<message>` for a positionless one. */
+const formatFinding = (file: string, finding: SteeringFinding): string =>
+  finding.line !== undefined ? `${file}:${finding.line + 1}: ${finding.message}` : finding.message
+
 const runCheckCommand = (
   mode: string,
   file: string,
@@ -1097,7 +1101,9 @@ const runCheckCommand = (
     const toError = (e: unknown): Error => (e instanceof Error ? e : new Error(String(e)))
     const present = yield* fs.exists(file).pipe(Effect.mapError(toError))
     const errors = present
-      ? format.validate(yield* fs.readFileString(file).pipe(Effect.mapError(toError)))
+      ? format
+          .validate(yield* fs.readFileString(file).pipe(Effect.mapError(toError)))
+          .map((finding) => formatFinding(file, finding))
       : []
 
     if (errors.length === 0) {

--- a/src/testing/EmittedScriptRecognizer.ts
+++ b/src/testing/EmittedScriptRecognizer.ts
@@ -489,12 +489,15 @@ const recognizeGtdCheck = (repo: InMemRepo, block: string): BlockOutcome | undef
   // An ABSENT file has nothing to check and exits 0 — `runCheckCommand`'s own
   // documented behavior. Validating `""` instead would report every "missing
   // header" finding the format has, turning "the reviewer deleted the file"
-  // (a case the sign-off guard owns) into a script failure.
+  // (a case the review-doc guard owns) into a script failure.
   const content = repo.readFile(file)
   if (content === undefined) return { kind: "noop" }
   const findings = format.validate(content)
   if (findings.length > 0) {
-    return { kind: "failed", error: `gtd check ${mode} ${file}: ${findings.join("; ")}` }
+    const formatted = findings.map((f) =>
+      f.line !== undefined ? `${file}:${f.line + 1}: ${f.message}` : f.message,
+    )
+    return { kind: "failed", error: `gtd check ${mode} ${file}: ${formatted.join("; ")}` }
   }
   return { kind: "noop" }
 }

--- a/src/testing/GitTiers.ts
+++ b/src/testing/GitTiers.ts
@@ -738,7 +738,7 @@ export const runGitServiceContract = (makeTier: () => GitTier): void => {
     // every path the reviewed range ADDED out of the index, leaving it
     // untracked but present on disk. An index-based answer calls each of those
     // a deletion (`git diff --name-status <base>` compares base to the INDEX),
-    // which made the review sign-off guard refuse every sign-off whose
+    // which made the review-doc guard refuse every sign-off whose
     // `reviewFile` the window does not pin back. The port answers by CONTENT
     // instead — these four cases are that contract.
     describe("with a base, over paths the index no longer carries", () => {
@@ -765,7 +765,7 @@ export const runGitServiceContract = (makeTier: () => GitTier): void => {
         ])
       })
 
-      it("reports an untracked path REMOVED from disk as D — the deletion the sign-off guard must catch", async () => {
+      it("reports an untracked path REMOVED from disk as D — the deletion the review-doc guard must catch", async () => {
         const head = openWindowOver("- [ ] one\n")
         t.seed.deleteFile("REVIEW.md")
         expect(await runGit(t, (g) => g.changedPaths(head))).toEqual([
@@ -786,8 +786,8 @@ export const runGitServiceContract = (makeTier: () => GitTier): void => {
       // tree legitimately holds CRLF, so a RAW byte comparison calls an
       // untouched file modified — and a spurious `M` on the review doc is a
       // spurious "the human edited something real" (`StepGuards`'s
-      // `hasCodeChange`), which walks the sign-off guard straight past its
-      // unticked-box check. The fake has no filters at all, so it answers
+      // `hasCodeChange`), which flips a clean sign-off onto the feedback edge
+      // — a full re-plan nobody asked for. The fake has no filters at all, so it answers
       // "unchanged" by construction; this pins real git to the same answer.
       it("omits an untracked path that only differs by a clean filter's normalization", async () => {
         t.seed.writeFile(".gitattributes", "* text=auto\n")

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -190,8 +190,8 @@
 # `build.review.await-review` goes to `build.review.deciding`, which CAPTURES
 # the raw material (never interprets it) and routes on the step's shape —
 # THREE edges out of the review tail, not one:
-#   * the SIGN-OFF edge: no comment at all (every box ticked, no REVIEW.md
-#     note, no code edit) -> the diff is a bare REVIEW.md deletion ->
+#   * the SIGN-OFF edge: no comment at all (no REVIEW.md note, no code edit)
+#     -> the diff is a bare REVIEW.md deletion ->
 #     build.squashing -> done (the whole process collapses into one commit).
 #   * the NON-ACTIONABLE edge: some comment exists, but `build.review.collecting`
 #     judges it non-actionable (the human left only an approving remark, e.g. a
@@ -214,9 +214,9 @@
 #     build.review again), not a quick fix-and-re-review; there is no
 #     baseline check on the way back in (`re-unwind` is not an entry, so
 #     `entryGate` never runs on this path).
-# Two dead ends never commit: the review-signoff guard (src/StepGuards.ts)
-# REFUSES a step that leaves a box unticked with no comment (finish reviewing
-# first) and a deleted REVIEW.md (restore it and tick the boxes).
+# One dead end never commits: the review-doc guard (src/StepGuards.ts) REFUSES
+# a deleted REVIEW.md — restore it, or leave a note (or edit code) to request
+# changes. A tick only records that a hunk was read; it never gates a land.
 #
 # The shared health pair (`build.health.check`/`.escalate`, plus its own
 # `build.fix`) no longer serves a feedback loop at all — with the implementer's
@@ -965,10 +965,18 @@ machines:
           - Somewhere in the document: `<!-- base: <%= it.reviewBase %> -->`
           - At least one `## <Chunk Title>` heading, grouping hunks semantically
             (same feature/refactor/fix, even across files) — a short explanation of
-            what changed and why, then one `- [ ] ./path/to/file.ts#42 — note` file
-            pointer per hunk (checkboxes are for the human to tick, not you; every
-            path is `./`-relative, with an optional `#line` and an optional
-            ` — note`).
+            what changed and why, then one file pointer per hunk (checkboxes are
+            for the human to tick, not you; every path is `./`-relative, with an
+            optional `#line`). The pointer's OWN line carries nothing but the
+            pointer — no note, no dash. Its explanation goes on the line(s)
+            beneath it instead:
+
+                - [ ] ./path/to/file.ts#42
+                  what this hunk does, with room to run to several lines
+
+            Text after the pointer token on the pointer's own line is a
+            validation error, not just a style nit — an older-format doc like
+            `- [ ] ./path/to/file.ts#42 — note` is UNLANDABLE.
 
           This prompt carries no diff — read the changes yourself. The range runs
           from `<%= it.reviewBase %>` to the working tree (committed turns plus
@@ -993,10 +1001,10 @@ machines:
         #
         # Every human step here routes to `deciding`, which decides sign-off vs.
         # feedback from the step's CONTENT (a comment, not a tick). Ticking a box
-        # only records "I reviewed this hunk". Two dead ends can't be told apart by a
-        # file-pattern edge, so the review-signoff guard (`src/StepGuards.ts`)
-        # catches them BEFORE the step commits and refuses: an unfinished
-        # review (a box still `- [ ]` with no comment) and a deleted REVIEW.md.
+        # only records "I reviewed this hunk" — it never gates a land, whatever the
+        # boxes say. The one dead end that CAN'T be told apart by a file-pattern
+        # edge is a deleted REVIEW.md, so the review-doc guard
+        # (`src/StepGuards.ts`) catches it BEFORE the step commits and refuses.
         reviewWindow: true
         message: |
           `<%= it.vars.reviewFile %>` holds the review record for the process — one
@@ -1006,9 +1014,9 @@ machines:
 
           When you've been through the whole diff, run `gtd land`:
 
-          - **Sign off** — tick EVERY box and leave no comment — no note in
+          - **Sign off** — leave no comment — no note in
             `<%= it.vars.reviewFile %>`, no code edit — to collapse the process into
-            one commit (**build.squashing**).
+            one commit (**build.squashing**), whatever the boxes say.
           - **Request changes** — leave a comment: a note on a
             `<%= it.vars.reviewFile %>` line, or a direct code edit — to send a FULL
             development lap (**review.deciding** → **review.collecting** →
@@ -1019,8 +1027,7 @@ machines:
             genuinely non-actionable comment (an approving remark with no code
             edit) skips the lap and signs off straight away.
 
-          Stepping with a box still unticked and no comment is refused (finish
-          reviewing first); so is deleting `<%= it.vars.reviewFile %>`.
+          Deleting `<%= it.vars.reviewFile %>` is refused.
         on:
           "* **": deciding
 
@@ -1038,9 +1045,10 @@ machines:
           #!/usr/bin/env bash
           # gtd check turn — decide the human's review step from its CONTENT. HEAD is
           # the human's `await-review -> deciding` commit; HEAD^ is the `reviewing`
-          # commit that wrote the agent's original REVIEW.md (the sign-off gate
-          # refuses an incomplete step, so `deciding` is entered exactly once per
-          # round — nothing commits in between). It is FEEDBACK when the human left
+          # commit that wrote the agent's original REVIEW.md (`await-review`'s single
+          # `"* **": deciding` edge means EVERY human step there lands here, so
+          # `deciding` is entered exactly once per round — nothing else commits in
+          # between). It is FEEDBACK when the human left
           # a comment: a note in REVIEW.md (any edit beyond a "[ ]"->"[x]" tick) OR a
           # hand-edit to any file this round outside the declared stateDir or the
           # state's own reviewFile (which is var-configurable and may live outside

--- a/tests/integration/features/abandon.feature
+++ b/tests/integration/features/abandon.feature
@@ -88,7 +88,8 @@ Feature: gtd abandon — end the process underway without completing it
 
       ## Add calc.ts
 
-      - [ ] ./src/calc.ts#1 — new export
+      - [ ] ./src/calc.ts#1
+      new export
       """
     When I run gtd land
     Then it succeeds

--- a/tests/integration/features/check.feature
+++ b/tests/integration/features/check.feature
@@ -61,7 +61,8 @@ Feature: gtd check <mode> <file> — the standalone leaf validator
 
       ## Add thing.ts
 
-      - [ ] ./src/thing.ts#1 — new export
+      - [ ] ./src/thing.ts#1
+      new export
       """
     When I run gtd with args "check review REVIEW.md"
     Then it succeeds
@@ -75,7 +76,8 @@ Feature: gtd check <mode> <file> — the standalone leaf validator
 
       ## Add thing.ts
 
-      - [ ] ./src/thing.ts#1 — new export
+      - [ ] ./src/thing.ts#1
+      new export
       """
     When I run gtd with args "check review REVIEW.md"
     Then it fails

--- a/tests/integration/features/deciding-path-literal.feature
+++ b/tests/integration/features/deciding-path-literal.feature
@@ -39,7 +39,8 @@ Feature: the review scripts exclude stateDir/reviewFile by literal path, not by 
       <!-- base: 0000000 -->
 
       ## calc
-      - [ ] ./src/calc.ts#1 — new add function
+      - [ ] ./src/calc.ts#1
+      new add function
       """
     And ".gtd/REVIEW.md" is modified to:
       """
@@ -48,7 +49,8 @@ Feature: the review scripts exclude stateDir/reviewFile by literal path, not by 
       <!-- base: 0000000 -->
 
       ## calc
-      - [x] ./src/calc.ts#1 — new add function
+      - [x] ./src/calc.ts#1
+      new add function
       """
     And a file "agtd/notes.md" with:
       """

--- a/tests/integration/features/default-workflow.feature
+++ b/tests/integration/features/default-workflow.feature
@@ -186,7 +186,8 @@ Feature: The bundled unified workflow — one flow, end to end
 
       ## Add greeter.ts
 
-      - [ ] ./src/greeter.ts#1 — new export
+      - [ ] ./src/greeter.ts#1
+      new export
       """
     When I run gtd land
     Then it succeeds
@@ -195,7 +196,7 @@ Feature: The bundled unified workflow — one flow, end to end
     Then it succeeds
     And stdout contains "State: build.review.await-review"
 
-    # await-review: tick every box, leave no comment -> sign-off
+    # await-review: leave no comment -> sign-off (ticking the box just records that it was read)
     Given ".gtd/REVIEW.md" is modified to:
       """
       # Review: abc1234
@@ -203,7 +204,8 @@ Feature: The bundled unified workflow — one flow, end to end
 
       ## Add greeter.ts
 
-      - [x] ./src/greeter.ts#1 — new export
+      - [x] ./src/greeter.ts#1
+      new export
       """
     When I run gtd land
     Then it succeeds
@@ -242,7 +244,8 @@ Feature: The bundled unified workflow — one flow, end to end
       <!-- base: abc1234def5678901234567890123456789abcd -->
 
       ## calc
-      - [ ] ./src/calc.ts#1 — new add function
+      - [ ] ./src/calc.ts#1
+      new add function
       """
     # await-review: a hand-edit to real code is feedback
     Given a file "src/calc.ts" with:
@@ -308,7 +311,8 @@ Feature: The bundled unified workflow — one flow, end to end
       <!-- base: abc1234def5678901234567890123456789abcd -->
 
       ## calc
-      - [ ] ./src/calc.ts#1 — new add function
+      - [ ] ./src/calc.ts#1
+      new add function
       """
     # await-review: a hand-edit to real code is feedback
     Given a file "src/calc.ts" with:
@@ -378,7 +382,8 @@ Feature: The bundled unified workflow — one flow, end to end
       <!-- base: abc1234def5678901234567890123456789abcd -->
 
       ## calc
-      - [ ] ./src/calc.ts#1 — new add function
+      - [ ] ./src/calc.ts#1
+      new add function
       """
     # await-review: a note is still feedback-shaped from deciding's own
     # point of view (any REVIEW.md edit beyond a tick), even though it's just
@@ -389,7 +394,8 @@ Feature: The bundled unified workflow — one flow, end to end
       <!-- base: abc1234def5678901234567890123456789abcd -->
 
       ## calc
-      - [x] ./src/calc.ts#1 — new add function — nice work, looks great
+      - [x] ./src/calc.ts#1
+      new add function — nice work, looks great
       """
     When I run gtd land
     Then it succeeds
@@ -494,7 +500,8 @@ Feature: The bundled unified workflow — one flow, end to end
       <!-- base: abc1234def5678901234567890123456789abcd -->
 
       ## Chunk
-      - [x] ./src/thing.ts#1 — looks great, nice work
+      - [x] ./src/thing.ts#1
+      looks great, nice work
       """
     And the file ".gtd/REVIEW.md" is deleted
     And the working tree is committed as "gtd(human): build.review.await-review → build.review.deciding"
@@ -1052,7 +1059,7 @@ Feature: The bundled unified workflow — one flow, end to end
     And the last commit subject is "gtd(check): build.health.check → build.health.escalate"
 
   @inmem
-  Scenario: deleting REVIEW.md at await-review is refused — sign off by ticking every box, not by deleting
+  Scenario: deleting REVIEW.md at await-review is refused — sign off by leaving no comment, not by deleting
     Given a test project
     And the workflow
     And a commit "gtd(check): build.review.await-review" that adds ".gtd/REVIEW.md" with:
@@ -1076,7 +1083,7 @@ Feature: The bundled unified workflow — one flow, end to end
     And the commit count is unchanged
 
   @inmem
-  Scenario: stepping at await-review with a box still unticked and no comment is refused — finish reviewing first
+  Scenario: a sign-off lands even with a box still unticked — a tick only records that a hunk was read
     Given a test project
     And the workflow
     And a commit "gtd(check): build.review.await-review" that adds ".gtd/REVIEW.md" with:
@@ -1100,12 +1107,13 @@ Feature: The bundled unified workflow — one flow, end to end
       - [x] ./src/a.ts#1
       - [ ] ./src/b.ts#1
       """
-    And I record the commit count
     When I run gtd land
-    Then it fails
-    And stderr contains "still unticked and no comment"
-    # Nothing committed — the reviewer stays at the gate.
-    And the commit count is unchanged
+    Then it succeeds
+    And the last commit subject is "gtd(human): build.review.await-review → build.review.deciding"
+    Given the file ".gtd/REVIEW.md" is deleted
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(check): build.review.deciding → build.squashing"
 
   @inmem
   Scenario: at await-review, gtd next surfaces the sign-off vs. feedback contract in its human-gate message
@@ -1122,9 +1130,9 @@ Feature: The bundled unified workflow — one flow, end to end
       """
     When I run gtd next
     Then it succeeds
-    And stdout contains "**Sign off** — tick EVERY box and leave no comment"
+    And stdout contains "**Sign off** — leave no comment"
     And stdout contains "**Request changes** — leave a comment"
-    And stdout contains "no comment is refused"
+    And stdout contains "Deleting `.gtd/REVIEW.md` is refused."
 
   @inmem
   Scenario: a code edit at await-review is feedback — it routes to review-deciding (which turns it into a fix + re-review round)

--- a/tests/integration/features/lsp.feature
+++ b/tests/integration/features/lsp.feature
@@ -191,7 +191,8 @@ Feature: gtd lsp — the steering-file LSP server (stdio)
       ## Add calculator
 
       - [ ] ./src/calc.ts#1
-      - [x] ./src/calc.ts#5 — subtract
+      - [x] ./src/calc.ts#5
+        subtract
       """
     Then the LSP response has no error
     And the LSP response result points to "src/calc.ts" at line 4
@@ -211,7 +212,8 @@ Feature: gtd lsp — the steering-file LSP server (stdio)
 
       ## Add budget alerts
 
-      - [ ] ./src/server/email/budget-threshold.ts#31 — non-obvious import
+      - [ ] ./src/server/email/budget-threshold.ts#31
+        non-obvious import
       """
     Then the LSP response has no error
     And the LSP response result points to "src/server/email/budget-threshold.ts" at line 30

--- a/tests/integration/features/machine-memory.feature
+++ b/tests/integration/features/machine-memory.feature
@@ -250,11 +250,12 @@ Feature: Machine-scoped memory — a computed <scope>#<hash> key, not an authore
 
       ## Add widget.ts
 
-      - [ ] ./src/widget.ts#1 — new export
+      - [ ] ./src/widget.ts#1
+      new export
       """
     Given a commit "gtd(human): build.review.deciding" that adds "src/marker-2.txt" with:
       """
-      the human's await-review turn, ticking every box with no comment
+      the human's await-review turn, no comment
       """
     When I run gtd next with "--json"
     Then it succeeds
@@ -305,7 +306,8 @@ Feature: Machine-scoped memory — a computed <scope>#<hash> key, not an authore
 
       ## Add widget.ts
 
-      - [ ] ./src/widget.ts#1 — new export
+      - [ ] ./src/widget.ts#1
+      new export
       """
     Given a commit "gtd(human): build.review.deciding" that adds ".gtd/REVIEW_RAW.md" with:
       """
@@ -382,7 +384,8 @@ Feature: Machine-scoped memory — a computed <scope>#<hash> key, not an authore
 
       ## Add widget.ts
 
-      - [ ] ./src/widget.ts#1 — new export
+      - [ ] ./src/widget.ts#1
+      new export
       """
     Given a commit "gtd(human): build.review.deciding" that adds ".gtd/REVIEW_RAW.md" with:
       """
@@ -429,11 +432,12 @@ Feature: Machine-scoped memory — a computed <scope>#<hash> key, not an authore
 
       ## Add widget.ts
 
-      - [ ] ./src/widget.ts#1 — new export
+      - [ ] ./src/widget.ts#1
+      new export
       """
     Given a commit "gtd(human): build.review.deciding" that adds "src/marker-2.txt" with:
       """
-      the human's await-review turn, ticking every box with no comment
+      the human's await-review turn, no comment
       """
     # deciding's clean sign-off short-circuits straight to build.squashing —
     # simulated the same way the sibling scenarios above simulate it.
@@ -492,11 +496,12 @@ Feature: Machine-scoped memory — a computed <scope>#<hash> key, not an authore
 
       ## Repair
 
-      - [ ] ./src/repair.ts#1 — new export
+      - [ ] ./src/repair.ts#1
+      new export
       """
     Given a commit "gtd(human): build.review.deciding" that adds "src/marker.txt" with:
       """
-      the human's await-review turn, ticking every box with no comment
+      the human's await-review turn, no comment
       """
     Given a commit "gtd(check): build.squashing" that adds ".gtd/COMMIT_MSG.md" with:
       """
@@ -594,11 +599,12 @@ Feature: Machine-scoped memory — a computed <scope>#<hash> key, not an authore
 
       ## Add widget.ts
 
-      - [ ] ./src/widget.ts#1 — new export
+      - [ ] ./src/widget.ts#1
+      new export
       """
     Given a commit "gtd(human): build.review.deciding" that adds "src/marker-2.txt" with:
       """
-      the human's await-review turn, ticking every box with no comment
+      the human's await-review turn, no comment
       """
     Given a commit "gtd(check): build.squashing" that adds ".gtd/COMMIT_MSG.md" with:
       """

--- a/tests/integration/features/prompt-diff-ranges.feature
+++ b/tests/integration/features/prompt-diff-ranges.feature
@@ -47,7 +47,8 @@ Feature: Prompts carry diff RANGES, never diff CONTENT
       <!-- base: 0000000 -->
 
       ## calc
-      - [ ] ./src/calc.ts#1 — new add function
+      - [ ] ./src/calc.ts#1
+      new add function
       """
     And a commit "gtd(human): build.review.await-review → build.review.deciding" that adds ".gtd/REVIEW.md" with:
       """
@@ -56,7 +57,8 @@ Feature: Prompts carry diff RANGES, never diff CONTENT
       <!-- base: 0000000 -->
 
       ## calc
-      - [x] ./src/calc.ts#1 — new add function — also handle negatives
+      - [x] ./src/calc.ts#1
+      new add function — also handle negatives
       """
     And I mark the current commit as "review-commit"
     When I run gtd next with "--json"

--- a/tests/integration/features/retained-history.feature
+++ b/tests/integration/features/retained-history.feature
@@ -101,7 +101,8 @@ Feature: gtd restore — undo a squash (or an abandon) by hard-resetting to the 
 
       ## Add thing.ts
 
-      - [ ] ./src/thing.ts#1 — new export
+      - [ ] ./src/thing.ts#1
+      new export
       """
     When I run gtd land
     Then it succeeds
@@ -113,7 +114,8 @@ Feature: gtd restore — undo a squash (or an abandon) by hard-resetting to the 
 
       ## Add thing.ts
 
-      - [x] ./src/thing.ts#1 — new export
+      - [x] ./src/thing.ts#1
+      new export
       """
     When I run gtd land
     Then it succeeds
@@ -298,7 +300,8 @@ Feature: gtd restore — undo a squash (or an abandon) by hard-resetting to the 
 
       ## Add thing.ts
 
-      - [ ] ./src/thing.ts#1 — new export
+      - [ ] ./src/thing.ts#1
+      new export
       """
     When I run gtd land
     Then it succeeds
@@ -310,7 +313,8 @@ Feature: gtd restore — undo a squash (or an abandon) by hard-resetting to the 
 
       ## Add thing.ts
 
-      - [x] ./src/thing.ts#1 — new export
+      - [x] ./src/thing.ts#1
+      new export
       """
     When I run gtd land
     Then it succeeds
@@ -421,7 +425,8 @@ Feature: gtd restore — undo a squash (or an abandon) by hard-resetting to the 
 
       ## Add one.ts
 
-      - [ ] ./src/one.ts#1 — new export
+      - [ ] ./src/one.ts#1
+      new export
       """
     When I run gtd land
     Then it succeeds
@@ -433,7 +438,8 @@ Feature: gtd restore — undo a squash (or an abandon) by hard-resetting to the 
 
       ## Add one.ts
 
-      - [x] ./src/one.ts#1 — new export
+      - [x] ./src/one.ts#1
+      new export
       """
     When I run gtd land
     Then it succeeds
@@ -533,7 +539,8 @@ Feature: gtd restore — undo a squash (or an abandon) by hard-resetting to the 
 
       ## Add two.ts
 
-      - [ ] ./src/two.ts#1 — new export
+      - [ ] ./src/two.ts#1
+      new export
       """
     When I run gtd land
     Then it succeeds
@@ -545,7 +552,8 @@ Feature: gtd restore — undo a squash (or an abandon) by hard-resetting to the 
 
       ## Add two.ts
 
-      - [x] ./src/two.ts#1 — new export
+      - [x] ./src/two.ts#1
+      new export
       """
     When I run gtd land
     Then it succeeds

--- a/tests/integration/features/review-feedback-guards.feature
+++ b/tests/integration/features/review-feedback-guards.feature
@@ -44,10 +44,8 @@ Feature: Review feedback — capture, classification, and the loop-back guards
       """
     # The committed REVIEW.md already carries a non-`./`-prefixed "- [ ]" note,
     # untouched by the human's edit below. Only the real file pointer is
-    # ticked, with no other comment — this used to be refused (the old raw
-    # regex counted the note's box too); now `untickedFiles` counts only
-    # recognized `./`-prefixed hunk pointers inside `##` chunks, so it signs
-    # off cleanly.
+    # ticked, with no other comment — it signs off cleanly, because the
+    # review-doc guard no longer reads tick state at all.
     And a commit "gtd(check): build.review.await-review" that adds ".gtd/REVIEW.md" with:
       """
       # Review: abc1234
@@ -59,7 +57,8 @@ Feature: Review feedback — capture, classification, and the loop-back guards
       Follow-up ideas, not part of this review:
       - [ ] consider renaming the module later
 
-      - [ ] ./src/calc.ts#1 — new add function
+      - [ ] ./src/calc.ts#1
+      new add function
       """
     Given ".gtd/REVIEW.md" is modified to:
       """
@@ -72,7 +71,8 @@ Feature: Review feedback — capture, classification, and the loop-back guards
       Follow-up ideas, not part of this review:
       - [ ] consider renaming the module later
 
-      - [x] ./src/calc.ts#1 — new add function
+      - [x] ./src/calc.ts#1
+      new add function
       """
     When I run gtd land
     Then it succeeds
@@ -92,7 +92,8 @@ Feature: Review feedback — capture, classification, and the loop-back guards
       <!-- base: 0000000 -->
 
       ## calc
-      - [ ] ./src/calc.ts#1 — new add function
+      - [ ] ./src/calc.ts#1
+      new add function
       """
     # await-review: the human leaves a note (a change beyond a tick) → feedback
     Given ".gtd/REVIEW.md" is modified to:
@@ -102,7 +103,8 @@ Feature: Review feedback — capture, classification, and the loop-back guards
       <!-- base: 0000000 -->
 
       ## calc
-      - [x] ./src/calc.ts#1 — new add function — rename `add` to `sum`
+      - [x] ./src/calc.ts#1
+      new add function — rename `add` to `sum`
       """
     When I run gtd land
     Then it succeeds

--- a/tests/integration/features/review-signoff-outside-gtd.feature
+++ b/tests/integration/features/review-signoff-outside-gtd.feature
@@ -18,7 +18,7 @@ Feature: Review sign-off reaches build.squashing even when reviewFile lives outs
   AGENTS.md and review-feedback-guards.feature, which simulate this same state
   for the pure-engine routing rules instead).
 
-  Scenario: a clean sign-off (all boxes ticked, no comment, no code edit) reaches build.squashing, not build.review.collecting
+  Scenario: a clean sign-off (no comment, no code edit) reaches build.squashing, not build.review.collecting
     Given a test project
     And a gtd config file at ".gtdrc" with:
       """
@@ -32,7 +32,8 @@ Feature: Review sign-off reaches build.squashing even when reviewFile lives outs
       <!-- base: 0000000 -->
 
       ## calc
-      - [ ] ./src/calc.ts#1 — new add function
+      - [ ] ./src/calc.ts#1
+      new add function
       """
     And a commit "gtd(human): build.review.await-review → build.review.deciding" that adds "REVIEW.md" with:
       """
@@ -41,7 +42,8 @@ Feature: Review sign-off reaches build.squashing even when reviewFile lives outs
       <!-- base: 0000000 -->
 
       ## calc
-      - [x] ./src/calc.ts#1 — new add function
+      - [x] ./src/calc.ts#1
+      new add function
       """
     When I run gtd next with "--json"
     And I execute the printed check script
@@ -78,7 +80,8 @@ Feature: Review sign-off reaches build.squashing even when reviewFile lives outs
       <!-- base: 0000000 -->
 
       ## calc
-      - [ ] ./src/calc.ts#1 — new add function
+      - [ ] ./src/calc.ts#1
+      new add function
       """
     And a commit "gtd(human): build.review.await-review → build.review.deciding" that adds "REVIEW.md" with:
       """
@@ -87,7 +90,8 @@ Feature: Review sign-off reaches build.squashing even when reviewFile lives outs
       <!-- base: 0000000 -->
 
       ## calc
-      - [x] ./src/calc.ts#1 — new add function
+      - [x] ./src/calc.ts#1
+      new add function
       """
     When I run gtd next with "--json"
     And I execute the printed check script

--- a/tests/integration/features/review-window-untracked.feature
+++ b/tests/integration/features/review-window-untracked.feature
@@ -12,13 +12,13 @@ Feature: An open review window reports untracked-but-present files by content, n
   `src/Git.ts`) — absent at the base is `A`, different bytes are `M`, identical
   bytes are no change at all.
 
-  Without that, the review-signoff guard (`src/StepGuards.ts`) saw a phantom
-  `D <reviewFile>` and refused EVERY sign-off with "was deleted — restore it and
-  tick the boxes", with the file sitting untouched in the working tree. The
-  bundled `.gtd/REVIEW.md` hid it: `.gtd` is the one directory the window pins
-  back into the index (`buildOpenWindowScript`'s `restoreStagedFrom`), so the
-  doc stays TRACKED there. A `reviewFile` repointed to the repo root — an
-  ordinary `vars:` override — is not pinned, and so was unlandable.
+  Without that, the review-doc guard (`src/StepGuards.ts`) saw a phantom
+  `D <reviewFile>` and refused EVERY sign-off with "was deleted — restore it",
+  with the file sitting untouched in the working tree. The bundled
+  `.gtd/REVIEW.md` hid it: `.gtd` is the one directory the window pins back
+  into the index (`buildOpenWindowScript`'s `restoreStagedFrom`), so the doc
+  stays TRACKED there. A `reviewFile` repointed to the repo root — an ordinary
+  `vars:` override — is not pinned, and so was unlandable.
 
   Every scenario here is live, because the phantom deletion is real git's index
   behaviour: the in-memory double compares the base tree to the worktree
@@ -26,6 +26,16 @@ Feature: An open review window reports untracked-but-present files by content, n
   (`InMemRepo.changedPathsWorktree`), so an @inmem scenario cannot fail on this.
   The contract test that pins the two tiers together on it lives in
   `src/testing/GitTiers.ts`.
+
+  Coverage gap: the review-doc guard's `fileDeleted` branch is the only thing
+  it checks now, and deciding that needs no `head` read at all — so the
+  deletion scenario below no longer exercises `GuardContext.head`'s
+  `windowHead` read. That read's production plumbing is untouched (kept for a
+  future guard, see `src/StepGuards.ts`), but this file's tick-completeness
+  scenario was its only regression coverage, and it is gone along with the
+  guard's tick check. No in-memory scenario can replace it either — the
+  in-memory double never had the phantom-deletion behaviour this file exists
+  for.
 
   Background:
     Given a test project
@@ -46,7 +56,8 @@ Feature: An open review window reports untracked-but-present files by content, n
       <!-- base: 0000000 -->
 
       ## calc
-      - [ ] ./src/calc.ts#1 — new add function
+      - [ ] ./src/calc.ts#1
+      new add function
       """
 
   Scenario: the review doc the window left untracked is not pending at all — it is present and unchanged
@@ -61,7 +72,7 @@ Feature: An open review window reports untracked-but-present files by content, n
     And stdout does not contain "D REVIEW.md"
     And the git status contains "?? REVIEW.md"
 
-  Scenario: ticking every box signs off — the reviewer's edit reads as a modification
+  Scenario: a tick with no comment signs off — the reviewer's edit reads as a modification
     Given I run gtd land
     And "REVIEW.md" is modified to:
       """
@@ -70,7 +81,8 @@ Feature: An open review window reports untracked-but-present files by content, n
       <!-- base: 0000000 -->
 
       ## calc
-      - [x] ./src/calc.ts#1 — new add function
+      - [x] ./src/calc.ts#1
+      new add function
       """
     When I run gtd land
     Then it succeeds
@@ -84,43 +96,5 @@ Feature: An open review window reports untracked-but-present files by content, n
     Then it fails
     And stderr contains "was deleted"
     # A refusal emits no script, so the window stays open for the reviewer to
-    # restore the file and tick.
-    And the git ref "refs/worktree/gtd/review-head" exists
-
-  # The tick-completeness half of the same guard, through an OPEN window and a
-  # root-level reviewFile — the two things that each independently made it
-  # unreachable. It compares the doc on disk against its PRE-TURN committed copy,
-  # which lives at the window's saved head, not at real HEAD (rewound to the
-  # review base, where the doc does not exist yet); and "did the human edit
-  # something other than gtd's own files" must not count the reviewFile itself
-  # just because it sits outside `.gtd/`.
-  Scenario: a box left unticked with no comment is refused — finish reviewing first
-    # Two hunks to review, so ticking one still leaves the pass unfinished.
-    Given "REVIEW.md" is modified to:
-      """
-      # Review: abc1234
-
-      <!-- base: 0000000 -->
-
-      ## calc
-      - [ ] ./src/calc.ts#1 — new add function
-      - [ ] ./src/calc.ts#2 — its export
-      """
-    And I run gtd land
-    # Tick the first hunk only, leave the second, add no note and no code edit.
-    And "REVIEW.md" is modified to:
-      """
-      # Review: abc1234
-
-      <!-- base: 0000000 -->
-
-      ## calc
-      - [x] ./src/calc.ts#1 — new add function
-      - [ ] ./src/calc.ts#2 — its export
-      """
-    And I record the commit count
-    When I run gtd land
-    Then it fails
-    And stderr contains "still unticked and no comment"
-    And the commit count is unchanged
+    # restore the file.
     And the git ref "refs/worktree/gtd/review-head" exists

--- a/tests/integration/features/review-window.feature
+++ b/tests/integration/features/review-window.feature
@@ -49,7 +49,8 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
       <!-- base: 0000000 -->
 
       ## calc
-      - [ ] ./src/calc.ts#1 — new add function
+      - [ ] ./src/calc.ts#1
+      new add function
       """
 
   @inmem
@@ -104,12 +105,12 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
     Then it fails
     And stderr contains "was deleted"
     # A refusal emits no script at all, so the window stays exactly as it was —
-    # the reviewer can restore the file and tick.
+    # the reviewer can restore the file.
     And the git ref "refs/worktree/gtd/review-head" exists
     And the last commit subject is "chore: init gtd workflow"
 
   @inmem
-  Scenario: Ticking every box with no comment signs off — the window closes and routes to build.review.deciding
+  Scenario: No comment signs off, boxes ticked along the way or not — the window closes and routes to build.review.deciding
     Given I run gtd land
     And ".gtd/REVIEW.md" is modified to:
       """
@@ -118,12 +119,13 @@ Feature: Review checkout window — the pending review diff surfaces in the edit
       <!-- base: 0000000 -->
 
       ## calc
-      - [x] ./src/calc.ts#1 — new add function
+      - [x] ./src/calc.ts#1
+      new add function
       """
     When I run gtd land
     Then it succeeds
-    # Every box ticked, no note, no code edit — a clean sign-off hands to the
-    # deterministic check, which collapses the process from there.
+    # No note, no code edit — a clean sign-off hands to the deterministic
+    # check, which collapses the process from there.
     And the last commit subject is "gtd(human): build.review.await-review → build.review.deciding"
     And the git ref "refs/worktree/gtd/review-head" does not exist
 

--- a/tests/integration/features/state-dir.feature
+++ b/tests/integration/features/state-dir.feature
@@ -24,7 +24,8 @@ Feature: The require-revert guard exempts a relocated plumbing directory (it.sta
       <!-- base: abc1234def5678901234567890123456789abcd -->
 
       ## calc
-      - [ ] ./src/calc.ts#1 — new add function
+      - [ ] ./src/calc.ts#1
+      new add function
       """
     # await-review: the human's own step leaves a note on the review doc and
     # writes a scratch note under the relocated plumbing directory — never
@@ -35,7 +36,8 @@ Feature: The require-revert guard exempts a relocated plumbing directory (it.sta
       <!-- base: abc1234def5678901234567890123456789abcd -->
 
       ## calc
-      - [x] ./src/calc.ts#1 — new add function — looks fine, but see my note
+      - [x] ./src/calc.ts#1
+      new add function — looks fine, but see my note
       """
     And a file "workflow-state/notes.md" with:
       """

--- a/tests/integration/features/styled-steering.feature
+++ b/tests/integration/features/styled-steering.feature
@@ -72,8 +72,10 @@ Feature: the voice survives the parsers it shares a prompt with (package 03, tas
       **New pure function, no side effects.** Confirm the signature and the
       one test that pins it.
 
-      - [ ] ./src/calc.ts#1 — exported `add`, two `number` params
-      - [ ] ./src/calc.test.ts#1 — happy-path coverage only
+      - [ ] ./src/calc.ts#1
+        Exported `add`, two `number` params.
+      - [ ] ./src/calc.test.ts#1
+        Happy-path coverage only.
       """
     When I run gtd land
     Then it succeeds

--- a/tests/integration/features/validate.feature
+++ b/tests/integration/features/validate.feature
@@ -86,7 +86,8 @@ Feature: gtd validate — self-validating the resolved rest's steering file
 
       ## Add thing.ts
 
-      - [ ] ./src/thing.ts#1 — new export
+      - [ ] ./src/thing.ts#1
+      new export
       """
     When I run gtd with args "validate"
     Then it succeeds
@@ -101,7 +102,8 @@ Feature: gtd validate — self-validating the resolved rest's steering file
 
       ## Add thing.ts
 
-      - [ ] ./src/thing.ts#1 — new export
+      - [ ] ./src/thing.ts#1
+      new export
       """
     When I run gtd with args "validate"
     Then it fails


### PR DESCRIPTION
Ticking a review-doc box only ever recorded "I read this hunk" — it never carried decision weight, since sign-off vs. feedback was already routed by `deciding`'s content check (a note or code edit means feedback). Requiring every box ticked before a sign-off could land was a second, redundant gate riding on the same pre-turn-head/`hasCodeChange` plumbing that the content check depends on, so a bug in either exemption (a `reviewFile` outside `stateDir`, a relocated plumbing dir) could make the tick gate falsely refuse a clean sign-off or go silently inert. Collapsing to one gate removes that failure mode.

## Changes

- Renamed `reviewSignoffGuard` to `reviewDocGuard` (`src/StepGuards.ts`) and dropped its checkbox-completeness check; it now only refuses a deleted review file. `untickedFiles` and the checkbox-normalizing comparison it depended on are gone from `src/ReviewDoc.ts`.
- **REVIEW.md format:** a hunk's explanation now belongs on the line(s) below its pointer, not trailing the same line — this makes room for multi-paragraph notes. Text trailing the pointer token on its own line is now a validation error instead of being silently accepted as a same-line note.
- `SteeringFormat.validate` returns positioned `SteeringFinding[]` (`{ message, line? }`) instead of bare strings, so `gtd validate` / `gtd check` print `<file>:<line>: <message>` and the LSP underlines the offending pointer line instead of the whole document.
- Updated `AGENTS.md`, `README.md`, `unified.yaml`'s reviewer-facing prompts, and the affected feature files/tests to match: reviewing is now purely note/code-driven, and ticking boxes is optional bookkeeping with no gate behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)