### PR TITLE
fix(engine): scope retry caps to the current episode, not the whole process

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ No chat scrollback. No lost sessions. No infinite fix loops. Just git.
 - **Harness agnostic.** gtd emits prompts to stdout (or JSON). Claude Code, a
   bash loop, a CI job, or you reading it out loud — the workflow doesn't care
   who executes it.
-- **Bounded, not runaway.** Fix attempts are capped (`retry` on a state). When
-  the cap is hit, gtd redirects to a human gate instead of burning tokens
-  rewriting the same test for the 47th time.
+- **Bounded, not runaway.** A check/fix loop's fix attempts are capped per red
+  episode (`retry` on a state) — the count resets once the process moves on and
+  a later red starts fresh. When the cap is hit, gtd redirects to a human gate
+  instead of burning tokens rewriting the same test for the 47th time. Not every
+  loop in the bundled workflow carries a cap, though: the per-package
+  spec-review loop has none, and spins until it's satisfied.
 - **Your call on history.** Every intermediate `gtd(actor): from → to` commit is
   a real, attributed commit — the subject names both the state the work was done
   in and where it advanced to, nothing hidden in chat. Squash them into one

--- a/src/Edge.ts
+++ b/src/Edge.ts
@@ -697,8 +697,16 @@ const renderOnEdgesOrFail = (
  * A shallow clone of `def` whose `state`'s `on` is replaced by
  * `renderedOnEdges` — used to feed `PatternMachine.step`, which matches only
  * `def.states[state].on` for the state it's invoked at. Only the RESTING
- * state needs patching: `step`'s retry/target logic keys on state NAMES, not
- * on any other state's `on`, so every other state is left as-is.
+ * state needs patching, even though `step`'s retry counter now reads every
+ * state's `on` targets (plus `retry.otherwise`) to derive a capped state's
+ * source set. That's still sound because `renderOnEdges` renders a pattern
+ * KEY only and passes each edge's `target` through verbatim — the source-set
+ * computation reads only `target` strings, never pattern keys, so every
+ * other state's un-patched, unrendered-key `on` still reports the right
+ * targets. Warning: if a future change ever templated a state's `on`
+ * TARGET (not just its pattern key), that would silently mis-scope every
+ * retry budget, because the source-set computation reads targets from every
+ * state, and `withRenderedOn` patches only the one being rested at.
  */
 const withRenderedOn = (
   def: WorkflowDefinition,

--- a/src/PatternMachine.test.ts
+++ b/src/PatternMachine.test.ts
@@ -99,6 +99,45 @@ const retryWorkflow: WorkflowDefinition = def(
   "start",
 )
 
+/**
+ * A check/fix/review loop capping the FIXER rather than the checker — the
+ * shape the bundled template actually uses, and the only shape in which an
+ * out-of-loop reset is reachable: `checking` routes red to `fixing` and
+ * green to `reviewing`; `fixing` carries a retry cap and routes back to
+ * `checking`; `reviewing` also routes back to `checking`. `fixing`'s only
+ * source is `checking` — `reviewing` and `escalate` are not sources of
+ * `fixing`, so either one interleaved in the trace resets `fixing`'s count.
+ */
+const fixerRetryWorkflow: WorkflowDefinition = def(
+  {
+    checking: {
+      actor: "check",
+      script: "npm test",
+      on: [
+        ["A FEEDBACK.md", "fixing"],
+        ["C", "reviewing"],
+      ],
+    },
+    fixing: {
+      actor: "agent",
+      prompt: "fix it",
+      retry: { max: 2, otherwise: "escalate" },
+      on: [["* *", "checking"]],
+    },
+    reviewing: {
+      actor: "human",
+      message: "review",
+      on: [["* *", "checking"]],
+    },
+    escalate: {
+      actor: "human",
+      message: "stuck",
+      on: [["* *", "checking"]],
+    },
+  },
+  "checking",
+)
+
 const change = (status: PendingChange["status"], path: string): PendingChange => ({
   status,
   path,
@@ -714,9 +753,11 @@ describe("step — retry redirection", () => {
     })
   })
 
-  it("counts every occurrence in the trace, regardless of what's interleaved with it", () => {
+  it("redirects even with its own loop partner (fixing) interleaved — the reset only fires for a state outside the loop, see the fixerRetryWorkflow tests below", () => {
     // "checking" appears 3 times here — already past its max=2 cap — so this
-    // still redirects even though "fixing" entries sit between them.
+    // still redirects even though "fixing" entries sit between them: "fixing"
+    // is one of "checking"'s sources (its own "on" targets "checking"), so
+    // interleaving with it never resets the count.
     const decision = step(retryWorkflow, "fixing", "agent", {
       changes: [change("M", "x.ts")],
       processTrace: ["checking", "fixing", "checking", "fixing", "checking", "fixing"],
@@ -727,6 +768,42 @@ describe("step — retry redirection", () => {
       actor: "agent",
       from: "fixing",
       to: "escalate",
+    })
+  })
+
+  it("interleaved loop partner does not reset — and the cap still fires within one episode (fixerRetryWorkflow caps the fixer, the shape the bundled template uses)", () => {
+    // "fixing"'s only source is "checking" (checking's own "A FEEDBACK.md"
+    // row targets it) — so the two "checking" entries interleaved between the
+    // two "fixing" entries do NOT reset the count. Two prior "fixing" visits
+    // meets its max: 2 cap, so this third attempted entry redirects.
+    const decision = step(fixerRetryWorkflow, "checking", "check", {
+      changes: [change("A", "FEEDBACK.md")],
+      processTrace: ["checking", "fixing", "checking", "fixing"],
+    })
+    expect(decision).toEqual({
+      kind: "commit",
+      subject: "gtd(check): checking → escalate",
+      actor: "check",
+      from: "checking",
+      to: "escalate",
+    })
+  })
+
+  it("out-of-loop state resets: an intervening `reviewing` entry (not a source of `fixing`) restores the budget", () => {
+    // Same shape as above, but a "reviewing" entry sits between the two
+    // "checking"/"fixing" pairs. "reviewing" is not one of "fixing"'s
+    // sources, so it resets the count back to zero — only the LAST
+    // "checking" → "fixing" pair counts, well under the max: 2 cap.
+    const decision = step(fixerRetryWorkflow, "checking", "check", {
+      changes: [change("A", "FEEDBACK.md")],
+      processTrace: ["checking", "fixing", "checking", "reviewing", "checking", "fixing"],
+    })
+    expect(decision).toEqual({
+      kind: "commit",
+      subject: "gtd(check): checking → fixing",
+      actor: "check",
+      from: "checking",
+      to: "fixing",
     })
   })
 
@@ -758,11 +835,20 @@ describe("step — retry redirection", () => {
       },
       "s",
     )
-    // "a" is at its cap (1 prior visit) so it redirects to "b" — which is
-    // ALSO at its cap (1 prior visit) — so it redirects again to "c".
+    // Per-episode counting means a trace of just ["a", "b"] would no longer
+    // work here: "b" is not one of "a"'s sources, so it would reset "a"'s own
+    // count back to zero and the first hop would never fire. Landing at "b"
+    // is itself the redirect this test wants to prove chains further, so the
+    // trace instead shows "a" re-entered AFTER that reset (["a", "b", "a"]):
+    // the trailing "a" is "a"'s one (fresh, post-reset) episode visit, which
+    // already meets its max=1 cap, so THIS turn's attempt to enter "a" again
+    // redirects to "b". "b" is at its own cap too — because "a" is one of
+    // "b"'s sources (it's "a"'s own `retry.otherwise`), the leading "a" in
+    // the trace does NOT reset "b"'s count, so "b"'s one prior visit still
+    // counts, meeting its own max=1 cap — so it redirects again to "c".
     const decision = step(workflow, "s", "human", {
       changes: [change("A", "x")],
-      processTrace: ["a", "b"],
+      processTrace: ["a", "b", "a"],
     })
     expect(decision).toEqual({ kind: "squash", state: "c", template: "chore: c" })
   })
@@ -911,6 +997,28 @@ describe("step — attempt commits (clean tree, no-C prompt state)", () => {
       processTrace: ["working"],
     })
     expect(decision).toEqual({ kind: "squash", state: "done", template: "chore: done" })
+  })
+
+  it("attempt counting is unchanged: a clean-tree attempt at `fixing` counts from zero once an intervening `reviewing` entry resets the episode", () => {
+    // "fixing" appears twice, but "reviewing" (not one of "fixing"'s
+    // sources) sits between them and resets the count — so at this clean
+    // attempt, only the LAST "fixing" entry counts (1), still under max: 2.
+    const trace = ["fixing", "checking", "reviewing", "checking", "fixing"]
+    expect(wouldAttempt(fixerRetryWorkflow, "fixing", trace)).toBe(true)
+    const decision = step(fixerRetryWorkflow, "fixing", "agent", {
+      changes: [],
+      processTrace: trace,
+    })
+    // Identical shape to a fresh (empty-trace) attempt — the reset means this
+    // is exactly as if "fixing" had never been visited before.
+    expect(decision).toEqual({
+      kind: "commit",
+      subject: "gtd(agent): fixing",
+      actor: "agent",
+      from: "fixing",
+      to: "fixing",
+      attempt: true,
+    })
   })
 })
 

