### PR TITLE
feat(workflow): move package merge authority to architecture.author

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -182,8 +182,8 @@ commit. The input's intent isn't lost: it survives in history for
 `design.triage` to read.
 
 **Concern**: One ordered, independently greenable unit of work `design.triage`
-groups the process's start diff into — the unit `architecture.decompose` later
-turns 1:1 into a package.
+groups the process's start diff into — a unit `architecture.author` may later
+coarsen by re-merging it with another concern whose file footprint coincides.
 
 **Product concern** / **Technical concern**: A concern's classification — a
 product concern is a user-facing/requirements decision, raised (if it has an
@@ -219,7 +219,8 @@ file, carrying candidate answers as checkboxes plus a free-text slot. It becomes
 an **answered question** by moving under `## Answered Questions` as prose.
 
 **Package**: One independently buildable and independently greenable slice a
-concern turns into — `architecture.decompose`'s output, one file per concern.
+concern turns into — `architecture.decompose`'s output, one file per concern as
+it stands after `architecture.author`'s possible re-merging.
 
 **Satisfied package**: A package whose acceptance criteria are already met
 before its build turn runs — recorded as evidence in `.gtd/SATISFIED.md` rather

--- a/README.md
+++ b/README.md
@@ -165,12 +165,13 @@ check+answer gate shape, again skipping the human stop when nothing is open),
 deleting `.gtd/REQUIREMENTS.md` once its content is folded in. Once those are
 settled, `architecture.decompose` is a purely mechanical write-out — **one
 package file per concern**, in the settled order, with no merge/split judgement
