### PR TITLE
fix(steering): detect format/validate contradictions and allow same-line review notes

### DIFF
--- a/.gtdrc.json
+++ b/.gtdrc.json
@@ -4,7 +4,13 @@
     "testCommand": "npm test"
   },
   "modes": {
-    "qa": {},
-    "review": {}
+    "qa": {
+      "format": "npx oxfmt --no-error-on-unmatched-pattern --write '<%= it.file %>'",
+      "validate": "node ./dist/gtd.bundle.mjs check qa '<%= it.file %>'"
+    },
+    "review": {
+      "format": "npx oxfmt --no-error-on-unmatched-pattern --write '<%= it.file %>'",
+      "validate": "node ./dist/gtd.bundle.mjs check review '<%= it.file %>'"
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -202,50 +202,49 @@ The process converges on that same shared tail: an agent hands you a
 `.gtd/REVIEW.md` checkbox review of the diff — the prompt never inlines the diff
 itself; it names the commit the changes are based at and the agent runs
 `git diff` to read the range before writing the review. Each hunk is a
-`- [ ] ./path/to/file.ts#42` pointer with its explanation on the line(s) BELOW
-it, not trailing the pointer on the same line:
+`- [ ] ./path/to/file.ts#42` pointer, and its explanation can either sit on the
+line(s) below it or trail the pointer on the same line — both forms are equally
+valid:
 
 ```
 - [ ] ./path/to/file.ts#42
   what this hunk does, with room to run to several lines
+- [ ] ./path/to/file.ts#99 — a same-line note works too
 ```
 
-Text after the pointer token on the pointer's own line is a validation error —
-`gtd check`/`gtd validate`/the LSP all reject it — and, because the review
-gate's own emitted script runs that same check ahead of every commit, upgrading
-gtd mid-review leaves an already-open `.gtd/REVIEW.md` written in the old
-same-line form UNLANDABLE until every pointer in it is hand-edited into the new
-shape; there is no migration tool. If a styled `.gtd/REVIEW.md` ever comes out
-malformed some other way (a paragraph where a `- [ ] ./path#line` row belongs),
-`gtd check review` refuses the step the same way: the file stays exactly as
-written in the working tree, unlanded, and re-running the same prompt is the
-recovery — nothing is lost. While the process rests at that gate, the landing
-script opens a **review checkout window**: HEAD is rewound to the review base
-with the working tree untouched, so the whole reviewable change shows up as
-ordinary uncommitted changes in your editor's normal git integration (and files
-added during the process show up as ordinary untracked files, so discarding one
-deletes it — an untracked file you leave alone is not a pending change, and only
-actually removing it from disk counts as a deletion). The next landing's own
-script closes the window before it commits. Tick a box as you review each hunk
-(ticking just records "I read this"), and leave a **comment** to request
-changes: a note on a line, an inline `// TODO`-style comment in the code, or a
-direct code edit. A comment sends a FULL development lap, not a quick
-fix-and-re-review: an agent first judges whether your comment is actually
-actionable (a genuinely approving remark with no code edit short-circuits
-straight to sign-off instead), and an actionable round is re-planned from
-scratch through triage, architecture, and the package queue again — a hand-edit
-you made during review is treated as a **sketch**, the same as any other change
-that starts a process, not a fix the agent builds on: it is reverted out of the
-tree first, and your intent survives only in your own review-round commit for
-triage to read. There is no baseline check on the way back into planning. Only
-the turn that drafts the final squash message resumes the session that built the
-feature in the first place (the review tail is nested inside that build identity
-rather than sitting beside it) — an actionable round leaves that identity
-entirely, so it starts a fresh session like any other process. A comment is what
-asks for changes; landing with no comment signs off, whatever the boxes say,
-which collapses the whole process into one commit (a **squash finale** whose
-message an agent drafts). Deleting `.gtd/REVIEW.md` is refused — the guard only
-asks whether the step's diff deletes the file.
+The one rule an explanation must follow either way: it must never itself START
+with a bare `./path` token, since that parses as a second hunk pointer rather
+than a note. If a styled `.gtd/REVIEW.md` ever comes out malformed some other
+way (a paragraph where a `- [ ] ./path#line` row belongs), `gtd check review`
+refuses the step the same way: the file stays exactly as written in the working
+tree, unlanded, and re-running the same prompt is the recovery — nothing is
+lost. While the process rests at that gate, the landing script opens a **review
+checkout window**: HEAD is rewound to the review base with the working tree
+untouched, so the whole reviewable change shows up as ordinary uncommitted
+changes in your editor's normal git integration (and files added during the
+process show up as ordinary untracked files, so discarding one deletes it — an
+untracked file you leave alone is not a pending change, and only actually
+removing it from disk counts as a deletion). The next landing's own script
+closes the window before it commits. Tick a box as you review each hunk (ticking
+just records "I read this"), and leave a **comment** to request changes: a note
+on a line, an inline `// TODO`-style comment in the code, or a direct code edit.
+A comment sends a FULL development lap, not a quick fix-and-re-review: an agent
+first judges whether your comment is actually actionable (a genuinely approving
+remark with no code edit short-circuits straight to sign-off instead), and an
+actionable round is re-planned from scratch through triage, architecture, and
+the package queue again — a hand-edit you made during review is treated as a
+**sketch**, the same as any other change that starts a process, not a fix the
+agent builds on: it is reverted out of the tree first, and your intent survives
+only in your own review-round commit for triage to read. There is no baseline
+check on the way back into planning. Only the turn that drafts the final squash
+message resumes the session that built the feature in the first place (the
+review tail is nested inside that build identity rather than sitting beside it)
+— an actionable round leaves that identity entirely, so it starts a fresh
+session like any other process. A comment is what asks for changes; landing with
+no comment signs off, whatever the boxes say, which collapses the whole process
+into one commit (a **squash finale** whose message an agent drafts). Deleting
+`.gtd/REVIEW.md` is refused — the guard only asks whether the step's diff
+deletes the file.
 
 A second entry, the same review tail's own direct entry point —
 `gtd --entry review-gate.check --var reviewBase=<commitish>` starts a brand new
@@ -1030,15 +1029,32 @@ After an agent turn at a state that declares `file:`+`mode:`, run the script:
 either `gtd next --json`'s own embedded `.validate` field (present at every
 `prompt` beat that hands over a validatable file), or, standalone,
 `gtd validate`'s own plain-text output — both resolve the exact same script from