--- a/src/PatternMachine.ts
+++ b/src/PatternMachine.ts
@@ -519,6 +519,35 @@ const matchOn = (
   return undefined
 }
 
+/** Every state `state`'s edges can enter: its `on` targets plus its `retry.otherwise` redirect. */
+const edgeTargets = (state: StateDef): readonly StateName[] => [
+  ...(state.on ?? []).map(([, target]) => target),
+  ...(state.retry !== undefined ? [state.retry.otherwise] : []),
+]
+
+/** Every state whose edges can enter `target` — structural, derived from `def` alone. */
+const sourcesOf = (def: WorkflowDefinition, target: StateName): ReadonlySet<StateName> =>
+  new Set(
+    Object.entries(def.states)
+      .filter(([, state]) => edgeTargets(state).includes(target))
+      .map(([name]) => name),
+  )
+
+/** `target`'s entries since the process last left `target`'s loop. */
+const episodeVisits = (
+  def: WorkflowDefinition,
+  target: StateName,
+  trace: readonly StateName[],
+): number => {
+  const sources = sourcesOf(def, target)
+  let count = 0
+  for (const name of trace) {
+    if (name === target) count += 1
+    else if (!sources.has(name)) count = 0
+  }
+  return count
+}
+
 /**
  * Apply retry redirection to a raw `on`-match target: if the target has a
  * `retry` cap and has already been entered `max` times in `trace`, redirect
@@ -530,6 +559,12 @@ const matchOn = (
  * documented choice — the plan leaves "recursively?" open; a config that
  * builds such a cycle is almost certainly a bug, but the engine must still
  * terminate rather than hang.
+ *
+ * "Entered `max` times" now counts an EPISODE, not the whole process trace:
+ * `episodeVisits` above resets to zero at the first trace entry of a state
+ * that is neither `target` itself nor one of `target`'s structural sources
+ * (`sourcesOf`) — so a red caused by an unrelated part of the process no
+ * longer spends this target's budget.
  */
 const applyRetry = (
   def: WorkflowDefinition,
@@ -540,7 +575,7 @@ const applyRetry = (
   if (visited.has(target)) return target
   const targetDef = def.states[target]
   if (targetDef?.retry === undefined) return target
-  const priorVisits = trace.filter((name) => name === target).length
+  const priorVisits = episodeVisits(def, target, trace)
   if (priorVisits < targetDef.retry.max) return target
   return applyRetry(def, targetDef.retry.otherwise, trace, new Set([...visited, target]))
 }
@@ -921,8 +956,7 @@ const validateReachability = (def: WorkflowDefinition, names: readonly string[])
   const queue: StateName[] = [...roots]
   while (queue.length > 0) {
     const state = def.states[queue.shift()!]!
-    const targets = (state.on ?? []).map(([, target]) => target)
-    if (state.retry !== undefined) targets.push(state.retry.otherwise)
+    const targets = [...edgeTargets(state)]
     for (const target of targets) {
       if (def.states[target] !== undefined && !visited.has(target)) {
         visited.add(target)

--- a/src/workflows/templates.test.ts
+++ b/src/workflows/templates.test.ts
@@ -39,6 +39,15 @@ describe("the bundled unified workflow template", () => {
     expect(definition.states[definition.entries.default]).toBeDefined()
   })
 
+  it("declares `retry` on exactly build.fix and packages.item.fix-suite, and nothing else (package 01)", () => {
+    const { definition } = compileTemplate()
+    const withRetry = Object.entries(definition.states)
+      .filter(([, state]) => state.retry !== undefined)
+      .map(([name]) => name)
+      .sort()
+    expect(withRetry).toEqual(["build.fix", "packages.item.fix-suite"])
+  })
+
   it("pins the `file:` prepend round trip: every compiled value starts with `.gtd/`, no raw declaration does", () => {
     const { definition } = compileTemplate()
     const compiledFiles = Object.values(definition.states)

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -752,9 +752,8 @@ machines:
   # `build.review.deciding` and here with no `entryGate` in between, so a red
   # the revert causes is otherwise ambient. Left for
   # `packages.item.health.check` to trip over instead, it would spend one of
-  # `packages.item.fix-suite`'s retry cap — process-pooled across every
-  # package, the same pattern `specReview.review`'s own retry comment
-  # documents — on breakage the package itself never caused.
+  # `packages.item.fix-suite`'s (per-episode) retry attempts on breakage the
+  # package itself never caused.
   # ▸ planner identity — `model:` declared once here, stamped onto `triage`
   # (its only prompt state; `gate.answer` is a human turn and carries no
   # prompt).
@@ -1412,16 +1411,11 @@ machines:
       review:
         actor: agent
         label: Reviewing the package
-        # Bounded per process: once entered `max` times, a transition into it is
-        # redirected to `$onApproved` (force-close the package and move on — the
-        # unresolved concern is deferred to the shared human review at the tail,
-        # which sees the whole diff anyway). NOTE the cap is PROCESS-scoped, so it
-        # pools across packages — the same documented limitation the shared
-        # `build.fix` cap has (see the README's "Why" section, "Bounded, not
-        # runaway").
-        retry:
-          max: 3
-          otherwise: $onApproved
+        # No retry cap here: the loop only ever re-enters through
+        # `fix-spec`/`health.check`, so under the per-episode retry rule this
+        # state's episode count can never exceed 1 and a cap could never fire.
+        # The spec-review loop is genuinely unbounded — see the README's
+        # "Bounded, not runaway" bullet and this package's own risk note.
         prompt: |
           <%~ it.vars.styleBlock %>
 
@@ -1626,9 +1620,9 @@ machines:
           # gtd check turn (the package closer) — remove the just-reviewed package
           # file (its path is in NEXT.md) plus any leftover spec feedback and
           # already-satisfied evidence, so `picking` selects the NEXT package (or
-          # falls through to review when the queue is empty). Reached on approval
-          # (spec review clean) and on the spec review retry cap (force-close,
-          # deferring the concern to the tail).
+          # falls through to review when the queue is empty). Reached only on
+          # spec-review approval — the spec-review loop carries no retry cap,
+          # so there is no force-close path here.
           set +e
           pkg=$(cat .gtd/NEXT.md 2>/dev/null)
           [ -n "$pkg" ] && rm -f "$pkg"

--- a/tests/integration/features/default-workflow.feature
+++ b/tests/integration/features/default-workflow.feature
@@ -1084,6 +1084,29 @@ Feature: The bundled unified workflow — one flow, end to end
     When I run gtd land
     Then it succeeds
     And the last commit subject is "gtd(check): build.health.check → build.health.escalate"
+    # The human takes the escalate gate's own "Retry check" edge — any change
+    # at all routes back to build.health.check ("* **": check), restoring
+    # build.fix's spent budget: build.health.escalate's only "on" target is
+    # "check", so it is not one of build.fix's sources, and per the
+    # per-episode retry rule an intervening non-source entry resets the count.
+    Given a file ".gtd/marker2.md" with:
+      """
+      retrying after escalation
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(human): build.health.escalate → build.health.check"
+    # A second red run: if the budget were still process-pooled (the OLD
+    # whole-trace rule), this would see build.fix's 3 prior visits and bounce
+    # straight back to build.health.escalate. Reaching build.fix instead is
+    # the proof the human gate genuinely restored it.
+    Given a file ".gtd/FEEDBACK.md" with:
+      """
+      attempt 5 failed
+      """
+    When I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(check): build.health.check → build.fix"
 
   @inmem
   Scenario: deleting REVIEW.md at await-review is refused — sign off by leaving no comment, not by deleting

--- a/tests/shell/corpus/workflow.packages.item.closing.sh
+++ b/tests/shell/corpus/workflow.packages.item.closing.sh
@@ -2,9 +2,9 @@
 # gtd check turn (the package closer) — remove the just-reviewed package
 # file (its path is in NEXT.md) plus any leftover spec feedback and
 # already-satisfied evidence, so `picking` selects the NEXT package (or
-# falls through to review when the queue is empty). Reached on approval
-# (spec review clean) and on the spec review retry cap (force-close,
-# deferring the concern to the tail).
+# falls through to review when the queue is empty). Reached only on
+# spec-review approval — the spec-review loop carries no retry cap,
+# so there is no force-close path here.
 set +e
 pkg=$(cat .gtd/NEXT.md 2>/dev/null)
 [ -n "$pkg" ] && rm -f "$pkg"


### PR DESCRIPTION
## What

A state's `retry.max` counted **every prior visit across the entire process trace**, so two unrelated reds landing in the same capped state shared one budget. An early, unrelated failure (e.g. an ambient revert-caused break) could exhaust a cap meant for a later, real fix loop.

`episodeVisits` (`src/PatternMachine.ts`) now resets the count to zero at the first trace entry that is neither the target state nor one of its **structural sources** (`sourcesOf`, derived from `on` targets and `retry.otherwise` across the whole definition). Only a contiguous run counts as one episode; moving on to unrelated states clears the slate for the next red.

## Consequences

- **`packages.item.review`'s `retry: max 3` is removed.** Under per-episode counting it could never fire — that loop only re-enters via `fix-spec`/`health.check`, so its episode count never exceeds 1. Rather than leave a dead cap, the spec-review loop is now documented as genuinely unbounded, and the README's "Bounded, not runaway" bullet says so explicitly.
- **`withRenderedOn`'s doc comment** (`src/Edge.ts`) now spells out why templating an `on` **target** (not just a pattern key) would silently mis-scope every retry budget: the source-set computation reads targets from every state, but only the resting state's `on` gets rendered.
- `validateReachability` and the new source-set derivation share one `edgeTargets` helper.

## Tests

- `src/PatternMachine.test.ts` — a new `fixerRetryWorkflow` (caps the *fixer*, the shape the bundled template uses) covers: interleaved loop partner does **not** reset; out-of-loop state **does**; attempt-counting resets identically to a fresh trace. The chained-redirect test's trace was updated to remain reachable under the new rule.
- `src/workflows/templates.test.ts` — pins `retry` to exactly `build.fix` and `packages.item.fix-suite`.
- `tests/integration/features/default-workflow.feature` — after `build.health.escalate`, taking the human's "Retry check" edge restores `build.fix`'s budget; under the old whole-trace rule the next red would have bounced straight back to escalate.

`npm test` green (all 9 tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)