### PR TITLE
feat(workflow): gate open questions behind a three-part bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,19 @@ itself — the prompt never inlines it; it finds the entry commit (the one
 `unwind` reverted) and runs `git show` against it — and groups that diff into an
 ORDERED list of **concerns**, each one able to leave the test suite green on its
 own, classifying each as **product** (a user-facing/requirements decision) or
-**technical** (an implementation decision). It raises open questions for the
-product concerns only, in `.gtd/REQUIREMENTS.md`, folding EVERYTHING the entry
-commit added into those concerns — a scratch sketch and a hand-edited code
-change alike, since the unwind already reverted both; nothing is left to delete.
+**technical** (an implementation decision). A concern's open point clears a
+three-part bar before it's ever raised as a question: the answer must be a
+genuine fork with divergent outcomes, the sketch/entry diff/history must not
+already settle it, and getting it wrong must survive all the way to human
+review. Anything below that bar — product or technical alike — triage decides
+itself, recording the decision and a one-line rationale under
+`## Answered Questions`, the same section a human-answered question lands in;
+only a product point that clears the bar is raised as an open question in
+`.gtd/REQUIREMENTS.md` (a technical point that clears it waits for the
+architecture phase to raise it), folding EVERYTHING the entry commit added into
+those concerns — a scratch sketch and a hand-edited code change alike, since the
+unwind already reverted both; nothing is left to delete. When every concern
+turns out to be technical, triage writes no `## Open Questions` section at all.
 A shared check+answer gate then probes `.gtd/REQUIREMENTS.md` for unanswered
 questions: each open question offers a couple of candidate answers plus a
 `- [ ] _your answer_` slot, and you tick exactly one per question (the gate
@@ -158,24 +167,36 @@ the plan as-is.
 
 Once the product questions are settled, `architecture.author` picks up as a
 **cold reader** — a separate machine with its own memory scope, so it does not
-resume the triage conversation but reads `.gtd/REQUIREMENTS.md` in full — and
-develops the _how_ for each settled concern, raising only technical open
-questions in `.gtd/ARCHITECTURE.md` (routed through that same shared
-check+answer gate shape, again skipping the human stop when nothing is open),
-deleting `.gtd/REQUIREMENTS.md` once its content is folded in. Once those are
-settled, `architecture.decompose` is a purely mechanical write-out — **one
-package file per concern**, in the settled order, with no merge/split judgement
-of its own (triage grouped the concerns, and `architecture.author` may already
-have re-merged some of them by file footprint) — handing off to the per-package
-build queue: each package (a set of independent tasks a single build turn fans
-out to parallel subagents) runs its own test loop and a per-package **agentic
-review** that verifies it against its own spec. A package whose work already
-landed (an earlier package's fix turn pulled it in) is not a dead end: the build
-turn records per-criterion evidence in `.gtd/SATISFIED.md` instead of
-implementing anything, and the package still goes through the checks and the
-spec review before closing out. If a queue item ever _does_ dead-end (a build
-turn that authors nothing stalls), the supported recovery is to write that same
-file yourself and `gtd land` — no hand-authored state commit.
+resume the triage conversation but reads `.gtd/REQUIREMENTS.md` in full (cold
+means no memory of that conversation, never no git access — it finds and reads
+the entry commit from history exactly as triage did) — and develops the _how_
+for each settled concern. Because it is the first state that knows the _how_, it
+is also the one state allowed to re-merge concerns whose file footprints
+coincide (never split), recording every merge under a `## Merged Concerns`
+heading. The same three-part bar applies to every technical point here too: only
+one that clears it is raised as an open question in `.gtd/ARCHITECTURE.md`;
+everything below the bar, author decides itself and records under
+`## Answered Questions` right alongside triage's own settled points, all of
+which author treats as SETTLED regardless of whether they're product or
+technical. Open questions are routed through that same shared check+answer gate
+shape, again skipping the human stop when nothing is open, and
+`.gtd/REQUIREMENTS.md` is deleted once its content is folded in. A process where
+nothing ever clears the bar runs both phases straight through with no human stop
+at all — the existing review tail, which sees the whole diff anyway, is the
+veto. Once those are settled, `architecture.decompose` is a purely mechanical
+write-out — **one package file per concern**, in the settled order, with no
+merge/split judgement of its own (triage grouped the concerns, and
+`architecture.author` may already have re-merged some of them by file footprint)
+— handing off to the per-package build queue: each package (a set of independent
+tasks a single build turn fans out to parallel subagents) runs its own test loop
+and a per-package **agentic review** that verifies it against its own spec. A
+package whose work already landed (an earlier package's fix turn pulled it in)
+is not a dead end: the build turn records per-criterion evidence in
+`.gtd/SATISFIED.md` instead of implementing anything, and the package still goes
+through the checks and the spec review before closing out. If a queue item ever
+_does_ dead-end (a build turn that authors nothing stalls), the supported
+recovery is to write that same file yourself and `gtd land` — no hand-authored
+state commit.
 
 The process converges on that same shared tail: an agent hands you a
 `.gtd/REVIEW.md` checkbox review of the diff — the prompt never inlines the diff

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -62,13 +62,18 @@
 #   * designPlan (encap)      — the triage phase's one conversation: group the
 #                               diff that started the process into ordered,
 #                               classified concerns and resolve the PRODUCT
-#                               ones' open questions (`design.*`: triage,
-#                               gate.check, gate.answer). ▸ planner.
+#                               ones' open questions that clear the bar — a
+#                               genuine fork, not already settled, worth
+#                               surviving to review — deciding every
+#                               sub-threshold point itself instead
+#                               (`design.*`: triage, gate.check,
+#                               gate.answer). ▸ planner.
 #   * archPlan (encap)        — the technical phase's one conversation: a COLD
 #                               read of the settled concerns, resolving the
-#                               TECHNICAL open questions, then a mechanical
-#                               decomposition into package files
-#                               (`architecture.*`: author, gate.check,
+#                               TECHNICAL open questions that clear the same
+#                               bar (same decide-it-yourself sink below it),
+#                               then a mechanical decomposition into package
+#                               files (`architecture.*`: author, gate.check,
 #                               gate.answer, decompose). A separate machine
 #                               from `designPlan` (not one fused machine) —
 #                               its own memory scope, since there may be a
@@ -164,15 +169,18 @@
 #
 # Once the product questions are settled, `architecture.author` picks up as a
 # COLD reader (a separate machine, a separate memory scope — it reads
-# `REQUIREMENTS.md` in full rather than resuming design's conversation),
-# develops the *how* for each settled concern, and — now that it knows each
-# concern's file footprint — may re-merge concerns whose footprints coincide
-# (never split), recording every merge under its own `## Merged Concerns`
-# heading and raising only TECHNICAL open questions — routed through the
-# same shared `questionGate` shape (`architecture.gate`) over
-# `ARCHITECTURE.md`. Once those are settled, `architecture.decompose` is a
-# purely mechanical write-out: one package file per concern, in the settled
-# — possibly coarsened — order, with no merge/split judgement of its own.
+# `REQUIREMENTS.md` in full rather than resuming design's conversation; COLD
+# means no memory of that conversation, never no git access — it still reads
+# the entry commit from history), develops the *how* for each settled
+# concern, and — now that it knows each concern's file footprint — may
+# re-merge concerns whose footprints coincide (never split), recording every
+# merge under its own `## Merged Concerns` heading and raising a TECHNICAL
+# open question only when it clears the same three-part bar triage does,
+# deciding every sub-threshold point itself — routed through the same shared
+# `questionGate` shape (`architecture.gate`) over `ARCHITECTURE.md`. Once
+# those are settled, `architecture.decompose` is a purely mechanical
+# write-out: one package file per concern, in the settled — possibly
+# coarsened — order, with no merge/split judgement of its own.
 #
 # From there the per-package build queue (`packages.*`) and the shared review
 # + squash tail (`build.*`) are UNCHANGED from before this restructure — see
@@ -730,7 +738,8 @@ machines:
 
   # ── ENCAPSULATION: the triage phase's one conversation ─────────────────────
   # Groups the diff that started the process into ordered, classified
-  # concerns and resolves the PRODUCT ones' open questions — one machine
+  # concerns and resolves the PRODUCT ones' open questions that clear the
+  # bar — deciding every sub-threshold point itself instead — one machine
   # identity across the whole back-and-forth, so the agent explores the
   # codebase once and the human's answer rationale survives every return lap.
   # `triage`'s prompt reads THREE laps off the requirements file's own
@@ -818,11 +827,29 @@ machines:
 
           2. Classify each concern as PRODUCT (a user-facing/requirements
              decision) or TECHNICAL (an implementation decision).
-          3. For every PRODUCT concern with an open point you cannot settle
-             yourself, add a question under a `## Open Questions` heading near
-             the top: one `### <question>` sub-heading each, followed by a
-             checkbox list of candidate answers — aim for TWO concrete options
-             plus a final free-text slot, ALL left UNTICKED:
+          3. For every concern's open point, PRODUCT or TECHNICAL, a question
+             is warranted only when all three hold: the answer is a genuine
+             fork with divergent outcomes — user-visible for a product
+             question, materially different implementations for a technical
+             one; the sketch, the entry diff, and history do not already
+             settle it (treat anything the entry diff states explicitly — a
+             directive in `.gtd/TODO.md`, a committed choice in a hand-edit —
+             as already settled, and on a review loop-back lap treat
+             whatever the human's own review-round edit or note states
+             explicitly the same way); and getting it wrong would survive
+             all the way to the human review tail.
+
+             Anything below that bar, PRODUCT or TECHNICAL alike, decide
+             yourself: record the decision under `## Answered Questions` —
+             the same section a human-answered question lands in — as
+             `### <the point phrased as a question>` followed by the
+             decision and a one-line rationale in prose, no checkboxes.
+
+             A question that clears the bar is written under a
+             `## Open Questions` heading near the top and takes this shape:
+             one `### <question>` sub-heading each, followed by a checkbox
+             list of candidate answers — TWO concrete options plus a final
+             free-text slot, ALL left UNTICKED:
 
                  ### <the question>
 
@@ -833,6 +860,9 @@ machines:
              Raise questions ONLY for product concerns here — a technical
              concern's open points wait for the next phase. Never tick a box
              yourself — the human ticks exactly one per question.
+
+             When every concern in this lap is TECHNICAL, write no
+             `## Open Questions` section at all.
           4. Fold EVERYTHING the entry commit added into the concerns above —
              a scratch note and a real code edit are both just a SKETCH of
              the intent, a spec to be finished, never work to be preserved;
@@ -915,15 +945,18 @@ machines:
   # A separate machine from `designPlan` — its own memory scope, since there
   # may be a handover between the user-facing and the technical phase: this
   # phase does NOT resume design's conversation, it reads
-  # `.gtd/REQUIREMENTS.md` cold. Resolves the TECHNICAL open
-  # questions, then decomposes the settled concerns into package files.
-  # Merge authority lives HERE, in `author` — it is the first state that
-  # knows the *how*, so it alone may re-merge concerns whose file footprints
-  # coincide (never split); `decompose` remains the mechanical write-out,
-  # carrying `author`'s settled — possibly coarsened — grouping over
-  # verbatim. ▸ planner identity — `model:` declared once here, stamped onto
-  # `author` and `decompose` (its own prompt states; `gate.answer` is a human
-  # turn and carries no prompt).
+  # `.gtd/REQUIREMENTS.md` cold — COLD means no memory of that conversation,
+  # never no git access; it still finds and reads the entry commit from
+  # history the same way triage does. Resolves the TECHNICAL open questions
+  # that clear the same bar triage's own do, deciding every sub-threshold
+  # point itself instead, then decomposes the settled concerns into package
+  # files. Merge authority lives HERE, in `author` — it is the first state
+  # that knows the *how*, so it alone may re-merge concerns whose file
+  # footprints coincide (never split); `decompose` remains the mechanical
+  # write-out, carrying `author`'s settled — possibly coarsened — grouping
+  # over verbatim. ▸ planner identity — `model:` declared once here, stamped
+  # onto `author` and `decompose` (its own prompt states; `gate.answer` is a
+  # human turn and carries no prompt).
   archPlan:
     model: <%= it.vars.plannerModel %>
     system: <%~ it.vars.architectPersona %>
@@ -952,9 +985,18 @@ machines:
           You do NOT resume the design conversation — this is a separate
           machine with its own memory, a COLD read every time. Read
           `.gtd/REQUIREMENTS.md` (the settled, ordered, classified
-          concerns) in full. Treat every product decision recorded there —
-          plain prose or a resolved `## Answered Questions` entry — as
-          SETTLED; never re-open it.
+          concerns) in full. Treat every decision recorded there — plain
+          prose or a resolved `## Answered Questions` entry, PRODUCT or
+          TECHNICAL alike — as SETTLED; never re-open it.
+
+          COLD means the machine carries no conversational memory of
+          triage's own back-and-forth; it never meant no git access. This
+          process started at commit `<%= it.startCommit %>`. Find the
+          process's first turn yourself: run
+          `git rev-list --ancestry-path <%= it.startCommit %>..HEAD | tail -1`
+          then `git show` that commit to see everything that started this
+          process: a hand-edit to real code, a scratch note in some file,
+          or both.
 
           On the FIRST lap, develop `.gtd/ARCHITECTURE.md` from
           those concerns: for each one, in the same order, work out the *how*
@@ -978,11 +1020,29 @@ machines:
           larger packages — the smallest independently valuable change, not
           the smallest change that compiles.
 
-          For every open TECHNICAL point you cannot settle yourself, add a
-          question under a `## Open Questions` heading exactly as the
-          requirements phase does: one `### <question>` each, followed by a
-          checkbox list — TWO concrete options plus a final free-text slot,
-          ALL left UNTICKED:
+          For every open TECHNICAL point, a question is warranted
+          only when all three hold: the answer is a genuine fork with
+          divergent outcomes — user-visible for a product question,
+          materially different implementations for a technical one; the
+          sketch, the entry diff, and history do not already settle it
+          (treat anything the entry diff states explicitly — a directive
+          in `.gtd/TODO.md`, a committed choice in a hand-edit — as
+          already settled, and on a review loop-back lap treat whatever
+          the human's own review-round edit or note states explicitly the
+          same way); and getting it wrong would survive all the way to
+          the human review tail.
+
+          Anything below that bar, decide yourself: record the decision
+          under `## Answered Questions` — the same section a
+          human-answered question lands in — as
+          `### <the point phrased as a question>` followed by the decision
+          and a one-line rationale in prose, no checkboxes.
+
+          A question that clears the bar is written under a
+          `## Open Questions` heading, exactly as the requirements phase
+          does: one `### <question>` each, followed by a checkbox list —
+          TWO concrete options plus a final free-text slot, ALL left
+          UNTICKED:
 
               ### <the question>
 

--- a/tests/integration/features/default-workflow.feature
+++ b/tests/integration/features/default-workflow.feature
@@ -861,6 +861,33 @@ Feature: The bundled unified workflow — one flow, end to end
     And ".gtd/ARCHITECTURE.md" exists
 
   @inmem
+  Scenario: a question must clear the three-part bar, or the planner decides it itself
+    Given a test project
+    And the workflow
+    And a commit "gtd(check): design.triage" that adds ".gtd/REQUIREMENTS.md" with:
+      """
+      ## Greeting export
+
+      Add a `greet()` export returning a friendly string.
+      """
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "only when all three hold"
+
+    # architecture.author's copy of the bar must be the byte-identical
+    # criteria — this identical-string assertion is the only guard against
+    # the two inlined copies drifting apart.
+    Given a commit "gtd(check): architecture.author" that adds ".gtd/REQUIREMENTS.md" with:
+      """
+      ## Greeting export
+
+      Add a `greet()` export returning a friendly string. No open questions.
+      """
+    When I run gtd next
+    Then it succeeds
+    And stdout contains "only when all three hold"
+
+  @inmem
   Scenario: a package whose work already landed closes out via .gtd/SATISFIED.md
     Given a test project
     And the workflow


### PR DESCRIPTION
## What

`design.triage` and `architecture.author` could raise a human-facing question for **any** point they couldn't settle themselves, stalling the process on low-stakes decisions. Both now apply the same three-part bar before raising one:

1. the answer is a genuine fork with divergent outcomes (user-visible for product, materially different implementations for technical),
2. the sketch / entry diff / history don't already settle it,
3. getting it wrong would survive all the way to the human review tail.

Anything **below** the bar — product or technical alike — the agent decides itself, recording the decision plus a one-line rationale under `## Answered Questions` (the same section a human-answered question lands in) instead of stalling on a checkbox gate.

## Consequences

- When every concern in a lap is technical, triage writes no `## Open Questions` section at all — so a process where nothing clears the bar runs design **and** architecture straight through with **no human stop**. The existing review tail, which sees the whole diff anyway, is the veto.
- `architecture.author` now also treats triage's technical decisions as settled, not just product ones.
- Clarified that COLD (`archPlan`'s separate memory scope) means no memory of triage's conversation, never no git access — `author` gets the same `git rev-list --ancestry-path`/`git show` instruction triage has, so it can read the entry commit itself.
- `architecture.author`'s copy of the bar is worded identically to triage's; a new `@inmem` scenario asserts the exact string in both prompts to guard the two inlined copies from drifting apart.

## Also in here

Dropped `npx oxfmt --write` from the `qa`/`review` steering modes in `.gtdrc.json`. oxfmt's markdown reflow can mangle these hand-authored files badly enough to deadlock the review validator, so both modes fall back to format-only (`{}`).

## Verification

`npm test` green (9/9 tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)