-one shared resolver. Exit 0 means the file is well-formed — proceed to
-`gtd land`. A non-zero exit means the script's own captured output IS a
-complete, ready-to-send fix prompt (an instruction plus the findings, see
-`src/Emit.ts`'s `failurePromptWrapper`): send it back to the same agent session
-verbatim, and cap how many fix attempts you allow yourself — the driver owns
-that retry count, not gtd. Landing never TRUSTS that you validated, either: the
-emitted `land` script carries the same format/validate commands ahead of its own
-commit and fails without committing when they fail, so a malformed file is never
-captured whether or not you ran the validate script first.
+one shared resolver. This field is now populated even at a FIRST-WRITE beat,
+before the steering file exists at all: the script itself carries a leading
+`[ -f <file> ] || exit 0` guard rather than gtd checking existence ahead of
+time, so a driver's `while [ -n "$gtd_validate" ]` repair loop is armed from the
+very first turn at a state, not just the second and later ones. Exit 0 means the
+file is well-formed (or genuinely doesn't exist yet) — proceed to `gtd land`. A
+non-zero exit usually means the script's own captured output IS a complete,
+ready-to-send fix prompt (an instruction plus the findings, see `src/Emit.ts`'s
+`failurePromptWrapper`): send it back to the same agent session verbatim, and
+cap how many fix attempts you allow yourself — the driver owns that retry count,
+not gtd. Landing never TRUSTS that you validated, either: the emitted `land`
+script carries the same format/validate commands ahead of its own commit and
+fails without committing when they fail, so a malformed file is never captured
+whether or not you ran the validate script first.
+
+A non-zero exit can ALSO mean something the fix loop cannot fix: a mode whose
+`format:` command breaks its own validator, a config bug gtd detects by
+formatting a canonical sample and re-checking it before the real file's own
+findings are ever reported. That message is unmistakably different — it says
+this is a CONFIGURATION BUG, not the steering file, and tells the agent to stop
+and end its turn rather than edit anything. gtd's exit-code contract stays
+closed at five numbers (below), so nothing distinguishes the two cases at the
+process level — a driver's fix loop is still the CORRECT thing to run in both
+cases, it just can never win a contradiction: its 3-attempt cap is what ends
+one, not a fix. Reading the message text before re-prompting is what keeps an
+agent from thrashing on a document it cannot fix.
 
 ### Failure taxonomy and recovery
 

--- a/src/Emit.test.ts
+++ b/src/Emit.test.ts
@@ -8,6 +8,7 @@ import {
   combinedScript,
   DID_NOT_RUN_COMMENT,
   emitScripts,
+  fileExistsGuard,
   type EmitPreconditions,
   type EmitStep,
 } from "./Emit.js"
@@ -198,6 +199,25 @@ describe("emitScripts — a script with no gitWrite steps omits the retry helper
 
   it("is still syntactically valid POSIX sh", () => {
     expect(runShCheckSyntax(required)).toBe(0)
+  })
+})
+
+describe("fileExistsGuard", () => {
+  it("renders a plain OR-list test, never an if/fi block", () => {
+    expect(fileExistsGuard(".gtd/REVIEW.md")).toBe(`[ -f '.gtd/REVIEW.md' ] || exit 0`)
+  })
+
+  it("shell-quotes a file path containing a single quote", () => {
+    expect(fileExistsGuard("it's.md")).toBe(`[ -f 'it'\\''s.md' ] || exit 0`)
+  })
+
+  it("is syntactically valid POSIX sh on its own", () => {
+    expect(runShCheckSyntax(fileExistsGuard(".gtd/REVIEW.md"))).toBe(0)
+  })
+
+  it("exits 0 (not 1) when the guard trips, unlike headAssertion/reviewWindowAssertion", () => {
+    const result = spawnSync("sh", ["-c", fileExistsGuard("/no/such/file-for-sure")])
+    expect(result.status).toBe(0)
   })
 })
 

--- a/src/Emit.ts
+++ b/src/Emit.ts
@@ -110,6 +110,24 @@ export const headAssertion = (expectedHead: string): string => {
 }
 
 /**
+ * `[ -f <file> ] || exit 0` — the OR-list guard `src/program.ts`'s
+ * `resolveValidateScript` leads its emitted script with (once the
+ * contradiction round-trip/skip notice, if any, has already run): when the
+ * declared steering file is absent from the working tree — including at a
+ * first-write beat, before the producing agent has written it at all — there
+ * is nothing left to format or validate, so the script exits 0 rather than
+ * running the mode's commands against a file that doesn't exist. An OR list,
+ * never an `if`, for the same `set -eu` reason `headAssertion` documents
+ * above: in an OR list, `-e` exempts every command but the last, so the
+ * failing `[ ... ]` on the left never trips `set -e` on its own — only the
+ * explicit `exit 0` on the right does, and it exits the whole script
+ * cleanly. Exported (alongside `headAssertion`/`reviewWindowAssertion`) so
+ * `src/testing/EmittedScriptRecognizer.ts` can re-derive and string-compare
+ * this exact shape.
+ */
+export const fileExistsGuard = (file: string): string => `[ -f ${shellQuote(file)} ] || exit 0`
+
+/**
  * Same shape as `headAssertion`, for the saved-head ref a review window
  * pins. `--verify --quiet ... 2>/dev/null` makes a MISSING ref read as an
  * empty string rather than erroring the substitution itself — the assertion

--- a/src/Lsp.test.ts
+++ b/src/Lsp.test.ts
@@ -269,19 +269,19 @@ describe("diagnosticsFor", () => {
     expect(diagnosticsFor(undefined, "anything")).toEqual([])
   })
 
-  it("underlines exactly one line for a positioned review finding (a trailing-text pointer)", () => {
+  it("underlines exactly one line for a positioned review finding (a second-pointer note)", () => {
     const content = [
       "# Review: abc1234",
       "<!-- base: abc1234def5678901234567890123456789abcd -->",
       "",
       "## Add thing.ts",
       "",
-      "- [ ] ./src/thing.ts#1 — legacy trailing note",
+      "- [ ] ./src/thing.ts#1 — ./src/other.ts#2",
       "",
     ].join("\n")
     const diagnostics = diagnosticsFor(resolveBuiltInMode("review"), content)
     expect(diagnostics).toHaveLength(1)
-    expect(diagnostics[0]?.message).toContain("has text on the pointer line")
+    expect(diagnostics[0]?.message).toContain("starts with a second pointer")
     expect(diagnostics[0]?.range).toEqual({
       start: { line: 5, character: 0 },
       end: { line: 5, character: content.split("\n")[5]!.length },

--- a/src/ModeContradiction.test.ts
+++ b/src/ModeContradiction.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildModeContradictionCheck,
+  contradictionMessage,
+  modeContradictionSkipNotice,
+} from "./ModeContradiction.js"
+import { shellQuote } from "./GitScript.js"
+
+describe("buildModeContradictionCheck", () => {
+  const inputs = {
+    mode: "qa",
+    samplePath: "/fixture-scratch/gtd-mode-sample-qa-12345.md",
+    sample: "Sample plan.\n",
+    formatCommand: "npx oxfmt --write '/fixture-scratch/gtd-mode-sample-qa-12345.md'",
+  }
+
+  it("pins the block's exact bytes against a path the test supplies", () => {
+    const block = buildModeContradictionCheck(inputs)
+    const pathQ = shellQuote(inputs.samplePath)
+    const messageQ = shellQuote(contradictionMessage(inputs.mode, inputs.formatCommand))
+    expect(block).toBe(
+      [
+        `printf '%s' ${shellQuote(inputs.sample)} > ${pathQ}`,
+        inputs.formatCommand,
+        `gtd check qa ${pathQ} >/dev/null 2>&1 || {`,
+        `  printf '%s\\n' ${messageQ} >&2`,
+        `  cat ${pathQ} >&2`,
+        `  rm -f ${pathQ}`,
+        `  exit 1`,
+        `}`,
+        `rm -f ${pathQ}`,
+      ].join("\n"),
+    )
+  })
+
+  it("has no blank lines — the block must stay one Emit.ts block", () => {
+    const block = buildModeContradictionCheck(inputs)
+    expect(block.split("\n\n").length).toBe(1)
+  })
+
+  it("writes the sample with printf '%s', never a heredoc", () => {
+    const block = buildModeContradictionCheck(inputs)
+    expect(block.startsWith(`printf '%s' ${shellQuote(inputs.sample)} > `)).toBe(true)
+    expect(block).not.toContain("<<")
+  })
+
+  it("runs the rendered format: command verbatim, right after the printf line", () => {
+    const block = buildModeContradictionCheck(inputs)
+    const afterPrintf = block.slice(
+      `printf '%s' ${shellQuote(inputs.sample)} > ${shellQuote(inputs.samplePath)}\n`.length,
+    )
+    expect(afterPrintf.startsWith(inputs.formatCommand)).toBe(true)
+  })
+
+  it("re-validates via gtd check <mode> <samplePath> with output discarded", () => {
+    const block = buildModeContradictionCheck(inputs)
+    expect(block).toContain(`gtd check qa '${inputs.samplePath}' >/dev/null 2>&1 || {`)
+  })
+
+  it("on failure prints the message, cats the sample, removes it, and exits non-zero", () => {
+    const block = buildModeContradictionCheck(inputs)
+    const failureBranch = block.slice(block.indexOf("|| {"))
+    expect(failureBranch).toContain(`cat '${inputs.samplePath}' >&2`)
+    expect(failureBranch).toContain(`rm -f '${inputs.samplePath}'`)
+    expect(failureBranch).toContain(`exit 1`)
+  })
+
+  it("on success removes the sample and continues (no trailing exit)", () => {
+    const block = buildModeContradictionCheck(inputs)
+    expect(block.endsWith(`rm -f '${inputs.samplePath}'`)).toBe(true)
+  })
+
+  it("shell-quotes a sample containing single quotes and newlines safely", () => {
+    const sample = "a 'quoted' sample\nwith two lines\n"
+    const block = buildModeContradictionCheck({ ...inputs, sample })
+    expect(
+      block.startsWith(`printf '%s' ${shellQuote(sample)} > ${shellQuote(inputs.samplePath)}`),
+    ).toBe(true)
+  })
+})
+
+describe("contradictionMessage", () => {
+  const message = contradictionMessage("review", "npx oxfmt --write '<file>'")
+
+  it("names the mode", () => {
+    expect(message).toContain('"review"')
+  })
+
+  it("tells the agent this is a configuration bug and not the steering file", () => {
+    expect(message.toLowerCase()).toContain("configuration bug")
+    expect(message).toContain("Do NOT edit the steering file")
+  })
+
+  it("tells the agent to stop and end its turn", () => {
+    expect(message.toLowerCase()).toContain("stop and end your turn")
+  })
+
+  it("names the exact rendered format: command", () => {
+    expect(message).toContain("npx oxfmt --write '<file>'")
+  })
+
+  it("is not fixPromptInstruction's text and shares no wording that blames the turn", () => {
+    expect(message).not.toContain("Your last turn")
+    expect(message).not.toContain("Fix these format violations")
+  })
+})
+
+describe("modeContradictionSkipNotice", () => {
+  it("is a single printf-to-stderr line naming the mode", () => {
+    const line = modeContradictionSkipNotice("adr")
+    expect(line.split("\n").length).toBe(1)
+    expect(line).toContain(">&2")
+    expect(line).toContain("adr")
+    expect(line.toLowerCase()).toContain("skip")
+  })
+})

--- a/src/ModeContradiction.ts
+++ b/src/ModeContradiction.ts
@@ -1,0 +1,104 @@
+/**
+ * The steering-mode CONTRADICTION round-trip: a pure bash-block builder that
+ * catches a mode whose `format:` command breaks its own `validate:` —
+ * something gtd can detect mechanically without ever touching the real
+ * steering file: format a copy of the format's own canonical sample
+ * (`SteeringFormat.sample`), re-validate the result with `gtd check <mode>`,
+ * and fail loudly (never silently) when the round-trip broke it.
+ *
+ * Pure: no Effect, no git, no filesystem, no ambient reads. Every value this
+ * module needs — the scratch path, the sample bytes, the mode's already-
+ * rendered `format:` command — arrives as an argument; `src/program.ts`
+ * resolves the scratch path (`EnvVars`) and renders the `format:` template
+ * (with `it.file` bound to that scratch path, never the real file), and this
+ * module only concatenates the block those values assemble into.
+ *
+ * `printf '%s'` over a `shellQuote`d sample, never a heredoc — no delimiter
+ * chosen ahead of time can collide with the sample's own bytes. `gtd check
+ * <mode> <samplePath>` is the re-validation: the same in-process parser a
+ * seeded `validate:` command already leaf-invokes, so this adds no new
+ * mechanism and assumes no new binary on `$PATH` beyond `gtd` itself.
+ * `cat`ing the formatted sample to stderr on failure is what gives a human
+ * reader "what the round-trip turned the sample into" — only knowable at run
+ * time, so it can't be baked into the message string ahead of it.
+ *
+ * The message is written for two readers at once, because gtd validate's own
+ * exit code carries no second meaning (see the README's exit-code table) —
+ * the message text is the WHOLE signal distinguishing "the config is broken"
+ * from "the file is malformed". To the agent, first and unmistakably: this is
+ * a configuration bug, not the steering file — do not edit it, stop and end
+ * the turn (without this, an agent handed "validation failed" up to 3 times
+ * under a driver's fix-retry cap will thrash on the document and can mangle
+ * good work before the loop dies). To the human, second: which mode
+ * contradicts itself and the exact rendered `format:` command that ran — the
+ * `cat`'d sample (assembled by the block itself, not this message) is the
+ * third piece, enough together to fix `.gtdrc.json` or the formatter's own
+ * config without reproducing the failure by hand. Deliberately NOT
+ * `src/program.ts`'s `fixPromptInstruction` text (which blames the TURN) and
+ * sharing no wording with it — since the exit code no longer distinguishes
+ * the two cases, reusing that wrapper would erase the distinction completely.
+ */
+
+import { shellQuote } from "./GitScript.js"
+
+/** Every value `buildModeContradictionCheck` needs, already resolved/rendered by the caller. */
+export interface ModeContradictionInputs {
+  /** The mode name (e.g. `"qa"`/`"review"`) — named in the message and passed to `gtd check`. */
+  readonly mode: string
+  /** An absolute, literal scratch path (never re-derived by this module) the sample is written to, formatted at, and removed from. */
+  readonly samplePath: string
+  /** The format's own canonical sample (`SteeringFormat.sample`), written verbatim via `printf '%s'`. */
+  readonly sample: string
+  /** The mode's `format:` command, ALREADY RENDERED with `it.file` bound to `samplePath` — this module renders nothing. */
+  readonly formatCommand: string
+}
+
+/**
+ * The two-reader message `buildModeContradictionCheck` prints to stderr ahead
+ * of the `cat`'d formatted sample. Exported on its own so a test (or a future
+ * caller) can assert on its exact text without re-deriving the whole block.
+ */
+export const contradictionMessage = (mode: string, formatCommand: string): string =>
+  `gtd: mode "${mode}"'s format: command breaks its own validator — this is a ` +
+  `CONFIGURATION BUG, not a problem with the steering file. Do NOT edit the ` +
+  `steering file — stop and end your turn now.\n` +
+  `The rendered format: command that ran:\n${formatCommand}\n` +
+  `What it turned mode "${mode}"'s own canonical sample into:`
+
+/**
+ * The round-trip block itself — one self-contained bash fragment with no
+ * blank lines (so `src/Emit.ts`'s `assembleScript` never splits it from a
+ * sibling step), meant to run BEFORE `[ -f <file> ] || exit 0` in the emitted
+ * validate script (see `src/program.ts`'s `resolveValidateScript`) so it still
+ * fires at a first-write beat where the real steering file does not exist
+ * yet. Exits non-zero (after printing the message and the formatted sample)
+ * on a contradiction; otherwise removes the sample and falls through.
+ */
+export const buildModeContradictionCheck = (inputs: ModeContradictionInputs): string => {
+  const { mode, samplePath, sample, formatCommand } = inputs
+  const pathQ = shellQuote(samplePath)
+  const messageQ = shellQuote(contradictionMessage(mode, formatCommand))
+  return [
+    `printf '%s' ${shellQuote(sample)} > ${pathQ}`,
+    formatCommand,
+    `gtd check ${mode} ${pathQ} >/dev/null 2>&1 || {`,
+    `  printf '%s\\n' ${messageQ} >&2`,
+    `  cat ${pathQ} >&2`,
+    `  rm -f ${pathQ}`,
+    `  exit 1`,
+    `}`,
+    `rm -f ${pathQ}`,
+  ].join("\n")
+}
+
+/**
+ * The one-line skip notice for a mode whose validator is EXTERNAL (a user
+ * `validate:` command that is not gtd's own seeded string) — coverage is the
+ * two built-in modes only (`src/SteeringFormats.ts`'s registry), so there is
+ * no in-process parser to round-trip a sample through. Printed to stderr and
+ * nothing else runs — silence would read as a clean bill of health.
+ */
+export const modeContradictionSkipNotice = (mode: string): string => {
+  const message = `gtd: mode "${mode}" has an external validate: command — skipping the format/validate contradiction check`
+  return `printf '%s\\n' ${shellQuote(message)} >&2`
+}

--- a/src/OpenQuestions.ts
+++ b/src/OpenQuestions.ts
@@ -67,6 +67,23 @@ export type OpenQuestionStatus = "open" | "answered"
  */
 export const FREE_TEXT_PLACEHOLDER = "_your answer_"
 
+/**
+ * `QA_FORMAT`'s canonical sample (see `SteeringFormat.sample`'s doc comment) —
+ * a minimal, valid `qa`-mode document: one open question with two options plus
+ * the unfilled free-text slot. Deliberately not authored to survive any
+ * particular formatter.
+ */
+const QA_SAMPLE = `Sample plan. Add a thing.
+
+## Open Questions
+
+### Which option?
+
+- [ ] Option A
+- [ ] Option B
+- [ ] ${FREE_TEXT_PLACEHOLDER}
+`
+
 /** One checkbox option under an OPEN question: its ticked state, its text (the free-text placeholder normalized to `""`), and its source line span for editor tooling. */
 export interface QuestionOption {
   readonly checked: boolean
@@ -420,6 +437,7 @@ const questionActions: SteeringFormat["actions"] = (content, range) => {
 
 /** The `qa` steering format: gtd's own in-process open-questions checkbox format — validation, outline, and code actions, no `pointerAt` (an open question's options have nothing to jump to). Its one finding is always positionless — this format has no notion of a per-line problem. */
 export const QA_FORMAT: SteeringFormat = {
+  sample: QA_SAMPLE,
   validate: (content) => parseOpenQuestions(content).errors.map((message) => ({ message })),
   outline: questionsOutline,
   actions: questionActions,

--- a/src/ReviewDoc.test.ts
+++ b/src/ReviewDoc.test.ts
@@ -336,8 +336,8 @@ describe("parseReviewDoc", () => {
   })
 })
 
-describe("parseReviewDoc — trailing text on the pointer's own line (invalid legacy form)", () => {
-  it("still parses as a pointer, with path, #line, and checked state intact", () => {
+describe("parseReviewDoc — a same-line note (trailing the pointer on its own line)", () => {
+  it("parses as a pointer, with path, #line, and checked state intact, and the trailing text as its note", () => {
     const content = [
       "# Review: abc1234",
       "<!-- base: abc1234def5678901234567890123456789abcd -->",
@@ -348,15 +348,17 @@ describe("parseReviewDoc — trailing text on the pointer's own line (invalid le
       "",
     ].join("\n")
     const result = parseReviewDoc(content)
-    expect(result.changesets[0]?.files[0]).toMatchObject({
+    expect(result.changesets[0]?.files[0]).toEqual({
       path: "./src/Edge.ts",
       line: 42,
       checked: true,
+      note: "what this hunk does",
       sourceLine: 5,
+      endLine: 5,
     })
   })
 
-  it("produces exactly one error, naming the chunk and the pointer, and carrying the pointer's sourceLine", () => {
+  it("produces zero validation errors for an ordinary same-line note", () => {
     const content = [
       "# Review: abc1234",
       "<!-- base: abc1234def5678901234567890123456789abcd -->",
@@ -366,16 +368,10 @@ describe("parseReviewDoc — trailing text on the pointer's own line (invalid le
       "- [ ] ./src/Edge.ts#42 — what this hunk does",
       "",
     ].join("\n")
-    expect(REVIEW_FORMAT.validate(content)).toEqual([
-      {
-        message:
-          'Chunk "Add thing.ts" hunk ./src/Edge.ts#42 has text on the pointer line — move the explanation to the line(s) below it',
-        line: 5,
-      },
-    ])
+    expect(REVIEW_FORMAT.validate(content)).toEqual([])
   })
 
-  it("does not also report 'no file pointers' for a chunk whose only pointer carries trailing text", () => {
+  it("does not report 'no file pointers' for a chunk whose only pointer carries a same-line note", () => {
     const content = [
       "# Review: abc1234",
       "<!-- base: abc1234def5678901234567890123456789abcd -->",
@@ -403,7 +399,7 @@ describe("parseReviewDoc — trailing text on the pointer's own line (invalid le
     expect(parseReviewDoc(content).changesets[0]?.files[0]?.path).toBe("./a-b/c-d.ts")
   })
 
-  it("the clean below-the-pointer form produces no errors", () => {
+  it("the clean below-the-pointer form still produces no errors", () => {
     const content = [
       "# Review: abc1234",
       "<!-- base: abc1234def5678901234567890123456789abcd -->",
@@ -412,6 +408,117 @@ describe("parseReviewDoc — trailing text on the pointer's own line (invalid le
       "",
       "- [ ] ./src/Edge.ts#42",
       "  what this hunk does",
+      "",
+    ].join("\n")
+    expect(REVIEW_FORMAT.validate(content)).toEqual([])
+  })
+
+  it("strips an em dash, en dash, or hyphen run from the same-line segment, identical to the below-pointer stripping", () => {
+    for (const dash of ["—", "–", "-", "---"]) {
+      const content = [
+        "# Review: abc1234",
+        "<!-- base: abc1234def5678901234567890123456789abcd -->",
+        "",
+        "## Chunk",
+        "",
+        `- [ ] ./src/calc.ts#1 ${dash} the note`,
+        "",
+      ].join("\n")
+      expect(parseReviewDoc(content).changesets[0]?.files[0]?.note).toBe("the note")
+    }
+  })
+
+  it("joins a same-line segment with below-pointer lines, single space, same-line segment first", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./src/calc.ts#1 — the same-line part",
+      "  the below-pointer part",
+      "",
+    ].join("\n")
+    const result = parseReviewDoc(content)
+    expect(result.changesets[0]?.files[0]?.note).toBe("the same-line part the below-pointer part")
+  })
+})
+
+describe("parseReviewDoc — a note starting with a second pointer is a positioned finding", () => {
+  it("a same-line note whose first token is itself a pointer token yields one finding at the pointer's own sourceLine", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add thing.ts",
+      "",
+      "- [ ] ./a.ts#1 ./b.ts#2",
+      "",
+    ].join("\n")
+    expect(REVIEW_FORMAT.validate(content)).toEqual([
+      {
+        message:
+          'Chunk "Add thing.ts" hunk ./a.ts#1\'s note starts with a second pointer (./b.ts#2) — give it its own "- [ ]" line',
+        line: 5,
+      },
+    ])
+  })
+
+  it("still fires when a separator sits between the two pointers, stripped before the check runs", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Add thing.ts",
+      "",
+      "- [ ] ./a.ts#1 — ./b.ts#2",
+      "",
+    ].join("\n")
+    expect(REVIEW_FORMAT.validate(content)).toEqual([
+      {
+        message:
+          'Chunk "Add thing.ts" hunk ./a.ts#1\'s note starts with a second pointer (./b.ts#2) — give it its own "- [ ]" line',
+        line: 5,
+      },
+    ])
+  })
+
+  it("does not fire for a below-pointer line opening with a bare path — only the same-line segment is checked", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./src/calc.ts#1",
+      "  ./src/foo.ts is the caller",
+      "",
+    ].join("\n")
+    expect(REVIEW_FORMAT.validate(content)).toEqual([])
+    expect(parseReviewDoc(content).changesets[0]?.files[0]?.note).toBe("./src/foo.ts is the caller")
+  })
+
+  it("does not fire for a same-line note whose first word merely contains a dot", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./src/calc.ts#1 — e.g. this explains it",
+      "",
+    ].join("\n")
+    expect(REVIEW_FORMAT.validate(content)).toEqual([])
+  })
+
+  it("does not fire for a bare './' token, reusing parseFilePointer's own minimum-path-length rule", () => {
+    const content = [
+      "# Review: abc1234",
+      "<!-- base: abc1234def5678901234567890123456789abcd -->",
+      "",
+      "## Chunk",
+      "",
+      "- [ ] ./src/calc.ts#1 — ./ is not a real path",
       "",
     ].join("\n")
     expect(REVIEW_FORMAT.validate(content)).toEqual([])
@@ -495,7 +602,7 @@ describe("toggleFilePointer", () => {
     expect(toggleFilePointer(reviewDoc, 3)).toBeUndefined()
   })
 
-  it("still toggles a legacy trailing-note pointer line, round-tripping the rest", () => {
+  it("still toggles a same-line-note pointer line, round-tripping the rest", () => {
     const content = [
       "# Review: abc1234",
       "<!-- base: abc1234def5678901234567890123456789abcd -->",
@@ -586,7 +693,7 @@ describe("REVIEW_FORMAT", () => {
     expect(continuationEdit.range.start.line).toBe(5)
   })
 
-  it("actions still offer the toggle on a legacy trailing-note pointer line", () => {
+  it("actions still offer the toggle on a same-line-note pointer line", () => {
     const content = [
       "# Review: abc1234",
       "<!-- base: abc1234def5678901234567890123456789abcd -->",

--- a/src/ReviewDoc.ts
+++ b/src/ReviewDoc.ts
@@ -14,7 +14,7 @@
  *
  * - [ ] ./path/to/file.ts#42
  *   what this hunk does, with room to run to several lines
- * - [ ] ./path/to/file.ts#99
+ * - [ ] ./path/to/file.ts#99 — or the note can trail the pointer on its own line
  * ```
  *
  * Required: the `# Review: <hash>` header (as the document's first non-blank
@@ -22,15 +22,18 @@
  * with a non-empty title and at least one `- [ ]` / `- [x]` file pointer.
  *
  * A file pointer's path is ONE whitespace-delimited `./`-relative token, with
- * an optional `#<line>` suffix of that same token — nothing else may follow on
- * the pointer's own line; a hyphen (or em/en dash) in a filename is part of the
- * path, never a separator. **Text after the pointer token on the pointer's own
- * line is a validation error** — the explanation belongs on the line(s) below
- * it instead. Every line after a pointer belongs to that pointer as its
+ * an optional `#<line>` suffix of that same token — a hyphen (or em/en dash) in
+ * a filename is part of the path, never a separator. The explanation may trail
+ * the pointer on its own same line, continue on the line(s) below it, or both
+ * — same-line text first, then the below-pointer lines, joined with a single
+ * space. Every line after a pointer belongs to that pointer as its
  * explanation (`note`), until the next pointer or the next `##` heading;
  * indentation is optional, and a blank line between two continuation
  * paragraphs stays inside the span. Only lines before a chunk's FIRST pointer
- * are chunk-level description.
+ * are chunk-level description. **The one surviving rule: a note never begins
+ * with a bare `./path` token** — that parses as a second hunk pointer instead
+ * of an explanation, and gtd flags it as a positioned finding rather than
+ * silently swallowing the second hunk.
  *
  * **The format's single source of truth.** This module is the EXECUTABLE SPEC
  * of that format — its own unit tests (`ReviewDoc.test.ts`) are the format's
@@ -58,14 +61,12 @@ export interface ReviewFile {
   readonly path: string
   readonly line?: number
   readonly checked: boolean
-  /** The pointer's explanation, gathered from the lines BELOW it, joined with " ". */
+  /** The pointer's explanation: same-line text (if any) first, then the lines gathered from BELOW it, joined with " ". */
   readonly note?: string
   /** 0-based line index of this file pointer's own `- [ ]`/`- [x]` line in REVIEW.md, for editor tooling. */
   readonly sourceLine: number
   /** 0-based index of the last NON-BLANK line of this pointer's span; equals `sourceLine` when it has no explanation. */
   readonly endLine: number
-  /** Text found after the pointer token on the pointer's OWN line — the invalid legacy form. Absent when the line is clean. */
-  readonly trailingText?: string
 }
 
 export interface Changeset {
@@ -83,14 +84,29 @@ export interface ReviewDoc {
   readonly errors: readonly string[]
 }
 
+/**
+ * `REVIEW_FORMAT`'s canonical sample (see `SteeringFormat.sample`'s doc
+ * comment) — a minimal, valid `review`-mode document: the header, the base
+ * comment, and one chunk with one file pointer. Deliberately not authored to
+ * survive any particular formatter.
+ */
+const REVIEW_SAMPLE = `# Review: sample123
+<!-- base: 0000000000000000000000000000000000000000 -->
+
+## Sample chunk
+
+- [ ] ./sample.ts#1
+what this hunk does
+`
+
 const HEADER_RE = /^#\s+Review:\s*(\S+)\s*$/
 const BASE_COMMENT_RE = /^<!--\s*base:\s*(\S+)\s*-->$/
 const CHUNK_HEADING_RE = /^##\s+(.+)$/
-/** One `- [ ]`/`- [x]` pointer line: the box, the whitespace-delimited pointer token, and (invalidly) whatever trails it. */
+/** One `- [ ]`/`- [x]` pointer line: the box, the whitespace-delimited pointer token, and the inline note segment that trails it. */
 const FILE_POINTER_RE = /^-\s*\[([ xX])\]\s*(\S+)(?:\s+(.*))?$/
 /** A pointer token's trailing `#<line>` (greedy, so a `#` inside the path stays in it). */
 const POINTER_LINE_RE = /^(.*)#(\d+)$/
-/** The optional dash a continuation line may lead with — em dash, en dash, or hyphens. */
+/** The optional dash that may lead the inline note segment or a continuation line — em dash, en dash, or hyphens. */
 const NOTE_SEPARATOR_RE = /^[—–-]+\s*/
 
 /** The `# Review: <hash>` header, required as the document's first non-blank line. */
@@ -114,26 +130,33 @@ interface ParsedPointer {
   readonly line?: number
   readonly checked: boolean
   readonly sourceLine: number
-  /** Whatever trailed the pointer token on its own line, trimmed — present exactly when that line is invalid (Task 2). */
-  readonly trailingText?: string
+  /** Whatever trailed the pointer token on its own line, trimmed — the note's first segment, not an error carrier. Absent when the line is clean. */
+  readonly inlineNote?: string
 }
 
-/** One `- [ ]` / `- [x]` file-pointer line, or `undefined` if `line` isn't one. The regex is unchanged from the legacy same-line-note form — a line WITH trailing text still parses, so the resulting error can point at it precisely (see the module docstring). */
+/** True when `token` parses as a file pointer's path token — leading `./`, and a path longer than two characters once an optional `#<line>` suffix is stripped. The single source of truth for "is this a pointer token", shared by `parseFilePointer` and the second-pointer finding below so the two can never drift apart. */
+const isPointerToken = (token: string): boolean => {
+  if (!token.startsWith("./")) return false
+  const lineMatch = POINTER_LINE_RE.exec(token)
+  const path = lineMatch ? lineMatch[1]! : token
+  return path.length > 2 // `./` with nothing after it is not a path
+}
+
+/** One `- [ ]` / `- [x]` file-pointer line, or `undefined` if `line` isn't one. Text trailing the pointer token on its own line still parses — it becomes the note's inline segment (see the module docstring), not an error. */
 const parseFilePointer = (line: string, sourceLine: number): ParsedPointer | undefined => {
   const match = FILE_POINTER_RE.exec(line)
   if (!match) return undefined
   const token = match[2]!
-  if (!token.startsWith("./")) return undefined
+  if (!isPointerToken(token)) return undefined
   const lineMatch = POINTER_LINE_RE.exec(token)
   const path = lineMatch ? lineMatch[1]! : token
-  if (path.length <= 2) return undefined // `./` with nothing after it is not a path
-  const trailingText = (match[3] ?? "").trim()
+  const inlineNote = (match[3] ?? "").trim()
   return {
     checked: match[1] !== " ",
     path,
     ...(lineMatch ? { line: Number(lineMatch[2]) } : {}),
     sourceLine,
-    ...(trailingText.length > 0 ? { trailingText } : {}),
+    ...(inlineNote.length > 0 ? { inlineNote } : {}),
   }
 }
 
@@ -164,15 +187,6 @@ const pointerEndIndex = (body: readonly BodyLine[], index: number): number => {
   return end
 }
 
-/** The trailing-text validation error for one pointer whose own line carries text after the pointer token. */
-const trailingTextError = (title: string, pointer: ParsedPointer): SteeringFinding => {
-  const target = pointer.line !== undefined ? `${pointer.path}#${pointer.line}` : pointer.path
-  return {
-    message: `Chunk "${title}" hunk ${target} has text on the pointer line — move the explanation to the line(s) below it`,
-    line: pointer.sourceLine,
-  }
-}
-
 /** Joins a pointer's gathered explanation: every non-blank line strictly between `startIndex` and `endIndex` (inclusive), each stripped of a leading dash, joined with a single space. */
 const gatherNote = (body: readonly BodyLine[], startIndex: number, endIndex: number): string => {
   const noteLines: string[] = []
@@ -183,7 +197,39 @@ const gatherNote = (body: readonly BodyLine[], startIndex: number, endIndex: num
   return noteLines.join(" ").trim()
 }
 
-/** One pointer's parsed `ReviewFile` (span + gathered note), its trailing-text error when its own line carried one, and the body index just past its span for the caller to resume from. */
+/**
+ * The second-pointer validation error: a note whose first token is itself a
+ * pointer token. The relaxed same-line form would otherwise silently read
+ * `- [ ] ./a.ts#1 ./b.ts#2` (or with a separator, `- [ ] ./a.ts#1 — ./b.ts#2`)
+ * as ONE pointer whose note is `./b.ts#2`, dropping the second hunk entirely —
+ * this is the one case the relaxed parser must still refuse, and it points at
+ * the pointer's own `sourceLine` so it renders as a positioned finding.
+ */
+const secondPointerError = (
+  title: string,
+  pointer: ParsedPointer,
+  secondToken: string,
+): SteeringFinding => {
+  const target = pointer.line !== undefined ? `${pointer.path}#${pointer.line}` : pointer.path
+  return {
+    message: `Chunk "${title}" hunk ${target}'s note starts with a second pointer (${secondToken}) — give it its own "- [ ]" line`,
+    line: pointer.sourceLine,
+  }
+}
+
+/**
+ * One pointer's parsed `ReviewFile` — its note composed from the inline
+ * (same-line) segment first, then the lines gathered from below it, joined
+ * with a single space — plus the second-pointer finding when the inline
+ * segment itself opens with a pointer token, and the body index just past
+ * this pointer's span for the caller to resume from.
+ *
+ * The second-pointer check is scoped to the inline segment ALONE, never the
+ * composed note: a below-pointer explanation that legitimately opens with a
+ * path (`./src/foo.ts is the caller`) must not be refused — refusing a
+ * legitimate explanation is exactly the class of hard stop this format
+ * relaxation exists to remove.
+ */
 const parsePointerSpan = (
   title: string,
   body: readonly BodyLine[],
@@ -191,17 +237,22 @@ const parsePointerSpan = (
   pointer: ParsedPointer,
 ): { readonly file: ReviewFile; readonly error?: SteeringFinding; readonly nextIndex: number } => {
   const endIndex = pointerEndIndex(body, index)
-  const note = gatherNote(body, index, endIndex)
-  const { trailingText, ...pointerFields } = pointer
+  const inlineSegment = (pointer.inlineNote ?? "").replace(NOTE_SEPARATOR_RE, "")
+  const belowNote = gatherNote(body, index, endIndex)
+  const note = [inlineSegment, belowNote].filter((segment) => segment.length > 0).join(" ")
+  const { inlineNote: _inlineNote, ...pointerFields } = pointer
   const file: ReviewFile = {
     ...pointerFields,
     endLine: body[endIndex]!.line,
     ...(note.length > 0 ? { note } : {}),
-    ...(trailingText !== undefined ? { trailingText } : {}),
   }
+  const secondToken = inlineSegment.split(/\s+/)[0] ?? ""
+  const error = isPointerToken(secondToken)
+    ? secondPointerError(title, pointer, secondToken)
+    : undefined
   return {
     file,
-    ...(trailingText !== undefined ? { error: trailingTextError(title, pointer) } : {}),
+    ...(error ? { error } : {}),
     nextIndex: endIndex + 1,
   }
 }
@@ -264,7 +315,7 @@ const splitChunks = (
   return chunks
 }
 
-/** Parses every `##` chunk into a `Changeset`, collecting one error per chunk with no file pointers plus each chunk body's own trailing-text errors. */
+/** Parses every `##` chunk into a `Changeset`, collecting one error per chunk with no file pointers plus each chunk body's own second-pointer errors. */
 const parseChangesets = (
   lines: readonly string[],
 ): { readonly changesets: readonly Changeset[]; readonly errors: readonly SteeringFinding[] } => {
@@ -468,6 +519,7 @@ const reviewPointerAt = (
 
 /** The `review` steering format: gtd's own in-process review-checkbox format — validation, outline, code actions, and `pointerAt` (a hunk pointer's go-to-definition target). */
 export const REVIEW_FORMAT: SteeringFormat = {
+  sample: REVIEW_SAMPLE,
   validate: (content) => parseReviewFindings(content).findings,
   outline: reviewOutline,
   actions: reviewActions,

--- a/src/SteeringFormat.ts
+++ b/src/SteeringFormat.ts
@@ -71,6 +71,20 @@ export interface SteeringFinding {
  * has none; `review` does).
  */
 export interface SteeringFormat {
+  /**
+   * A canonical, hand-authored example of this format — the CLEAREST minimal
+   * document that satisfies its own `validate`, nothing more. Required (not
+   * optional) so a new built-in format can't ship without one:
+   * `src/SteeringFormats.test.ts` asserts `validate(sample)` returns zero
+   * findings for every registry entry, and `src/ModeContradiction.ts` round-
+   * trips this exact string through a mode's `format:` command to catch a
+   * formatter that breaks its own validator (see that module's doc comment).
+   * Deliberately NOT authored to survive any particular formatter — a
+   * formatter that reflows this sample into something invalid IS the
+   * contradiction the round-trip exists to find, so designing the sample
+   * around one would hide the very bug it reports.
+   */
+  readonly sample: string
   readonly validate: (content: string) => readonly SteeringFinding[]
   readonly outline: (content: string) => readonly SteeringOutlineNode[]
   readonly actions: (

--- a/src/SteeringFormats.test.ts
+++ b/src/SteeringFormats.test.ts
@@ -49,3 +49,18 @@ describe("seededValidateCommand / isSeededValidateCommand", () => {
     expect(isSeededValidateCommand("qa", `gtd check qa "<%= it.file %>"`)).toBe(false)
   })
 })
+
+describe("every registry entry's sample", () => {
+  // Load-bearing, not a nicety (see the package's own doc comment on this
+  // acceptance criterion): `src/ModeContradiction.ts` round-trips this exact
+  // sample through a mode's declared `format:` command, then re-validates it
+  // — a sample that doesn't validate clean to begin with would hard-stop
+  // every prompt beat that declares `file:`+`mode:`, at 3 wasted agent turns
+  // each, with no way to tell a real contradiction from a drifted fixture.
+  it("validates clean under its own format's parser", () => {
+    for (const mode of builtInModeNames()) {
+      const format = steeringFormatFor(mode)!
+      expect(format.validate(format.sample)).toEqual([])
+    }
+  })
+})

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -836,12 +836,155 @@ describe("gtd next --json — embedded validate script", () => {
     expect(next.validate).toBe(validateStdout.replace(/\n$/, ""))
   })
 
-  it("omits validate when the declared file is absent from the working tree", async () => {
+  it("still embeds a validate script when the declared file is absent — the existence check moved INSIDE the script (package 2)", async () => {
+    // A first-write beat (the declared file doesn't exist yet) used to
+    // withhold `validate` entirely, silencing every driver's repair loop
+    // (`while [ -n "$gtd_validate" ]`) at exactly the beat that needs it.
+    // Existence is now a leading `[ -f <file> ] || exit 0` guard INSIDE the
+    // emitted script instead, evaluated once the script actually runs.
     const repo = seededRepoAtWorking()
     const { stdout, exitCode } = await run(repo, "next", "--json")
     expect(exitCode).toBe(0)
     const parsed = JSON.parse(stdout) as Record<string, unknown>
-    expect(parsed).not.toHaveProperty("validate")
+    expect(parsed).toHaveProperty("validate")
+    expect(parsed.validate).toContain(`[ -f '.gtd/PLAN.md' ] || exit 0`)
+    expect(parsed.validate).toContain(`gtd check qa '.gtd/PLAN.md'`)
+  })
+})
+
+describe("gtd validate — the mode-contradiction round-trip (package 2, Requirement B)", () => {
+  /** Same as `run`, but with an injected env — needed to pin the round-trip's scratch path deterministically (`TMPDIR`). */
+  const runEnv = async (
+    repo: InMemRepo,
+    env: Readonly<Record<string, string | undefined>>,
+    ...args: string[]
+  ): Promise<{ readonly stdout: string; readonly stderr: string; readonly exitCode: number }> => {
+    const { io, result } = makeCapturingCliIo(repo, env)
+    await Effect.runPromise(runCli(["node", "gtd.js", ...args], io))
+    return result()
+  }
+
+  const workflowWithMode = (modesYaml: string, stateMode = "qa"): string =>
+    [
+      "workflow:",
+      "  modes:",
+      modesYaml,
+      "  entry:",
+      "    default: root",
+      "  machines:",
+      "    root:",
+      "      entry: idle",
+      "      states:",
+      "        idle:",
+      "          actor: human",
+      "          message: write NOTE.md to start a process",
+      "          on:",
+      '            "* **": working',
+      "        working:",
+      "          actor: agent",
+      '          file: "PLAN.md"',
+      `          mode: ${stateMode}`,
+      "          prompt: do the work",
+      "          on:",
+      '            "* **": idle',
+      "",
+    ].join("\n")
+
+  const seededRepoAtWorking = (modesYaml: string, stateMode = "qa"): InMemRepo => {
+    const repo = new InMemRepo()
+    repo.writeFile(".gtdrc.yaml", workflowWithMode(modesYaml, stateMode))
+    repo.commitAllWithPrefix("chore: add custom workflow")
+    repo.writeFile("NOTE.md", "a note\n")
+    repo.commitAllWithPrefix("gtd(human): working")
+    return repo
+  }
+
+  it("a live built-in validator (qa, with a declared format:) emits the round-trip BEFORE the existence guard, using the scratch path under TMPDIR", async () => {
+    const repo = seededRepoAtWorking(
+      ["    qa:", '      format: "my-formatter <%= it.file %>"'].join("\n"),
+    )
+    const { stdout, exitCode } = await runEnv(repo, { TMPDIR: "/fixture-scratch" }, "validate")
+    expect(exitCode).toBe(0)
+
+    const samplePath = `/fixture-scratch/gtd-mode-sample-qa-${process.pid}.md`
+    const roundTripIndex = stdout.indexOf(`printf '%s' `)
+    const guardIndex = stdout.indexOf(`[ -f '.gtd/PLAN.md' ] || exit 0`)
+    // The REAL format command, rendered against the real file — distinct
+    // from the round-trip's OWN copy of "my-formatter" (rendered against the
+    // scratch sample path), which appears earlier, inside the message text.
+    const formatIndex = stdout.indexOf(`my-formatter .gtd/PLAN.md`)
+    const validateIndex = stdout.indexOf(`gtd_validate_out=`)
+
+    expect(roundTripIndex).toBeGreaterThan(-1)
+    expect(guardIndex).toBeGreaterThan(-1)
+    // Ordering per the package's "How" section: round-trip/notice, guard, format:, validate:.
+    expect(roundTripIndex).toBeLessThan(guardIndex)
+    expect(guardIndex).toBeLessThan(formatIndex)
+    expect(formatIndex).toBeLessThan(validateIndex)
+
+    expect(stdout).toContain(samplePath)
+    expect(stdout).toContain(`my-formatter ${samplePath}`)
+    expect(stdout).toContain(`gtd check qa '${samplePath}' >/dev/null 2>&1 || {`)
+    expect(stdout).toContain("CONFIGURATION BUG")
+    expect(stdout).toContain("Do NOT edit the steering file")
+  })
+
+  it("an external validate: command (a genuine override, not gtd's own seeded string) prints a one-line skip notice instead of the round-trip", async () => {
+    const repo = seededRepoAtWorking(
+      ["    qa:", '      format: "my-formatter <%= it.file %>"', '      validate: "true"'].join(
+        "\n",
+      ),
+    )
+    const { stdout, exitCode } = await runEnv(repo, { TMPDIR: "/fixture-scratch" }, "validate")
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('mode "qa" has an external validate: command')
+    expect(stdout).toContain("skipping")
+    expect(stdout).not.toContain("printf '%s' ")
+    expect(stdout).not.toContain("CONFIGURATION BUG")
+  })
+
+  it("a format-only mode (no validate at all) emits neither the round-trip nor the skip notice — just the guard and the format command", async () => {
+    const repo = seededRepoAtWorking(
+      ["    prose:", '      format: "my-formatter <%= it.file %>"'].join("\n"),
+      "prose",
+    )
+    const { stdout, exitCode } = await runEnv(repo, { TMPDIR: "/fixture-scratch" }, "validate")
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain(`[ -f '.gtd/PLAN.md' ] || exit 0`)
+    expect(stdout).toContain("my-formatter .gtd/PLAN.md")
+    expect(stdout).not.toContain("printf '%s' ")
+    expect(stdout).not.toContain("CONFIGURATION BUG")
+    expect(stdout).not.toContain("skipping")
+  })
+
+  it("no format: command at all emits neither — same as before this package", async () => {
+    const repo = seededRepoAtWorking("    qa: {}")
+    const { stdout, exitCode } = await runEnv(repo, { TMPDIR: "/fixture-scratch" }, "validate")
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain(`[ -f '.gtd/PLAN.md' ] || exit 0`)
+    expect(stdout).not.toContain("printf '%s' ")
+    expect(stdout).not.toContain("skipping")
+  })
+
+  it("resolves the scratch dir from node:os's tmpdir() when TMPDIR is unset or empty", async () => {
+    const repo = seededRepoAtWorking(
+      ["    qa:", '      format: "my-formatter <%= it.file %>"'].join("\n"),
+    )
+    const { stdout, exitCode } = await runEnv(repo, {}, "validate")
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain(`gtd-mode-sample-qa-${process.pid}.md`)
+  })
+
+  it("gtd validate the COMMAND still exits 0 even when the emitted SCRIPT would fail if run", async () => {
+    // gtd itself never runs the script — it only prints it — so a
+    // contradiction inside the printed script never surfaces as gtd
+    // validate's own exit code (see the README's closed five-number
+    // exit-code table).
+    const repo = seededRepoAtWorking(
+      ["    qa:", '      format: "my-formatter <%= it.file %>"'].join("\n"),
+    )
+    const { exitCode } = await runEnv(repo, { TMPDIR: "/fixture-scratch" }, "validate")
+    expect(exitCode).toBe(0)
   })
 })
 
@@ -1123,22 +1266,22 @@ describe("gtd check <mode> <file>", () => {
 
   it("a positioned finding prints '<file>:<line>: <message>' with a 1-based line number, on stderr", async () => {
     const repo = bareRepo()
-    const trailingTextDoc = [
+    const secondPointerDoc = [
       "# Review: abc1234",
       "<!-- base: abc1234def5678901234567890123456789abcd -->",
       "",
       "## Add calculator",
       "",
-      "- [ ] ./src/calc.ts#1 — legacy trailing note",
+      "- [ ] ./src/calc.ts#1 — ./src/other.ts#2",
       "",
     ].join("\n")
-    repo.writeFile("REVIEW.md", trailingTextDoc)
+    repo.writeFile("REVIEW.md", secondPointerDoc)
     const { stdout, stderr, exitCode } = await run(repo, "check", "review", "REVIEW.md")
     expect(exitCode).toBe(1)
     expect(stdout).toBe("")
-    // The trailing-text pointer is the 0-based 6th line (index 5) — printed 1-based as 6.
+    // The offending pointer is the 0-based 6th line (index 5) — printed 1-based as 6.
     expect(stderr).toContain(
-      'REVIEW.md:6: Chunk "Add calculator" hunk ./src/calc.ts#1 has text on the pointer line — move the explanation to the line(s) below it',
+      'REVIEW.md:6: Chunk "Add calculator" hunk ./src/calc.ts#1\'s note starts with a second pointer (./src/other.ts#2) — give it its own "- [ ]" line',
     )
   })
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path"
+import { tmpdir } from "node:os"
 import { FileSystem } from "@effect/platform"
 import { Effect, Either, Option, Runtime } from "effect"
 import type { ArtifactOut, Command, Needs } from "./Cli.js"
@@ -49,7 +50,14 @@ import { deletesFile, enforceStepGuards } from "./StepGuards.js"
 import { unansweredQuestions } from "./OpenQuestions.js"
 import { builtInModeNames, seededValidateCommand, steeringFormatFor } from "./SteeringFormats.js"
 import type { SteeringFinding } from "./SteeringFormat.js"
-import { resolveSteeringMode, renderSteeringCommands, unknownModeMessage } from "./SteeringMode.js"
+import {
+  resolveSteeringMode,
+  renderSteeringCommands,
+  steeringCapabilities,
+  unknownModeMessage,
+  type ResolvedMode,
+} from "./SteeringMode.js"
+import { buildModeContradictionCheck, modeContradictionSkipNotice } from "./ModeContradiction.js"
 import {
   contentKindOf,
   initialStateOf,
@@ -78,7 +86,13 @@ import {
 } from "./Beat.js"
 import { renderModeCommand, renderStateTemplate, type TemplateContext } from "./PatternTemplates.js"
 import { deleteRef, hardResetTo, mixedResetTo, updateRef } from "./GitScript.js"
-import { combinedScript, emitScripts, type EmitPreconditions, type EmitStep } from "./Emit.js"
+import {
+  combinedScript,
+  emitScripts,
+  fileExistsGuard,
+  type EmitPreconditions,
+  type EmitStep,
+} from "./Emit.js"
 import {
   abandonedOutcome,
   abandonNoopOutcome,
@@ -272,8 +286,13 @@ const steeringModeSteps = (
     if (resolved === undefined) {
       return yield* Effect.fail(new Error(unknownModeMessage(rest.def, rest.state, mode)))
     }
-    const commands = yield* renderSteeringCommands(resolved, file, rest.context)
-    return commands.map((command): EmitStep => ({ kind: "command", command }))
+    // The LAST command carries `onFailure: fixPromptInstruction(file)` when the
+    // validator is a command — the same wrapper `resolveValidateScript`'s own
+    // script uses — so a failing validate INSIDE this landing step's script
+    // prints the routable fix prompt instead of bare findings (package 2's
+    // Requirement A: the one path that fired on the stuck worktree used to
+    // print thirteen raw findings a driver can't route).
+    return yield* renderSteeringModeCommandSteps(resolved, file, rest.context)
   })
 
 /**
@@ -817,40 +836,25 @@ const emitsValidatablePrompt = (rendered: RenderedRest): boolean =>
   rendered.kind === "prompt" && rendered.file !== undefined && rendered.mode !== undefined
 
 /**
- * Resolve the resting state's own steering-file validate script — the SAME
- * script both `gtd validate --json` (`runValidateCommand`, its thin caller
- * now) and `gtd next --json`'s embedded `validate` field emit, from one
- * shared resolver so the two surfaces can't drift. `undefined` = nothing to
- * validate: no `file:`+`mode:` declared, or the declared file is absent from
- * the working tree. An unknown `mode:` FAILS this Effect (exactly as
- * `runValidateCommand` always has) — `runNextCommand` is the one caller that
- * degrades that failure to omitting `validate`, mirroring how the plain-text
- * self-validation instruction already degrades on the same failure.
+ * Render `resolved`'s format:/validate: commands as `EmitStep[]`, wrapping
+ * the LAST one with `onFailure: fixPromptInstruction(file)` when the
+ * validator is a command — shared by `resolveValidateScript`'s own script
+ * (`gtd validate`/`gtd next --json`'s embedded `.validate`) and
+ * `steeringModeSteps`' landing-time one, so the two can never drift on which
+ * command gets the routable fix prompt (package 2's Requirement A: before
+ * this, `steeringModeSteps` carried no `onFailure` at all, so a failing
+ * landing-time validate printed thirteen raw findings a driver couldn't
+ * route).
  */
-const resolveValidateScript = (
-  rest: Rest,
-): Effect.Effect<
-  { readonly file: string; readonly mode: StateMode; readonly script: string } | undefined,
-  Error,
-  FileSystem.FileSystem
-> =>
+const renderSteeringModeCommandSteps = (
+  resolved: ResolvedMode,
+  file: string,
+  context: TemplateContext,
+): Effect.Effect<readonly EmitStep[], Error> =>
   Effect.gen(function* () {
-    const file = rest.hints.file
-    const mode = rest.stateDef.mode
-    if (file === undefined || mode === undefined) return undefined
-
-    const fs = yield* FileSystem.FileSystem
-    const toError = (e: unknown): Error => (e instanceof Error ? e : new Error(String(e)))
-    const present = yield* fs.exists(file).pipe(Effect.mapError(toError))
-    if (!present) return undefined
-
-    const resolved = resolveSteeringMode(rest.def, mode)
-    if (resolved === undefined) {
-      return yield* Effect.fail(new Error(unknownModeMessage(rest.def, rest.state, mode)))
-    }
-    const commands = yield* renderSteeringCommands(resolved, file, rest.context)
+    const commands = yield* renderSteeringCommands(resolved, file, context)
     const lastIndex = commands.length - 1
-    const steps: EmitStep[] = commands.map(
+    return commands.map(
       (command, index): EmitStep => ({
         kind: "command",
         command,
@@ -859,6 +863,140 @@ const resolveValidateScript = (
           : {}),
       }),
     )
+  })
+
+/**
+ * The scratch directory a contradiction round-trip's sample is written
+ * under: `EnvVars.all["TMPDIR"]` when set and non-empty, `node:os`'s
+ * `tmpdir()` otherwise — never a `/tmp` literal or `mktemp`
+ * (`tests/tooling/no-tmp-assumption.test.ts` scans `src/` for both). Reading
+ * `EnvVars` first is what makes the emitted script deterministic in unit
+ * tests, which inject a fixed `TMPDIR`.
+ */
+const scratchDir = (envVars: {
+  readonly all: Readonly<Record<string, string | undefined>>
+}): string => {
+  const configured = envVars.all["TMPDIR"]
+  return configured !== undefined && configured.length > 0 ? configured : tmpdir()
+}
+
+/**
+ * `<scratchDir>/gtd-mode-sample-<mode>-<pid>.md` — an absolute literal baked
+ * in at EMIT time (never re-derived by a shell variable at run time: a
+ * `format:` template like `npx oxfmt --write '<%= it.file %>'` renders
+ * `it.file` inside single quotes, which no shell expands, so `mktemp`/
+ * `${TMPDIR:-/tmp}` forms would never actually resolve). `<pid>` is
+ * `process.pid`, so two concurrent `gtd` processes never collide. The `.md`
+ * suffix is load-bearing — without it a formatter may refuse the file
+ * outright (a raw `format:` failure, not the contradiction finding this
+ * exists to produce).
+ */
+const scratchSamplePath = (
+  envVars: { readonly all: Readonly<Record<string, string | undefined>> },
+  mode: StateMode,
+): string => join(scratchDir(envVars), `gtd-mode-sample-${mode}-${process.pid}.md`)
+
+/**
+ * The contradiction round-trip/skip-notice tier for `resolved`'s `mode:`,
+ * read off `steeringCapabilities` — no new resolution vocabulary (see
+ * `src/SteeringMode.ts`). `formatCommand` absent means nothing to round-trip
+ * (no formatter, no contradiction to find): empty. Otherwise, three cases —
+ * a LIVE built-in validator (covers `qa`/`review` under gtd's seeded
+ * `gtd check <mode> '<file>'` validator, and the `builtin` validator kind)
+ * runs the round-trip against that format's own canonical sample
+ * (`SteeringFormat.sample`); an EXTERNAL validator (a genuine user
+ * `validate:` override, or any command-validated non-built-in mode) prints a
+ * one-line skip notice instead — coverage is the two built-in modes only, and
+ * silence would read as a clean bill of health; a format-only mode with
+ * neither (no in-process parser at all) has nothing to round-trip either:
+ * empty, same as no formatter.
+ *
+ * Emitted BEFORE `Emit.ts`'s `fileExistsGuard` in the caller's step list —
+ * that is the whole reason to use a bundled sample rather than the real file:
+ * it keeps the check alive at a first-write beat where the real steering file
+ * does not exist yet (see the package's own "How" section).
+ */
+const modeContradictionSteps = (
+  resolved: ResolvedMode,
+  mode: StateMode,
+  context: TemplateContext,
+): Effect.Effect<readonly EmitStep[], Error, EnvVars> =>
+  Effect.gen(function* () {
+    if (resolved.formatCommand === undefined) return []
+    const capabilities = steeringCapabilities(resolved)
+    if (capabilities.format !== undefined && capabilities.liveValidate !== undefined) {
+      const envVars = yield* EnvVars
+      const samplePath = scratchSamplePath(envVars, mode)
+      const formatCommand = yield* Effect.try({
+        try: () => renderModeCommand(resolved.formatCommand!, { ...context, file: samplePath }),
+        catch: (e) =>
+          new Error(
+            `mode "${mode}": "format" command failed to render — ${
+              e instanceof Error ? e.message : String(e)
+            }`,
+          ),
+      })
+      const block = buildModeContradictionCheck({
+        mode,
+        samplePath,
+        sample: capabilities.format.sample,
+        formatCommand,
+      })
+      return [{ kind: "command", command: block }]
+    }
+    if (capabilities.externalValidate === true) {
+      return [{ kind: "command", command: modeContradictionSkipNotice(mode) }]
+    }
+    return []
+  })
+
+/**
+ * Resolve the resting state's own steering-file validate script — the SAME
+ * script both `gtd validate --json` (`runValidateCommand`, its thin caller
+ * now) and `gtd next --json`'s embedded `validate` field emit, from one
+ * shared resolver so the two surfaces can't drift. `undefined` = nothing to
+ * validate at all: no `file:`+`mode:` declared. An unknown `mode:` FAILS this
+ * Effect (exactly as `runValidateCommand` always has) — `runNextCommand` is
+ * the one caller that degrades that failure to omitting `validate`,
+ * mirroring how the plain-text self-validation instruction already degrades
+ * on the same failure.
+ *
+ * The declared file's PRESENCE is no longer checked here in TS-land: a
+ * missing file used to short-circuit this whole function to `undefined`,
+ * which withheld the repair loop at exactly the first-write beat that needs
+ * it (every `while [ -n "$gtd_validate" ]` driver loop only fires when this
+ * field is non-empty — see the package's own doc comment). Existence is
+ * instead evaluated INSIDE the emitted script itself, via `Emit.ts`'s
+ * `fileExistsGuard`, once it is knowable (after the turn) — an `EmitStep`
+ * list is always produced when `file:`+`mode:` are both declared, even for a
+ * file that turns out absent; that script's own `[ -f <file> ] || exit 0`
+ * then exits 0 with nothing to do, preserving the "a turn that legitimately
+ * wrote nothing burns no fix turns" property. The contradiction round-trip
+ * (`modeContradictionSteps`) is emitted BEFORE that guard, so it still runs
+ * at that same first-write beat, ahead of it.
+ */
+const resolveValidateScript = (
+  rest: Rest,
+): Effect.Effect<
+  { readonly file: string; readonly mode: StateMode; readonly script: string } | undefined,
+  Error,
+  EnvVars
+> =>
+  Effect.gen(function* () {
+    const file = rest.hints.file
+    const mode = rest.stateDef.mode
+    if (file === undefined || mode === undefined) return undefined
+
+    const resolved = resolveSteeringMode(rest.def, mode)
+    if (resolved === undefined) {
+      return yield* Effect.fail(new Error(unknownModeMessage(rest.def, rest.state, mode)))
+    }
+
+    const steps: EmitStep[] = [
+      ...(yield* modeContradictionSteps(resolved, mode, rest.context)),
+      { kind: "command", command: fileExistsGuard(file) },
+      ...(yield* renderSteeringModeCommandSteps(resolved, file, rest.context)),
+    ]
     const script = emitScripts(headPreconditions(rest.context.currentCommit), steps).required
     return { file, mode, script }
   })

--- a/src/testing/EmittedScriptRecognizer.test.ts
+++ b/src/testing/EmittedScriptRecognizer.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   combinedScript,
   emitScripts,
+  fileExistsGuard,
   headAssertion,
   reviewWindowAssertion,
   type EmitStep,
@@ -24,6 +25,7 @@ import {
   REVIEW_HEAD_REF,
 } from "../ReviewWindow.js"
 import { commitOutcome, noteOutcome, OUTCOME_PREAMBLE } from "../OutcomeScript.js"
+import { buildModeContradictionCheck, modeContradictionSkipNotice } from "../ModeContradiction.js"
 import { applyEmittedScript, preconditionHeadEquals } from "./EmittedScriptRecognizer.js"
 import { InMemRepo } from "./InMemRepo.js"
 import type { ScriptedCommand } from "./Layers.js"
@@ -245,6 +247,131 @@ describe("applyEmittedScript — gtd check <mode> <file>", () => {
 
     expect(result.ok).toBe(false)
     expect(result.error).toContain("gtd check qa")
+  })
+})
+
+describe("applyEmittedScript — Emit.ts's fileExistsGuard", () => {
+  it("is a no-op continuation when the file is present", () => {
+    const repo = new InMemRepo()
+    repo.writeFile(".gtd/PLAN.md", "content")
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, fileExistsGuard(".gtd/PLAN.md"))
+
+    expect(result).toEqual({ ok: true })
+  })
+
+  it("stops the whole script (successfully) when the file is absent — unlike every other guard, it does not fail", () => {
+    const repo = new InMemRepo()
+
+    const script = [fileExistsGuard(".gtd/PLAN.md"), "gtd check qa '.gtd/PLAN.md'"].join("\n\n")
+    const result = applyEmittedScript(repo, NO_COMMANDS, script)
+
+    expect(result).toEqual({ ok: true })
+  })
+
+  it("a subsequent block after the guard trips is never applied", () => {
+    const repo = new InMemRepo()
+    const commands: ReadonlyMap<string, ScriptedCommand> = new Map([
+      ["./should-not-run.sh", { kind: "rewrite", file: "MARKER.md", content: "ran" }],
+    ])
+
+    const script = [fileExistsGuard(".gtd/PLAN.md"), "./should-not-run.sh"].join("\n\n")
+    applyEmittedScript(repo, commands, script)
+
+    expect(repo.readFile("MARKER.md")).toBeUndefined()
+  })
+})
+
+describe("applyEmittedScript — ModeContradiction.ts's skip notice", () => {
+  it("is an inert no-op — a mode with an external validator prints a notice and continues", () => {
+    const repo = new InMemRepo()
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, modeContradictionSkipNotice("adr"))
+
+    expect(result).toEqual({ ok: true })
+  })
+})
+
+describe("applyEmittedScript — ModeContradiction.ts's contradiction round-trip", () => {
+  const samplePath = "/fixture-scratch/gtd-mode-sample-qa-1234.md"
+  const sample = "Sample plan.\n\n## Open Questions\n\n### Which?\n\n- [ ] A\n- [ ] B\n"
+
+  it("passes (and cleans up the scratch file) when the formatter leaves the sample valid", () => {
+    const repo = new InMemRepo()
+    const commands: ReadonlyMap<string, ScriptedCommand> = new Map([
+      ["my-formatter " + samplePath, { kind: "exit", status: 0, output: "" }],
+    ])
+    const block = buildModeContradictionCheck({
+      mode: "qa",
+      samplePath,
+      sample,
+      formatCommand: `my-formatter ${samplePath}`,
+    })
+
+    const result = applyEmittedScript(repo, commands, block)
+
+    expect(result).toEqual({ ok: true })
+    expect(repo.readFile(samplePath)).toBeUndefined()
+  })
+
+  it("fails (and cleans up the scratch file) when the formatter breaks the sample under its own parser", () => {
+    const repo = new InMemRepo()
+    const commands: ReadonlyMap<string, ScriptedCommand> = new Map([
+      [
+        "my-formatter " + samplePath,
+        {
+          kind: "rewrite",
+          file: samplePath,
+          content: "## Open Questions\n\n### \n\nblank heading, invalid",
+        },
+      ],
+    ])
+    const block = buildModeContradictionCheck({
+      mode: "qa",
+      samplePath,
+      sample,
+      formatCommand: `my-formatter ${samplePath}`,
+    })
+
+    const result = applyEmittedScript(repo, commands, block)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain("CONFIGURATION BUG")
+    expect(result.error).toContain("### ")
+    expect(repo.readFile(samplePath)).toBeUndefined()
+  })
+
+  it("fails loudly on an unscripted format: command rather than silently passing", () => {
+    const repo = new InMemRepo()
+    const block = buildModeContradictionCheck({
+      mode: "qa",
+      samplePath,
+      sample,
+      formatCommand: "unregistered-formatter " + samplePath,
+    })
+
+    const result = applyEmittedScript(repo, NO_COMMANDS, block)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain("unscripted command")
+    expect(repo.readFile(samplePath)).toBeUndefined()
+  })
+
+  it("leaves nothing in the repo either way — no untracked path for changedPaths to report", () => {
+    const repo = new InMemRepo()
+    const commands: ReadonlyMap<string, ScriptedCommand> = new Map([
+      ["my-formatter " + samplePath, { kind: "exit", status: 0, output: "" }],
+    ])
+    const block = buildModeContradictionCheck({
+      mode: "qa",
+      samplePath,
+      sample,
+      formatCommand: `my-formatter ${samplePath}`,
+    })
+
+    applyEmittedScript(repo, commands, block)
+
+    expect(repo.pathsUnder("").includes(samplePath)).toBe(false)
   })
 })
 

--- a/src/testing/EmittedScriptRecognizer.ts
+++ b/src/testing/EmittedScriptRecognizer.ts
@@ -56,11 +56,17 @@ import {
 import {
   DID_NOT_RUN_COMMENT,
   failurePromptWrapper,
+  fileExistsGuard,
   headAssertion,
   PRESENTATION_FAILURE_WARNING,
   PRESENTATION_ONLY_COMMENT,
   reviewWindowAssertion,
 } from "../Emit.js"
+import {
+  buildModeContradictionCheck,
+  contradictionMessage,
+  modeContradictionSkipNotice,
+} from "../ModeContradiction.js"
 import { OUTCOME_PREAMBLE } from "../OutcomeScript.js"
 import {
   buildCloseWindowScript,
@@ -70,6 +76,7 @@ import {
   type WindowRefs,
 } from "../ReviewWindow.js"
 import { steeringFormatFor } from "../SteeringFormats.js"
+import type { SteeringFormat } from "../SteeringFormat.js"
 import type { InMemRepo } from "./InMemRepo.js"
 import type { ScriptedCommand } from "./Layers.js"
 
@@ -119,6 +126,16 @@ type BlockOutcome =
   | { readonly kind: "noop" }
   | { readonly kind: "applied" }
   | { readonly kind: "failed"; readonly error: string }
+  /**
+   * `Emit.ts`'s `fileExistsGuard` tripping on an absent file: a real
+   * `[ -f <file> ] || exit 0` exits the WHOLE script cleanly right there,
+   * unlike every other guard here (`recognizePrecondition`/
+   * `recognizeHeadAssertion`/etc.), which either no-op or fail the script —
+   * this is the one shape that succeeds EARLY, skipping every remaining
+   * block. `applyEmittedScript`'s loop stops on this exactly like it stops
+   * on a `"failed"` block, but reports `{ ok: true }`.
+   */
+  | { readonly kind: "stopped" }
 
 /** Bash's own no-op preamble decoration — never a failure, never applies anything. */
 const SET_FLAGS_RE = /^set\s+-\S+(\s+\S+)*$/
@@ -307,6 +324,22 @@ const recognizeReviewWindowRefAssertion = (
 }
 
 /**
+ * `src/Emit.ts`'s REAL `fileExistsGuard` block — `src/program.ts`'s
+ * `resolveValidateScript` leads every emitted validate script with it now
+ * (package 2: the `fs.exists` short-circuit moved OUT of TS-land and into
+ * the script itself). Re-derives the block from the extracted path and
+ * compares full strings, same discipline as `recognizeHeadAssertion`. Unlike
+ * every OTHER guard in this file, a tripped `fileExistsGuard` does not fail
+ * the script — a real `exit 0` there ends it successfully right there — so
+ * this is the one recognizer that can report `{ kind: "stopped" }`.
+ */
+const recognizeFileExistsGuard = (repo: InMemRepo, block: string): BlockOutcome | undefined => {
+  const [file] = extractQuotedTokens(block)
+  if (file === undefined || fileExistsGuard(file) !== block) return undefined
+  return repo.readFile(file) !== undefined ? { kind: "noop" } : { kind: "stopped" }
+}
+
+/**
  * `src/Emit.ts`'s `gtd_retry` bash FUNCTION DEFINITION (`RETRY_HELPER`) —
  * present as its own block whenever any step is a `gitWrite`. Defining a
  * function is inert (it does nothing until called), so this is always a
@@ -481,6 +514,179 @@ const recognizeFailurePromptWrapper = (
   return innerOutcome
 }
 
+/**
+ * `src/ModeContradiction.ts`'s `modeContradictionSkipNotice` — a mode whose
+ * validator is EXTERNAL (a genuine user `validate:` override, or any
+ * command-validated non-built-in mode). A single loosely-recognized `printf`
+ * line, re-derived and compared against the real builder from the mode name
+ * embedded in its own (decoded) message text — same "call the real builder,
+ * never hand-copy its template" discipline as every other recognizer here,
+ * just extracting the one argument (`mode`) the builder needs from the
+ * message rather than from the shell syntax around it.
+ */
+const SKIP_NOTICE_MODE_RE = /mode "([^"]+)" has an external validate:/
+
+const recognizeModeContradictionSkipNotice = (block: string): BlockOutcome | undefined => {
+  // Two quoted tokens: the literal `printf` format string `'%s\n'` first,
+  // then the message itself.
+  const [, message] = extractQuotedTokens(block)
+  if (message === undefined) return undefined
+  const match = SKIP_NOTICE_MODE_RE.exec(message)
+  if (!match) return undefined
+  const mode = match[1]!
+  if (modeContradictionSkipNotice(mode) !== block) return undefined
+  return { kind: "noop" }
+}
+
+/**
+ * `src/ModeContradiction.ts`'s `buildModeContradictionCheck` — the
+ * contradiction round-trip block `src/program.ts`'s `resolveValidateScript`
+ * emits ahead of `fileExistsGuard` for a mode with a LIVE built-in validator
+ * and a declared `format:` (package 2, Requirement B). The block carries no
+ * blank line of its own, so it always arrives here as ONE block.
+ *
+ * Extraction, in order: `extractQuotedTokens` pulls the sample (the printf
+ * line's SECOND quoted argument, after its literal `'%s'` format string) and
+ * the scratch path (its third) off the WHOLE block — reliable regardless of
+ * how many literal newlines the sample itself carries, the same property the
+ * multi-line git builders above rely on. The scratch path is then enough to
+ * build its own `shellQuote`d form
+ * and find the fixed `<pathQ> >/dev/null 2>&1 || {\n` suffix that follows
+ * `gtd check <mode> ` — walking backward from there recovers `mode`, and
+ * everything between the printf line and that same line is the mode's
+ * rendered `format:` command. Every extracted piece is then confirmed by
+ * RE-RUNNING `buildModeContradictionCheck` and comparing the full block
+ * string, exactly like every other builder-backed recognizer here — so a
+ * wrong guess anywhere in the extraction just fails to recognize (returns
+ * `undefined`) rather than mis-simulating.
+ *
+ * Simulation: writes the sample to the scratch path, runs the extracted
+ * `format:` command through `recognizeScriptedCommand` (the ONLY way a
+ * command can execute against the in-memory tier — real bash is
+ * unreachable there), re-validates whatever ended up at the scratch path
+ * with the format's own parser, and cleans the scratch path up either way —
+ * mirroring the real script's `rm -f` on both the failure and success paths.
+ * An unscripted `format:` command fails loudly (mirroring
+ * `makeScriptedCommandRunner`'s own "unscripted command" error) rather than
+ * silently succeeding.
+ */
+/** Everything `parseModeContradictionCheck` recovers from a matched block — enough for `simulateModeContradictionCheck` to run it, with no further parsing. */
+interface ParsedModeContradictionCheck {
+  readonly mode: string
+  readonly samplePath: string
+  readonly sample: string
+  readonly formatCommand: string
+  readonly format: SteeringFormat
+}
+
+/**
+ * Parses `block` back into `buildModeContradictionCheck`'s own inputs, or
+ * `undefined` when it isn't one — split out of `recognizeModeContradictionCheck`
+ * so extraction (many small guards, no repo effects) and simulation (few
+ * guards, all the effects) each stay simple enough to read as their own
+ * function. Confirmed, like every other builder-backed recognizer here, by
+ * RE-RUNNING `buildModeContradictionCheck` on the recovered pieces and
+ * requiring a byte-for-byte match — a wrong guess anywhere just fails to
+ * parse rather than mis-simulating.
+ */
+/** The printf line's own pieces — the sample bytes, the scratch path, and the literal PREFIX text (up to and including that path) — or `undefined` when `block` doesn't open with `printf '%s' ...`. */
+const parsePrintfPrefix = (
+  block: string,
+):
+  | { readonly sample: string; readonly samplePath: string; readonly prefix: string }
+  | undefined => {
+  if (!block.startsWith("printf '%s' ")) return undefined
+  // Three leading quoted tokens: the literal printf format string `'%s'`
+  // first, then the sample, then the scratch path.
+  const [, sample, samplePath] = extractQuotedTokens(block)
+  if (sample === undefined || samplePath === undefined) return undefined
+  const prefix = `printf '%s' ${shellQuote(sample)} > ${shellQuote(samplePath)}`
+  if (!block.startsWith(`${prefix}\n`)) return undefined
+  return { sample, samplePath, prefix }
+}
+
+/** The mode name and `format:` command sandwiched between the printf `prefix` and the fixed `gtd check <mode> <pathQ> >/dev/null ...` line, or `undefined` when that line isn't there right after it. */
+const parseModeAndFormatCommand = (
+  block: string,
+  prefix: string,
+  pathQ: string,
+): { readonly mode: string; readonly formatCommand: string } | undefined => {
+  const suffix = ` ${pathQ} >/dev/null 2>&1 || {\n`
+  const suffixIndex = block.indexOf(suffix, prefix.length + 1)
+  if (suffixIndex === -1) return undefined
+  const lineStart = block.lastIndexOf("\ngtd check ", suffixIndex)
+  if (lineStart === -1) return undefined
+  const mode = block.slice(lineStart + "\ngtd check ".length, suffixIndex)
+  if (mode.length === 0 || /\s/.test(mode)) return undefined
+  return { mode, formatCommand: block.slice(prefix.length + 1, lineStart) }
+}
+
+const parseModeContradictionCheck = (block: string): ParsedModeContradictionCheck | undefined => {
+  const prefixParts = parsePrintfPrefix(block)
+  if (prefixParts === undefined) return undefined
+  const { sample, samplePath, prefix } = prefixParts
+
+  const modeParts = parseModeAndFormatCommand(block, prefix, shellQuote(samplePath))
+  if (modeParts === undefined) return undefined
+  const { mode, formatCommand } = modeParts
+
+  const format = steeringFormatFor(mode)
+  if (format === undefined) return undefined
+  if (buildModeContradictionCheck({ mode, samplePath, sample, formatCommand }) !== block) {
+    return undefined
+  }
+  return { mode, samplePath, sample, formatCommand, format }
+}
+
+/**
+ * Runs one PARSED round-trip against `repo`: writes the sample to the
+ * scratch path, runs its `format:` command through the scripted-command
+ * table (the only way a command executes against the in-memory tier — real
+ * bash is unreachable there), re-validates whatever ended up at the scratch
+ * path with the format's own parser, and cleans the scratch path up on
+ * every path out — mirroring the real script's `rm -f` on both the failure
+ * and success branches. An unscripted `format:` command fails loudly
+ * (mirroring `makeScriptedCommandRunner`'s own "unscripted command" error)
+ * rather than silently succeeding.
+ */
+const simulateModeContradictionCheck = (
+  repo: InMemRepo,
+  commands: ReadonlyMap<string, ScriptedCommand>,
+  parsed: ParsedModeContradictionCheck,
+): BlockOutcome => {
+  const { mode, samplePath, sample, formatCommand, format } = parsed
+  repo.writeFile(samplePath, sample)
+  const formatOutcome = recognizeScriptedCommand(repo, commands, formatCommand)
+  if (formatOutcome === undefined) {
+    repo.deleteFile(samplePath)
+    return {
+      kind: "failed",
+      error: `unscripted command "${formatCommand}" — declare it with a Given step`,
+    }
+  }
+  if (formatOutcome.kind === "failed") {
+    repo.deleteFile(samplePath)
+    return formatOutcome
+  }
+  const formatted = repo.readFile(samplePath) ?? sample
+  const findings = format.validate(formatted)
+  repo.deleteFile(samplePath)
+  if (findings.length === 0) return { kind: "noop" }
+  return {
+    kind: "failed",
+    error: `${contradictionMessage(mode, formatCommand)}\n${formatted}`,
+  }
+}
+
+const recognizeModeContradictionCheck = (
+  repo: InMemRepo,
+  commands: ReadonlyMap<string, ScriptedCommand>,
+  block: string,
+): BlockOutcome | undefined => {
+  const parsed = parseModeContradictionCheck(block)
+  return parsed === undefined ? undefined : simulateModeContradictionCheck(repo, commands, parsed)
+}
+
 const GTD_CHECK_RE = /^gtd check (\S+) (.+)$/
 
 /** `gtd check <mode> <file>` — a non-empty findings array fails the script, mirroring a real invocation's non-zero exit under `set -e`. */
@@ -644,35 +850,65 @@ const splitBlocks = (script: string): readonly string[] => {
  * non-zero scripted-command exit — exactly like `set -euo pipefail` stops a
  * real script. No block after the failing one is applied.
  */
+/**
+ * Every recognizer `applyEmittedScript` tries, in order — pulled out of that
+ * function's own body (which used to be one long `??` chain) into a plain
+ * array so trying each one is a single loop rather than N branches: the
+ * behavior is identical (first non-`undefined` wins), but a flat loop over
+ * data keeps `applyEmittedScript` itself simple regardless of how many
+ * recognizers this module accumulates.
+ */
+const recognizersFor = (
+  repo: InMemRepo,
+  commands: ReadonlyMap<string, ScriptedCommand>,
+): ReadonlyArray<(block: string) => BlockOutcome | undefined> => [
+  (block) => recognizeSetFlags(block),
+  (block) => recognizeDidNotRunComment(block),
+  (block) => recognizePrecondition(repo, block),
+  (block) => recognizeHeadAssertion(repo, block),
+  (block) => recognizeReviewWindowRefAssertion(repo, block),
+  (block) => recognizeFileExistsGuard(repo, block),
+  (block) => recognizeRetryHelperDefinition(block),
+  (block) => recognizeGitBuilders(repo, block),
+  (block) => recognizeReviewWindowClose(repo, block),
+  (block) => recognizeReviewWindowOpen(repo, block),
+  (block) => recognizeRetryWrappedGitWrite(repo, block),
+  (block) => recognizeFailurePromptWrapper(repo, commands, block),
+  (block) => recognizePresentationSubshell(repo, commands, block),
+  (block) => recognizeModeContradictionSkipNotice(block),
+  (block) => recognizeModeContradictionCheck(repo, commands, block),
+  (block) => recognizeGtdCheck(repo, block),
+  (block) => recognizeOutcomePreamble(block),
+  (block) => recognizeOutcomeCall(block),
+  (block) => recognizeScriptedCommand(repo, commands, block),
+]
+
+/** The first recognizer (in `recognizersFor`'s declared order) that recognizes `block`, or `undefined` when none does. */
+const recognizeBlock = (
+  recognizers: ReadonlyArray<(block: string) => BlockOutcome | undefined>,
+  block: string,
+): BlockOutcome | undefined => {
+  for (const recognize of recognizers) {
+    const outcome = recognize(block)
+    if (outcome !== undefined) return outcome
+  }
+  return undefined
+}
+
 export const applyEmittedScript = (
   repo: InMemRepo,
   commands: ReadonlyMap<string, ScriptedCommand>,
   script: string,
 ): AppliedScriptResult => {
-  const blocks = splitBlocks(script)
+  const recognizers = recognizersFor(repo, commands)
 
-  for (const block of blocks) {
-    const outcome =
-      recognizeSetFlags(block) ??
-      recognizeDidNotRunComment(block) ??
-      recognizePrecondition(repo, block) ??
-      recognizeHeadAssertion(repo, block) ??
-      recognizeReviewWindowRefAssertion(repo, block) ??
-      recognizeRetryHelperDefinition(block) ??
-      recognizeGitBuilders(repo, block) ??
-      recognizeReviewWindowClose(repo, block) ??
-      recognizeReviewWindowOpen(repo, block) ??
-      recognizeRetryWrappedGitWrite(repo, block) ??
-      recognizeFailurePromptWrapper(repo, commands, block) ??
-      recognizePresentationSubshell(repo, commands, block) ??
-      recognizeGtdCheck(repo, block) ??
-      recognizeOutcomePreamble(block) ??
-      recognizeOutcomeCall(block) ??
-      recognizeScriptedCommand(repo, commands, block)
+  for (const block of splitBlocks(script)) {
+    const outcome = recognizeBlock(recognizers, block)
 
     if (outcome === undefined) {
       return { ok: false, error: `unrecognized script block: ${block.split("\n")[0]}` }
     }
+    if (outcome.kind === "stopped") return { ok: true }
     if (outcome.kind === "failed") {
       return { ok: false, error: outcome.error }
     }

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -1175,16 +1175,17 @@ machines:
             (same feature/refactor/fix, even across files) — a short explanation of
             what changed and why, then one file pointer per hunk (checkboxes are
             for the human to tick, not you; every path is `./`-relative, with an
-            optional `#line`). The pointer's OWN line carries nothing but the
-            pointer — no note, no dash. Its explanation goes on the line(s)
-            beneath it instead:
+            optional `#line`). The explanation can go on the line(s) beneath the
+            pointer, or trail it on the same line after a dash — both forms are
+            valid:
 
                 - [ ] ./path/to/file.ts#42
                   what this hunk does, with room to run to several lines
 
-            Text after the pointer token on the pointer's own line is a
-            validation error, not just a style nit — an older-format doc like
-            `- [ ] ./path/to/file.ts#42 — note` is UNLANDABLE.
+                - [ ] ./path/to/other.ts#7 — shorter note, same line as the pointer
+
+            Either way, the explanation itself must never START with a bare
+            `./path` token — that parses as a second hunk pointer, not a note.
 
           This prompt carries no diff — read the changes yourself. The range runs
           from `<%= it.reviewBase %>` to the working tree (committed turns plus

--- a/tests/integration/features/emitted-scripts-under-dash.feature
+++ b/tests/integration/features/emitted-scripts-under-dash.feature
@@ -121,3 +121,40 @@ Feature: Emitted scripts actually run under a real POSIX shell (dash), not just 
     And the git log contains "chore: calculator done"
     And "src/calc.ts" exists
     And "FEEDBACK_NOTE.md" does not exist
+
+  Scenario: the mode-contradiction round-trip (package 2) also runs under dash, not just bash-flavored sh
+    # This scenario replaces the Background's own .gtdrc with one declaring a
+    # built-in mode paired with a hostile format: — the round-trip's own
+    # printf/cat/pipe machinery (src/ModeContradiction.ts's
+    # buildModeContradictionCheck) must parse and run under a genuinely
+    # POSIX-only shell, exactly like every other emitted script in this file.
+    Given a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        modes:
+          review:
+            format: "sed -i.bak 's/^- \\[/* [/' <%= it.file %> && rm -f <%= it.file %>.bak"
+        entry:
+          default: root
+        machines:
+          root:
+            entry: idle
+            states:
+              idle:
+                actor: human
+                message: "start"
+                on:
+                  "* **": reviewing
+              reviewing:
+                actor: agent
+                file: REVIEW.md
+                mode: review
+                prompt: "review"
+                on:
+                  "* **": idle
+      """
+    And an empty commit "gtd(human): reviewing"
+    When I run gtd with args "validate"
+    Then it fails
+    And stderr contains "CONFIGURATION BUG"
+    And stderr contains "Do NOT edit the steering file"

--- a/tests/integration/features/steering-modes.feature
+++ b/tests/integration/features/steering-modes.feature
@@ -755,6 +755,55 @@ Feature: Pluggable steering-file modes — a mode is a format command plus a val
     And stdout contains ".gtd/docs/adr.md: valid"
     And ".gtd/docs/adr.md" contains "status: DRAFT"
 
+  @live
+  Scenario: a format-only custom mode at a first-write beat now emits a script (the guard plus the format command), not "nothing to validate"
+    # Package 2, Requirement A/B combined: before this package, an absent
+    # steering file short-circuited to "nothing to validate" in TS-land — a
+    # format-only mode (no in-process parser at all, so no round-trip and no
+    # skip notice either) now still gets a real script: the existence guard
+    # plus its own format: command, evaluated once the script actually runs.
+    # Inspected via the unexecuted `gtd next --sh` text.
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        modes:
+          adr:
+            format: "sed 's/draft/DRAFT/' <%= it.file %> > <%= it.file %>.tmp && mv <%= it.file %>.tmp <%= it.file %>"
+        entry:
+          default: root
+        machines:
+          root:
+            entry: idle
+            states:
+              idle:
+                actor: human
+                message: "start a decision record"
+                on:
+                  "* **": drafting
+              drafting:
+                actor: agent
+                prompt: "Write the ADR."
+                file: docs/adr.md
+                mode: adr
+                on:
+                  "* **": idle
+      """
+    And an empty commit "gtd(human): drafting"
+    When I run gtd next with "--sh"
+    Then it succeeds
+    # gtd_validate's own value is itself shell-quoted for --sh (every literal
+    # `'` inside it becomes the POSIX `'\''` escape), so the guard/format
+    # command are matched by their quote-independent substrings.
+    And stdout contains "gtd_validate="
+    And stdout contains "-f "
+    And stdout contains ".gtd/docs/adr.md"
+    And stdout contains "] || exit 0"
+    And stdout contains "sed "
+    And stdout contains "draft/DRAFT"
+    And stdout does not contain "CONFIGURATION BUG"
+    And stdout does not contain "skipping the format/validate contradiction check"
+
   @inmem
   Scenario: the answer-completeness gate still fires on a qa-mode state even when its validate: command is overridden
     # The semantic upgrade: the gate asks steeringCapabilities for the FORMAT
@@ -868,3 +917,132 @@ Feature: Pluggable steering-file modes — a mode is a format command plus a val
     Then it fails
     And stderr contains "path-shim:"
     And stderr contains the gtd version under test
+
+  # ── The mode-contradiction round-trip (package 2, Requirement B) ──────────
+  # A mode whose declared `format:` breaks its own validator is a config bug
+  # gtd can detect mechanically: format a copy of the built-in format's own
+  # canonical sample, re-validate it with `gtd check <mode>`, and fail loudly
+  # BEFORE the real steering file's own findings are ever reported. Coverage
+  # is the two built-in modes only (`qa`/`review`) — the fixture pairs one of
+  # them with a deliberately hostile one-liner `format:`, never a synthetic
+  # mode, and never a real formatter binary.
+
+  @live
+  Scenario: a built-in mode paired with a format: that breaks its own validator is caught before any real file exists
+    # The hostile one-liner rewrites every "- [ ]" review hunk marker to
+    # "* [ ]" — REVIEW_FORMAT's parser only recognizes a hunk pointer that
+    # starts with "- [", so the round-trip's re-validation finds the
+    # reformatted sample invalid. No `.gtd/REVIEW.md` is ever written in this
+    # scenario — the whole point is that the check still fires at this
+    # first-write beat, ahead of `fileExistsGuard`.
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        modes:
+          review:
+            format: "sed -i.bak 's/^- \\[/* [/' <%= it.file %> && rm -f <%= it.file %>.bak"
+        entry:
+          default: root
+        machines:
+          root:
+            entry: idle
+            states:
+              idle:
+                actor: human
+                message: "start"
+                on:
+                  "* **": reviewing
+              reviewing:
+                actor: agent
+                file: REVIEW.md
+                mode: review
+                prompt: "review"
+                on:
+                  "* **": idle
+      """
+    And an empty commit "gtd(human): reviewing"
+    When I run gtd with args "validate"
+    Then it fails
+    And stderr contains "mode \"review\""
+    And stderr contains "CONFIGURATION BUG"
+    And stderr contains "Do NOT edit the steering file"
+    And stderr contains "sed -i.bak"
+    # No file findings alongside it — the round-trip aborts the script before
+    # the real file's own format:/validate: commands ever run.
+    And stderr does not contain "Chunk"
+    And stderr does not contain "REVIEW.md has no"
+
+  @live
+  Scenario: the same repo with the formatter removed exits 0 — no contradiction to find
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        entry:
+          default: root
+        machines:
+          root:
+            entry: idle
+            states:
+              idle:
+                actor: human
+                message: "start"
+                on:
+                  "* **": reviewing
+              reviewing:
+                actor: agent
+                file: REVIEW.md
+                mode: review
+                prompt: "review"
+                on:
+                  "* **": idle
+      """
+    And an empty commit "gtd(human): reviewing"
+    When I run gtd with args "validate"
+    Then it succeeds
+
+  @live
+  Scenario: a mode carrying only a user validate: command prints that the contradiction check was skipped, loudly
+    # Coverage is the two built-in modes only, so a genuine user `validate:`
+    # override has no in-process parser to round-trip a sample through — the
+    # emitted script prints a one-line skip notice instead of silently saying
+    # nothing (silence would read as a clean bill of health). Inspected via
+    # the unexecuted `gtd next --sh` script text rather than a live run: the
+    # notice prints to stderr, and a SUCCESSFUL script's stderr is exactly
+    # the thing `gtd validate`'s own driving harness discards once the
+    # script exits 0 (see world.ts's validateVerdict) — the raw script text
+    # is the deterministic way to prove the line is really there.
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        modes:
+          review:
+            format: "true"
+            validate: "true"
+        entry:
+          default: root
+        machines:
+          root:
+            entry: idle
+            states:
+              idle:
+                actor: human
+                message: "start"
+                on:
+                  "* **": reviewing
+              reviewing:
+                actor: agent
+                file: REVIEW.md
+                mode: review
+                prompt: "review"
+                on:
+                  "* **": idle
+      """
+    And an empty commit "gtd(human): reviewing"
+    When I run gtd next with "--sh"
+    Then it succeeds
+    And stdout contains "gtd_validate="
+    And stdout contains "mode \"review\" has an external validate: command"
+    And stdout contains "skipping the format/validate contradiction check"

--- a/tests/integration/features/tmpdir-and-git-dir.feature
+++ b/tests/integration/features/tmpdir-and-git-dir.feature
@@ -27,3 +27,46 @@ Feature: Honoring $TMPDIR and $GIT_DIR — gtd assumes nothing about /tmp or <cw
     And the repository's default ".git" directory was never recreated
     And nothing was written under the overridden TMPDIR
     And gtd next --json reports the log path under the relocated git dir
+
+  Scenario: the emitted validate script may write under TMPDIR while gtd itself still writes nothing there
+    # Package 2's mode-contradiction round-trip (src/ModeContradiction.ts,
+    # src/program.ts's scratchSamplePath) writes a scratch sample under
+    # $TMPDIR — but only the EMITTED SCRIPT does that, once a driver runs it;
+    # gtd the process still names no "/tmp" literal and calls no mktemp (see
+    # tests/tooling/no-tmp-assumption.test.ts). Inspected via the unexecuted
+    # `gtd next --sh` script text, since the round-trip cleans its own
+    # scratch file up on every path (success or failure) and leaves nothing
+    # on disk afterwards either way — a raw, unexecuted script is the only
+    # place the reference to $TMPDIR is ever observable.
+    Given a test project
+    And a gtd config file at ".gtdrc" with:
+      """
+      workflow:
+        modes:
+          review:
+            format: "true"
+        entry:
+          default: root
+        machines:
+          root:
+            entry: idle
+            states:
+              idle:
+                actor: human
+                message: "start"
+                on:
+                  "* **": reviewing
+              reviewing:
+                actor: agent
+                file: REVIEW.md
+                mode: review
+                prompt: "review"
+                on:
+                  "* **": idle
+      """
+    And an empty commit "gtd(human): reviewing"
+    And the repo's git dir relocated outside the worktree, with TMPDIR pointed at a fresh scratch directory
+    When I run gtd next with "--sh"
+    Then it succeeds
+    And stdout contains the overridden TMPDIR path
+    And nothing was written under the overridden TMPDIR

--- a/tests/integration/features/validate.feature
+++ b/tests/integration/features/validate.feature
@@ -108,6 +108,22 @@ Feature: gtd validate — self-validating the resolved rest's steering file
     Then it succeeds
     And stdout contains "nothing to validate at \"idle\""
 
+  Scenario: gtd next --sh at a first-write beat (the steering file does not exist yet) still emits a gtd_validate= assignment
+    # Package 2, Requirement A: `resolveValidateScript` used to short-circuit
+    # to `undefined` at exactly this beat (the `fs.exists` check happened in
+    # TS-land, before the turn had written anything), silencing every
+    # driver's `while [ -n "$gtd_validate" ]` repair loop right when it is
+    # needed most. Existence is now a leading `[ -f <file> ] || exit 0` guard
+    # INSIDE the emitted script instead, so `gtd_validate` is always assigned
+    # whenever the resting state declares both `file:` and `mode:`.
+    Given a test project
+    And the workflow
+    And an empty commit "gtd(human): design.triage"
+    When I run gtd next with "--sh"
+    Then it succeeds
+    And stdout contains "gtd_validate="
+    And stdout contains "gtd check qa"
+
   Scenario: plain `gtd next` appends the self-validation instruction at a producing agent state
     Given a test project
     And the workflow
@@ -176,7 +192,11 @@ Feature: gtd validate — self-validating the resolved rest's steering file
     Then it fails
     # The step's own required script runs the same validation ahead of its
     # commit, so the refusal is the checker's findings and a non-zero exit —
-    # nothing is committed.
+    # nothing is committed. Package 2, Requirement A: the landing script's
+    # own validate command now carries the SAME routable fix prompt
+    # `gtd validate`'s script does — the human/agent reading stderr gets a
+    # ready-to-send instruction, not bare findings.
+    And stderr contains "does not pass its own validation script"
     And stderr contains "has no question text"
     And the last commit subject is "gtd(human): design.gate.answer"
 

--- a/tests/integration/support/steps/tmpdir-gitdir.steps.ts
+++ b/tests/integration/support/steps/tmpdir-gitdir.steps.ts
@@ -80,3 +80,21 @@ Then(
     assert.strictEqual(parsed.log, join(world.customGitDir!, "gtd-loop.log"))
   },
 )
+
+/**
+ * Package 2: the mode-contradiction round-trip's scratch path
+ * (`src/program.ts`'s `scratchSamplePath`) resolves under the overridden
+ * `$TMPDIR` — proving the EMITTED script (never gtd itself, see
+ * `tests/tooling/no-tmp-assumption.test.ts`) is the thing that would write
+ * there once a driver runs it. Checked against the last result's stdout
+ * verbatim, unexecuted (`gtd next --sh`'s raw text) — the round-trip cleans
+ * its own scratch file up on every path, so nothing survives on disk to
+ * inspect afterwards either way.
+ */
+Then("stdout contains the overridden TMPDIR path", (world: GtdWorld) => {
+  assert.ok(world.customTmpDir, "no overridden TMPDIR — run the relocation step first")
+  assert.ok(
+    world.lastResult.stdout.includes(world.customTmpDir!),
+    `Expected stdout to reference the overridden TMPDIR ("${world.customTmpDir}"). Got:\n${world.lastResult.stdout}`,
+  )
+})


### PR DESCRIPTION
A mode's `format:` command can reflow a steering file into something its own `validate:` command rejects (e.g. oxfmt collapsing `REVIEW.md` into a shape the review parser refuses). That deadlocked the review loop with no way out — every fix attempt got reformatted back into the same broken shape.

## Two complementary fixes

**Same-line review notes.** `REVIEW.md`'s parser now accepts a hunk's explanation trailing the pointer on the same line, not just on the line(s) below it (`src/ReviewDoc.ts`). This removes a whole class of format/validate friction by making the validator agree with a shape formatters commonly produce. The one remaining rule: a note can't itself start with a bare `./path` token, since that would parse as a second pointer.

**Round-trip contradiction check.** For contradictions that can't be designed away, `src/ModeContradiction.ts` formats a copy of the mode's own canonical sample (`SteeringFormat.sample`) to a scratch path and re-validates it before validating the real file. If the round-trip breaks, the emitted script fails with a message that unmistakably blames the *config* (not the steering file) and tells the agent to stop rather than keep editing — deliberately distinct wording from the ordinary fix-prompt wrapper, since gtd's exit-code contract stays closed and can't carry a second meaning. External (non-built-in) validators can't be round-tripped in process, so they get a one-line skip notice instead of silence.

## Supporting changes

- `program.ts`: `steeringModeSteps` wraps its last command with the same `onFailure` fix-prompt as `resolveValidateScript`, so a landing-time validate failure is routable too.
- The declared `file:`'s existence check moved out of TS-land into the emitted script (`Emit.ts`'s `fileExistsGuard`), arming a driver's repair loop from a state's first turn instead of only the second.
- The scratch sample path resolves from `TMPDIR`/`os.tmpdir()` at emit time — never `mktemp` or a `/tmp` literal (per `tests/tooling/no-tmp-assumption.test.ts`) — so the rendered script stays deterministic and collision-free across concurrent gtd processes.

## Tests

`EmittedScriptRecognizer.ts` recognizes the new contradiction and skip-notice command shapes for `@inmem` scenarios. New feature files: `steering-modes.feature` (round-trip), `tmpdir-and-git-dir.feature` (scratch-path resolution), `emitted-scripts-under-dash.feature` (recognition under paths containing dashes). Full `npm test` green after rebase onto `main` (9/9 tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
