### PR TITLE
test: stop the visualize unit test from launching a real browser

### DIFF
--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -304,7 +304,12 @@ describe('gtd — warns on a state with no "C" row (package 03)', () => {
   it('gtd visualize prints no warning — needsOf is "config", not "state"', async () => {
     const repo = seededRepo()
     const { io, result } = makeCapturingCliIo(repo)
-    const fiber = Effect.runFork(runCli(["node", "gtd.js", "visualize", "--port", "0"], io))
+    // `--no-open` is load-bearing, not tidiness: without it the flag default is
+    // `open: true`, so this test really spawns the OS browser at a fresh random
+    // port on every unit run (and every `test:watch` save).
+    const fiber = Effect.runFork(
+      runCli(["node", "gtd.js", "visualize", "--port", "0", "--no-open"], io),
+    )
     // `visualize` blocks forever (a server) — give it a moment to flush its
     // startup line, then interrupt, exactly like the other visualize test in
     // this file below.


### PR DESCRIPTION
## What

`src/program.test.ts`'s `gtd visualize prints no warning` test really starts the
visualize server through `runCli`, but omitted `--no-open`. The flag table's
default is `open: !(--no-open ?? false)` → `true`, so `runVisualizeCommand`
called `openInBrowser`, which spawns the OS browser detached and unref'd.

With `--port 0` the server picks a fresh free port each run, so this opened a
new `http://127.0.0.1:<random>` tab on **every** `test:unit` run — and on every
save under `npm run test:watch`.

## Fix

Add `--no-open` to the argv, plus a comment saying the flag is load-bearing so
it doesn't get trimmed as noise later.

## Notes

- The sibling test below it (`program.test.ts:1642`) already passes
  `open: false` through `runCommand` directly — only this `runCli` path went
  through the flag default.
- The four `visualize.feature` scenarios are all usage errors and never start a
  server, so nothing there was affected.
- No guard added inside `openInBrowser` (e.g. on `process.env.VITEST`): that
  would mask the next occurrence instead of failing it, and the flag table is
  the surface that should decide this.

`npx turbo run test:unit --force` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)