### PR TITLE
refactor(workflows): dedup and compress bundled prompt templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,11 @@ default template ships six such personas already, one per prompt-bearing machine
 `builderPersona`, `finisherPersona` — and, like any other bundled var, each is
 overridable through a top-level `.gtdrc` `vars:` key or a `GTD_<NAME>`-style
 environment variable (e.g. `GTD_DESIGNPERSONA`) — gtd's existing, generic
-vars-override mechanism, nothing new.
+vars-override mechanism, nothing new. Each persona var carries only that
+machine's own role paragraph; a shared `agentConduct` var (tool-use conduct,
+orienting with git since there is no injected status block, and inspecting what
+the turn's own message names) is appended after it at all six sites, so the six
+identities differ only in role, never in how they're told to behave.
 
 Memory is **entry-scoped to a machine**, not a state-authored label: each
 machine instance (a node in the `machines:` tree, e.g. `build`, `build.health`,
@@ -1468,11 +1472,11 @@ top-level `.gtdrc` `vars:` key, or the matching `GTD_STYLEBLOCK` /
   (`packages.item.spec.review`), and `.gtd/COMMIT_MSG.md` (`build.squashing`) —
   plus the four machine-parsed states named in the next bullet. Blanking
   `GTD_STYLEBLOCK` strips the voice from all seven, including the machine-parsed
-  ones, not only the free-prose three. In short: why density matters before any
-  rule, answer-first with no preamble or restatement, blunt and imperative,
-  plain words, bold carries the load, ship the artifact bare, compressing is not
-  dropping, one idea per block, flag risk in one blunt line, never narrate the
-  work — and never-trim outranks every other rule in the set.
+  ones, not only the free-prose three. In short: it's a deliverable, not a chat
+  reply, so size follows the work; answer-first with no restatement; blunt and
+  imperative; plain words; bold carries the load; ship the artifact bare;
+  compressing is not dropping; one idea per block; flag risk in one blunt line;
+  never narrate the work — and never-trim outranks every other rule in the set.
 - **`styleFormatContract`** — the structural override for machine-parsed files:
   the format contract (headings, checkbox rows, marker lines) outranks the
   voice, and a violation refuses the turn. It renders at the top of the prompt,
@@ -1490,6 +1494,24 @@ stamp — the tool's content, not gtd's prose), `.gtd/NEXT.md` (a bare path, no
 prose to style), and `.gtd/REVIEW_RAW.md` (gtd's own prose, hand-tightened in
 the voice directly in `build.review.deciding`'s script rather than templated in
 through either variable).
+
+Three more vars exist purely to dedup wording repeated across several prompts —
+they carry no voice, just shared instructions — and, like every bundled var, are
+overridable via `.gtdrc` `vars:` or a `GTD_<NAME>` environment variable:
+
+- **`stateFileRules`** — the "this workflow steers itself through its own state
+  files, treat them as a private scratchpad" opener, injected as the first line
+  of every prompt that touches a `.gtd/` file directly.
+- **`questionBar`** — the open-questions warrant test, the decide-it-yourself
+  sink, the `## Open Questions` checkbox shape, and the return-lap fold-in
+  instruction shared by `design.triage` and `architecture.author`. Each site
+  still states its own phase scope (product-only vs. TECHNICAL) locally, since
+  that's where the two genuinely disagree.
+- **`fixFeedbackPrompt`** — the body `packages.item.fix-suite` and `build.fix`
+  share byte for byte: read `.gtd/FEEDBACK.md`, fix the code, leave it
+  uncommitted. `fix-suite` appends one extra sentence about implementing a later
+  package's work when that's the only way to green the suite; `build.fix` does
+  not.
 
 ### Lookup and precedence
 

--- a/src/workflows/templates.test.ts
+++ b/src/workflows/templates.test.ts
@@ -2,6 +2,7 @@ import { parse as parseYaml } from "yaml"
 import { describe, expect, it } from "vitest"
 import { validateDefinition } from "../PatternMachine.js"
 import { seededValidateCommand } from "../SteeringFormats.js"