-of its own (that already happened in triage's grouping) — handing off to the
-per-package build queue: each package (a set of independent tasks a single build
-turn fans out to parallel subagents) runs its own test loop and a per-package
-**agentic review** that verifies it against its own spec. A package whose work
-already landed (an earlier package's fix turn pulled it in) is not a dead end:
-the build turn records per-criterion evidence in `.gtd/SATISFIED.md` instead of
+of its own (triage grouped the concerns, and `architecture.author` may already
+have re-merged some of them by file footprint) — handing off to the per-package
+build queue: each package (a set of independent tasks a single build turn fans
+out to parallel subagents) runs its own test loop and a per-package **agentic
+review** that verifies it against its own spec. A package whose work already
+landed (an earlier package's fix turn pulled it in) is not a dead end: the build
+turn records per-criterion evidence in `.gtd/SATISFIED.md` instead of
 implementing anything, and the package still goes through the checks and the
 spec review before closing out. If a queue item ever _does_ dead-end (a build
 turn that authors nothing stalls), the supported recovery is to write that same

--- a/src/workflows/templates.test.ts
+++ b/src/workflows/templates.test.ts
@@ -490,6 +490,78 @@ describe("the bundled unified workflow template", () => {
       }
     }
   })
+
+  // Package 01 (decomposition granularity rules): design.triage's grouping
+  // step gains a vertical-slicing test and a distinct-acceptance test beside
+  // the green floor, and architecture.author gains footprint-based merge
+  // authority — both carry the same literal fewer-larger-packages bias, and
+  // neither states it as a number. Pinned by stable keyword, never a whole
+  // sentence, so a later reword doesn't red this suite for no reason.
+
+  it("design.triage's grouping step states the vertical-slicing test and the distinct-acceptance test (package 01)", () => {
+    const { definition } = compileTemplate()
+    const prompt = definition.states["design.triage"]!.prompt!
+
+    // Vertical, not horizontal: slice by capability, never by layer; a
+    // prep-only concern (types, scaffolding, renames) folds into its consumer.
+    expect(prompt).toMatch(/vertical/i)
+    expect(prompt).toMatch(/capability/i)
+    expect(prompt).toMatch(/never by layer/i)
+    expect(prompt).toMatch(/scaffolding/i)
+
+    // Distinct acceptance: an observable check that fails before, passes after.
+    expect(prompt).toMatch(/fails\s+before it and passes after/i)
+    expect(prompt).toMatch(/merge it into\s+its neighbour/i)
+  })
+
+  it("architecture.author states the footprint/merge rule under a dedicated `## Merged Concerns` heading, merge only, never split (package 01)", () => {
+    const { definition } = compileTemplate()
+    const prompt = definition.states["architecture.author"]!.prompt!
+
+    expect(prompt).toMatch(/file footprint/i)
+    expect(prompt).toMatch(/## Merged Concerns/)
+    expect(prompt).toMatch(/merge only, never to split/i)
+    expect(prompt).toMatch(/carrying both merged requirements\s+verbatim/i)
+    expect(prompt).toMatch(/raises no open question and stops for no\s+human/i)
+    // It explicitly refuses to route a merge to architecture.gate for a veto.
+    expect(prompt).toMatch(/do not route it to `architecture\.gate` for a veto/i)
+  })
+
+  it("the fewer-larger-packages bias is the same literal sentence in both design.triage and architecture.author (package 01)", () => {
+    const { definition } = compileTemplate()
+    const normalize = (s: string): string => s.replace(/\s+/g, " ").trim().toLowerCase()
+    const triagePrompt = normalize(definition.states["design.triage"]!.prompt!)
+    const authorPrompt = normalize(definition.states["architecture.author"]!.prompt!)
+
+    const bias =
+      "prefer fewer, larger packages — the smallest independently valuable change, not the smallest change that compiles"
+    expect(triagePrompt).toContain(bias)
+    expect(authorPrompt).toContain(bias)
+  })
+
+  it("neither the vertical/distinct-acceptance prose nor the footprint/merge prose states a package count as a digit (package 01)", () => {
+    const { definition } = compileTemplate()
+
+    // Slice out just the new prose in each prompt (between stable anchors
+    // either side of it), rather than the whole prompt — both prompts
+    // legitimately carry unrelated digits elsewhere (design.triage's own
+    // numbered steps "1."-"4.").
+    const triagePrompt = definition.states["design.triage"]!.prompt!
+    const triageStart = triagePrompt.indexOf("Two more tests sit beside")
+    const triageEnd = triagePrompt.indexOf("2. Classify each concern")
+    expect(triageStart).toBeGreaterThan(-1)
+    expect(triageEnd).toBeGreaterThan(triageStart)
+    const triageSlice = triagePrompt.slice(triageStart, triageEnd)
+    expect(triageSlice).not.toMatch(/[0-9]/)
+
+    const authorPrompt = definition.states["architecture.author"]!.prompt!
+    const authorStart = authorPrompt.indexOf("You now know the *how*")
+    const authorEnd = authorPrompt.indexOf("For every open TECHNICAL point")
+    expect(authorStart).toBeGreaterThan(-1)
+    expect(authorEnd).toBeGreaterThan(authorStart)
+    const authorSlice = authorPrompt.slice(authorStart, authorEnd)
+    expect(authorSlice).not.toMatch(/[0-9]/)
+  })
 })
 
 describe("the bundled template's machine boundaries line up with conversational identity (package 08/02)", () => {

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -165,12 +165,14 @@
 # Once the product questions are settled, `architecture.author` picks up as a
 # COLD reader (a separate machine, a separate memory scope — it reads
 # `REQUIREMENTS.md` in full rather than resuming design's conversation),
-# develops the *how* for each settled concern, and raises only TECHNICAL open
-# questions — routed through the same shared `questionGate` shape
-# (`architecture.gate`) over `ARCHITECTURE.md`. Once those are settled,
-# `architecture.decompose` is a purely mechanical write-out: one package file
-# per concern, in the settled order — no merge/split judgement, since that
-# already happened in triage's grouping.
+# develops the *how* for each settled concern, and — now that it knows each
+# concern's file footprint — may re-merge concerns whose footprints coincide
+# (never split), recording every merge under its own `## Merged Concerns`
+# heading and raising only TECHNICAL open questions — routed through the
+# same shared `questionGate` shape (`architecture.gate`) over
+# `ARCHITECTURE.md`. Once those are settled, `architecture.decompose` is a
+# purely mechanical write-out: one package file per concern, in the settled
+# — possibly coarsened — order, with no merge/split judgement of its own.
 #
 # From there the per-package build queue (`packages.*`) and the shared review
 # + squash tail (`build.*`) are UNCHANGED from before this restructure — see
@@ -803,6 +805,17 @@ machines:
              its own, in the order you'd want them built. If a concern would
              red-light tests that a later concern is meant to fix, that is
              not a valid split: merge the two into one concern.
+
+          Two more tests sit beside that green floor, not instead of it.
+          Vertical, not horizontal: slice by capability, never by layer. A
+          concern that only prepares for a later one — types, scaffolding,
+          renames — is folded into the first concern that uses it. Distinct
+          acceptance: each concern needs an observable check that fails
+          before it and passes after; if you can't name one, merge it into
+          its neighbour. Prefer fewer, larger packages — the smallest
+          independently valuable change, not the smallest change that
+          compiles.
+
           2. Classify each concern as PRODUCT (a user-facing/requirements
              decision) or TECHNICAL (an implementation decision).
           3. For every PRODUCT concern with an open point you cannot settle
@@ -903,9 +916,12 @@ machines:
   # may be a handover between the user-facing and the technical phase: this
   # phase does NOT resume design's conversation, it reads
   # `.gtd/REQUIREMENTS.md` cold. Resolves the TECHNICAL open
-  # questions, then mechanically decomposes the settled concerns into package
-  # files (no merge/split judgement — that already happened in triage's
-  # grouping). ▸ planner identity — `model:` declared once here, stamped onto
+  # questions, then decomposes the settled concerns into package files.
+  # Merge authority lives HERE, in `author` — it is the first state that
+  # knows the *how*, so it alone may re-merge concerns whose file footprints
+  # coincide (never split); `decompose` remains the mechanical write-out,
+  # carrying `author`'s settled — possibly coarsened — grouping over
+  # verbatim. ▸ planner identity — `model:` declared once here, stamped onto
   # `author` and `decompose` (its own prompt states; `gate.answer` is a human
   # turn and carries no prompt).
   archPlan:
@@ -944,6 +960,24 @@ machines:
           those concerns: for each one, in the same order, work out the *how*
           — file/module structure, data models, library/tech-stack choices,
           error-handling strategy — building on the *what* already settled.
+
+          You now know the *how*, so you know each concern's file footprint —
+          list each concern's primary paths. Merge concerns whose footprints
+          center on the same files into one, unless the later one only
+          consumes an interface the earlier one creates: that exception is
+          what keeps a genuine build-on-top sequence from collapsing into one
+          blob. This authority is to merge only, never to split — granting
+          split authority here would work directly against the goal; the
+          whole problem is over-granularity. Record every merge under a
+          dedicated `## Merged Concerns` heading, carrying both merged requirements
+          verbatim so the per-package spec review still covers each one
+          independently. A merge raises no open question and stops for no
+          human — do not route it to `architecture.gate` for a veto; the
+          human still sees every merge when they review the plan, and the
+          per-package spec review is the real safety net. Prefer fewer,
+          larger packages — the smallest independently valuable change, not
+          the smallest change that compiles.
+
           For every open TECHNICAL point you cannot settle yourself, add a
           question under a `## Open Questions` heading exactly as the
           requirements phase does: one `### <question>` each, followed by a
@@ -1009,20 +1043,24 @@ machines:
 
           If you wrote `.gtd/ARCHITECTURE.md` earlier in this
           conversation, work from what you already settled; otherwise read it
-          (the converged technical plan) yourself. It already lists an ORDERED
-          set of concerns with every merge/split judgement made — this turn is
-          a mechanical write-out, not a planning one.
+          (the converged technical plan) yourself. It already lists an
+          ORDERED set of concerns with every merge/split judgement
+          `architecture.author` made — this turn is a mechanical write-out,
+          not a planning one. A `## Merged Concerns` heading there is a
+          record of those merges, never a concern of its own: write no
+          package file for it.
 
           Write one package file per concern, in the settled order, under
           `.gtd/packages/` (e.g.
           `.gtd/packages/01-name.md`,
           `.gtd/packages/02-name.md`, ...). Each package file
-          carries that concern's requirement (so it can be reviewed against
-          its spec), its independent tasks, and each task's acceptance
+          carries that concern's requirement(s) (so it can be reviewed
+          against its spec — both, independently, when the concern was
+          merged), its independent tasks, and each task's acceptance
           criteria as `- [ ]` checkboxes and relevant paths. Do NOT merge or
