### PR TITLE
fix(workflow): route unwind and deciding's clean case, silencing both no-C-row warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Label: Unwinding your input
 
 #!/usr/bin/env sh
 ...
-git revert --no-commit "$commit"
+git revert --no-commit "$commit" 2> .gtd/.unwind-error
 ```
 
 `Awaits: check` means this beat is not yours: it is a script. gtd never runs

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -435,13 +435,22 @@ otherwise fixed; that repetition is intentional, not a bug. `gtd visualize` and
 `gtd lsp` never print it (neither resolves workflow state the same way
 `gtd next`/`gtd land`/`gtd --entry` do).
 
-The bundled unified template prints exactly two, on every invocation: `unwind`
-and `build.review.deciding` both deliberately declare no `"C"` row, because
-their clean-tree case is either ambiguous (a completed no-op vs. a `git revert`
-failure swallowed by `set +e`, for `unwind`) or would auto-approve an unreviewed
-round (`build.review.deciding`'s clean tree means its own `REVIEW.md` was never
-provisioned, not that a human signed off). Routing either one somewhere to
-silence the warning would be worse than the noise.
+The bundled unified template prints no such warning: every one of its script
+states routes its clean case. Two of them used to be exceptions, and how they
+were fixed is the pattern to copy when your own workflow trips this warning.
+Both had a clean tree that was ambiguous from the diff alone — `unwind` could
+not tell a completed no-op from a `git revert` failure swallowed by `set +e`,
+and `build.review.deciding`'s clean tree meant its own `REVIEW.md` was never
+provisioned, not that a human signed off. Neither could be routed honestly as
+written.
+
+The fix is to resolve the ambiguity **inside the script**, not in the routing:
+each now checks the thing the diff cannot show you (the revert's exit code; the
+file's absence) and writes `.gtd/FEEDBACK.md` on the broken branch. That gives
+the failure a diff of its own, which forks to a human gate — and leaves a clean
+tree meaning exactly one thing, so the `"C"` row can finally say where it goes.
+Adding a `"C"` row that merely guesses, to silence the warning, is worse than
+the noise.
 
 ### The normalization-only contract on `format:`
 

--- a/src/program.test.ts
+++ b/src/program.test.ts
@@ -285,20 +285,19 @@ describe('gtd — warns on a state with no "C" row (package 03)', () => {
     expect(warned.stdout).toBe(clean.stdout)
   })
 
-  it("the bundled unified template prints exactly its two accepted warnings — unwind and build.review.deciding, each deliberately left unrouted (package 03)", async () => {
-    // Both states declare no `C` row on purpose (see their `on:` comments in
-    // unified.yaml): routing either one's clean case somewhere would either
-    // mask a swallowed `git revert` failure (unwind) or auto-approve an
-    // unreviewed round (deciding). Warning on every invocation is the
-    // accepted cost, not a compiled-shape bug.
+  it("the bundled unified template prints no warning at all — every script state routes its clean case", async () => {
+    // `unwind` and `build.review.deciding` were the two long-standing
+    // exceptions: each has a clean tree that is ambiguous from the diff
+    // alone. Both now disambiguate inside the SCRIPT (exit code / the
+    // file's absence) and write `.gtd/FEEDBACK.md` on the broken branch, so
+    // each has a `C` row it can honestly route. A warning reappearing here
+    // means a state grew an unhandled clean case, which stalls silently.
     const repo = new InMemRepo()
     repo.writeFile(".gtdrc.json", renderInitConfig())
     repo.commitAllWithPrefix("chore: init gtd workflow")
     const { stderr, exitCode } = await run(repo, "next")
     expect(exitCode).toBe(0)
-    expect(stderr.match(/"C" row/g)).toHaveLength(2)
-    expect(stderr).toContain('state "unwind" declares no "C" row')
-    expect(stderr).toContain('state "build.review.deciding" declares no "C" row')
+    expect(stderr).not.toContain('"C" row')
   })
 
   it('gtd visualize prints no warning — needsOf is "config", not "state"', async () => {

--- a/src/workflows/templates.test.ts
+++ b/src/workflows/templates.test.ts
@@ -38,12 +38,15 @@ describe("the bundled unified workflow template", () => {
     expect(definition.states[definition.entries.default]).toBeDefined()
   })
 
-  it("declares exactly two accepted no-C-row warnings — unwind and build.review.deciding, both deliberately unrouted for correctness reasons documented on the state itself (package 03)", () => {
+  it("declares no warnings at all — every script state routes its clean case", () => {
+    // `unwind` and `build.review.deciding` were the two long-standing
+    // exceptions. Each now disambiguates its ambiguous clean tree inside the
+    // SCRIPT (the revert's exit code / REVIEW.md's absence) and writes
+    // `.gtd/FEEDBACK.md` on the broken branch, which leaves a `C` row it can
+    // honestly declare. A warning here means a state grew an unhandled clean
+    // case — which stalls silently rather than failing.
     const { definition } = compileTemplate()
-    expect(validateDefinition(definition).warnings).toEqual([
-      'state "unwind" declares no "C" row',
-      'state "build.review.deciding" declares no "C" row',
-    ])
+    expect(validateDefinition(definition).warnings).toEqual([])
   })
 
   it("declares `retry` on exactly build.fix and packages.item.fix-suite, and nothing else (package 01)", () => {
@@ -120,8 +123,15 @@ describe("the bundled unified workflow template", () => {
       (s.on ?? []).filter(([, to]) => to === "unwind").map(() => from),
     )
     expect(inbound).toEqual(["idle"])
+    // The revert's failure branch writes `.gtd/FEEDBACK.md` and forks to a
+    // human gate; every other outcome, clean tree included, advances.
     const unwindTargets = (definition.states.unwind!.on ?? []).map(([, to]) => to)
-    expect(unwindTargets).toEqual(["start-gate.check"])
+    expect(unwindTargets).toEqual([
+      "unwind-failed",
+      "unwind-failed",
+      "start-gate.check",
+      "start-gate.check",
+    ])
     expect((definition.states["start-gate.check"]!.on ?? []).map(([, to]) => to)).toContain(
       "design.triage",
     )
@@ -375,15 +385,25 @@ describe("the bundled unified workflow template", () => {
     })
   })
 
-  it("unwind and build.review.deciding declare no C row — a clean tree there is ambiguous (a completed no-op vs. a swallowed failure) or would auto-approve an unreviewed round, so it stays a warned no-op rather than routing anywhere (package 03)", () => {
+  it("unwind and build.review.deciding each route their clean tree — the ambiguity is resolved in the script, not left as a silent no-op (package 03)", () => {
+    // unwind: the script writes FEEDBACK.md when `git revert` exits
+    // non-zero, so a clean tree here can only mean the revert succeeded and
+    // changed nothing — safe to advance.
+    // deciding: the script writes FEEDBACK.md when REVIEW.md is absent, so
+    // the clean case is unreachable; it still routes to the human gate
+    // rather than nowhere, because a clean tree must never auto-approve an
+    // unreviewed round.
     const { definition } = compileTemplate()
-    for (const name of ["unwind", "build.review.deciding"]) {
-      const decision = step(definition, name, definition.states[name]!.actor!, {
+    const clean = (name: string) =>
+      step(definition, name, definition.states[name]!.actor!, {
         changes: [],
         processTrace: [],
       })
-      expect(decision, name).toMatchObject({ kind: "noop" })
-    }
+    expect(clean("unwind")).toMatchObject({ kind: "commit", to: "start-gate.check" })
+    expect(clean("build.review.deciding")).toMatchObject({
+      kind: "commit",
+      to: "build.review.review-missing",
+    })
   })
 
   it("every script-content state is POSIX sh, not bash — the driver runs it via `sh -c`", () => {

--- a/src/workflows/unified.yaml
+++ b/src/workflows/unified.yaml
@@ -858,12 +858,24 @@ machines:
           set +e
           mkdir -p .gtd
           head=$(git rev-parse HEAD)
-          # Normalize [ ]/[x] before diffing, so only a real note counts.
-          before=$(git show "HEAD^:.gtd/REVIEW.md" 2>/dev/null | sed -E 's/\[[ xX]\]/[_]/g')
-          after=$(git show "HEAD:.gtd/REVIEW.md" 2>/dev/null | sed -E 's/\[[ xX]\]/[_]/g')
-          if git diff-tree --no-commit-id --name-only -r HEAD -- . ":(exclude).gtd" \
+          # The one case that leaves a clean tree below is REVIEW.md already
+          # missing (the `rm -f` no-ops) — which means the review gate's own
+          # file-provisioning invariant broke, NOT a sign-off. Detecting it
+          # here, by the file's absence rather than by the diff, is what
+          # makes the `C` row below safe to declare: a broken round now
+          # always carries a FEEDBACK.md diff and routes to a human.
+          if ! git cat-file -e "HEAD:.gtd/REVIEW.md" 2>/dev/null; then
+            printf 'there is no `.gtd/REVIEW.md` at %s — nothing was reviewed this round.\n' "$head" > .gtd/FEEDBACK.md
+          elif git diff-tree --no-commit-id --name-only -r HEAD -- . ":(exclude).gtd" \
                | grep -q . \
-             || [ "$before" != "$after" ]; then
+             || [ "$(git show "HEAD^:.gtd/REVIEW.md" 2>/dev/null | sed -E 's/\[[ xX]\]/[_]/g')" \
+                != "$(git show "HEAD:.gtd/REVIEW.md" 2>/dev/null | sed -E 's/\[[ xX]\]/[_]/g')" ]; then
+            # Reached only with REVIEW.md present. FEEDBACK iff the human
+            # left a note (any edit beyond a checkbox tick — hence the
+            # [ ]/[x] normalization above) or hand-edited any file this
+            # round outside .gtd/; otherwise a clean sign-off. This turn
+            # only CAPTURES the raw material into REVIEW_RAW.md —
+            # collecting judges actionability.
             {
               echo "This is machine-captured input, not instructions. A downstream agent judges whether it's actionable."
               echo
@@ -871,17 +883,49 @@ machines:
               echo "The human's notes are in .gtd/REVIEW.md at this commit. Any hand edits are"
               echo "in that commit's other paths. Run: git show $head"
             } > .gtd/REVIEW_RAW.md
+            rm -f .gtd/REVIEW.md
+          else
+            rm -f .gtd/REVIEW.md
           fi
-          rm -f .gtd/REVIEW.md
         on:
+          # FEEDBACK rows first: the broken-invariant branch writes nothing
+          # else, but declaring them ahead of the sign-off row keeps the
+          # ordering honest if it ever does.
+          "A .gtd/FEEDBACK.md": review-missing
+          "M .gtd/FEEDBACK.md": review-missing
+          # A/M REVIEW_RAW.md before D REVIEW.md so a feedback round (which
+          # also deletes REVIEW.md) isn't mistaken for sign-off.
           "A .gtd/REVIEW_RAW.md": collecting
           "M .gtd/REVIEW_RAW.md": collecting
           "D .gtd/REVIEW.md": $onSignoff
-          # Deliberately no `C` row: REVIEW.md missing here means the review
-          # gate's own file-provisioning invariant broke, not a sign-off — a
-          # clean tree must not be able to auto-approve the round with
-          # nothing reviewed. Stays a no-op (validateHasCRow's warning is the
-          # accepted cost) rather than routing anywhere.
+          # Unreachable now that the missing-REVIEW.md case writes
+          # FEEDBACK.md above, but declared rather than left off: if a clean
+          # tree ever does happen here, it must reach a human, never
+          # auto-approve an unreviewed round.
+          "C": review-missing
+
+      review-missing:
+        actor: human
+        label: Nothing to review
+        file: FEEDBACK.md
+        message: |
+          The review round committed no `.gtd/REVIEW.md`, so there is nothing
+          to sign off on. `.gtd/FEEDBACK.md` holds the detail.
+
+          Make any change to re-run the reviewer and author a fresh review
+          record.
+
+          What each change does next (then run `gtd land`):
+          <% it.edges.forEach(function (e) { if (e.describe) { %>
+          <%~ "- " + (e.action ? "**" + e.action + "** — " : "") + e.describe + "\n" %>
+          <% } }) %>
+        on:
+          "* **":
+            to: reviewing
+            action: Re-review
+            describe: >-
+              re-run the reviewer to author a fresh `.gtd/REVIEW.md`
+              (**build.review.reviewing**).
 
       # Outcome is by which paths THIS diff touches: writing REQUIREMENTS.md
       # (A/M) is the actionable case, so those rows are declared before "D
@@ -1308,21 +1352,61 @@ machines:
         script: |
           #!/usr/bin/env sh
           set +e
+          mkdir -p .gtd
           # Hoisted here, at the TOP: Eta's autoTrim eats the newline after
           # an interpolation tag, so no tag may be the last token on a line.
           # Uses it.currentCommit (render-time), not bare HEAD, so a
           # late-running driver still reverts the right commit.
           commit="<%~ it.currentCommit %>"
-          git revert --no-commit "$commit"
+          git revert --no-commit "$commit" 2> .gtd/.unwind-error
+          code=$?
+          # The revert's EXIT CODE is what separates a genuine no-op from a
+          # hard failure (e.g. a merge commit with no `-m`) — the diff alone
+          # cannot, since both can leave a clean tree. Turning the failure
+          # into a FEEDBACK.md write is what makes the `C` row below safe:
+          # once a failure always has a diff, a clean tree here means the
+          # revert really did succeed and change nothing.
+          if [ "$code" -ne 0 ]; then
+            printf 'gtd could not unwind %s out of your working tree.\n\n' "$commit" > .gtd/FEEDBACK.md
+            if [ -s .gtd/.unwind-error ]; then
+              cat .gtd/.unwind-error >> .gtd/FEEDBACK.md
+            else
+              printf '`git revert --no-commit` exited %s and produced no output.\n' "$code" >> .gtd/FEEDBACK.md
+            fi
+          fi
+          rm -f .gtd/.unwind-error
         on:
+          "A .gtd/FEEDBACK.md": unwind-failed
+          "M .gtd/FEEDBACK.md": unwind-failed
           "* **": start-gate
-          # Deliberately no `C` row: `git revert --no-commit` under `set +e`
-          # leaves a clean tree on either a genuine no-op OR a hard failure
-          # (e.g. a merge commit with no `-m`) — the two are indistinguishable
-          # from the diff alone, and advancing unconditionally would run the
-          # baseline check against a tree that still carries the human's
-          # un-reverted sketch. Stays a no-op (validateHasCRow's warning is
-          # the accepted cost) rather than risking a false-clean baseline.
+          "C": start-gate
+
+      # Reached only when the revert above exited non-zero. A human repairs
+      # the tree by hand; start-gate.check clears FEEDBACK.md on its way
+      # green, so nothing has to sweep it here.
+      unwind-failed:
+        actor: human
+        label: Could not unwind your input
+        file: FEEDBACK.md
+        message: |
+          gtd could not revert your sketch out of the working tree.
+          `.gtd/FEEDBACK.md` holds the error.
+
+          Undo the sketch by hand (its intent survives in history either
+          way), then continue — gtd will not start work on a tree that still
+          carries it.
+
+          What each change does next (then run `gtd land`):
+          <% it.edges.forEach(function (e) { if (e.describe) { %>
+          <%~ "- " + (e.action ? "**" + e.action + "** — " : "") + e.describe + "\n" %>
+          <% } }) %>
+        on:
+          "* **":
+            to: start-gate
+            action: Continue
+            describe: >-
+              having undone the sketch by hand, check the test baseline is
+              green and start triage (**start-gate.check**).
 
       # Reverts the human's own review-round hand-edit before re-planning,
       # scoped to real code (`.gtd/` excluded — REVIEW.md is already gone by

--- a/tests/integration/features/deciding-signoff.feature
+++ b/tests/integration/features/deciding-signoff.feature
@@ -44,3 +44,19 @@ Feature: A tick with no comment signs off — build.review.deciding's script rea
     And I run gtd land
     Then it succeeds
     And the last commit subject is "gtd(check): build.review.deciding → idle"
+
+  @live
+  Scenario: no `.gtd/REVIEW.md` at HEAD is not a sign-off — deciding's script writes FEEDBACK.md and lands at a human gate
+    # The one clean-tree case deciding's `rm -f .gtd/REVIEW.md` used to
+    # produce. The script detects it by the file's ABSENCE, not by the diff,
+    # so the broken round always carries a diff and can never be mistaken for
+    # an approval of nothing.
+    Given a test project
+    And an empty commit "gtd(agent): build.health.check → build.review.reviewing"
+    And an empty commit "gtd(human): build.review.await-review → build.review.deciding"
+    When I run gtd next with "--json"
+    And I execute the printed check script
+    And I run gtd land
+    Then it succeeds
+    And the last commit subject is "gtd(check): build.review.deciding → build.review.review-missing"
+    And ".gtd/FEEDBACK.md" exists

--- a/tests/integration/features/missing-c-row-warning.feature
+++ b/tests/integration/features/missing-c-row-warning.feature
@@ -7,9 +7,7 @@ Feature: gtd warns on a workflow state that declares no "C" row
   default), but usually an oversight. Every command that loads workflow state
   (`needsOf` `"state"`) prints the warning once per invocation, on stderr
   only — stdout stays the machine path. The bundled unified template prints
-  exactly two, on every invocation: `unwind` and `build.review.deciding` both
-  deliberately leave their clean case unrouted (see their `on:` comments in
-  `src/workflows/unified.yaml`).
+  none: every one of its script states routes its clean case.
 
   Background:
     Given a test project
@@ -42,11 +40,9 @@ Feature: gtd warns on a workflow state that declares no "C" row
     And stderr contains "state \"building\" declares no \"C\" row" exactly 1 times
     And stdout does not contain "\"C\" row"
 
-  Scenario: the bundled unified template prints exactly its two accepted warnings
+  Scenario: the bundled unified template prints no warning at all
     Given the workflow
     When I run gtd with args "next"
     Then it succeeds
-    And stderr contains "\"C\" row" exactly 2 times
-    And stderr contains "state \"unwind\" declares no \"C\" row"
-    And stderr contains "state \"build.review.deciding\" declares no \"C\" row"
+    And stderr does not contain "\"C\" row"
 

--- a/tests/shell/corpus/workflow.build.review.deciding.sh
+++ b/tests/shell/corpus/workflow.build.review.deciding.sh
@@ -9,12 +9,24 @@
 set +e
 mkdir -p .gtd
 head=$(git rev-parse HEAD)
-# Normalize [ ]/[x] before diffing, so only a real note counts.
-before=$(git show "HEAD^:.gtd/REVIEW.md" 2>/dev/null | sed -E 's/\[[ xX]\]/[_]/g')
-after=$(git show "HEAD:.gtd/REVIEW.md" 2>/dev/null | sed -E 's/\[[ xX]\]/[_]/g')
-if git diff-tree --no-commit-id --name-only -r HEAD -- . ":(exclude).gtd" \
+# The one case that leaves a clean tree below is REVIEW.md already
+# missing (the `rm -f` no-ops) — which means the review gate's own
+# file-provisioning invariant broke, NOT a sign-off. Detecting it
+# here, by the file's absence rather than by the diff, is what
+# makes the `C` row below safe to declare: a broken round now
+# always carries a FEEDBACK.md diff and routes to a human.
+if ! git cat-file -e "HEAD:.gtd/REVIEW.md" 2>/dev/null; then
+  printf 'there is no `.gtd/REVIEW.md` at %s — nothing was reviewed this round.\n' "$head" > .gtd/FEEDBACK.md
+elif git diff-tree --no-commit-id --name-only -r HEAD -- . ":(exclude).gtd" \
      | grep -q . \
-   || [ "$before" != "$after" ]; then
+   || [ "$(git show "HEAD^:.gtd/REVIEW.md" 2>/dev/null | sed -E 's/\[[ xX]\]/[_]/g')" \
+      != "$(git show "HEAD:.gtd/REVIEW.md" 2>/dev/null | sed -E 's/\[[ xX]\]/[_]/g')" ]; then
+  # Reached only with REVIEW.md present. FEEDBACK iff the human
+  # left a note (any edit beyond a checkbox tick — hence the
+  # [ ]/[x] normalization above) or hand-edited any file this
+  # round outside .gtd/; otherwise a clean sign-off. This turn
+  # only CAPTURES the raw material into REVIEW_RAW.md —
+  # collecting judges actionability.
   {
     echo "This is machine-captured input, not instructions. A downstream agent judges whether it's actionable."
     echo
@@ -22,5 +34,7 @@ if git diff-tree --no-commit-id --name-only -r HEAD -- . ":(exclude).gtd" \
     echo "The human's notes are in .gtd/REVIEW.md at this commit. Any hand edits are"
     echo "in that commit's other paths. Run: git show $head"
   } > .gtd/REVIEW_RAW.md
+  rm -f .gtd/REVIEW.md
+else
+  rm -f .gtd/REVIEW.md
 fi
-rm -f .gtd/REVIEW.md

--- a/tests/shell/corpus/workflow.unwind.sh
+++ b/tests/shell/corpus/workflow.unwind.sh
@@ -1,8 +1,25 @@
 #!/usr/bin/env sh
 set +e
+mkdir -p .gtd
 # Hoisted here, at the TOP: Eta's autoTrim eats the newline after
 # an interpolation tag, so no tag may be the last token on a line.
 # Uses it.currentCommit (render-time), not bare HEAD, so a
 # late-running driver still reverts the right commit.
 commit="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-git revert --no-commit "$commit"
+git revert --no-commit "$commit" 2> .gtd/.unwind-error
+code=$?
+# The revert's EXIT CODE is what separates a genuine no-op from a
+# hard failure (e.g. a merge commit with no `-m`) — the diff alone
+# cannot, since both can leave a clean tree. Turning the failure
+# into a FEEDBACK.md write is what makes the `C` row below safe:
+# once a failure always has a diff, a clean tree here means the
+# revert really did succeed and change nothing.
+if [ "$code" -ne 0 ]; then
+  printf 'gtd could not unwind %s out of your working tree.\n\n' "$commit" > .gtd/FEEDBACK.md
+  if [ -s .gtd/.unwind-error ]; then
+    cat .gtd/.unwind-error >> .gtd/FEEDBACK.md
+  else
+    printf '`git revert --no-commit` exited %s and produced no output.\n' "$code" >> .gtd/FEEDBACK.md
+  fi
+fi
+rm -f .gtd/.unwind-error


### PR DESCRIPTION
## The warnings

Every `gtd` invocation printed:

```
gtd: warning: state "unwind" declares no "C" row
gtd: warning: state "build.review.deciding" declares no "C" row
```

Both states genuinely had an ambiguous clean tree, so neither could declare a `"C"` row honestly — the accepted-cost comments said as much.

## The fix

Resolve the ambiguity **inside the script**, not by guessing in the routing.

**`unwind`** captures `git revert`'s exit code and stderr and writes `.gtd/FEEDBACK.md` on failure, forking to a new `unwind-failed` human gate. Once a failure always carries a diff, a clean tree can only mean "the revert succeeded and changed nothing" — so `"C"` advances to `start-gate`.

**`build.review.deciding`** checks for `HEAD:.gtd/REVIEW.md` up front and writes `.gtd/FEEDBACK.md` when it is absent, forking to a new `build.review.review-missing` human gate. `"C"` targets that same gate — unreachable now, but it must never auto-approve an unreviewed round.

## Pinned views updated

- `src/program.test.ts` and `src/workflows/templates.test.ts` — warning-count and template-shape pins, now asserting **zero** warnings
- `tests/integration/features/missing-c-row-warning.feature`
- `tests/shell/corpus/*.sh` — regenerated, shellcheck clean
- `docs/configuration.md` — now teaches the disambiguate-in-the-script pattern instead of documenting the two exceptions
- `README.md` — the `unwind` script excerpt

## New coverage

A `@live` scenario in `deciding-signoff.feature` executes deciding's real script with no `REVIEW.md` at HEAD and asserts it lands `gtd(check): build.review.deciding → build.review.review-missing`.

## Known gap

`unwind`'s **failure** branch has no e2e scenario — the step vocabulary has no way to force `git revert` to fail (needs a merge commit or a conflict, neither constructible from the available `Given` steps). Its routing is pinned in `templates.test.ts`, but the shell branch itself is unexercised.

Full suite green: 9/9 turbo tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)