+import { renderStateTemplate, varsOnlyContext } from "../PatternTemplates.js"
 import type { MachineNode } from "../Machines.js"
 import {
   compileTemplate,
@@ -504,27 +505,87 @@ describe("the bundled unified workflow template", () => {
     expect(authorPrompt).toContain(bias)
   })
 
-  it("neither the vertical/distinct-acceptance prose nor the footprint/merge prose states a package count as a digit (package 01)", () => {
+  it("neither the vertical/distinct-acceptance prose nor the footprint/merge prose states a package count as a digit (package 01, 02)", () => {
     const { definition } = compileTemplate()
 
-    // Slice out just the new prose (between stable anchors), rather than the
-    // whole prompt — both prompts legitimately carry unrelated digits
-    // elsewhere (design.triage's own numbered steps "1."-"4.").
+    // Slice out just the new prose, bounded by the `## ` lap headings a
+    // reword cannot move — both prompts carry unrelated digits elsewhere.
     const triagePrompt = definition.states["design.triage"]!.prompt!
-    const triageStart = triagePrompt.indexOf("Two more tests sit beside")
-    const triageEnd = triagePrompt.indexOf("2. Classify each concern")
+    const triageStart = triagePrompt.indexOf("## First lap")
+    const triageEnd = triagePrompt.indexOf("## Return lap")
     expect(triageStart).toBeGreaterThan(-1)
     expect(triageEnd).toBeGreaterThan(triageStart)
     const triageSlice = triagePrompt.slice(triageStart, triageEnd)
     expect(triageSlice).not.toMatch(/[0-9]/)
 
     const authorPrompt = definition.states["architecture.author"]!.prompt!
-    const authorStart = authorPrompt.indexOf("You now know the *how*")
-    const authorEnd = authorPrompt.indexOf("For every open TECHNICAL point")
+    const authorStart = authorPrompt.indexOf("## First lap")
+    const authorEnd = authorPrompt.indexOf("## Return lap")
     expect(authorStart).toBeGreaterThan(-1)
     expect(authorEnd).toBeGreaterThan(authorStart)
     const authorSlice = authorPrompt.slice(authorStart, authorEnd)
     expect(authorSlice).not.toMatch(/[0-9]/)
+  })
+
+  it("both planner prompts carry their three/two lap headers (package 02)", () => {
+    const { definition } = compileTemplate()
+    const triagePrompt = definition.states["design.triage"]!.prompt!
+    expect(triagePrompt).toMatch(/## First lap/)
+    expect(triagePrompt).toMatch(/## Return lap/)
+    expect(triagePrompt).toMatch(/## Review loop-back/)
+    // Order matters: first, then return, then review loop-back.
+    const firstIdx = triagePrompt.indexOf("## First lap")
+    const returnIdx = triagePrompt.indexOf("## Return lap")
+    const loopBackIdx = triagePrompt.indexOf("## Review loop-back")
+    expect(firstIdx).toBeLessThan(returnIdx)
+    expect(returnIdx).toBeLessThan(loopBackIdx)
+    // The old numbered steps are gone — renumbered as sub-headings instead.
+    expect(triagePrompt).not.toMatch(/^\s*\d+\.\s/m)
+
+    const authorPrompt = definition.states["architecture.author"]!.prompt!
+    expect(authorPrompt).toMatch(/## First lap/)
+    expect(authorPrompt).toMatch(/## Return lap/)
+    expect(authorPrompt.indexOf("## First lap")).toBeLessThan(authorPrompt.indexOf("## Return lap"))
+  })
+
+  // Package 01 (shared prompt vars): a misspelt `it.vars.<name>` tag or a
+  // blanked override renders the literal string `undefined` into an agent's
+  // prompt — silently, with no throw and no warning (Eta just stringifies
+  // the missing lookup). Rendering every prompt/system value against the
+  // bundled `vars:` defaults is the only automated defence against that.
+  it("renders every prompt/system value against the bundled vars defaults with no leaked `undefined` (package 01)", () => {
+    const { definition, vars } = compileTemplate()
+    const context = { ...varsOnlyContext(vars), read: () => "stub file content" }
+    for (const [name, state] of Object.entries(definition.states)) {
+      const fields = { script: state.script, prompt: state.prompt, message: state.message }
+      for (const [field, content] of Object.entries(fields)) {
+        if (content === undefined) continue
+        const rendered = renderStateTemplate(content, context)
+        expect(rendered, `state "${name}" field "${field}"`).not.toMatch(/undefined/)
+      }
+    }
+    for (const [machineName, machine] of Object.entries(
+      parseYaml(unifiedYaml).machines as Record<string, { system?: string }>,
+    )) {
+      if (machine.system === undefined) continue
+      const rendered = renderStateTemplate(machine.system, context)
+      expect(rendered, `machine "${machineName}" system`).not.toMatch(/undefined/)
+    }
+  })
+
+  it("a misspelt `it.vars` tag renders the literal `undefined` — proving the assertion above would catch one (package 01)", () => {
+    const { vars } = compileTemplate()
+    const context = { ...varsOnlyContext(vars), read: () => "stub file content" }
+    expect(renderStateTemplate("A <%~ it.vars.thisNameDoesNotExist %> B", context)).toBe(
+      "A undefined B",
+    )
+  })
+
+  it("a checkbox-few-shot pin on questionBar, the shared open-questions block (package 01)", () => {
+    const { vars } = compileTemplate()
+    expect(vars.questionBar).toMatch(/- \[ ] <first option.*rationale>/)
+    expect(vars.questionBar).toMatch(/- \[ ] <second option>/)
+    expect(vars.questionBar).toMatch(/- \[ ] _your answer_/)
   })
 })
 

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -33,68 +33,68 @@ vars:
   # no upstream text ships. A point-in-time derivation with no refresh
   # mechanism.
   styleBlock: |-
-    This block opens with why density matters, not with rule one: the reader
-    has a finite attention budget, and burying the line that mattered fails as
-    hard as cutting it. This is motivation, not a rule — it commands nothing
-    and never outranks never-trim.
+    This file is a deliverable, not a chat reply — size follows the work, and
+    padding is the target of any cut. Lead with the answer immediately; never
+    circle back to restate it once it has landed.
 
-    This file is a deliverable, not a chat reply. Its size follows the work —
-    write what the task demands, and let padding, not length, be the target of
-    any cut.
-
-    Lead with the answer or the decision immediately. Skip the throat-clearing
-    opener, and never circle back to restate the point once it has landed.
-
-    Write in flat, commanding sentences — commit to the claim rather than
-    hedging it.
-
-    Favor everyday vocabulary over technical shorthand; where a term is
-    unavoidable, define it in five words or fewer on first use.
+    Write flat, commanding sentences — commit to the claim, do not hedge it.
+    Favor everyday vocabulary; where a term is unavoidable, define it in five
+    words or fewer on first use.
 
     In markdown, bold carries the load: bold the claim, not the sentence around
-    it. The test: reading only the bold text yields the full point and every
-    risk, or the bolding is wrong.
+    it — reading only the bold text must yield the full point and every risk.
 
-    Above every rule in this block: never trim a risk, a number, a threshold,
-    or a scoped condition to save space. A claim that only holds under some
-    condition ships with that condition. It outranks every other rule here.
+    Never trim a risk, a number, a threshold, or a scoped condition to save
+    space. This outranks every other rule here.
 
-    Ship the artifact bare. Output only what was asked for — no lead-in, no
-    "here's the…", no sign-off wrapped around it. A generated file consumed
-    as-is turns a wrapper into a defect.
+    Ship the artifact bare — no lead-in, no sign-off wrapped around it.
+    Compressing is not dropping: a task with three load-bearing parts ships all
+    three, each shorter, never two of three.
 
-    Compressing is not dropping. A task with three load-bearing parts ships all
-    three, each shorter — reporting two of three findings has failed the brief,
-    not fulfilled it.
-
-    One idea per block; break when the idea shifts. Blocks may run any length,
-    but one unbroken paragraph is a defect even when short.
-
-    Flag risk and uncertainty in one blunt line. This is never-trim's
-    constructive twin: that rule forbids deleting a caveat, this one forbids
-    dissolving it into hedged prose.
-
-    Never narrate the work — do it. Skip lines like "I will now list the
-    concerns"; a file has no reason to describe its own composition.
+    One idea per block; break when the idea shifts. Flag risk in one blunt
+    line rather than hedged prose. Never narrate the work — do it.
   styleFormatContract: |-
-    This file is machine-read. Its format contract outranks every style rule
-    above it: keep every `##`/`###` heading this state specifies, every
-    `- [ ]` checkbox row, and every required marker line exactly as specified.
+    This file is machine-read; its format contract outranks every style rule
+    above it: keep every `##`/`###` heading, every `- [ ]` checkbox row, and
+    every marker line exactly as specified — do not renumber or rename a
+    heading or replace a checkbox list with prose. A parser reads these
+    literally; a violation refuses the turn outright.
 
-    Do not replace a checkbox list with prose paragraphs. Do not renumber or
-    rename a required heading. Do not drop a marker line. A parser reads these
-    literally, and a violation refuses the turn outright — this is not a
-    polite request, it is the one thing standing between this output and a
-    failed parse.
-
-    The voice rules above still govern the prose that sits between these
-    structural elements. They do not govern the elements themselves.
+    Voice rules above govern the prose between these elements, never the
+    elements themselves.
 
   # One persona per prompt-bearing machine below, stamped as its `system:`
   # (see src/StateFields.ts's `system`). `--system-prompt` REPLACES a
   # harness's default system prompt — including its injected cwd/env/
   # git-status block — so each persona is written self-contained, restating
   # that context explicitly rather than relying on it.
+
+  # Shared conduct tail, appended after every persona's own role paragraph:
+  # use tools without asking, orient yourself with git, and go inspect what
+  # the turn's message names. Deliberately NOT named `*Persona`:
+  # `templates.test.ts` derives its six-name persona set from
+  # `it\.vars\.(\w+Persona)`, so that suffix would silently grow the set.
+  agentConduct: |-
+    You have shell and file tools — bash, read, write, edit — and you are
+    expected to use them without asking first. This runs unattended: there is
+    no one to grant permission, confirm a command, or approve a plan before
+    you act. Investigate with real commands rather than assuming what a file,
+    a commit, or a decision's status actually is, then act on what you find.
+
+    You are already inside a git repository, at the working directory you
+    should treat as your whole world for this turn. There is no injected
+    status block — no cwd, no branch, no recent history, no tree state. Run
+    `git status`, `git log`, `ls` and the like yourself before you do
+    anything else; that is the normal first move of this turn, not an extra
+    step.
+
+    The message you receive each turn names a commit, a range, or a file for
+    you to go inspect yourself — `git show`, `git diff`, reading the file
+    directly — never a diff or a summary rendered into the conversation. Go
+    look before you act. Across the several turns one conversation may span,
+    work from what you already read and settled earlier rather than
+    re-deriving it from a cold read every time, unless the turn's own
+    instructions tell you this is a fresh, cold pass.
   designPersona: |-
     You are the product-facing planning voice in an autonomous build pipeline
     called gtd. Your job is to turn a raw, half-formed sketch — a hand-edit to
@@ -103,28 +103,6 @@ vars:
     human about the product decisions that list depends on. You are read by
     that human, so write plainly and decisively; you are not read by a parser
     except where a state's own instructions say otherwise.
-
-    You have shell and file tools — bash, read, write, edit — and you are
-    expected to use them without asking first. Nobody is watching this turn
-    interactively: there is no one to grant permission, confirm a destructive
-    command, or approve a plan before you act. Investigate with real commands
-    (`git log`, `git show`, `ls`, `cat`) rather than assuming what a file or a
-    commit contains, then act.
-
-    You are already inside a git repository, at the working directory you
-    should treat as your whole world for this turn. Nothing has told you the
-    current branch, the recent commit history, or whether the tree is clean —
-    there is no injected status block. Run `git status`, `git log`, `ls` and
-    similar yourself before you do anything else; that is the normal first
-    move of this turn, not an extra step.
-
-    The message you receive each turn is an instruction that names commits,
-    paths, or file names for you to go inspect yourself — `git show <hash>`,
-    `git diff`, reading a file directly — never a rendered diff pasted into
-    the conversation. Expect to go look. Across the several turns this
-    conversation may span, remember what you already read and settled in an
-    earlier turn rather than re-deriving it from a cold read every time —
-    unless the turn's own instructions tell you this is a fresh, cold pass.
   architectPersona: |-
     You are the technical planning voice in an autonomous build pipeline
     called gtd. You take over once the product-facing concerns are settled,
@@ -137,25 +115,6 @@ vars:
     further judgement call: the grouping and ordering were already decided
     upstream, and this final step is a mechanical write-out of a plan you
     already converged on.
-
-    You have shell and file tools — bash, read, write, edit — and you are
-    expected to use them without asking first. This runs unattended: there is
-    no one present to confirm a step or approve a draft before you commit to
-    it. Investigate with real commands rather than assuming a file's contents
-    or a decision's status, then act on what you find.
-
-    You are already inside a git repository, at the working directory you
-    should treat as your whole world for this turn. There is no injected
-    status block telling you the branch, recent history, or tree state — run
-    `git status`, `git log`, `ls` and the like yourself before doing anything
-    else.
-
-    The message you receive each turn names files and, where relevant, commit
-    ranges for you to go read yourself — never a diff or a plan rendered
-    inline. Go look before you decide anything. When a later turn in this
-    same conversation asks you to mechanically write out package files, work
-    from the plan you already settled rather than re-deriving it, unless
-    instructed to read it fresh.
   reviewerPersona: |-
     You are the independent reviewing mind in an autonomous build pipeline
     called gtd — deliberately a separate identity from whichever agent wrote
@@ -166,24 +125,6 @@ vars:
     feedback — a note, a hand-edit — and classifying whether it is genuinely
     actionable or just an approving remark, without fixing anything yourself
     either way. You judge and you classify; you never build.
-
-    You have shell and file tools — bash, read, write, edit — and you are
-    expected to use them without asking first. This runs unattended, so act
-    on what you find rather than pausing for confirmation. Investigate with
-    real commands — `git log`, `git show`, `git diff` — rather than assuming
-    what changed.
-
-    You are already inside a git repository, at the working directory you
-    should treat as your whole world for this turn. There is no injected
-    status block: no cwd banner, no environment summary, no memory-file list,
-    no git-status readout. Run `git status`, `git log`, `ls` yourself first.
-
-    The message you receive each turn names a commit range or a file for you
-    to inspect yourself — `git show`, `git diff` against the range it gives
-    you — not a diff pasted into the conversation. Go read the actual history
-    before you write or judge anything; the range is often wider than the
-    single round in front of you, so check what it actually spans rather than
-    assuming it matches your last turn.
   specReviewerPersona: |-
     You are the adversarial spec-conformance checker in an autonomous build
     pipeline called gtd, reviewing one freshly-built work package against the
@@ -194,54 +135,15 @@ vars:
     and when nothing is, you write nothing at all, because a clean turn from
     you IS the approval. You never fix a problem you find; naming it
     precisely enough for someone else's fix turn to act on is the whole job.
-
-    You have shell and file tools — bash, read, write, edit — and you are
-    expected to use them without asking first. Nobody is present to confirm a
-    verdict interactively, so investigate with real commands and commit to
-    what you find rather than hedging or asking for permission to look.
-
-    You are already inside a git repository, at the working directory you
-    should treat as your whole world for this turn. There is no injected
-    status block — no cwd, no environment summary, no git status handed to
-    you. Orient yourself with `git status`, `git log`, `ls` and the like
-    before judging anything.
-
-    The message you receive each turn names a spec file to read and a commit
-    range for you to inspect yourself — `git show`, `git diff` — never a
-    diff rendered inline, and the range is often wider than the one package
-    you are checking, since it can span everything built so far in this
-    process. Go look before you approve or object; do not assume the range
-    matches only the most recent change.
   builderPersona: |-
     You are the TDD implementer in an autonomous build pipeline called gtd.
     Your job is to build exactly one package's declared scope end to end,
     tests first, and to come back and fix things when redirected: a failing
     check's output, or a reviewer's concrete feedback. Stay strictly inside
-    the package in front of you — never wander into another package's files
-    or tasks just because you can see them, and never refactor code the
-    current task doesn't touch. When fixing, treat the feedback you're given
-    as the diagnosis to act on, not a suggestion to second-guess without
-    evidence — but if it is simply wrong, say so by discarding it rather than
-    forcing a change onto code that doesn't need one.
-
-    You have shell and file tools — bash, read, write, edit — and you are
-    expected to use them without asking first. This runs unattended: there is
-    no one to approve a plan or confirm a command before you run it. Write
-    the failing test, watch it fail, then make it pass — investigate the
-    actual current state of the code and the suite with real commands rather
-    than assuming either.
-
-    You are already inside a git repository, at the working directory you
-    should treat as your whole world for this turn. There is no injected
-    status block — no cwd, no environment info, no memory-file paths, no git
-    status. Run `git status`, `git log`, `ls` yourself before you start
-    editing anything.
-
-    The message you receive each turn names the package spec, the feedback
-    file, or the check output for you to read yourself at its actual path —
-    never a diff or a rendered summary handed to you inline. Go read the
-    file, and where a commit range is named, go inspect it with `git show` or
-    `git diff` rather than expecting the change pasted in front of you.
+    the package in front of you, touching neither another package's files nor
+    code outside the current task. Treat feedback you're given as the
+    diagnosis to act on; discard it, with reason, only when it is simply
+    wrong.
   finisherPersona: |-
     You are the closing identity in an autonomous build pipeline called gtd —
     the last coder this process hands work to before everything it touched is
@@ -255,23 +157,80 @@ vars:
     and become part of one final message, so make that message earn its
     place as the historical record.
 
-    You have shell and file tools — bash, read, write, edit — and you are
-    expected to use them without asking first. This runs unattended, so act
-    on what you find rather than waiting for confirmation. Investigate the
-    actual commit range and the actual failing output with real commands
-    rather than assuming either.
+  # The scratchpad-opener sentence shared by every prompt-content state (see
+  # STATE_FIELDS's `prompt`) — this workflow's own state files are its private
+  # working notes, never project code or documentation a human reads. Injected
+  # as the leading line of all eleven prompt bodies that touch a `.gtd/` file
+  # directly; each state's own "the only state file this turn touches is X"
+  # sentence stays local, immediately after the tag. Three states splice a
+  # role clause into this same opening sentence (`build.review.collecting`,
+  # `packages.item.spec.review`, `build.squashing`) — those hoist the clause to
+  # its own leading sentence ahead of the tag instead, keeping every word.
+  stateFileRules: |-
+    You are an autonomous coding agent. This workflow steers itself
+    through its own state files — treat them as its private scratchpad,
+    never as project code or documentation.
+  # The open-questions warrant test, decide-it-yourself sink, and `## Open
+  # Questions` checkbox shape shared by `design.triage` and
+  # `architecture.author` — written phase-agnostic (no PRODUCT/TECHNICAL
+  # bake-in) so both sites can inject it verbatim. Each site's own
+  # phase-scope sentence (triage: product-only, technical waits; architecture:
+  # every point here is TECHNICAL) stays local around the tag — the two
+  # genuinely disagree on scope, so that sentence is never shared.
+  # `questionBarReturn` is the return-lap half — split out so each site can
+  # inject it under its own `## Return lap` heading instead of burying
+  # return-lap behaviour inside the first lap's own section.
+  questionBar: |-
+    For every open point, a question is warranted only when all three hold:
+    the answer is a genuine fork with divergent outcomes — user-visible for a
+    product question, materially different implementations for a technical
+    one; the sketch, the entry diff, and history do not already settle it
+    (treat anything the entry diff states explicitly — a directive in
+    `.gtd/TODO.md`, a committed choice in a hand-edit — as already settled,
+    and on a review loop-back lap treat whatever the human's own review-round
+    edit or note states explicitly the same way); and getting it wrong would
+    survive all the way to the human review tail.
 
-    You are already inside a git repository, at the working directory you
-    should treat as your whole world for this turn. There is no injected
-    status block — no cwd, no environment summary, no git status. Run
-    `git status`, `git log`, `ls` yourself before acting.
+    Anything below that bar, decide yourself: record the decision under
+    `## Answered Questions` — the same section a human-answered question
+    lands in — as `### <the point phrased as a question>` followed by the
+    decision and a one-line rationale in prose, no checkboxes.
 
-    The message you receive each turn names a commit range or a feedback file
-    for you to go inspect yourself — `git show`, `git diff`, reading the file
-    directly — never a diff rendered inline into the conversation. Go look
-    before you write the commit message or the fix; if you already built the
-    range earlier in this same conversation, work from what you already know
-    rather than re-deriving it.
+    A question that clears the bar is written under a `## Open Questions`
+    heading near the top and takes this shape: one `### <question>`
+    sub-heading each, followed by a checkbox list of candidate answers — two
+    concrete options plus a final free-text slot, all left unticked:
+
+        ### <the question>
+
+        - [ ] <first option — a concrete answer, a few words of rationale>
+        - [ ] <second option>
+        - [ ] _your answer_
+
+    Never tick a box yourself — the human ticks exactly one per question.
+  questionBarReturn: |-
+    The human has ticked one option per question (or replaced
+    `_your answer_` with their own text): fold each chosen answer into its
+    concern's prose, then move the question into a `## Answered Questions`
+    section as `### <question>` followed by the resolved answer in plain
+    prose (drop the checkboxes). Never re-raise a deleted question; treat a
+    deleted `## Open Questions` section as acceptance. Omit `## Open
+    Questions` entirely once there are none left.
+  # The body `packages.item.fix-suite` and `build.fix` share byte for byte —
+  # both fix a red `.gtd/FEEDBACK.md`. `fix-suite` appends its own
+  # cross-package paragraph right after this tag (before the shared
+  # "Leave everything uncommitted" close, which stays local at both sites so
+  # the appended paragraph lands in the same position it renders in today);
+  # `build.fix` renders the tag alone.
+  fixFeedbackPrompt: |-
+    The only state file this turn touches is `.gtd/FEEDBACK.md`; fix it per its
+    contents, or delete it if the feedback turns out to be wrong. Do not
+    create other files to hold notes or output.
+
+    Read `.gtd/FEEDBACK.md` (the failing test output) and fix the
+    code so the suite passes. Keep the change focused — do not refactor
+    unrelated code. If the feedback is wrong, empty or delete
+    `.gtd/FEEDBACK.md` instead of "fixing" a non-issue.
 
 entry:
   default: unified
@@ -428,7 +387,11 @@ machines:
   # ▸ planner identity.
   designPlan:
     model: <%= it.vars.plannerModel %>
-    system: <%~ it.vars.designPersona %>
+    system: |-
+      <%~ it.vars.designPersona %>
+
+
+      <%~ it.vars.agentConduct %>
     params: [onArchitecture]
     entry: triage
     states:
@@ -447,15 +410,14 @@ machines:
           <%~ it.vars.styleFormatContract %>
 
 
-          You are an autonomous coding agent. This workflow steers itself
-          through its own state files — treat them as its private scratchpad,
-          never as project code or documentation. The only state file this
-          turn touches is `.gtd/REQUIREMENTS.md`; develop it. Do
+          <%~ it.vars.stateFileRules %>
+
+          The only state file this turn touches is `.gtd/REQUIREMENTS.md`; develop it. Do
           not create other files to hold notes or output.
 
           `.gtd/TODO.md` is the likely home of the sketch that
           started this process. Despite living beside this workflow's own
-          state files, it is the HUMAN'S INPUT — the sketch to be folded into
+          state files, it is the human's input — the sketch to be folded into
           the concerns below like any other part of the start diff. It is
           never a state file to preserve, and never gtd bookkeeping to ignore.
 
@@ -471,15 +433,22 @@ machines:
           process: a hand-edit to real code, a scratch note in some file, or
           both.
 
-          On the FIRST lap, `.gtd/REQUIREMENTS.md` does not exist
-          yet (or holds whatever the human's own change happened to leave
-          there). Build it from that start diff:
+          Whichever lap this is, leave `.gtd/REQUIREMENTS.md` uncommitted and
+          finish your turn once it reflects this lap's own work below.
 
-          1. Group the diff into an ORDERED list of CONCERNS — each one a
-             coherent piece of work that can leave the test suite GREEN on
-             its own, in the order you'd want them built. If a concern would
-             red-light tests that a later concern is meant to fix, that is
-             not a valid split: merge the two into one concern.
+          ## First lap
+
+          `.gtd/REQUIREMENTS.md` does not exist yet (or holds whatever the
+          human's own change happened to leave there). Build it from that
+          start diff:
+
+          ### Group into concerns
+
+          Group the diff into an ordered list of concerns — each one a
+          coherent piece of work that can leave the test suite green on
+          its own, in the order you'd want them built. If a concern would
+          red-light tests that a later concern is meant to fix, that is
+          not a valid split: merge the two into one concern.
 
           Two more tests sit beside that green floor, not instead of it.
           Vertical, not horizontal: slice by capability, never by layer. A
@@ -491,76 +460,46 @@ machines:
           independently valuable change, not the smallest change that
           compiles.
 
-          2. Classify each concern as PRODUCT (a user-facing/requirements
-             decision) or TECHNICAL (an implementation decision).
-          3. For every concern's open point, PRODUCT or TECHNICAL, a question
-             is warranted only when all three hold: the answer is a genuine
-             fork with divergent outcomes — user-visible for a product
-             question, materially different implementations for a technical
-             one; the sketch, the entry diff, and history do not already
-             settle it (treat anything the entry diff states explicitly — a
-             directive in `.gtd/TODO.md`, a committed choice in a hand-edit —
-             as already settled, and on a review loop-back lap treat
-             whatever the human's own review-round edit or note states
-             explicitly the same way); and getting it wrong would survive
-             all the way to the human review tail.
+          ### Classify each concern
 
-             Anything below that bar, PRODUCT or TECHNICAL alike, decide
-             yourself: record the decision under `## Answered Questions` —
-             the same section a human-answered question lands in — as
-             `### <the point phrased as a question>` followed by the
-             decision and a one-line rationale in prose, no checkboxes.
+          Classify each concern as PRODUCT (a user-facing/requirements
+          decision) or TECHNICAL (an implementation decision).
 
-             A question that clears the bar is written under a
-             `## Open Questions` heading near the top and takes this shape:
-             one `### <question>` sub-heading each, followed by a checkbox
-             list of candidate answers — TWO concrete options plus a final
-             free-text slot, ALL left UNTICKED:
+          <%~ it.vars.questionBar %>
 
-                 ### <the question>
 
-                 - [ ] <first option — a concrete answer, a few words of rationale>
-                 - [ ] <second option>
-                 - [ ] _your answer_
+          Raise questions only for product concerns here — a technical
+          concern's open points wait for the next phase. When every concern
+          in this lap is TECHNICAL, write no `## Open Questions` section at
+          all.
 
-             Raise questions ONLY for product concerns here — a technical
-             concern's open points wait for the next phase. Never tick a box
-             yourself — the human ticks exactly one per question.
+          ### Fold in the sketch
 
-             When every concern in this lap is TECHNICAL, write no
-             `## Open Questions` section at all.
-          4. Fold EVERYTHING the entry commit added into the concerns above —
-             a scratch note and a real code edit are both just a SKETCH of
-             the intent, a spec to be finished, never work to be preserved;
-             `unwind` already reverted both out of the tree, so there is
-             nothing left to delete. Describe each piece under the concern it
-             belongs to.
+          Fold everything the entry commit added into the concerns above —
+          a scratch note and a real code edit are both just a sketch of
+          the intent, a spec to be finished, never work to be preserved;
+          `unwind` already reverted both out of the tree, so there is
+          nothing left to delete. Describe each piece under the concern it
+          belongs to.
 
-          On a RETURN lap the human has ticked one option per question (or
-          replaced `_your answer_` with their own text) in
-          `.gtd/REQUIREMENTS.md`. For each answered question: fold
-          the chosen answer into its concern's prose, then MOVE the question
-          down into a `## Answered Questions` section as `### <question>`
-          followed by the resolved answer in plain PROSE (drop the
-          checkboxes). Never re-raise a question the human deleted; if the
-          human deleted the whole `## Open Questions` section, treat every
-          product concern as accepted and surface no new questions unless
-          something is genuinely still blocking. Omit `## Open Questions`
-          entirely once there are none left.
+          ## Return lap
 
-          On a REVIEW LOOP-BACK lap, `.gtd/REQUIREMENTS.md`
-          already holds concerns and none of them have a ticked-but-unfolded
-          answer waiting — that shape means a completed REVIEW ROUND put
-          this material here, not a question you asked. Develop those
-          existing concerns further with whatever the round raised; never
-          rediscover or regroup them from a cold read the way the FIRST lap
-          does.
+          <%~ it.vars.questionBarReturn %>
+
+          ## Review loop-back
+
+          `.gtd/REQUIREMENTS.md` already holds concerns and none of them
+          have a ticked-but-unfolded answer waiting — that shape means a
+          completed REVIEW round put this material here, not a question you
+          asked. Develop those existing concerns further with whatever the
+          round raised; never rediscover or regroup them from a cold read
+          the way the first lap does.
 
           The human's own edit from that review round has been reverted out
           of the working tree the same way the entry commit is — read it
           from history, never the working tree: run
-          `git show <%= it.reviewBase %>` to see it. (On a FIRST lap that
-          same hash IS the process's own diff base, `<%= it.startCommit %>`,
+          `git show <%= it.reviewBase %>` to see it. (On the first lap that
+          same hash is the process's own diff base, `<%= it.startCommit %>`,
           so this branch does not apply: `.gtd/REQUIREMENTS.md`
           does not exist yet for a review round to have happened against.)
 
@@ -569,20 +508,17 @@ machines:
           re-open one. A genuinely open PRODUCT point in the round's own
           material may still raise a fresh question under
           `## Open Questions`: the product gate sits on this path exactly as
-          it does on a first lap, and will ask it.
+          it does on the first lap, and will ask it.
 
           Before grouping anything on this lap, run
           `<%= it.vars.testCommand %>` yourself as part of reading the
           situation: a review loop-back runs no green-baseline gate between
-          the revert above and this turn, so the tree may already be RED —
+          the revert above and this turn, so the tree may already be red —
           reverting the human's edit can undo a fix that edit had put in. If
-          the suite is red, make that breakage the FIRST concern in your
+          the suite is red, make that breakage the first concern in your
           ordered list, ahead of everything else — every later concern's
           "leaves the suite green on its own" property assumes the suite
           already started green.
-
-          Leave `.gtd/REQUIREMENTS.md` uncommitted and finish your
-          turn.
         on:
           "* **": gate.check
 
@@ -613,7 +549,11 @@ machines:
   # `decompose` carries that grouping over verbatim. ▸ planner identity.
   archPlan:
     model: <%= it.vars.plannerModel %>
-    system: <%~ it.vars.architectPersona %>
+    system: |-
+      <%~ it.vars.architectPersona %>
+
+
+      <%~ it.vars.agentConduct %>
     params: [onPackages]
     entry: author
     states:
@@ -629,21 +569,21 @@ machines:
           <%~ it.vars.styleFormatContract %>
 
 
-          You are an autonomous coding agent. This workflow steers itself
-          through its own state files — treat them as its private scratchpad,
-          never as project code or documentation. The only state files this
+          <%~ it.vars.stateFileRules %>
+
+          The only state files this
           turn touches are `.gtd/ARCHITECTURE.md` (write it) and
           `.gtd/REQUIREMENTS.md` (delete it once its content is
           folded in). Do not create other files to hold notes or output.
 
-          You do NOT resume the design conversation — this is a separate
-          machine with its own memory, a COLD read every time. Read
+          You do not resume the design conversation — this is a separate
+          machine with its own memory, a cold read every time. Read
           `.gtd/REQUIREMENTS.md` (the settled, ordered, classified
           concerns) in full. Treat every decision recorded there — plain
           prose or a resolved `## Answered Questions` entry, PRODUCT or
-          TECHNICAL alike — as SETTLED; never re-open it.
+          TECHNICAL alike — as settled; never re-open it.
 
-          COLD means the machine carries no conversational memory of
+          Cold means the machine carries no conversational memory of
           triage's own back-and-forth; it never meant no git access. This
           process started at commit `<%= it.startCommit %>`. Find the
           process's first turn yourself: run
@@ -652,10 +592,17 @@ machines:
           process: a hand-edit to real code, a scratch note in some file,
           or both.
 
-          On the FIRST lap, develop `.gtd/ARCHITECTURE.md` from
-          those concerns: for each one, in the same order, work out the *how*
-          — file/module structure, data models, library/tech-stack choices,
-          error-handling strategy — building on the *what* already settled.
+          Whichever lap this is, once `.gtd/ARCHITECTURE.md` is written,
+          delete `.gtd/REQUIREMENTS.md` — its content has been folded in and
+          it must not linger. Leave everything uncommitted and finish your
+          turn.
+
+          ## First lap
+
+          Develop `.gtd/ARCHITECTURE.md` from those concerns: for each one,
+          in the same order, work out the *how* — file/module structure,
+          data models, library/tech-stack choices, error-handling strategy —
+          building on the *what* already settled.
 
           You now know the *how*, so you know each concern's file footprint —
           list each concern's primary paths. Merge concerns whose footprints
@@ -674,49 +621,14 @@ machines:
           larger packages — the smallest independently valuable change, not
           the smallest change that compiles.
 
-          For every open TECHNICAL point, a question is warranted
-          only when all three hold: the answer is a genuine fork with
-          divergent outcomes — user-visible for a product question,
-          materially different implementations for a technical one; the
-          sketch, the entry diff, and history do not already settle it
-          (treat anything the entry diff states explicitly — a directive
-          in `.gtd/TODO.md`, a committed choice in a hand-edit — as
-          already settled, and on a review loop-back lap treat whatever
-          the human's own review-round edit or note states explicitly the
-          same way); and getting it wrong would survive all the way to
-          the human review tail.
+          Every open point here is TECHNICAL — triage already resolved the
+          product ones, one phase earlier.
 
-          Anything below that bar, decide yourself: record the decision
-          under `## Answered Questions` — the same section a
-          human-answered question lands in — as
-          `### <the point phrased as a question>` followed by the decision
-          and a one-line rationale in prose, no checkboxes.
+          <%~ it.vars.questionBar %>
 
-          A question that clears the bar is written under a
-          `## Open Questions` heading, exactly as the requirements phase
-          does: one `### <question>` each, followed by a checkbox list —
-          TWO concrete options plus a final free-text slot, ALL left
-          UNTICKED:
+          ## Return lap
 
-              ### <the question>
-
-              - [ ] <first option>
-              - [ ] <second option>
-              - [ ] _your answer_
-
-          Never tick a box yourself. On a RETURN lap the human has ticked one
-          option per question (or replaced `_your answer_` with their own
-          text): fold each chosen answer into the plan prose, then MOVE the
-          question into a `## Answered Questions` section as `### <question>`
-          + the resolved answer in plain PROSE (drop the checkboxes). Never
-          re-raise a deleted question; treat a deleted `## Open Questions`
-          section as acceptance. Omit `## Open Questions` once there are none
-          left.
-
-          Once `.gtd/ARCHITECTURE.md` is written, delete
-          `.gtd/REQUIREMENTS.md` — its content has been folded in
-          and it must not linger. Leave everything uncommitted and finish
-          your turn.
+          <%~ it.vars.questionBarReturn %>
         on:
           "* **": gate.check
 
@@ -748,9 +660,9 @@ machines:
           <%~ it.vars.styleBlock %>
 
 
-          You are an autonomous coding agent. This workflow steers itself through
-          its own state files — treat them as its private scratchpad, never as
-          project code or documentation. The only state files this turn touches
+          <%~ it.vars.stateFileRules %>
+
+          The only state files this turn touches
           are the package files it writes under `.gtd/packages/` and
           `.gtd/ARCHITECTURE.md`, which it deletes. Do not create other
           files to hold notes or output.
@@ -758,7 +670,7 @@ machines:
           If you wrote `.gtd/ARCHITECTURE.md` earlier in this
           conversation, work from what you already settled; otherwise read it
           (the converged technical plan) yourself. It already lists an
-          ORDERED set of concerns with every merge/split judgement
+          ordered set of concerns with every merge/split judgement
           `architecture.author` made — this turn is a mechanical write-out,
           not a planning one. A `## Merged Concerns` heading there is a
           record of those merges, never a concern of its own: write no
@@ -771,7 +683,7 @@ machines:
           carries that concern's requirement(s) (so it can be reviewed
           against its spec — both, independently, when the concern was
           merged), its independent tasks, and each task's acceptance
-          criteria as `- [ ]` checkboxes and relevant paths. Do NOT merge or
+          criteria as `- [ ]` checkboxes and relevant paths. Do not merge or
           split concerns here — that judgement already happened in
           `architecture.author`; carry the settled grouping over verbatim.
           No package file may reference any other `.gtd/` file.
@@ -794,7 +706,11 @@ machines:
   # way, since `build`'s own scope has no prior turn to resume there.
   humanReview:
     model: <%= it.vars.plannerModel %>
-    system: <%~ it.vars.reviewerPersona %>
+    system: |-
+      <%~ it.vars.reviewerPersona %>
+
+
+      <%~ it.vars.agentConduct %>
     entry: reviewing
     states:
       reviewing:
@@ -812,14 +728,13 @@ machines:
           <%~ it.vars.styleFormatContract %>
 
 
-          You are an autonomous coding agent. This workflow steers itself
-          through its own state files — treat them as its private scratchpad,
-          never as project code or documentation. The only state file this
-          turn touches is `.gtd/REVIEW.md`; write it at exactly
+          <%~ it.vars.stateFileRules %>
+
+          The only state file this turn touches is `.gtd/REVIEW.md`; write it at exactly
           that path. Do not create other files to hold notes or output.
 
           Write `.gtd/REVIEW.md` to help a human review the changes in
-          this EXACT format:
+          this exact format:
 
           - First non-blank line: `# Review: <%= it.currentCommit.slice(0, 7) %>`
           - Somewhere in the document: `<!-- base: <%= it.reviewBase %> -->`
@@ -841,7 +756,7 @@ machines:
                   and here is more detail, continued below it
 
             A note that sits entirely on the line(s) beneath the pointer is
-            also valid. Either way, the explanation itself must never START
+            also valid. Either way, the explanation itself must never start
             with a bare `./path` token — that parses as a second hunk pointer,
             not a note.
 
@@ -951,11 +866,13 @@ machines:
 
 
           You are an autonomous coding agent judging and classifying a round
-          of review feedback. This workflow steers itself through its own
-          state files — treat them as its private scratchpad, never as
-          project code or documentation. The only state files this turn
+          of review feedback.
+
+          <%~ it.vars.stateFileRules %>
+
+          The only state files this turn
           touches are `.gtd/REQUIREMENTS.md` and
-          `.gtd/REVIEW_RAW.md`, which it deletes — do NOT change any
+          `.gtd/REVIEW_RAW.md`, which it deletes — do not change any
           other file: you classify, you do not build.
 
           The raw review material is: <%~ it.read(".gtd/REVIEW_RAW.md") %>
@@ -964,46 +881,47 @@ machines:
           conversation, work from what you already reviewed; otherwise read that
           commit's diff yourself before classifying anything.
 
-          The round is ACTIONABLE if any of the following is true:
+          The round is actionable if any of the following is true:
 
-          1. The human left a NOTE on `.gtd/REVIEW.md` — a note is
+          1. The human left a note on `.gtd/REVIEW.md` — a note is
              anything beyond a checkbox flip, regardless of whether the box
              itself is ticked (ticking means only "I read this hunk", never
-             sign-off). A note is a MANDATORY concern below, whether or not
+             sign-off). A note is a mandatory concern below, whether or not
              its box is ticked.
-          2. The human ADDED a code comment this round (a `+` line that is a
+          2. The human added a code comment this round (a `+` line that is a
              comment, in a hand-edited file) — even a plain-prose one. That
-             comment is an INSTRUCTION: describe it as a concern below, and
+             comment is an instruction: describe it as a concern below, and
              note that the comment line itself is transient — it must not
              survive the lap that satisfies it.
           3. The human hand-edited any non-comment code this round. That code
              is no longer an already-committed intent to build on top of — it
-             is a SKETCH, like the entry commit's own diff: describe what it
+             is a sketch, like the entry commit's own diff: describe what it
              was reaching for under the concern it belongs to, and expect the
              lap that follows to re-derive it from scratch. Never say the
              human's lines are final or that they must survive unchanged.
 
-          The round is NOT actionable only when none of the above holds — the
+          The round is not actionable only when none of the above holds — the
           human left nothing but an approving remark (a compliment, a "looks
           good", or similar) with no code edit and no substantive note. Never
-          invent actionability to justify a lap, and never dismiss a real note
-          or edit as approval.
+          invent actionability where the definition above doesn't hold — it
+          manufactures a lap nothing asked for — and never dismiss a real note
+          or edit as approval, which drops feedback the human left.
 
-          If the round is ACTIONABLE: write `.gtd/REQUIREMENTS.md`
-          with an ORDERED list of CONCERNS, each classified PRODUCT (a
+          If the round is actionable: write `.gtd/REQUIREMENTS.md`
+          with an ordered list of concerns, each classified PRODUCT (a
           user-facing/requirements decision) or TECHNICAL (an implementation
           decision) — the same shape `design.triage` builds, one
           `## <heading>` per concern, in the order you'd want them built. Fold
           every note, comment, and hand-edit from this round in under the
-          concern it belongs to, per the rules above. Raise NO open
+          concern it belongs to, per the rules above. Raise no open
           questions here — write no `## Open Questions` section;
           `design.triage` owns that, one phase later. Then delete
           `.gtd/REVIEW_RAW.md` and finish your turn.
 
-          If the round is NOT actionable: delete
+          If the round is not actionable: delete
           `.gtd/REVIEW_RAW.md` and finish your turn, writing nothing
           to `.gtd/REQUIREMENTS.md` — consuming the capture with no
-          other change IS the sign-off.
+          other change is the sign-off.
         on:
           "A .gtd/REQUIREMENTS.md": $onFeedback
           "M .gtd/REQUIREMENTS.md": $onFeedback
@@ -1013,7 +931,11 @@ machines:
   # identity; fixing findings is a coder action (packages.item.fix-spec).
   specReview:
     model: <%= it.vars.plannerModel %>
-    system: <%~ it.vars.specReviewerPersona %>
+    system: |-
+      <%~ it.vars.specReviewerPersona %>
+
+
+      <%~ it.vars.agentConduct %>
     params: [onApproved, onFix]
     entry: review
     states:
@@ -1030,9 +952,11 @@ machines:
 
 
           You are an autonomous coding agent reviewing a freshly-built work package
-          against its own spec. This workflow steers itself through its own
-          state files — treat them as its private scratchpad, never as project
-          code or documentation. The only state file this turn touches is
+          against its own spec.
+
+          <%~ it.vars.stateFileRules %>
+
+          The only state file this turn touches is
           `.gtd/SPEC_FEEDBACK.md`; write it only when — and only
           when — you find problems. Do not create other files to hold notes or
           output.
@@ -1048,7 +972,7 @@ machines:
           Note the range is process-wide (from the start of the whole build, not
           just this package), so it can span earlier packages too.
 
-          - If it fully satisfies the spec, write NOTHING and finish your turn — a
+          - If it fully satisfies the spec, write nothing and finish your turn — a
             clean turn is your approval.
           - If it does not, write `.gtd/SPEC_FEEDBACK.md` listing the
             concrete problems for a fix turn to address. Be specific.
@@ -1104,7 +1028,11 @@ machines:
   # -> picking is the one upward-resolving target in the file, hence $onNext.
   packageItem:
     model: <%= it.vars.coderModel %>
-    system: <%~ it.vars.builderPersona %>
+    system: |-
+      <%~ it.vars.builderPersona %>
+
+
+      <%~ it.vars.agentConduct %>
     params: [onNext]
     entry: building
     states:
@@ -1112,10 +1040,10 @@ machines:
         actor: agent
         label: Building
         prompt: |
-          You are an autonomous coding agent. This workflow steers itself
-          through its own state files — treat them as its private scratchpad,
-          never as project code or documentation. The only state file this
-          turn may write is `.gtd/SATISFIED.md` (see below); do NOT
+          <%~ it.vars.stateFileRules %>
+
+          The only state file this
+          turn may write is `.gtd/SATISFIED.md` (see below); do not
           delete the package file (the spec-review gate reads it after you)
           and never touch `.gtd/NEXT.md` — the `picking` state owns
           it.
@@ -1131,10 +1059,10 @@ machines:
           If any criterion is outstanding, implement the package normally and
           do not write that file.
 
-          That file describes a set of INDEPENDENT tasks. Implement ALL of them in
+          That file describes a set of independent tasks. Implement all of them in
           this one turn, fanning the independent tasks out to parallel subagents
           where your harness supports it — each task is self-contained and can be
-          built concurrently. Implement EXACTLY the tasks this package describes — no
+          built concurrently. Implement exactly the tasks this package describes — no
           more, no less; leave every other package file untouched. Use TDD
           discipline within each task.
 
@@ -1157,17 +1085,11 @@ machines:
         label: Fixing the check
         file: FEEDBACK.md
         prompt: |
-          You are an autonomous coding agent. This workflow steers itself
-          through its own state files — treat them as its private scratchpad,
-          never as project code or documentation. The only state file this
-          turn touches is `.gtd/FEEDBACK.md`; fix it per its
-          contents, or delete it if the feedback turns out to be wrong. Do not
-          create other files to hold notes or output.
+          <%~ it.vars.stateFileRules %>
 
-          Read `.gtd/FEEDBACK.md` (the failing test output) and fix the
-          code so the suite passes. Keep the change focused — do not refactor
-          unrelated code. If the feedback is wrong, empty or delete
-          `.gtd/FEEDBACK.md` instead of "fixing" a non-issue. If the
+          <%~ it.vars.fixFeedbackPrompt %>
+
+          If the
           only way to green the suite is to implement work that another
           package file describes, make the smallest change that gets there and
           do it — that later package will then legitimately report itself
@@ -1185,9 +1107,8 @@ machines:
         label: Fixing review feedback
         file: SPEC_FEEDBACK.md
         prompt: |
-          You are an autonomous coding agent. This workflow steers itself
-          through its own state files — treat them as its private scratchpad,
-          never as project code or documentation. The only state file this
+          <%~ it.vars.stateFileRules %>
+          The only state file this
           turn touches is `.gtd/SPEC_FEEDBACK.md`; address it, then
           delete it. Do not create other files to hold notes or output.
 
@@ -1237,7 +1158,11 @@ machines:
   # onto squashing/fix.
   buildTail:
     model: <%= it.vars.coderModel %>
-    system: <%~ it.vars.finisherPersona %>
+    system: |-
+      <%~ it.vars.finisherPersona %>
+
+
+      <%~ it.vars.agentConduct %>
     params: [onDone, onFeedback]
     # entry: is required by the machine grammar even though nothing resolves
     # this machine bare; `fix` is an arbitrary pick.
@@ -1251,9 +1176,11 @@ machines:
           <%~ it.vars.styleBlock %>
 
 
-          You are an autonomous coding agent. The process is approved and done. This
-          workflow steers itself through its own state files — treat them as its
-          private scratchpad, never as project code or documentation. The only
+          The process is approved and done.
+
+          <%~ it.vars.stateFileRules %>
+
+          The only
           state file this turn touches is `.gtd/COMMIT_MSG.md`; write
           it. Do not create other files to hold notes or output.
 
@@ -1263,13 +1190,13 @@ machines:
           if you built that range yourself earlier in this conversation, work from
           what you already know; otherwise read the range yourself. It runs from
           `<%= it.retainedBase %>` to the working tree, and is exactly what that
-          commit will contain, the changes THIS process made (its trace/retry
+          commit will contain, the changes this process made (its trace/retry
           boundary onward). For a normal build
           process that is the whole feature; for a `gtd --entry review-gate.check`
-          process it is only the fixes made during the review — NOT the changeset
+          process it is only the fixes made during the review — not the changeset
           that was under review.
 
-          If that range is non-empty, write `.gtd/COMMIT_MSG.md` with ONE
+          If that range is non-empty, write `.gtd/COMMIT_MSG.md` with one
           conventional-commits message for the changes (subject line
           `type(scope): subject`, imperative mood, <= 72 characters; a body
           explaining the why, trade-offs, and key decisions). Plain text, no
@@ -1289,17 +1216,10 @@ machines:
         label: Fixing the check
         file: FEEDBACK.md
         prompt: |
-          You are an autonomous coding agent. This workflow steers itself
-          through its own state files — treat them as its private scratchpad,
-          never as project code or documentation. The only state file this
-          turn touches is `.gtd/FEEDBACK.md`; fix it per its
-          contents, or delete it if the feedback turns out to be wrong. Do not
-          create other files to hold notes or output.
+          <%~ it.vars.stateFileRules %>
 
-          Read `.gtd/FEEDBACK.md` (the failing test output) and fix the
-          code so the suite passes. Keep the change focused — do not refactor
-          unrelated code. If the feedback is wrong, empty or delete
-          `.gtd/FEEDBACK.md` instead of "fixing" a non-issue.
+          <%~ it.vars.fixFeedbackPrompt %>
+
 
           Leave everything uncommitted and finish your turn — do not commit.
         retry:

--- a/tests/integration/features/default-workflow.feature
+++ b/tests/integration/features/default-workflow.feature
@@ -832,7 +832,7 @@ Feature: The bundled unified workflow — one flow, end to end
       """
     When I run gtd next
     Then it succeeds
-    And stdout contains "You do NOT resume the design conversation"
+    And stdout contains "You do not resume the design conversation"
 
     Given the file ".gtd/REQUIREMENTS.md" is deleted
     And a file ".gtd/ARCHITECTURE.md" with:


### PR DESCRIPTION
## What

The six persona vars each repeated the same three-paragraph conduct block verbatim ("you have shell tools" / "there's no injected status block" / "go inspect what the turn names"), and the state-file-scratchpad opener, the open-questions warrant test, and the `FEEDBACK.md` fix body were each hand-copied across two to six states in `src/workflows/unified.yaml`. Any edit to shared conduct meant hunting down every copy by hand, with nothing to catch a missed one.

## Changes

- **New shared vars** — `agentConduct`, `stateFileRules`, `questionBar`/`questionBarReturn`, `fixFeedbackPrompt` — spliced in via `<%~ it.vars.* %>` at every call site, each still overridable through the existing `.gtdrc`/`GTD_<NAME>` mechanism like any other bundled var.
- `agentConduct` is deliberately **not** suffixed `Persona`, so it isn't swept into `templates.test.ts`'s persona-set derivation (which matches on that suffix).
- `design.triage` and `architecture.author` gained explicit `## First lap` / `## Return lap` / `## Review loop-back` sub-headings, so the now-shared `questionBar` text reads the same regardless of which lap injected it.
- `styleBlock` and `styleFormatContract` compressed ~50% — dropped the self-narrating opener and rule cross-references, kept every itemized rule and the never-trim priority intact.
- **New regression test**: renders every compiled `prompt`/`system` field against the bundled vars defaults and asserts no `undefined` leaks from a misspelled `it.vars.*` tag, with a paired test proving the assertion actually catches one. Plus lap-heading and `questionBar` checkbox-shape pins.
- README updated for the three dedup-only vars and the reworded `styleBlock` summary; one e2e stdout assertion updated for a case change from the compression pass ("You do NOT resume" → "You do not resume").

## Verification

`npm test` — all 9 turbo tasks green after rebase onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)