-          split concerns here — that judgement already happened upstream;
-          carry the settled grouping over verbatim. No package file may
-          reference any other `.gtd/` file.
+          split concerns here — that judgement already happened in
+          `architecture.author`; carry the settled grouping over verbatim.
+          No package file may reference any other `.gtd/` file.
 
           Once the package files are written, delete
           `.gtd/ARCHITECTURE.md`. Leave everything uncommitted and


### PR DESCRIPTION
## Problem

`design.triage` grouped concerns before anyone knew implementation details, so `architecture.decompose` could only write that grouping out verbatim. A concern that turned out to share a file footprint with another had no later chance to merge — biasing the whole pipeline toward too many small packages.

## Change

**Merge authority moves to `architecture.author`.** It's the first state that knows the *how*, so it alone may re-merge concerns whose file footprints coincide:

- Merge-only, **never split** — granting split authority here works against the goal (over-granularity is the problem).
- Every merge recorded under a dedicated `## Merged Concerns` heading, carrying **both requirements verbatim** so the per-package spec review still checks each independently.
- Deliberately **skips `architecture.gate`** — routing a merge through a human veto defeats the point. The human still sees every merge when reviewing the plan, and the per-package spec review is the real safety net.
- Exception preserved: a later concern that only *consumes* an interface the earlier one creates is not merged, so genuine build-on-top sequences don't collapse into one blob.

`architecture.decompose` stays a purely mechanical write-out of the settled (possibly coarsened) grouping, and writes no package file for the `## Merged Concerns` record.

**`design.triage` keeps its own share of the bias** — two new tests beside the existing green-floor split test:

- *Vertical, not horizontal* — slice by capability, never by layer; prep-only concerns (types, scaffolding, renames) fold into their consumer.
- *Distinct acceptance* — a concern with no observable check that fails before / passes after gets merged into its neighbour.

Both states carry the identical "prefer fewer, larger packages" sentence verbatim.

## Tests

Four cases in `src/workflows/templates.test.ts`, pinned by stable keyword/heading rather than full sentences so a reword doesn't red the suite:

- `design.triage` states the vertical-slicing and distinct-acceptance tests
- `architecture.author` states the footprint/merge rule, the `## Merged Concerns` heading, merge-only, and the explicit gate refusal
- the fewer-larger-packages bias is the **same literal sentence** in both prompts, so they can't drift apart
- neither new prose block states the package count as a digit — no magic number can sneak back in

`CONTEXT.md` and `README.md` updated to describe the new decompose/author split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)